### PR TITLE
[xkcd] added latest and newest keywords and redirected comic forum posts

### DIFF
--- a/modules/xkcd.py
+++ b/modules/xkcd.py
@@ -54,8 +54,8 @@ def xkcd(jenni, input):
                     pass
                 website = google_search("site:xkcd.com "+ query)
                 chkForum = re.match(re.compile(r'.*?([0-9].*?):.*'), find_title(website)) # regex for comic specific forum threads
-                if (chkForum == True):
-                    website = "http://xkcd.com/" + match.groups()[0].lstrip('0')
+                if (chkForum):
+                    website = "http://xkcd.com/" + chkForum.groups()[0].lstrip('0')
     if website: # format and say result
         website += ' [' + find_title(website)[6:] + ']'
         jenni.say(website)


### PR DESCRIPTION
if the result should have reached a thread on the forum dedicated to a specific comic strip it will now redirect to the comic itself.
the latest and newest keywords now direct to http://xkcd.com/ instead of whatever forum posts they used to direct to.
