### PR TITLE
RSS module has SQL injection vulnerability

### DIFF
--- a/willie/modules/rss.py
+++ b/willie/modules/rss.py
@@ -66,19 +66,19 @@ def manage_rss(willie, trigger):
             fg_colour = fg_colour.zfill(2)
         if bg_colour:
             bg_colour = bg_colour.zfill(2)
-        c.execute('INSERT INTO rss VALUES ("%s","%s","%s","%s","%s")' % (channel, site_name, site_url, fg_colour, bg_colour))
+        c.execute('INSERT INTO rss VALUES (?,?,?,?,?)',  (channel, site_name, site_url, fg_colour, bg_colour))
         conn.commit()
         c.close()
         willie.reply("Successfully added values to database.")
     elif len(text) == 3 and text[1] == 'del':
         # .rss del ##channel
-        c.execute('DELETE FROM rss WHERE channel = "%s"' % channel)
+        c.execute('DELETE FROM rss WHERE channel = ?', (channel,))
         conn.commit()
         c.close()
         willie.reply("Successfully removed values from database.")
     elif len(text) >= 4 and text[1] == 'del':
         # .rss del ##channel Site_Name
-        c.execute('DELETE FROM rss WHERE channel = "%s" and site_name = "%s"', (channel, " ".join(text[3:])))
+        c.execute('DELETE FROM rss WHERE channel = ? and site_name = ?', (channel, " ".join(text[3:])))
         conn.commit()
         c.close()
         willie.reply("Successfully removed the site from the given channel.")
@@ -149,7 +149,7 @@ def read_feeds(willie):
 
         # only print if new entry
         sql_text = (feed_channel, feed_site_name, entry.title, article_url)
-        cur.execute('SELECT * FROM recent WHERE channel = "%s" AND site_name = "%s" and article_title = "%s" AND article_url = "%s"' % sql_text)
+        cur.execute('SELECT * FROM recent WHERE channel = ? AND site_name = ? and article_title = ? AND article_url = ?', sql_text)
         if len(cur.fetchall()) < 1:
 
             response = site_name_effect + " %s \x02%s\x02" % (entry.title, article_url)
@@ -159,7 +159,7 @@ def read_feeds(willie):
             willie.msg(feed_channel, response)
 
             t = (feed_channel, feed_site_name, entry.title, article_url,)
-            cur.execute('INSERT INTO recent VALUES ("%s", "%s", "%s", "%s")' % t)
+            cur.execute('INSERT INTO recent VALUES (?, ?, ?, ?)', t)
             conn.commit()
         else:
             if DEBUG:


### PR DESCRIPTION
Not sure if this affects MySQL, but at least using it with SQLite causes it to barf when my RSS feed has a string like this:

> foo: "blah blah can't do bleh won't blah."

due to the fact that the raw string was being put in the SQL query. This could allow the controller of a remote RSS feed Willie is watching to to execute arbitrary commands on the database if crafted right, but the more likely concern is just quotes in an RSS feed cause it to throw an error.
