### PR TITLE
Fix minor spelling error

### DIFF
--- a/scripts/willie
+++ b/scripts/willie
@@ -222,7 +222,7 @@ def main(argv=None):
                     os.kill(old_pid, signal.SIGKILL)
                     sys.exit(0)
                 elif opts.quit:
-                    stderr('Singaling Willie to stop gracefully')
+                    stderr('Signaling Willie to stop gracefully')
                     os.kill(old_pid, signal.SIGUSR1)
                     sys.exit(0)
             elif not tools.check_pid(old_pid) and (opts.kill or opts.quit):


### PR DESCRIPTION
Change 'Singaling' to 'Signaling' in shutdown message.
