### PR TITLE
[config] Split stored string before use in add_list

### DIFF
--- a/willie/config.py
+++ b/willie/config.py
@@ -222,7 +222,7 @@ class Config(object):
                                                                        option):
             m = "You currently have " + self.parser.get(section, option)
             if self.option(m + '. Would you like to keep them', True):
-                lst = self.parser.get(section, option)
+                lst = self.parser.get(section, option).split(',')
         mem = raw_input(prompt + ' ')
         while mem:
             lst.append(mem)


### PR DESCRIPTION
ConfigParser.get() reads configurations (eg. channel list) as a string causing wrong lists to be stored back and/or calling <string>.append which also caused a crash

i.e. If you run "willie -w" more than once, the previous config is loaded as a string. When ','.join(lst) is called and the result stored, the config file now holds "#,l,i,n,u,x,,,#a,l,g,o,s"
Similarly, any attempt to append to this string will fail.

Solution: Split the string before use, converting it to a Python list.
