### PR TITLE
Fixed comparison of nicknames to assume ascii and that '~' == '^'.

### DIFF
--- a/willie/tools.py
+++ b/willie/tools.py
@@ -85,7 +85,9 @@ class Nick(unicode):
     @staticmethod
     def _lower(nick):
         """Returns `nick` in lower case per RFC 2812"""
-        return nick.translate(Nick.translation_table)
+        if isinstance(nick, unicode):
+            nick = nick.encode("ascii")
+        return unicode(nick.translate(Nick.translation_table))
 
     def __hash__(self):
         return self._lowered.__hash__()


### PR DESCRIPTION
'~' is not actually an allowed character in nicknames but rfc2812 does define them as equivalent to '^', so for completeness sage I added it.

The real issue:
str.lower() takes locale into account, which could cause some nicknames
that are not equivalent to be treated as equivalent. Probably not in the
narrow character range allowed in nicknames, but better safe than sorry.
