### PR TITLE
fix Nick._lower(self)

### DIFF
--- a/willie/tools.py
+++ b/willie/tools.py
@@ -84,7 +84,7 @@ class Nick(unicode):
         # which may be useful at some point in the future.
         low = nick.lower().replace('{', '[').replace('}', ']')
         low = low.replace('|', '\\').replace('^', '~')
-        return l
+        return low
 
     def __hash__(self):
         return self._lowered.__hash__()


### PR DESCRIPTION
when this was rewritten, the internal variable l was renamed low, but this was not reflected in the return statement resulting in an error. this commit fixes that
