### PR TITLE
Per RFC 2812, PASS is required *before* NICK/USER.

### DIFF
--- a/willie/irc.py
+++ b/willie/irc.py
@@ -287,11 +287,12 @@ class Bot(asynchat.async_chat):
                                           % e)
                     os._exit(1)
             self.set_socket(self.ssl)
-        self.write(('NICK', self.nick))
-        self.write(('USER', self.user, '+iw', self.nick), self.name)
 
         if self.config.core.server_password is not None:
             self.write(('PASS', self.config.core.server_password))
+        self.write(('NICK', self.nick))
+        self.write(('USER', self.user, '+iw', self.nick), self.name)
+
         stderr('Connected.')
         self.last_ping_time = datetime.now();
         timeout_check_thread = threading.Thread(target=self._timeout_check)


### PR DESCRIPTION
RFC 2812, [section 3.1](http://tools.ietf.org/html/rfc2812#page-10) explicitly states, and reiterates in 3.1.1, that of NICK, USER, and PASS, PASS _can't_ be last, and it's recommended that it be first.

I ran into this because it breaks at least on Freenode.
