### PR TITLE
Fixed a few derps in help and updated info to 4.0 syntax

### DIFF
--- a/willie/modules/info.py
+++ b/willie/modules/info.py
@@ -44,7 +44,7 @@ def commands(bot, trigger):
 def help2(bot, trigger):
     response = (
         'Hi, I\'m a bot. Say ".commands" to me in private for a list ' +
-        'of my commands, or see http://bot.dftba.net for more ' +
+        'of my commands, or see http://willie.dftba.net for more ' +
         'general details. My owner is %s.'
     ) % bot.config.owner
     bot.reply(response)


### PR DESCRIPTION
There was a problem with .help, with a conflict created via the use of the same callable name, plus it was using input.group instead of trigger.group (not noticed for 5 months?). I also took the liberty to update info to v4.0 syntax (hope you update the tutorial (and docs?) with the new syntax)
