### PR TITLE
Fix for case issues in adminchannel.py with topic and mask

### DIFF
--- a/willie/modules/adminchannel.py
+++ b/willie/modules/adminchannel.py
@@ -319,7 +319,7 @@ def show_mask(bot, trigger):
         return
     if not bot.db:
         bot.say("I'm afraid I can't do that.")
-    elif trigger.sender in bot.db.preferences:
+    elif trigger.sender.lower() in bot.db.preferences:
         bot.say(bot.db.preferences.get(trigger.sender.lower(), 'topic_mask'))
     else:
         bot.say("%s")


### PR DESCRIPTION
topic() calls lower() on the channel name, but not on set_mask() and show_mask(). If the channel name is not lower case, topic doesn't find the topic mask row in the database as the where condition is case sensitive. According to RFC2812 http://tools.ietf.org/html/rfc2812#section-1.3 channel names should be case insensitive, so lower() on all the channel names seems more appropriate than removing lower() from topic()
