### PR TITLE
Add trigger.raw and fix issue #310

### DIFF
--- a/willie/bot.py
+++ b/willie/bot.py
@@ -490,6 +490,7 @@ class Willie(irc.Bot):
     class Trigger(unicode):
         def __new__(cls, text, origin, bytes, match, event, args, self):
             s = unicode.__new__(cls, text)
+            s.raw = origin.raw
             s.sender = origin.sender
             """
             The channel (or nick, in a private message) from which the

--- a/willie/coretasks.py
+++ b/willie/coretasks.py
@@ -14,6 +14,7 @@ responses to standard IRC codes without having to shove them all into the
 dispatch function in bot.py and making it easier to maintain.
 """
 import re
+import time
 import willie
 from willie.tools import Nick
 
@@ -43,8 +44,32 @@ def startup(bot, trigger):
         modes = 'B'
     bot.write(('MODE ', '%s +%s' % (bot.nick, modes)))
 
+    bot.memory['retry_join'] = dict()
     for channel in bot.config.core.get_list('channels'):
         bot.write(('JOIN', channel))
+
+
+@willie.module.event('477')
+@willie.module.rule('.*')
+@willie.module.priority('high')
+def retry_join(bot, trigger):
+    """
+    Give NickServ enough time to identify, and retry rejoining an
+    identified-only (+R) channel. Maximum of ten rejoin attempts.
+    """
+    channel = re.search('477 %s (.*?) :' % bot.nick, trigger.raw).group(1)
+    if channel in bot.memory['retry_join'].keys():
+        bot.memory['retry_join'][channel] += 1
+        if bot.memory['retry_join'][channel] > 10:
+            bot.debug(__file__, 'Failed to join %s after 10 attempts.' % channel, 'warning')
+            return
+    else:
+        bot.memory['retry_join'][channel] = 0
+        bot.write(('JOIN', channel))
+        return
+
+    time.sleep(6)
+    bot.write(('JOIN', channel))
 
 #Functions to maintain a list of chanops in all of willie's channels.
 

--- a/willie/irc.py
+++ b/willie/irc.py
@@ -39,8 +39,11 @@ from tools import verify_ssl_cn
 class Origin(object):
     source = re.compile(r'([^!]*)!?([^@]*)@?(.*)')
 
-    def __init__(self, bot, source, args):
+    def __init__(self, bot, raw, source, args):
         self.hostmask = source
+
+        # Full raw line from server
+        self.raw = raw
 
         #Split out the nick, user, and host from hostmask per the regex above.
         match = Origin.source.match(source or '')
@@ -385,7 +388,8 @@ class Bot(asynchat.async_chat):
         if line.endswith('\r'):
             line = line[:-1]
         self.buffer = u''
-        self.raw = line
+        raw = line
+        self.raw = raw
         if line.startswith(':'):
             source, line = line[1:].split(' ', 1)
         else:
@@ -410,7 +414,7 @@ class Bot(asynchat.async_chat):
             stderr('Nickname already in use!')
             self.handle_close()
 
-        origin = Origin(self, source, args)
+        origin = Origin(self, raw, source, args)
         self.dispatch(origin, text, args)
 
     def dispatch(self, origin, text, args):


### PR DESCRIPTION
This commit adds the `raw` property to the `Trigger` class, which is more accurate than using `bot.raw` to get the full raw line that triggered a function.

This also fixes issue #310: when Willie can't join a channel because it isn't identified, it joins as soon as it gets the message which should have given NickServ enough time to process identification. If not, each channel is retried 10 times with 6 second delays before giving a warning.
