### PR TITLE
Fix KeyError on QUIT event

### DIFF
--- a/willie/coretasks.py
+++ b/willie/coretasks.py
@@ -298,7 +298,9 @@ def track_join(bot, trigger):
 @willie.module.event('QUIT')
 @willie.module.unblockable
 def track_quit(bot, trigger):
-    del bot.privileges[trigger.sender][trigger.args[1]]
+    for chanprivs in bot.privileges.values():
+        if trigger.nick in chanprivs:
+            del chanprivs[trigger.nick]
 
 
 @willie.module.rule('.*')


### PR DESCRIPTION
The trigger object passed by a QUIT event doesn't include a sending
channel, so bot.privileges[trigger.sender] in coretasks.track_quit() was
throwing a KeyError. The bot now loops through and removes the
triggering nick from privileges for all channels, avoiding the error.
