### PR TITLE
[url] Fix for issue #369

### DIFF
--- a/willie/modules/url.py
+++ b/willie/modules/url.py
@@ -54,7 +54,7 @@ def setup(bot=None):
 
     if bot.config.has_option('url', 'exclude'):
         regexes = [re.compile(s) for s in
-                   bot.config.url.get_list(bot.config.url.exclude)]
+                   bot.config.url.get_list('exclude')]
     else:
         regexes = []
 


### PR DESCRIPTION
The problem was the `bot.config.<section>.get_list()` takes the name of the option, not the string as was being supplied until now.
In addition, I fixed another small issue in that reloading the module appeared to intend to extend the list of exclusions while it in fact replaced it. If that was not the intention I can fix it and also remove the number of lines of unnecessary code.
