### PR TITLE
ip.py: 'region_name' should be 'region_code'

### DIFF
--- a/willie/modules/ip.py
+++ b/willie/modules/ip.py
@@ -96,7 +96,10 @@ def ip(bot, trigger):
     host = socket.getfqdn(query)
     response = "[IP/Host Lookup] Hostname: %s" % host
     response += " | Location: %s" % gi_city.country_name_by_name(query)
-    region = gi_city.region_by_name(query)['region_code']
+    try:
+        region = gi_city.region_by_name(query)['region_name'] # pygeoip < 0.3.0
+    except:
+        region = gi_city.region_by_name(query)['region_code'] # pygeoip >= 0.3.0
     if region is not None:
         response += " | Region: %s" % region
     isp = gi_org.org_by_name(query)


### PR DESCRIPTION
This commit fix this issue

```
12:39  _Tux_> .ip 8.8.8.8
12:39  SuperLuserv2> Downloading GeoIP database, please wait...
12:39  SuperLuserv2> KeyError: 'region_name' (file "/usr/local/lib/python2.7/dist-packages/willie/modules/ip.py", line 99, in ip)
```
