### PR TITLE
[rss/clock] Add time format and time zone config options; take RSS time format from preferences

### DIFF
--- a/willie/modules/clock.py
+++ b/willie/modules/clock.py
@@ -11,6 +11,13 @@ import datetime
 from willie.module import commands, example, OP
 
 
+def configure(config):
+    config.interactive_add('clock', 'tz',
+                           'Preferred time zone (http://dft.ba/-tz)', 'UTC')
+    config.interactive_add('clock', 'time_format',
+                           'Preferred time format (http://strftime.net)', '%F - %T%Z')
+
+
 def setup(bot):
     #Having a db means pref's exists. Later, we can just use `if bot.db`.
     if bot.db and not bot.db.preferences.has_columns('tz'):
@@ -46,12 +53,10 @@ def f_time(bot, trigger):
             tz = bot.db.preferences.get(trigger.nick, 'tz')
         if not tz and trigger.sender in bot.db.preferences:
             tz = bot.db.preferences.get(trigger.sender, 'tz')
-        if not tz:
-            tz = 'UTC'
-    else:
-        tz = 'UTC'
-    tzi = pytz.timezone(tz)
-    now = datetime.datetime.now(tzi)
+        if not tz and bot.config.has_option('clock', 'tz'):
+            tz = bot.config.clock.tz
+
+    now = datetime.datetime.now(pytz.timezone(tz or 'UTC'))
 
     tformat = ''
     if bot.db:
@@ -111,6 +116,9 @@ def update_user_format(bot, trigger):
                 tz = bot.db.preferences.get(trigger.nick, 'tz')
             if not tz and trigger.sender in bot.db.preferences:
                 tz = bot.db.preferences.get(trigger.sender, 'tz')
+            if not tz and bot.config.has_option('clock', 'tz'):
+                tz = bot.config.clock.tz
+
         now = datetime.datetime.now(pytz.timezone(tz or 'UTC'))
         timef = ''
         try:
@@ -178,6 +186,9 @@ def update_channel_format(bot, trigger):
                 tz = bot.db.preferences.get(trigger.nick, 'tz')
             if not tz and trigger.sender in bot.db.preferences:
                 tz = bot.db.preferences.get(trigger.sender, 'tz')
+            if not tz and bot.config.has_option('clock', 'tz'):
+                tz = bot.config.clock.tz
+
         now = datetime.datetime.now(pytz.timezone(tz or 'UTC'))
         timef = ''
         try:


### PR DESCRIPTION
The clock module can now set global config options for time format and time zone. The time command will look for user or channel preferences first, and then for these config options.

The RSS module now reads time format from the same place: it will look for a channel preference, then for the config option. This replaces the DATEFORMAT constant added to the RSS module in a recent commit (as suggested by @embolalia).

Also a couple other minor changes to the RSS module.
