### PR TITLE
[remind] fix to duplicate column name: tz bug

### DIFF
--- a/willie/modules/remind.py
+++ b/willie/modules/remind.py
@@ -53,7 +53,7 @@ def setup(bot):
     if bot.db and not bot.db.preferences.has_columns('tz'):
         bot.db.preferences.add_columns(['tz'])
     if bot.db and not bot.db.preferences.has_columns('time_format'):
-        bot.db.preferences.add_columns(['tz'])
+        bot.db.preferences.add_columns(['time_format'])
 
     bot.rfn = filename(bot)
     bot.rdb = load_database(bot.rfn)


### PR DESCRIPTION
Willie fails to load remind.py module due to repeat attempt to add column ['tz'] to preferences table in the setup function.

```
Error in remind setup procedure: duplicate column name: tz
(db.py:669)
```

Changing second add_column to ['time_format'] at line 56 fixes the bug and appears to be the intended behavior.
