### PR TITLE
[irc] Only split args with spaces, fixes #406

### DIFF
--- a/willie/irc.py
+++ b/willie/irc.py
@@ -443,7 +443,7 @@ class Bot(asynchat.async_chat):
             args = argstr.split(' ')
             args.append(text)
         else:
-            args = line.split()
+            args = line.split(' ')
             text = args[-1]
 
         self.last_ping_time = datetime.now()


### PR DESCRIPTION
Before this commit, that `argstr.split()` was using Unicode whitespace in channel names as a delimiter, so a message to the channel `#hi 123` was being interpreted as:

```
[u'PRIVMSG', u'#hi', u'123', u'hello']
```

This commit fixes the problem by only allowing spaces, and now Willie interprets the channel name correctly:

```
[u'PRIVMSG', u'#hi\u2005123', u'hello']
```
