### PR TITLE
Added __repr__ for Nick class. Resolves #413 somewhat.

### DIFF
--- a/willie/tools.py
+++ b/willie/tools.py
@@ -249,6 +249,12 @@ class Nick(unicode):
         low = low.replace('|', '\\').replace('^', '~')
         return low
 
+    def __repr__(self):
+        return "%s(%r)" % (
+            self.__class__.__name__,
+            self.__str__()
+        )
+
     def __hash__(self):
         return self._lowered.__hash__()
 


### PR DESCRIPTION
Introduces proper representation for the Nick class to aid in debugging any quirkiness experienced with it. Should keep backwards compatibility for when Nick is used as a string.

[SO question explaining **str** and **repr** uses](http://stackoverflow.com/questions/1436703/difference-between-str-and-repr-in-python)
