### PR TITLE
[tell] Fixes #418. Error when not enough args given

### DIFF
--- a/willie/modules/tell.py
+++ b/willie/modules/tell.py
@@ -88,11 +88,20 @@ def get_user_time(bot, nick):
 def f_remind(bot, trigger):
     """Give someone a message the next time they're seen"""
     teller = trigger.nick
-
     verb = trigger.group(1)
-    tellee, msg = trigger.group(2).split(None, 1)
 
-    tellee = Nick(tellee.rstrip('.,:;'))
+    if not trigger.group(3):
+        bot.reply("%s whom?" % verb)
+        return
+
+    tellee = trigger.group(3).rstrip('.,:;')
+    msg = trigger.group(2).lstrip(tellee).lstrip()
+
+    if not msg:
+        bot.reply("%s %s what?" % (verb, tellee))
+        return
+
+    tellee = Nick(tellee)
 
     if not os.path.exists(bot.tell_filename):
         return


### PR DESCRIPTION
```
<Flyte> .tell
<Lurk> AttributeError: 'NoneType' object has no attribute 'split' (file "/home/flyte/workspace/willie/ve/local/lib/python2.7/site-packages/willie/modules/tell.py", line 93, in f_remind)
<Flyte> .tell Flyte
<Lurk> ValueError: need more than 1 value to unpack (file "/home/flyte/workspace/willie/ve/local/lib/python2.7/site-packages/willie/modules/tell.py", line 93, in f_remind)
```
