### PR TITLE
Updating the RSS module to work with ZNC partyline

### DIFF
--- a/willie/modules/rss.py
+++ b/willie/modules/rss.py
@@ -183,7 +183,7 @@ class RSSManager:
         """
         pattern = r'''
             ^\.rss\s+add
-            \s+([&#+!][^\s,]+)   # channel
+            \s+([~&#+!][^\s,]+)   # channel
             \s+("[^"]+"|[\w-]+)  # name, which can contain anything but quotes if quoted
             \s+(\S+)             # url
             (?:\s+(\d+))?        # foreground colour (optional)
@@ -223,7 +223,7 @@ class RSSManager:
         """
         pattern = r"""
             ^\.rss\s+del
-            (?:\s+([&#+!][^\s,]+))?  # channel (optional)
+            (?:\s+([~&#+!][^\s,]+))?  # channel (optional)
             (?:\s+("[^"]+"|[\w-]+))? # name (optional)
             """
         match = re.match(pattern, trigger.group(), re.IGNORECASE | re.VERBOSE)
@@ -263,7 +263,7 @@ class RSSManager:
 
         pattern = r"""
             ^\.rss\s+(enable|disable) # command
-            (?:\s+([&#+!][^\s,]+))?   # channel (optional)
+            (?:\s+([~&#+!][^\s,]+))?   # channel (optional)
             (?:\s+("[^"]+"|[\w-]+))?  # name (optional)
             """
         match = re.match(pattern, trigger.group(), re.IGNORECASE | re.VERBOSE)
@@ -294,7 +294,7 @@ class RSSManager:
         """Get information on all feeds in the database. Usage: .rss list [#channel] [Feed_Name]"""
         pattern = r"""
             ^\.rss\s+list
-            (?:\s+([&#+!][^\s,]+))?  # channel (optional)
+            (?:\s+([~&#+!][^\s,]+))?  # channel (optional)
             (?:\s+("[^"]+"|[\w-]+))? # name (optional)
             """
         match = re.match(pattern, trigger.group(), re.IGNORECASE | re.VERBOSE)


### PR DESCRIPTION
ZNC party line channels start with `~` characters (e.g., `~#bot`). This commit allows Willie to work with ZNC party line channels that contain this character.
