### PR TITLE
[various modules] Utilize Trigger.is_privmsg

### DIFF
--- a/willie/modules/admin.py
+++ b/willie/modules/admin.py
@@ -29,7 +29,7 @@ def configure(config):
 def join(bot, trigger):
     """Join the specified channel. This is an admin-only command."""
     # Can only be done in privmsg by an admin
-    if trigger.sender.startswith('#'):
+    if not trigger.is_privmsg:
         return
 
     if trigger.admin:
@@ -48,7 +48,7 @@ def join(bot, trigger):
 def part(bot, trigger):
     """Part the specified channel. This is an admin-only command."""
     # Can only be done in privmsg by an admin
-    if trigger.sender.startswith('#'):
+    if not trigger.is_privmsg:
         return
     if not trigger.admin:
         return
@@ -65,7 +65,7 @@ def part(bot, trigger):
 def quit(bot, trigger):
     """Quit from the server. This is an owner-only command."""
     # Can only be done in privmsg by the owner
-    if trigger.sender.startswith('#'):
+    if not trigger.is_privmsg:
         return
     if not trigger.owner:
         return
@@ -85,7 +85,7 @@ def msg(bot, trigger):
     Send a message to a given channel or nick. Can only be done in privmsg by an
     admin.
     """
-    if trigger.sender.startswith('#'):
+    if not trigger.is_privmsg:
         return
     if not trigger.admin:
         return
@@ -105,7 +105,7 @@ def me(bot, trigger):
     Send an ACTION (/me) to a given channel or nick. Can only be done in privmsg
     by an admin.
     """
-    if trigger.sender.startswith('#'):
+    if not trigger.is_privmsg:
         return
     if not trigger.admin:
         return
@@ -152,7 +152,7 @@ def hold_ground(bot, trigger):
 @willie.module.priority('low')
 def mode(bot, trigger):
     """Set a user mode on Willie. Can only be done in privmsg by an admin."""
-    if trigger.sender.startswith('#'):
+    if not trigger.is_privmsg:
         return
     if not trigger.admin:
         return
@@ -172,7 +172,7 @@ def set_config(bot, trigger):
     If there is no section, section will default to "core".
     If value is None, the option will be deleted.
     """
-    if trigger.sender.startswith('#'):
+    if not trigger.is_privmsg:
         bot.reply("This command only works as a private message.")
         return
     if not trigger.admin:
@@ -212,7 +212,7 @@ def set_config(bot, trigger):
 @willie.module.example('.save')
 def save_config(bot, trigger):
     """Save state of willies config object to the configuration file."""
-    if trigger.sender.startswith('#'):
+    if not trigger.is_privmsg:
         return
     if not trigger.admin:
         return

--- a/willie/modules/find.py
+++ b/willie/modules/find.py
@@ -26,7 +26,7 @@ def collectlines(bot, trigger):
     """Create a temporary log of what people say"""
 
     # Don't log things in PM
-    if not trigger.sender.startswith('#'):
+    if trigger.is_privmsg:
         return
 
     # Add a log for the channel and nick, if there isn't already one
@@ -70,7 +70,7 @@ def collectlines(bot, trigger):
 @priority('high')
 def findandreplace(bot, trigger):
     # Don't bother in PM
-    if not trigger.sender.startswith('#'):
+    if trigger.is_privmsg:
         return
 
     # Correcting other person vs self.

--- a/willie/modules/meetbot.py
+++ b/willie/modules/meetbot.py
@@ -131,7 +131,7 @@ def startmeeting(bot, trigger):
     if ismeetingrunning(trigger.sender):
         bot.say('Can\'t do that, there is already a meeting in progress here!')
         return
-    if not trigger.sender.startswith('#'):
+    if trigger.is_privmsg:
         bot.say('Can only start meetings in channels')
         return
     if not bot.config.has_section('meetbot'):

--- a/willie/modules/reload.py
+++ b/willie/modules/reload.py
@@ -133,14 +133,14 @@ def f_load(bot, trigger):
 @willie.module.thread(False)
 def pm_f_reload(bot, trigger):
     """Wrapper for allowing delivery of .reload command via PM"""
-    if not trigger.sender.startswith('#'):
+    if trigger.is_privmsg:
         f_reload(bot, trigger)
 
 
 @willie.module.commands('update')
 def pm_f_update(bot, trigger):
     """Wrapper for allowing delivery of .update command via PM"""
-    if not trigger.sender.startswith('#'):
+    if trigger.is_privmsg:
         f_update(bot, trigger)
 
 
@@ -149,7 +149,7 @@ def pm_f_update(bot, trigger):
 @willie.module.thread(False)
 def pm_f_load(bot, trigger):
     """Wrapper for allowing delivery of .load command via PM"""
-    if not trigger.sender.startswith('#'):
+    if trigger.is_privmsg:
         f_load(bot, trigger)
 
 

--- a/willie/modules/seen.py
+++ b/willie/modules/seen.py
@@ -53,7 +53,7 @@ def seen(bot, trigger):
 @rule('(.*)')
 @priority('low')
 def note(bot, trigger):
-    if trigger.sender.startswith('#'):
+    if not trigger.is_privmsg:
         nick = Nick(trigger.nick)
         seen_dict[nick]['timestamp'] = time.time()
         seen_dict[nick]['channel'] = trigger.sender


### PR DESCRIPTION
Replace `trigger.sender.startswith('#')` checks with `trigger.is_privmsg` in the following modules:
- admin
- find
- meetbot
- reload
- seen
