### PR TITLE
Fix #436

### DIFF
--- a/willie/config.py
+++ b/willie/config.py
@@ -30,8 +30,7 @@ modules which have a configuration function.
 The configuration function, if used, must be declared with the signature
 ``configure(config)``. To add options, use ``interactive_add``, ``add_list``
 and ``add_option``.
-"""
-"""
+
 Config - A config class and writing/updating utility for Willie
 Copyright 2012, Edward Powell, embolalia.net
 Copyright © 2012, Elad Alfassa <elad@fedoraproject.org>

--- a/willie/db.py
+++ b/willie/db.py
@@ -8,8 +8,7 @@ modules, simmilar functionallity can be found using ``db.preferences``.
 This class defines an interface for a semi-arbitrary database type. It is meant
 to allow module writers to operate without regard to how the end user has
 decided to set up the database.
-"""
-"""
+
 Copyright 2012, Edward D. Powell, embolalia.net
 Licensed under the Eiffel Forum License 2.
 
@@ -314,7 +313,7 @@ class Table(object):
 
     def __init__(self, db, name, columns, key):
         #This lets us have a pseudo-table to handle a non-existant table
-        if name is '_none':
+        if name == '_none':
             self.db = db
             self.columns = set()
             self.name = name

--- a/willie/test_tools.py
+++ b/willie/test_tools.py
@@ -124,7 +124,7 @@ def insert_into_module(func, module_name, base_name, prefix):
     module = sys.modules[module_name]
     # Make sure the func method does not overwrite anything.
     for i in xrange(1000):
-        func.__name__ = "%s_%s_%s" % (prefix, base_name, i)
+        func.__name__ = str("%s_%s_%s" % (prefix, base_name, i))
         if not hasattr(module, func.__name__):
             break
     setattr(module, func.__name__, func)

--- a/willie/web.py
+++ b/willie/web.py
@@ -6,9 +6,6 @@ The web class contains essential web-related functions for interaction with web
 applications or websites in your modules.  It supports HTTP GET, HTTP POST and
 HTTP HEAD.
 
-"""
-
-"""
 web.py - Web Facilities
 Copyright © 2008, Sean B. Palmer, inamidst.com
 Copyright © 2009, Michael Yanovich <yanovich.1@osu.edu>


### PR DESCRIPTION
- Fix minor bugs from unicode_literals changes

Squashed commit of the following:

commit 64e7b5a26f18f092b7fd09247a6468d32e76e381
Author: Peter Rowlands peter@pmrowla.com
Date:   Tue Jan 28 11:02:59 2014 -0600

```
Fix Table() error
```

commit 8f2b28123eb50035e5a1bc6f56e9877c84f370da
Author: Peter Rowlands peter@pmrowla.com
Date:   Tue Jan 28 10:52:02 2014 -0600

```
Fix tests

- __name__ must be a string type in Python 2.x, but with the unicode changes
  it was being set to a unicode type
```

commit 64e82b75c66dec0d9d51e3829f6cde0063b8b1cc
Author: Peter Rowlands peter@pmrowla.com
Date:   Tue Jan 28 10:23:09 2014 -0600

```
Partial fix for #436

- The only thing that can come before a __future__ import is a
  single module docstring (see pep 236)
```
