### PR TITLE
[core]: Fix bug introduced in commit 222b1f4

### DIFF
--- a/willie/irc.py
+++ b/willie/irc.py
@@ -444,6 +444,7 @@ class Bot(asynchat.async_chat):
         # messages will be split. Otherwise, we'd have to acocunt for the bot's
         # hostmask, which is hard.
         max_text_length = 400
+        encoded_text = text
         if isinstance(text, unicode):
             encoded_text = text.encode('utf-8')
         excess = ''


### PR DESCRIPTION
- If text was already encoded, the variable encoded_text was
  never set and was needed further down in the execution path. This 
  should fix the problem.

To reproduce simply use:
.commands
