### PR TITLE
Decode IMDB API output as utf-8

### DIFF
--- a/willie/modules/movie.py
+++ b/willie/modules/movie.py
@@ -23,7 +23,7 @@ def movie(bot, trigger):
     word = word.replace(" ", "+")
     uri = "http://www.imdbapi.com/?t=" + word
     u = web.get(uri, 30)
-    data = json.loads(u.decode())  # data is a Dict containing all the information we need
+    data = json.loads(u.decode('utf-8'))  # data is a Dict containing all the information we need
     if data['Response'] == 'False':
         if 'Error' in data:
             message = '[MOVIE] %s' % data['Error']


### PR DESCRIPTION
I noticed that .movie sometimes generates a UnicodeDecodeError
exception, e.g. issuing '.movie gravity' produced:

  UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position
  151: ordinal not in range(128) (file "willie/modules/movie.py", line 26,
  in movie)

Adding an explicit 'utf-8' to u.decode() on the IMDB API result resolves
the issue for me.
