### PR TITLE
Delete ad-hoc whitespace escaping in movie.py

### DIFF
--- a/willie/modules/movie.py
+++ b/willie/modules/movie.py
@@ -20,7 +20,6 @@ def movie(bot, trigger):
     if not trigger.group(2):
         return
     word = trigger.group(2).rstrip()
-    word = word.replace(" ", "+")
     uri = "http://www.imdbapi.com/?t=" + word
     u = web.get(uri, 30)
     data = json.loads(u.decode('utf-8'))  # data is a Dict containing all the information we need


### PR DESCRIPTION
As far as I can tell the web.get method handles this correctly via
urllib2.quote anyway. The pre-emptive replacement of " " with "+" in
movie.py results in a bogus doubly-escaped URI generated for a query
with a space, e.g.

.movie Groundhog Day

The resulting URI is http://www.imdbapi.com/?t=groundhog%2Bday, which is
bogus and produces a 'Movie not found!' reply.

Deleting that line and letting web.get handle it internally generates
the correct response.
