### PR TITLE
[core] Check if running with root privileges

### DIFF
--- a/willie.py
+++ b/willie.py
@@ -92,6 +92,14 @@ def main(argv=None):
                               'database configuration options.'))
         opts = parser.parse_args()
 
+        try:
+            if os.getuid() == 0 or os.geteuid() == 0:
+                stderr('Error: Do not run Willie with root privileges.')
+                sys.exit(1)
+        except AttributeError:
+            # Windows don't have os.getuid/os.geteuid
+            pass
+
         if opts.wizard:
             wizard('all', opts.config)
             return


### PR DESCRIPTION
Check if Willie is running with root privileges. If it does, print an error message and exit. 
This check will not work on Windows and I don't know if there is a _clean_ way for doing this on WIndows.

Closes #489.
