### PR TITLE
[currency.py]  Handle the error when no input parameters are specified.

### DIFF
--- a/willie/modules/currency.py
+++ b/willie/modules/currency.py
@@ -51,6 +51,8 @@ def get_rate(code):
 @example('.cur 20 EUR in USD')
 def exchange(bot, trigger):
     """Show the exchange rate between two currencies"""
+    if not trigger.group(2):
+        return bot.reply("No search term. An example: .cur 20 EUR in USD")    
     match = regex.match(trigger.group(2))
     if not match:
         # It's apologetic, because it's using Canadian data.


### PR DESCRIPTION
Stops the "TypeError: expected string or buffer (source unknown)" error when typing .cur and having no arguments supplied.

Quite the issue in my channel, apparently.
