### PR TITLE
Add option for SASL username

### DIFF
--- a/willie/coretasks.py
+++ b/willie/coretasks.py
@@ -403,7 +403,12 @@ def auth_proceed(bot, trigger):
         # How did we get here? I am not good with computer.
         return
     # Is this right?
-    sasl_token = '\0'.join((bot.nick, bot.nick, bot.config.core.sasl_password))
+    if bot.config.core.sasl_username:
+        sasl_username = bot.config.core.sasl_username
+    else:
+        sasl_username = bot.nick
+    sasl_token = '\0'.join((sasl_username, sasl_username,
+                           bot.config.core.sasl_password))
     # Spec says we do a base 64 encode on the SASL stuff
     bot.write(('AUTHENTICATE', base64.b64encode(sasl_token)))
 


### PR DESCRIPTION
In certain situations, the nick is not the same as the SASL username. This adds an option, `sasl_username`, but defaults to the nick if not supplied.
