### PR TITLE
debug call with Unicode string causes exception

### DIFF
--- a/willie/tools.py
+++ b/willie/tools.py
@@ -33,6 +33,7 @@ from collections import defaultdict
 import copy
 import ast
 import operator
+import codecs
 if sys.version_info.major >= 3:
     unicode = str
     iteritems  = dict.items
@@ -338,9 +339,9 @@ class OutputRedirect:
                     sys.__stdout__.write(string)
             except:
                 pass
-        logfile = open(self.logpath, 'a')
-        logfile.write(string)
-        logfile.close()
+
+        with codecs.open(self.logpath, 'a', encoding='utf-8') as logfile:
+            logfile.write(string.encode('utf-8'))
 
 
 #These seems to trace back to when we thought we needed a try/except on prints,


### PR DESCRIPTION
I tried to adopt the approach used elsewhere in Willie's code, but my results do _not_ actually resolve the problem noted in #507. Why is incredibly not-obvious to me, but if folks can point me in the right direction I'd love to finish this up so that it _does_ fix the problematic behavior.
