### PR TITLE
fix conftest.py to ignore the ipython module

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,2 +1,2 @@
 # This file lists files which should be ignored by pytest
-collect_ignore = ["setup.py", "willie.py", "ipython.py"]
+collect_ignore = ["setup.py", "willie.py", "willie/modules/ipython.py"]


### PR DESCRIPTION
I think this will correct the blacklist.
