### PR TITLE
[remind] Filter empty strings from the message

### DIFF
--- a/willie/modules/remind.py
+++ b/willie/modules/remind.py
@@ -125,7 +125,8 @@ periods = '|'.join(scaling.keys())
 def remind(bot, trigger):
     """Gives you a reminder in the given amount of time."""
     duration = 0
-    message = re.split('(\d+(?:\.\d+)? ?(?:' + periods + ')) ?', trigger.group(2))[1:]
+    message = filter(None, re.split('(\d+(?:\.\d+)? ?(?:' + periods + ')) ?',
+                                    trigger.group(2))[1:])
     reminder = ''
     stop = False
     for piece in message:


### PR DESCRIPTION
This fixes a problem with the .in command where not all of the arguments for the
duration get applied.

With the example command, you end a with a message containing:

``` python
['3h', '', '45m', 'Go to class']
```

That empty string there makes the following loop terminate before it gets to '45m'.
