### PR TITLE
Fix initial configuration with python 3

### DIFF
--- a/willie/config.py
+++ b/willie/config.py
@@ -53,6 +53,7 @@ import willie.bot
 if sys.version_info.major >= 3:
     unicode = str
     basestring = str
+    raw_input = input
 
 class ConfigurationError(Exception):
     """ Exception type for configuration errors """


### PR DESCRIPTION
Since the raw_input() function  has been renamed to input in python 3,
we replace it by input() in case willie is run from python3+
fix #554
