### PR TITLE
Fix whitespace problem with multi-line help.

### DIFF
--- a/willie/bot.py
+++ b/willie/bot.py
@@ -468,7 +468,7 @@ class Willie(irc.Bot):
                 trimmed = [lines[0].strip()]
                 if indent < sys.maxsize:
                     for line in lines[1:]:
-                        trimmed.append(line[indent:].rstrip())
+                        trimmed.append(" " + line[indent:].rstrip())
                 while trimmed and not trimmed[-1]:
                     trimmed.pop()
                 while trimmed and not trimmed[0]:


### PR DESCRIPTION
When executing for example
"Botname help action" or "Botname help at"
All the help lines are pasted togehter without even a whitespace between them.

This fixes that problem.
