### PR TITLE
Encode the log with UTF-8 (and also use "with-as");

### DIFF
--- a/willie/tools.py
+++ b/willie/tools.py
@@ -36,6 +36,7 @@ from collections import defaultdict
 import copy
 import ast
 import operator
+import codecs
 if sys.version_info.major >= 3:
     unicode = str
     iteritems  = dict.items
@@ -439,9 +440,8 @@ class OutputRedirect:
                     sys.__stdout__.write(string)
             except:
                 pass
-        logfile = open(self.logpath, 'a')
-        logfile.write(string)
-        logfile.close()
+        with codecs.open(self.logpath, 'a', encoding="utf8") as logfile:
+            logfile.write(string)
 
 
 #These seems to trace back to when we thought we needed a try/except on prints,


### PR DESCRIPTION
As the title says: When I used it in Python 2.7 and executed ".xkcd äöüß" it failed in write with:

```
Signature: UnicodeEncodeError: 'ascii' codec can't encode characters in position 6-9: ordinal not in range(128) (file "/home/xzise/Programms/willie/willie/tools.py", line 443, in write)
from xZise at 2014-08-08 15:14:10.827730:                                       
Message was: <xZise> .xkcd äöüß                                                 
Traceback (most recent call last):                                              
  File "/home/xzise/Programms/willie/willie/bot.py", line 741, in call          
    exit_code = func(willie, trigger)                                           
  File "/home/xzise/Programms/willie/willie/modules/xkcd.py", line 68, in xkcd  
    print trigger                                                               
  File "/home/xzise/Programms/willie/willie/tools.py", line 443, in write          
    logfile.write(string)                                                       
UnicodeEncodeError: 'ascii' codec can't encode characters in position 6-9: ordinal not in range(128)
```

But to be honest, I'm never sure if that is the best fix for that in python. As far as I know in Python 3 open itself also supports `encoding`.
