### PR TITLE
ignore characters that can't be decoded ( fixing #602 )

### DIFF
--- a/willie/web.py
+++ b/willie/web.py
@@ -73,7 +73,7 @@ def get(uri, timeout=20, headers=None, return_headers=False,
                 # attempt unicode on failure
                 encoding_match = None
         if not encoding_match:
-            bytes = bytes.decode('utf-8')
+            bytes = bytes.decode('utf-8', "ignore")
     if not return_headers:
         return bytes
     else:


### PR DESCRIPTION
This will just ignore (remove) the few non-unicode characters, but still decode the rest of the page.
