### PR TITLE
[search] skip duckduckgo adds and show first real link

### DIFF
--- a/willie/modules/search.py
+++ b/willie/modules/search.py
@@ -127,6 +127,8 @@ def duck_search(query):
     query = query.replace('!', '')
     uri = 'http://duckduckgo.com/html/?q=%s&kl=uk-en' % query
     bytes = web.get(uri)
+    if 'web-result"' in bytes: #filter out the adds on top of the page
+        bytes = bytes.split('web-result"')[1]
     m = r_duck.search(bytes)
     if m:
         return web.decode(m.group(1))


### PR DESCRIPTION
this fixes #599 

Maybe not the most elegant solution, but at least it works again.
