### PR TITLE
[github] Properly quote issue search query

### DIFF
--- a/willie/modules/github.py
+++ b/willie/modules/github.py
@@ -158,7 +158,7 @@ def findIssue(bot, trigger):
         else:
             return bot.reply('What are you searching for?')
     else:
-        URL = 'https://api.github.com/legacy/issues/search/%s/open/%s' % (gitAPI[1], trigger.group(2))
+        URL = 'https://api.github.com/legacy/issues/search/%s/open/%s' % (gitAPI[1], web.quote(trigger.group(2)))
 
     try:
         raw = web.get(URL)


### PR DESCRIPTION
Whitespaces when searching for issues were not quoted properly resulting in 

```
Willie> ValueError: No JSON object could be decoded (file "/usr/local/lib/python2.7/json/decoder.py", line 383, in raw_decode)
```

When searching for more than one keyword. This fixes it.
