### PR TITLE
[isup] add '.com' to sites with no '.' in them

### DIFF
--- a/willie/modules/isup.py
+++ b/willie/modules/isup.py
@@ -26,7 +26,8 @@ def isup(bot, trigger):
         else:
             site = 'http://' + site
     
-    if not '.' in site: site += ".com"
+    if not '.' in site:
+        site += ".com"
     
     try:
         response = web.get(site)


### PR DESCRIPTION
Allows shorter searches with website's name instead of URL in cases such as `.isup wikipedia` or `.isup gmail`
