### PR TITLE
[isup] add '.com' to sites with no '.' in them

### DIFF
--- a/willie/modules/isup.py
+++ b/willie/modules/isup.py
@@ -25,6 +25,10 @@ def isup(bot, trigger):
             return bot.reply("Try it again without the %s" % protocol)
         else:
             site = 'http://' + site
+    
+    if not '.' in site:
+        site += ".com"
+    
     try:
         response = web.get(site)
     except Exception:


### PR DESCRIPTION
Allows shorter searches with website's name instead of URL in cases such as .isup wikipedia or .isup gmail
