### PR TITLE
Change gitmodules URL for willie.wiki

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "docs/wiki"]
 	path = docs/wiki
-	url = git@github.com:embolalia/willie.wiki.git
+	url = git://github.com/embolalia/willie.wiki.git
 	branch = master


### PR DESCRIPTION
This was done because I got annoyed of having a server that repeatedly errored on this. I do not want the server to have access to my github account, and I also don't want it to error every time it pulls the git repo. It is a limited access server (OpenShift) So I am unable to change the configurations to have it not pull this submodule.
