### PR TITLE
[ssl] add optional support for certifi

### DIFF
--- a/willie/__init__.py
+++ b/willie/__init__.py
@@ -19,6 +19,8 @@ import threading
 import traceback
 import signal
 
+from willie.certs import get_cacert
+
 __version__ = '4.5.1-git'
 
 
@@ -31,12 +33,10 @@ def run(config):
     else:
         delay = 20
     # Inject ca_certs from config to web for SSL validation of web requests
-    web.ca_certs = '/etc/pki/tls/certs/ca-bundle.crt'
-    if hasattr(config, 'ca_certs') and config.ca_certs is not None:
-        web.ca_certs = config.ca_certs
-    elif not os.path.isfile(web.ca_certs):
-        web.ca_certs = '/etc/ssl/certs/ca-certificates.crt'
-    if not os.path.isfile(web.ca_certs):
+    ca_certs = getattr(config, 'ca_certs', None) or get_cacert()
+    if ca_certs is not None and os.path.isfile(ca_certs):
+        web.ca_certs = ca_certs
+    else:
         stderr('Could not open CA certificates file. SSL will not '
                'work properly.')
 

--- a/willie/certs.py
+++ b/willie/certs.py
@@ -1,0 +1,30 @@
+# coding=utf8
+"""
+certs.py - Willie certificates module
+Copyright 2014, Michael Sverdlik
+
+Licensed under the Eiffel Forum License 2.
+
+http://willie.dftba.net/
+
+This module provides simple method to discover Root CA certificate collection.
+It will try using http://certifi.io at first, and if not found fall back to
+searching in hard coded paths.
+"""
+from os.path import isfile
+
+# possible candidates for system root certificate store
+CA_PATHS = ['/etc/ssl/certs/ca-certificates.crt',
+            '/etc/pki/tls/certs/ca-bundle.crt']
+
+
+try:
+    from certifi import where as get_cacert
+except ImportError:
+    def get_cacert():
+        """
+        Return first found certificate bundle
+        """
+        for path in CA_PATHS:
+            if isfile(path):
+                return path

--- a/willie/irc.py
+++ b/willie/irc.py
@@ -26,6 +26,7 @@ import os
 import codecs
 import traceback
 from willie.tools import stderr, Nick
+from willie.certs import get_cacert
 try:
     import select
     import ssl
@@ -73,12 +74,8 @@ class Origin(object):
 
 class Bot(asynchat.async_chat):
     def __init__(self, config):
-        ca_certs = '/etc/pki/tls/cert.pem'
-        if config.ca_certs is not None:
-            ca_certs = config.ca_certs
-        elif not os.path.isfile(ca_certs):
-            ca_certs = '/etc/ssl/certs/ca-certificates.crt'
-        if not os.path.isfile(ca_certs):
+        ca_certs = getattr(config, 'ca_certs', None) or get_cacert()
+        if ca_certs is not None and not os.path.isfile(ca_certs):
             stderr('Could not open CA certificates file. SSL will not '
                    'work properly.')
 

--- a/willie/web.py
+++ b/willie/web.py
@@ -152,7 +152,7 @@ class VerifiedHTTPSConnection(httplib.HTTPConnection):
             if self._tunnel_host:
                 self.sock = sock
                 self._tunnel()
-            if not  os.path.exists(ca_certs):
+            if not os.path.exists(ca_certs):
                 raise Exception('CA Certificate bundle %s is not readable' % ca_certs)
             self.sock = ssl.wrap_socket(sock,
                                         ca_certs=ca_certs,


### PR DESCRIPTION
Certifi is a collection of root ca certificates, extracted from requests project.
It's much easier to use it, instead of bringing your own certificate collection (or trying to find system's collection).
It should help this project with:
- handling ssl errors originated by outdated root ca collection
- handling ssl errors because collection file was not found on the system
- supporting wider range of platforms out of the box (os x for example)

I wrote this after trying to run willie on OS X without success.
