### PR TITLE
Fix wildcard handling in get_hostmask_regex

### DIFF
--- a/willie/tools.py
+++ b/willie/tools.py
@@ -583,7 +583,7 @@ def format_time(db=None, config=None, zone=None, nick=None, channel=None,
 def get_hostmask_regex(mask):
     """Return a compiled `re.RegexObject` for an IRC hostmask"""
     mask = re.escape(mask)
-    mask.replace('\*', '.*')
+    mask = mask.replace(r'\*', '.*')
     return re.compile(mask + '$', re.I)
 
 


### PR DESCRIPTION
Strings are immutable, so the result of `replace()` needs to be assigned. Also switched to a raw string for `'\*'` since it's cleaner (`'\*'` is an invalid escape sequence even though python handles it fine and without a warning)
