### PR TITLE
Fix AttributeError in URL exclusion handler

### DIFF
--- a/willie/modules/url.py
+++ b/willie/modules/url.py
@@ -75,7 +75,7 @@ def setup(bot=None):
     else:
         exclude = bot.memory['url_exclude']
         if regexes:
-            exclude.append(regexes)
+            exclude.extend(regexes)
         bot.memory['url_exclude'] = exclude
 
     # Ensure that url_callbacks and last_seen_url are in memory


### PR DESCRIPTION
After a reload, the `setup()` for the URL module erroneously used `append()` instead of `extend()`, leading there to be a nested list inside of the exclusion regex list, which caused an `AttributeError` when the exclusion code attempted to call .search() on the elements of the list.

I reproduced this bug by doing the following:
1. Install a clean copy of willie and remove any pre-existing configuration
2. Add a URL exclude regex to my configuration
3. Run the bot (`python willie.py`)
4. As a bot administrator, say `willie: reload`
5. Paste a link in IRC

This resulted in:

```
AttributeError: 'list' object has no attribute 'search' (file "[redacted]/willie/modules/url.py", line 202, in <genexpr>)
```

There is another subtle issue that is not resolved by this pull request, which is that reloading the URL module will keep adding the same regexes to the list over and over again.  This could be mitigated by changing `bot.memory['url_exclude']` to be a `set` instead of a `list` and changing the references to it accordingly, or by clearing the list after a reload.  I'm not sure which option you think would be a better fit for willie; I would lean towards the `set` solution, which I would be happy to implement and add to this PR if you agree.
