### PR TITLE
allow op command for bot admins everywhere

### DIFF
--- a/willie/modules/adminchannel.py
+++ b/willie/modules/adminchannel.py
@@ -37,7 +37,7 @@ def op(bot, trigger):
     Command to op users in a room. If no nick is given,
     willie will op the nick who sent the command
     """
-    if bot.privileges[trigger.sender][trigger.nick] < OP:
+    if bot.privileges[trigger.sender][trigger.nick] < OP and not trigger.admin:
         return
     if bot.privileges[trigger.sender][bot.nick] < OP:
         return bot.reply("I'm not a channel operator!")


### PR DESCRIPTION
this is more consistent with the command's documentation, which does
say that the bot will op the user that gave the command if no user is
specified. yet this would never work if the user is not op.

i think admins will expect a bunch more commands to work (like voice,
deop and so on) so maybe a more unified access control system would be
necessary, but that should be a good start.
