### PR TITLE
leave the AS number in display

### DIFF
--- a/willie/modules/ip.py
+++ b/willie/modules/ip.py
@@ -87,7 +87,7 @@ def _find_geoip_db(bot):
 
 @commands('iplookup', 'ip')
 @example('.ip 8.8.8.8',
-         r'[IP/Host Lookup] Hostname: google-public-dns-a.google.com | Location: United States | Region: CA | ISP: Google Inc.',
+         r'[IP/Host Lookup] Hostname: google-public-dns-a.google.com | Location: United States | Region: CA | ISP: AS15169 Google Inc.',
          re=True,
          ignore='Downloading GeoIP database, please wait...')
 def ip(bot, trigger):


### PR DESCRIPTION
the ASN is very useful in diagnosing routing issue and distinguishing
between multiple networks with the same name. the ASNs are unique, the
network names are really not.
