### PR TITLE
avoid crashing on undetermined locations

### DIFF
--- a/willie/modules/ip.py
+++ b/willie/modules/ip.py
@@ -109,7 +109,7 @@ def ip(bot, trigger):
     try:
         response += " | Location: %s" % gi_city.country_name_by_name(query)
     except AttributeError:
-        pass
+        response += ' | Location: Unknown'
 
     region_data = gi_city.region_by_name(query)
     try:


### PR DESCRIPTION
this works around what is probably a bug in pygeoip:

```
01:21:44 <@anarcat> .ip 10.0.0.1
01:21:49 <peoplesmic> AttributeError: 'NoneType' object has no attribute 'get' (file "/usr/local/lib/python3.4/dist-packages/pygeoip/__init__.py", line 491, in country_name_by_addr)
```

it seems that, even internally, pygeoip doesn't handle very well
addresses that have no location defined... this patch should fix the
problem in willie until it is fixed upstream.
