### PR TITLE
[FIX] Added empty flush() method to prevent errors in multiproccess such...

### DIFF
--- a/willie/tools.py
+++ b/willie/tools.py
@@ -451,6 +451,9 @@ class OutputRedirect:
         self.stderr = stderr
         self.quiet = quiet
 
+    def flush(self, *args, **kwargs):
+	pass
+
     def write(self, string):
         """Write the given ``string`` to the logfile and terminal."""
         if not self.quiet:


### PR DESCRIPTION
... as 'OutputRedirect instance has no attribute 'flush' ... forking.py:116)
