### PR TITLE
Need to import Trigger

### DIFF
--- a/willie/bot.py
+++ b/willie/bot.py
@@ -23,6 +23,7 @@ import threading
 
 from datetime import datetime
 from willie import tools
+from willie.trigger import Trigger
 import willie.irc as irc
 from willie.db import WillieDB
 from willie.tools import (stderr, PriorityQueue, released, get_command_regexp,


### PR DESCRIPTION
w/o the import:

Traceback (most recent call last):
  File "/usr/lib/python2.7/asyncore.py", line 83, in read
    obj.handle_read_event()
  File "/usr/lib/python2.7/asyncore.py", line 449, in handle_read_event
    self.handle_read()
  File "/usr/lib/python2.7/asynchat.py", line 158, in handle_read
    self.found_terminator()
  File "/home/sujeet/willie/willie/irc.py", line 390, in found_terminator
    self.dispatch(pretrigger)
  File "/home/sujeet/willie/willie/bot.py", line 666, in dispatch
    trigger = Trigger(self.config, pretrigger, match)
NameError: global name 'Trigger' is not defined
