### PR TITLE
Need to import Identifier and Trigger

### DIFF
--- a/willie/bot.py
+++ b/willie/bot.py
@@ -25,10 +25,12 @@ from datetime import datetime
 from willie import tools
 import willie.irc as irc
 from willie.db import WillieDB
-from willie.tools import (stderr, PriorityQueue, released, get_command_regexp,
+from willie.tools import (stderr, PriorityQueue, Identifier, released, get_command_regexp,
                           iteritems, itervalues, deprecated_5)
+from willie.trigger import Trigger
 import willie.module as module
 from willie.logger import get_logger
+
 
 LOGGER = get_logger(__name__)
 


### PR DESCRIPTION
Otherwise the bot fails to start at all. Log included:

```
/usr/local/lib/python2.7/dist-packages/pytz/__init__.py:29: UserWarning: Module willie was already imported from /home/cactus/kountdown-bot/willie/willie/__init__.pyc, but /usr/local/lib/python2.7/dist-packages is being added to sys.path
  from pkg_resources import resource_stream

Welcome to Willie. Loading modules...


Error loading spellcheck: No module named enchant (modules/spellcheck.py:13)
Error in safety setup procedure: ConfigurationError: Safety module not configured (modules/safety.py:55)
Error loading reddit: No module named praw (modules/reddit.py:15)


Registered 41 modules,
3 modules failed to load


Connecting to irc.esper.net:6667...
Connected.
Traceback (most recent call last):
  File "/usr/lib/python2.7/asyncore.py", line 83, in read
    obj.handle_read_event()
  File "/usr/lib/python2.7/asyncore.py", line 449, in handle_read_event
    self.handle_read()
  File "/usr/lib/python2.7/asynchat.py", line 158, in handle_read
    self.found_terminator()
  File "/home/cactus/kountdown-bot/willie/willie/irc.py", line 390, in found_terminator
    self.dispatch(pretrigger)
  File "/home/cactus/kountdown-bot/willie/willie/bot.py", line 653, in dispatch
    nick_blocked = self._nick_blocked(pretrigger.nick)
  File "/home/cactus/kountdown-bot/willie/willie/bot.py", line 722, in _nick_blocked
    Identifier(bad_nick) == nick):
NameError: global name 'Identifier' is not defined

/home/cactus/kountdown-bot/willie/willie/tools.py:282: UserWarning: debugwill be removed in Willie 5.0. Please see http://willie.dftba.net/willie_5.html for more info.
  warnings.warn(thing + 'will be removed in Willie 5.0. Please see '
Traceback (most recent call last):
  File "/usr/lib/python2.7/asyncore.py", line 83, in read
    obj.handle_read_event()
  File "/usr/lib/python2.7/asyncore.py", line 449, in handle_read_event
    self.handle_read()
  File "/usr/lib/python2.7/asynchat.py", line 158, in handle_read
    self.found_terminator()
  File "/home/cactus/kountdown-bot/willie/willie/irc.py", line 390, in found_terminator
    self.dispatch(pretrigger)
  File "/home/cactus/kountdown-bot/willie/willie/bot.py", line 653, in dispatch
    nick_blocked = self._nick_blocked(pretrigger.nick)
  File "/home/cactus/kountdown-bot/willie/willie/bot.py", line 722, in _nick_blocked
    Identifier(bad_nick) == nick):
NameError: global name 'Identifier' is not defined

Traceback (most recent call last):
  File "/usr/lib/python2.7/asyncore.py", line 83, in read
    obj.handle_read_event()
  File "/usr/lib/python2.7/asyncore.py", line 449, in handle_read_event
    self.handle_read()
  File "/usr/lib/python2.7/asynchat.py", line 158, in handle_read
    self.found_terminator()
  File "/home/cactus/kountdown-bot/willie/willie/irc.py", line 390, in found_terminator
    self.dispatch(pretrigger)
  File "/home/cactus/kountdown-bot/willie/willie/bot.py", line 653, in dispatch
    nick_blocked = self._nick_blocked(pretrigger.nick)
  File "/home/cactus/kountdown-bot/willie/willie/bot.py", line 722, in _nick_blocked
    Identifier(bad_nick) == nick):
NameError: global name 'Identifier' is not defined

```
