### PR TITLE
Core: Delay 'CAP LS' until after USER to fix authentication issues under...

### DIFF
--- a/willie/irc.py
+++ b/willie/irc.py
@@ -280,11 +280,6 @@ class Bot(asynchat.async_chat):
                     os._exit(1)
             self.set_socket(self.ssl)
 
-        # Request list of server capabilities. IRCv3 servers will respond with
-        # CAP * LS (which we handle in coretasks). v2 servers will respond with
-        # 421 Unknown command, which we'll ignore
-        self.write(('CAP', 'LS'))
-
         if self.config.core.server_password is not None:
             self.write(('PASS', self.config.core.server_password))
         self.write(('NICK', self.nick))
@@ -296,6 +291,13 @@ class Bot(asynchat.async_chat):
         timeout_check_thread.start()
         ping_thread = threading.Thread(target=self._send_ping)
         ping_thread.start()
+
+        # Request list of server capabilities. IRCv3 servers will respond with
+        # CAP * LS (which we handle in coretasks). v2 servers will respond with
+        # 421 Unknown command, which we'll ignore
+        # This needs to come after Authentication as it can cause connection
+        # Issues
+        self.write(('CAP', 'LS'))
 
     def _timeout_check(self):
         while self.connected or self.connecting:


### PR DESCRIPTION
... rare cicumstances

On some servers it seems that issuing CAP before NICK and USER can cause the connection to fail.  I suspect it has something to do with a timeout while trying to ident, but can replicate this on multiple servers.

Example from a failed attempt via telnet.

Trying 2610:150:4b0f::...
Connected to chat.freenode.net.
Escape character is '^]'.
:morgan.freenode.net NOTICE \* :**\* Looking up your hostname...
:morgan.freenode.net NOTICE \* :**\* Checking Ident
:morgan.freenode.net NOTICE \* :**\* Couldn't look up your hostname
CAP LS
NICK atestuser
USER willie +iw willie :willie
:morgan.freenode.net NOTICE \* :**\* No Ident response
:morgan.freenode.net CAP \* LS :account-notify extended-join identify-msg multi-prefix sasl
ERROR :Closing Link: 2607:f4e8:120:10:44f5:dc8b:7e80:1b47 (Connection timed out)
Connection closed by foreign host.

Example after moving CAP LS to after Authentication:
Trying 2610:150:4b0f::...
Connected to chat.freenode.net.
Escape character is '^]'.
:morgan.freenode.net NOTICE \* :**\* Looking up your hostname...
:morgan.freenode.net NOTICE \* :**\* Checking Ident
:morgan.freenode.net NOTICE \* :**\* Couldn't look up your hostname
NICK atestuser
USER willie +iw willie :willie
CAP LS
:morgan.freenode.net NOTICE \* :**\* No Ident response
:morgan.freenode.net 001 atestuser :Welcome to the freenode Internet Relay Chat Network atestuser
[snip]
:morgan.freenode.net 376 atestuser :End of /MOTD command.
:atestuser MODE atestuser :+i
:morgan.freenode.net CAP atestuser LS :account-notify extended-join identify-msg multi-prefix sas
