### PR TITLE
Update last_ping_time variable on PING

### DIFF
--- a/willie/irc.py
+++ b/willie/irc.py
@@ -311,6 +311,7 @@ class Bot(asynchat.async_chat):
             if self.connected and (datetime.now() - self.last_ping_time).seconds > int(self.config.timeout) / 2:
                 try:
                     self.write(('PING', self.config.host))
+                    self.last_ping_time = datetime.now()
                 except socket.error:
                     pass
             time.sleep(int(self.config.timeout) / 2)


### PR DESCRIPTION
`self.last_ping_time` was not being updated (as far as I can tell) which caused `_timeout_check` to interpret it as timeout and disconnect the bot, even though `PING` was sent to the server.

This commit just modifies `self.last_ping_time` to be equal to `datetime.now()` after `PING` is written successfully.
