### PR TITLE
Treat error in connect as a disconnect

### DIFF
--- a/sopel/irc.py
+++ b/sopel/irc.py
@@ -173,7 +173,6 @@ class Bot(asynchat.async_chat):
             self.initiate_connect(host, port)
         except socket.error as e:
             stderr('Connection error: %s' % e)
-            self.hasquit = True
 
     def initiate_connect(self, host, port):
         stderr('Connecting to %s:%s...' % (host, port))


### PR DESCRIPTION
This is so that Willie attempts to reconnect when your network goes down, instead of exiting.