### PR TITLE
README: Update sopel package location in Arch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Installation
 Latest stable release
 =====================
 If you're on Arch, the easiest way to install is through your package
-manager. The package is named ``sopel`` in AUR. On other
+manager. The package is named ``sopel`` in [community] repository. On other
 distros, and pretty much any operating system you can run Python on, you can
 install `pip <https://pypi.python.org/pypi/pip/>`_, and do ``pip install
 sopel``. Failing all that, you can download the latest tarball from


### PR DESCRIPTION
I have uploaded a `sopel` package into [community], and want to update the installation instructions in README with this PR.

Link to PKGBUILD: https://projects.archlinux.org/svntogit/community.git/tree/trunk/PKGBUILD?h=packages/sopel

Thanks!