### PR TITLE
Fix safety module configuration

### DIFF
--- a/sopel/modules/safety.py
+++ b/sopel/modules/safety.py
@@ -56,8 +56,8 @@ def configure(config):
     )
     config.safety.configure_setting(
         'vt_api_key',
-        "Optionaly, enter a VirusTotal API key to improve malicious URL "
-        "protection. Otherwise, only the Malwarebytes DB will be used."
+        "Optionally, enter a VirusTotal API key to improve malicious URL "
+        "protection.\nOtherwise, only the Malwarebytes DB will be used."
     )
 
 

--- a/sopel/modules/safety.py
+++ b/sopel/modules/safety.py
@@ -36,7 +36,7 @@ known_good = []
 
 
 class SafetySection(StaticSection):
-    enabled_by_default = ValidatedAttribute('enabled_by_default', bool, True)
+    enabled_by_default = ValidatedAttribute('enabled_by_default', bool, default=True)
     """Enable URL safety in all channels where it isn't explicitly disabled."""
     known_good = ListAttribute('known_good')
     """List of "known good" domains to ignore."""


### PR DESCRIPTION
Configuring the module would previously bomb out with a TypeError because `default` was actually passed as `serialize`.