### PR TITLE
[help.py] Sort output alphabetically by module

### DIFF
--- a/sopel/modules/help.py
+++ b/sopel/modules/help.py
@@ -10,6 +10,7 @@ http://sopel.chat
 from __future__ import unicode_literals
 
 import textwrap
+import collections
 
 from sopel.formatting import bold
 from sopel.module import commands, rule, example, priority
@@ -50,7 +51,7 @@ def help(bot, trigger):
         )
 
         name_length = max(6, max(len(k) for k in bot.command_groups.keys()))
-        for category, cmds in bot.command_groups.items():
+        for category, cmds in collections.OrderedDict(sorted(bot.command_groups.items())).items():
             category = category.upper().ljust(name_length)
             cmds = '  '.join(cmds)
             msg = bold(category) + '  ' + cmds


### PR DESCRIPTION
Minor tweak, but it makes a ton of difference when you have a lot of modules loaded.