### PR TITLE
Allow ListAttribute to be a list or a set

### DIFF
--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -229,7 +229,7 @@ class ListAttribute(BaseValidated):
             return value
 
     def serialize(self, value):
-        if not isinstance(value, list):
+        if not isinstance(value, (list, set)):
             raise ValueError('ListAttribute value must be a list.')
         return ','.join(value)
 


### PR DESCRIPTION
Should fix coretasks' `.blocks add` command.