### PR TITLE
Fix blocking functionality

### DIFF
--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -147,7 +147,7 @@ def clean_callable(func, config):
     doc = trim_docstring(func.__doc__)
     example = None
 
-    func.unblockable = getattr(func, 'unblockable', True)
+    func.unblockable = getattr(func, 'unblockable', False)
     func.priority = getattr(func, 'priority', 'medium')
     func.thread = getattr(func, 'thread', True)
     func.rate = getattr(func, 'rate', 0)


### PR DESCRIPTION
Every function is currently forced unblockable, as the unblockable decorator doesn't allow a boolean value, and the default, when there is no decorator, is True. This PR fixes that behavior by making the default, when there is no decorator, False.