### PR TITLE
A quick fix to issue #885

### DIFF
--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -54,7 +54,7 @@ def duck_api(query):
     if '!bang' in query.lower():
         return 'https://duckduckgo.com/bang.html'
     
-    # This fixes issue #85 (https://github.com/sopel-irc/sopel/issues/885)
+    # This fixes issue #885 (https://github.com/sopel-irc/sopel/issues/885)
     # It seems that duckduckgo api redirects to its Instant answer API html page 
     # if the query constains special charactares that aren't urlencoded.
     # So in order to always get a JSON response back the query is urlencoded 

--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -13,6 +13,7 @@ import re
 from sopel import web
 from sopel.module import commands, example
 import json
+from urllib.parse import quote_plus
 
 
 def formatnumber(n):
@@ -53,6 +54,7 @@ def duck_api(query):
     if '!bang' in query.lower():
         return 'https://duckduckgo.com/bang.html'
 
+    query = quote_plus(query)
     uri = 'http://api.duckduckgo.com/?q=%s&format=json&no_html=1&no_redirect=1' % query
     results = json.loads(web.get(uri))
     if results['Redirect']:

--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -53,7 +53,11 @@ google_search = duck_search
 def duck_api(query):
     if '!bang' in query.lower():
         return 'https://duckduckgo.com/bang.html'
-
+    
+    # This fixes issue #85 (https://github.com/sopel-irc/sopel/issues/885)
+    # It seems that duckduckgo api redirects to its Instant answer API html page 
+    # if the query constains special charactares that aren't urlencoded.
+    # So in order to always get a JSON response back the query is urlencoded 
     query = quote_plus(query)
     uri = 'http://api.duckduckgo.com/?q=%s&format=json&no_html=1&no_redirect=1' % query
     results = json.loads(web.get(uri))

--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -13,9 +13,13 @@ import re
 from sopel import web
 from sopel.module import commands, example
 import json
-from urllib.parse import quote_plus
+import sys
 
-
+if sys.version_info.major < 3:
+    from urllib import quote_plus
+else:
+    from urllib.parse import quote_plus
+    
 def formatnumber(n):
     """Format a number with beautiful commas."""
     parts = list(str(n))


### PR DESCRIPTION
Issue #885 (https://github.com/sopel-irc/sopel/issues/885) was caused by the fact that the duckgogo query wasn't urlencoded previously which caused the API to return its HTML documentation page instead of a JSON document when the query contained characters that should be urlencoded.

I did a quick fix to the issue by urlencoding the query string with urllib.parse module's quote_plus() in /modules/search.py duck_api function. Now it doesn't crash on queries such as "#" or "100% sugar-free".