### PR TITLE
Ensure help output matches the example correctly

### DIFF
--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -142,7 +142,7 @@ def clean_callable(func, config):
     puts them in func._docs, and sets defaults"""
     nick = config.core.nick
     prefix = config.core.prefix
-    help_prefix = config.core.prefix
+    help_prefix = config.core.help_prefix
     func._docs = {}
     doc = trim_docstring(func.__doc__)
     example = None


### PR DESCRIPTION
When populating the functions' doc value, we were incorrectly checking if it started with just `prefix` instead of `help_prefix`. `prefix` is usually regex, so it's better to use `help_prefix`