### PR TITLE
fix handling of help_prefix

### DIFF
--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -142,7 +142,7 @@ def clean_callable(func, config):
     puts them in func._docs, and sets defaults"""
     nick = config.core.nick
     prefix = config.core.prefix
-    help_prefix = config.core.prefix
+    help_prefix = config.core.help_prefix
     func._docs = {}
     doc = trim_docstring(func.__doc__)
     example = None
@@ -173,8 +173,8 @@ def clean_callable(func, config):
         if hasattr(func, 'example'):
             example = func.example[0]["example"]
             example = example.replace('$nickname', nick)
-            if example[0] != help_prefix:
-                example = help_prefix + example[len(help_prefix):]
+            if not example.startswith(help_prefix):
+                example = help_prefix + example
         if doc or example:
             for command in func.commands:
                 func._docs[command] = (doc, example)


### PR DESCRIPTION
Currently any .help requests for command details will show examples with the first
character replaced by the configured prefix; by default, \.

e.g.:
<ddstreet> .help rand
<sopel> ddstreet: Replies with a random number between first and second argument.
<sopel> ddstreet: e.g. \.and 10 99

That is due to 2 things:

1. the local help_prefix var is set to config.core.prefix instead of
   config.core.help_prefix.

2. the first character in the example string is replaced by the help_prefix;
   instead the help_prefix should be prefixed to the example string.

This sets help_prefix correctly, adds the help_prefix to example correctly,
and uses example.startswith(help_prefix) instead of only comparing the first
character of example to help_prefix.