### PR TITLE
Fix UnboundLocalError

### DIFF
--- a/sopel/modules/find.py
+++ b/sopel/modules/find.py
@@ -110,6 +110,7 @@ def findandreplace(bot, trigger):
 
     # Look back through the user's lines in the channel until you find a line
     # where the replacement works
+    new_phrase = None
     for line in reversed(search_dict[trigger.sender][rnick]):
         if line.startswith("\x01ACTION"):
             me = True  # /me command


### PR DESCRIPTION
Fixes: UnboundLocalError: local variable 'new_phrase' referenced before assignment (file "<sopel_path>/sopel/modules/find.py", line 123, in findandreplace)