### PR TITLE
Fixed page not found error message to main chat. Strips invalid chars…

### DIFF
--- a/sopel/modules/seen.py
+++ b/sopel/modules/seen.py
@@ -35,12 +35,12 @@ def seen(bot, trigger):
         timestamp = format_time(bot.db, bot.config, tz, trigger.nick,
                                 trigger.sender, saw)
 
-        msg = "I last saw {} at {}".format(nick, timestamp)
+        msg = "I last saw {} at {} UTC".format(nick, timestamp) #UTC is hardcoded. Careful!
         if Identifier(channel) == trigger.sender:
             if action:
-                msg = msg + " in here, doing " + nick + " " + message
+                msg = msg #+ " in here, doing " + nick + " " + message
             else:
-                msg = msg + " in here, saying " + message
+                msg = msg #+ " in here, saying " + message
         else:
             msg += " in another channel."
         bot.say(str(trigger.nick) + ': ' + msg)

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -164,6 +164,10 @@ def process_urls(bot, trigger, urls):
             matched = check_callbacks(bot, trigger, new_url, new_url != url)
             if matched:
                 continue
+            # Then strip any invalid chars from end of it
+            invalid_url_chars = ['"', '<', '>', '{', '}', '^', '|']
+            for i in invalid_url_chars:
+                url = url.rstrip(i)
             # Finally, actually show the URL
             title = find_title(url)
             if title:


### PR DESCRIPTION
Users often surround URLs in brackets. Most commonly, I see <code>< ></code> used. Sopel includes the <code>></code> character at the end of the URL string and in some cases, it causes a Page Not Found error in main chat instead when it should announce the page title. This change strips common invalid characters from the end of the URL before it asks for the title. 

An example of a URL enclosed in <code>< ></code> that this would fix:
http://www.joelonsoftware.com/articles/ThePerilsofJavaSchools.html