### PR TITLE
[isup] fix bad indexes preventing bot from recognizing http protocols

### DIFF
--- a/sopel/modules/isup.py
+++ b/sopel/modules/isup.py
@@ -19,7 +19,7 @@ def isup(bot, trigger):
     if not site:
         return bot.reply("What site do you want to check?")
 
-    if site[:6] != 'http://' and site[:7] != 'https://':
+    if site[:7] != 'http://' and site[:8] != 'https://':
         if '://' in site:
             protocol = site.split('://')[0] + '://'
             return bot.reply("Try it again without the %s" % protocol)


### PR DESCRIPTION
`'http://'` is 7 characters long, so `site[:6]` can't ever match it. ditto for `'https://'` and `site[:7]`