### PR TITLE
[ip] Mask socket.gaierror

### DIFF
--- a/sopel/modules/ip.py
+++ b/sopel/modules/ip.py
@@ -118,6 +118,8 @@ def ip(bot, trigger):
         response += " | Location: %s" % gi_city.country_name_by_name(query)
     except AttributeError:
         response += ' | Location: Unknown'
+    except socket.gaierror:
+        return bot.say('[IP/Host Lookup] Unable to resolve IP/Hostname')
 
     region_data = gi_city.region_by_name(query)
     try:


### PR DESCRIPTION
We should only get `socket.gaierror` if the user passes an invalid IP or hostname, but it could be in the event that we don't have DNS configured on the machine or a multitude of other things, so we can be somewhat vague in the error message.