### PR TITLE
[countdown] fix remaining time calculation

### DIFF
--- a/sopel/modules/countdown.py
+++ b/sopel/modules/countdown.py
@@ -29,9 +29,9 @@ def generic_countdown(bot, trigger):
         except:
             bot.say("Please use correct format: .countdown 2012 12 21")
             return NOLIMIT
-        bot.say(str(diff.days) + " days, " + str(diff.seconds / 60 / 60)
+        bot.say(str(diff.days) + " days, " + str(diff.seconds // 3600)
                    + " hours and "
-                   + str(diff.seconds / 60 - diff.seconds / 60 / 60 * 60)
+                   + str(diff.seconds % 3600 // 60 )
                    + " minutes until "
                    + text[0] + " " + text[1] + " " + text[2])
     else:


### PR DESCRIPTION
User input `.countdown 2015 12 25`

Sopel old output `21 days, 7.8805555555555555 hours and 0.0 minutes until 2015 12 25`

Sopel new output `21 days, 7 hours and 34 minutes until 2015 12 25`