### PR TITLE
Add tracking of users and their accounts

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -286,7 +286,9 @@ class Sopel(irc.Bot):
                 match = regexp.match(text)
                 if not match:
                     continue
-                trigger = Trigger(self.config, pretrigger, match)
+                user_obj = self.users.get(pretrigger.nick)
+                account = user_obj.account if user_obj else None
+                trigger = Trigger(self.config, pretrigger, match, account)
                 wrapper = self.SopelWrapper(self, trigger)
 
                 for func in funcs:

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -99,6 +99,9 @@ class Sopel(irc.Bot):
         bitwise integer value, determined by combining the appropriate constants
         from `module`."""
 
+        self.channels_ = dict()  # name to chan obj
+        self.users = dict() # name to user obj
+
         self.db = SopelDB(config)
         """The bot's database."""
 

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -270,7 +270,7 @@ class Sopel(irc.Bot):
 
     def dispatch(self, pretrigger):
         args = pretrigger.args
-        event, args, text = pretrigger.event, args, args[-1]
+        event, args, text = pretrigger.event, args, args[-1] if args else ''
 
         if self.config.core.nick_blocks or self.config.core.host_blocks:
             nick_blocked = self._nick_blocked(pretrigger.nick)

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -99,8 +99,8 @@ class Sopel(irc.Bot):
         bitwise integer value, determined by combining the appropriate constants
         from `module`."""
 
-        self.channels_ = dict()  # name to chan obj
-        self.users = dict() # name to user obj
+        self.channels_ = tools.SopelMemory()  # name to chan obj
+        self.users = tools.SopelMemory() # name to user obj
 
         self.db = SopelDB(config)
         """The bot's database."""

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -39,6 +39,18 @@ else:
     py3 = False
 
 
+class _CapReq(object):
+    def __init__(self, prefix, module, failure=None, arg=None, success=None):
+        def nop(bot, cap):
+            pass
+        # TODO at some point, reorder those args to be sane
+        self.prefix = prefix
+        self.module = module
+        self.arg = arg
+        self.failure = failure or nop
+        self.success = success or nop
+
+
 class Sopel(irc.Bot):
     def __init__(self, config, daemon=False):
         irc.Bot.__init__(self, config)
@@ -85,12 +97,7 @@ class Sopel(irc.Bot):
         self.enabled_capabilities = set()
         """A set containing the IRCv3 capabilities that the bot has enabled."""
         self._cap_reqs = dict()
-        """A dictionary of capability requests
-
-        Maps the capability name to a list of tuples of the prefix ('-', '=',
-        or ''), the name of the requesting module, the function to call if the
-        the request is rejected, and the argument to the capability (or None).
-        """
+        """A dictionary of capability names to a list of requests"""
 
         self.privileges = dict()
         """A dictionary of channels to their users and privilege levels
@@ -381,7 +388,8 @@ class Sopel(irc.Bot):
                     )
                 )
 
-    def cap_req(self, module_name, capability, arg=None, failure_callback=None):
+    def cap_req(self, module_name, capability, arg=None, failure_callback=None,
+                success_callback=None):
         """Tell Sopel to request a capability when it starts.
 
         By prefixing the capability with `-`, it will be ensured that the
@@ -404,7 +412,12 @@ class Sopel(irc.Bot):
         request, the `failure_callback` function will be called, if provided.
         The arguments will be a `Sopel` object, and the capability which was
         rejected. This can be used to disable callables which rely on the
-        capability. In future versions
+        capability. It will be be called either if the server NAKs the request,
+        or if the server enabled it and later DELs it.
+
+        The `success_callback` function will be called upon acknowledgement of
+        the capability from the server, whether during the initial capability
+        negotiation, or later.
 
         If ``arg`` is given, and does not exactly match what the server
         provides or what other modules have requested for that capability, it is
@@ -415,16 +428,17 @@ class Sopel(irc.Bot):
         prefix = capability[0]
 
         entry = self._cap_reqs.get(cap, [])
-        if any((ent[3] != arg for ent in entry)):
+        if any((ent.arg != arg for ent in entry)):
             raise Exception('Capability conflict')
 
         if prefix == '-':
             if self.connection_registered and cap in self.enabled_capabilities:
                 raise Exception('Can not change capabilities after server '
                                 'connection has been completed.')
-            if any((ent[0] != '-' for ent in entry)):
+            if any((ent.prefix != '-' for ent in entry)):
                 raise Exception('Capability conflict')
-            entry.append((prefix, module_name, failure_callback, arg))
+            entry.append(_CapReq(prefix, module_name, failure_callback, arg,
+                                 success_callback))
             self._cap_reqs[cap] = entry
         else:
             if prefix != '=':
@@ -436,7 +450,8 @@ class Sopel(irc.Bot):
                                 'connection has been completed.')
             # Non-mandatory will callback at the same time as if the server
             # rejected it.
-            if any((ent[0] == '-' for ent in entry)) and prefix == '=':
+            if any((ent.prefix == '-' for ent in entry)) and prefix == '=':
                 raise Exception('Capability conflict')
-            entry.append((prefix, module_name, failure_callback, arg))
+            entry.append(_CapReq(prefix, module_name, failure_callback, arg,
+                                 success_callback))
             self._cap_reqs[cap] = entry

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -95,12 +95,24 @@ class Sopel(irc.Bot):
         self.privileges = dict()
         """A dictionary of channels to their users and privilege levels
 
+        Deprecated from 6.2.0; use bot.channels instead.
+
         The value associated with each channel is a dictionary of Identifiers to a
         bitwise integer value, determined by combining the appropriate constants
         from `module`."""
 
-        self.channels_ = tools.SopelMemory()  # name to chan obj
+        self.channels = tools.SopelMemory()  # name to chan obj
+        """A map of the channels that Sopel is in.
+
+        The keys are Identifiers of the channel names, and map to Channel
+        objects which contain the users in the channel and their permissions.
+        """
         self.users = tools.SopelMemory() # name to user obj
+        """A map of the users that Sopel is aware of.
+
+        In order for Sopel to be aware of a user, it must be in at least one
+        channel which they are also in.
+        """
 
         self.db = SopelDB(config)
         """The bot's database."""

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -405,17 +405,17 @@ def recieve_cap_ls_reply(bot, trigger):
         # Whether or not the server supports multi-prefix doesn't change how we
         # parse it, so we don't need to worry if it fails.
         bot._cap_reqs['multi-prefix'] = (['', 'coretasks', None, None],)
+    if 'away-notify' not in bot._cap_reqs:
+        bot._cap_reqs['away-notify'] = (['', 'coretasks', None, None],)
 
     def acct_warn(bot, cap):
         LOGGER.info('Server does not support {}, or it conflicts with a custom '
-                    'module. User account validation is not available.'.format(
-                        cap))
-    if 'account-notify' not in bot._cap_reqs:
-        bot._cap_reqs['account-notify'] = (['', 'coretasks', None, acct_warn],)
-    if 'extended-join' not in bot._cap_reqs:
-        bot._cap_reqs['extended-join'] = (['', 'coretasks', None, acct_warn],)
-    if 'away-notify' not in bot._cap_reqs:
-        bot._cap_reqs['away-notify'] = (['', 'coretasks', None, None],)
+                    'module. User account validation unavailable or limited.'
+                    .format(cap))
+    auth_caps = ['account-notify', 'extended-join', 'account-tag']
+    for cap in auth_caps:
+        if cap not in bot._cap_reqs:
+            bot._cap_reqs[cap] = (['', 'coretasks', None, acct_warn],)
 
     for cap, reqs in iteritems(bot._cap_reqs):
         # At this point, we know mandatory and prohibited don't co-exist, but

--- a/sopel/irc.py
+++ b/sopel/irc.py
@@ -64,9 +64,6 @@ class Bot(asynchat.async_chat):
         self.name = config.core.name
         """Sopel's "real name", as used for whois."""
 
-        self.channels = []
-        """The list of channels Sopel is currently in."""
-
         self.stack = {}
         self.ca_certs = ca_certs
         self.hasquit = False
@@ -78,20 +75,13 @@ class Bot(asynchat.async_chat):
         # Right now, only accounting for two op levels.
         # This might be expanded later.
         # These lists are filled in startup.py, as of right now.
+        # Are these even touched at all anymore? Remove in 7.0.
         self.ops = dict()
-        """
-        A dictionary mapping channels to a ``Identifier`` list of their operators.
-        """
+        """Deprecated. Use bot.channels instead."""
         self.halfplus = dict()
-        """
-        A dictionary mapping channels to a ``Identifier`` list of their half-ops and
-        ops.
-        """
+        """Deprecated. Use bot.channels instead."""
         self.voices = dict()
-        """
-        A dictionary mapping channels to a ``Identifier`` list of their voices,
-        half-ops and ops.
-        """
+        """Deprecated. Use bot.channels instead."""
 
         # We need this to prevent error loops in handle_error
         self.error_count = 0

--- a/sopel/irc.py
+++ b/sopel/irc.py
@@ -366,6 +366,8 @@ class Bot(asynchat.async_chat):
         self.buffer = ''
         self.last_ping_time = datetime.now()
         pretrigger = PreTrigger(self.nick, line)
+        if 'account-tag' not in self.enabled_capabilities:
+            pretrigger.tags.pop('account', None)
 
         if pretrigger.event == 'PING':
             self.write(('PONG', pretrigger.args[-1]))

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -46,6 +46,7 @@ class Channel(object):
         assert isinstance(user, User)
         self.users[user.nick] = user
         self.privileges[user.nick] = 0
+        user.channels[self.name] = self
 
     def rename_user(self, old, new):
         if old in self.users:

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -1,0 +1,64 @@
+# coding=utf-8
+from __future__ import unicode_literals, absolute_import, print_function, division
+
+import functools
+from sopel.tools import Identifier
+
+
+@functools.total_ordering
+class User(object):
+    def __init__(self, nick, user, host):
+        assert isinstance(nick, Identifier)
+        self.nick = nick
+        self.user = user
+        self.host = host
+        self.channels = {}
+
+    hostmask = property(lambda self: '{}!{}@{}'.format(self.nick, self.user,
+                                                       self.host))
+
+    def __eq__(self, other):
+        if not isinstance(other, User):
+            return NotImplemented
+        return self.name == other.name
+
+    def __lt__(self, other):
+        if not isinstance(other, User):
+            return NotImplemented
+        return self.name < other.name
+
+
+@functools.total_ordering
+class Channel(object):
+    def __init__(self, name):
+        assert isinstance(name, Identifier)
+        self.name = name
+        self.users = {}
+        self.privileges = {}
+
+    def clear_user(self, nick):
+        user = self.users[nick]
+        user.channels.pop(self.name, None)
+        del self.users[nick]
+        del self.privileges[nick]
+
+    def add_user(self, user):
+        assert isinstance(user, User)
+        self.users[user.nick] = user
+        self.privileges[user.nick] = 0
+
+    def rename_user(self, old, new):
+        if old in self.users:
+            self.users[new] = self.users.pop(old)
+        if old in self.privileges:
+            self.privileges[new] = self.privileges.pop(old)
+
+    def __eq__(self, other):
+        if not isinstance(other, Channel):
+            return NotImplemented
+        return self.name == other.name
+
+    def __lt__(self, other):
+        if not isinstance(other, Channel):
+            return NotImplemented
+        return self.name < other.name

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -20,12 +20,12 @@ class User(object):
     def __eq__(self, other):
         if not isinstance(other, User):
             return NotImplemented
-        return self.name == other.name
+        return self.nick == other.nick
 
     def __lt__(self, other):
         if not isinstance(other, User):
             return NotImplemented
-        return self.name < other.name
+        return self.nick < other.nick
 
 
 @functools.total_ordering

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -13,6 +13,8 @@ class User(object):
         self.user = user
         self.host = host
         self.channels = {}
+        self.account = None
+        self.away = None
 
     hostmask = property(lambda self: '{}!{}@{}'.format(self.nick, self.user,
                                                        self.host))

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -131,10 +131,10 @@ class Trigger(unicode):
     """True if the nick which triggered the command is the bot's owner."""
 
     def __new__(cls, config, message, match):
-        self = unicode.__new__(cls, message.args[-1])
+        self = unicode.__new__(cls, message.args[-1] if message.args else '')
         self._pretrigger = message
         self._match = match
-        self._is_privmsg = message.sender.is_nick()
+        self._is_privmsg = message.sender and message.sender.is_nick()
 
         def match_host_or_nick(pattern):
             pattern = sopel.tools.get_hostmask_regex(pattern)

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -129,8 +129,15 @@ class Trigger(unicode):
     """
     owner = property(lambda self: self._owner)
     """True if the nick which triggered the command is the bot's owner."""
+    account = property(lambda self: self.tags.get('account', self._account))
+    """The account name of the user sending the message.
 
-    def __new__(cls, config, message, match):
+    This is only available if either the account-tag or the account-notify and
+    extended-join capabilites are available. If this isn't the case, or the user
+    sending the message isn't logged in, this will be None.
+    """
+
+    def __new__(cls, config, message, match, account=None):
         self = unicode.__new__(cls, message.args[-1] if message.args else '')
         self._pretrigger = message
         self._match = match


### PR DESCRIPTION
This uses some of the code that @maxpowa wrote for #941, but gives a somewhat more intuitive API. It also paves the way for potentially adding direct support for away-notify and metadata-notify.

Since this being broken could have big security repurcussions (especially since I'd like to be able to make admins/owner pull from account tracking in the future), I'd like a few people to pick this over and see what I've broken before merging it.