### PR TITLE
Update project URL in module comments to http://sopel.chat

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,14 +2,14 @@ Submitting Issues
 -----------------
 
 When submitting issues to our
-[issue tracker](https://github.com/embolalia/willie/issues), it's important
+[issue tracker](https://github.com/sopel-irc/sopel/issues), it's important
 that you do the following:
 
 1. Describe your issue clearly and concisely.
-2. Give Willie the .version command, and include the output in your issue.
-3. Note the OS you're running Willie on, and how you installed Willie (via your
+2. Give Sopel the .version command, and include the output in your issue.
+3. Note the OS you're running Sopel on, and how you installed Sopel (via your
 package manager, pip, setup.py install, or running straight from source)
-4. Include relevant output from the log files in ~/.willie/logs.
+4. Include relevant output from the log files in ~/.sopel/logs.
 
 Committing Code
 ---------------

--- a/pytest_run.py
+++ b/pytest_run.py
@@ -9,7 +9,7 @@ pytest_run.py
 Copyright 2013, Ari Koivula, <ari@koivu.la>
 Licensed under the Eiffel Forum License 2.
 
-http://willie.dfbta.net
+http://sopel.chat
 """
 from __future__ import unicode_literals
 

--- a/sopel/modules/calc.py
+++ b/sopel/modules/calc.py
@@ -4,7 +4,7 @@ calc.py - Sopel Calculator Module
 Copyright 2008, Sean B. Palmer, inamidst.com
 Licensed under the Eiffel Forum License 2.
 
-http://sopel.dfbta.net
+http://sopel.chat
 """
 from __future__ import unicode_literals, absolute_import, print_function, division
 

--- a/sopel/modules/clock.py
+++ b/sopel/modules/clock.py
@@ -5,7 +5,7 @@ Copyright 2008-9, Sean B. Palmer, inamidst.com
 Copyright 2012, Edward Powell, embolalia.net
 Licensed under the Eiffel Forum License 2.
 
-http://sopel.dfbta.net
+http://sopel.chat
 """
 from __future__ import unicode_literals, absolute_import, print_function, division
 

--- a/sopel/modules/countdown.py
+++ b/sopel/modules/countdown.py
@@ -4,7 +4,7 @@ countdown.py - Sopel Countdown Module
 Copyright 2011, Michael Yanovich, yanovich.net
 Licensed under the Eiffel Forum License 2.
 
-http://sopel.dfbta.net
+http://sopel.chat
 """
 from __future__ import unicode_literals, absolute_import, print_function, division
 from sopel.module import commands, NOLIMIT

--- a/sopel/modules/unicode_info.py
+++ b/sopel/modules/unicode_info.py
@@ -5,7 +5,7 @@ Copyright 2013, Edward Powell, embolalia.net
 Copyright 2008, Sean B. Palmer, inamidst.com
 Licensed under the Eiffel Forum License 2.
 
-http://sopel.dfbta.net
+http://sopel.chat
 """
 from __future__ import unicode_literals, absolute_import, print_function, division
 import unicodedata

--- a/sopel/modules/version.py
+++ b/sopel/modules/version.py
@@ -60,7 +60,7 @@ def ctcp_version(bot, trigger):
 @sopel.module.rate(20)
 def ctcp_source(bot, trigger):
     bot.write(('NOTICE', trigger.nick),
-              '\x01SOURCE https://github.com/Embolalia/sopel/\x01')
+              '\x01SOURCE https://github.com/sopel-irc/sopel/\x01')
 
 
 @sopel.module.rule('\x01PING\s(.*)\x01')


### PR DESCRIPTION
Update project website URL in comments for some modules. These were probably missed during the initial change because they were mistyped. 

URL in comments were `http://sopel.dfbta.net` instead of `http://sopel.dftba.net`

Updated to the new URL `http://sopel.chat`