### PR TITLE
[dice] Case insensitivity and better error handling for negative numbers.

### DIFF
--- a/sopel/modules/dice.py
+++ b/sopel/modules/dice.py
@@ -184,7 +184,7 @@ def roll(bot, trigger):
     if not trigger.group(2):
         return bot.reply("No dice to roll.")
     arg_str = trigger.group(2)
-    dice_expressions = re.findall(dice_regexp, arg_str)
+    dice_expressions = re.findall(dice_regexp, arg_str, re.IGNORECASE)
     arg_str = arg_str.replace("%", "%%")
     arg_str = re.sub(dice_regexp, "%s", arg_str)
 

--- a/sopel/modules/dice.py
+++ b/sopel/modules/dice.py
@@ -156,7 +156,10 @@ def _roll_dice(bot, dice_expression):
 
     if result.group('drop_lowest'):
         drop = int(result.group('drop_lowest'))
-        dice.drop_lowest(drop)
+        if drop >= 0:
+            dice.drop_lowest(drop)
+        else:
+            bot.reply("I can't drop the lowest %d dice. =(" % drop)
 
     return dice
 

--- a/sopel/modules/dice.py
+++ b/sopel/modules/dice.py
@@ -124,10 +124,10 @@ class DicePouch:
 def _roll_dice(bot, dice_expression):
     result = re.search(
         r"""
-        (?P<dice_num>\d*)
+        (?P<dice_num>-?\d*)
         d
-        (?P<dice_type>\d+)
-        (v(?P<drop_lowest>\d+))?
+        (?P<dice_type>-?\d+)
+        (v(?P<drop_lowest>-?\d+))?
         $""",
         dice_expression,
         re.IGNORECASE | re.VERBOSE)
@@ -139,6 +139,11 @@ def _roll_dice(bot, dice_expression):
     if dice_type <= 0:
         bot.reply("I don't have any dice with %d sides. =(" % dice_type)
         return None  # Signal there was a problem
+
+    # Can't roll a negative number of dice.
+    if dice_num < 0:
+        bot.reply("I'd rather not roll a negative amount of dice. =(")
+        return None # Signal there was a problem
 
     # Upper limit for dice should be at most a million. Creating a dict with
     # more than a million elements already takes a noticeable amount of time
@@ -176,7 +181,7 @@ def roll(bot, trigger):
     """
     # This regexp is only allowed to have one captured group, because having
     # more would alter the output of re.findall.
-    dice_regexp = r"\d*d\d+(?:v\d+)?"
+    dice_regexp = r"-?\d*[dD]-?\d+(?:[vV]-?\d+)?"
 
     # Get a list of all dice expressions, evaluate them and then replace the
     # expressions in the original string with the results. Replacing is done
@@ -184,7 +189,7 @@ def roll(bot, trigger):
     if not trigger.group(2):
         return bot.reply("No dice to roll.")
     arg_str = trigger.group(2)
-    dice_expressions = re.findall(dice_regexp, arg_str, re.IGNORECASE)
+    dice_expressions = re.findall(dice_regexp, arg_str)
     arg_str = arg_str.replace("%", "%%")
     arg_str = re.sub(dice_regexp, "%s", arg_str)
 


### PR DESCRIPTION
## Case insensitivity
Instead of matching for the literal `d` or `v`, match `[dD]` and `[vV]` appropriately.

## Negative numbers
Match an optional `-` character before each possible number, and handle negative inputs in the `_roll_dice` method. There was already a check for negative `dice_type`, but because the `-` wasn't being captured, this code wasn't being used. I added a check for `dice_num < 0` (which returns `None`) and `drop < 0` (which ignores the `drop_lowest` value entirely).

Partially addresses #874