### PR TITLE
SNI support using Python requests for .url

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pytz
 praw
 pyenchant
 pygeoip
+requests

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -181,15 +181,18 @@ def check_callbacks(bot, trigger, url, run=True):
 
 def find_title(url):
     """Return the title for the given URL."""
-    with closing(requests.get(url, stream=True)) as response:
-        try:
-            content = ''
-            for line in response.iter_lines(decode_unicode=True):
-                content += line
-                if '</title>' in content or len(content) > max_bytes:
-                    break
-        except UnicodeDecodeError:
-            return  # Fail silently when data can't be decoded
+    response = requests.get(url, stream=True)
+    try:
+        content = ''
+        for line in response.iter_lines(decode_unicode=True):
+            content += line
+            if '</title>' in content or len(content) > max_bytes:
+                break
+    except UnicodeDecodeError:
+        return  # Fail silently when data can't be decoded
+    finally:
+        # need to close the connexion because we have not read all the data
+        response.close()
 
     # Some cleanup that I don't really grok, but was in the original, so
     # we'll keep it (with the compiled regexes made global) for now.


### PR DESCRIPTION
without this, SNI-enabled sites, which are becoming more and more
popular, are not displayed by the URL plugin

a good site to test with is: https://sni.velox.ch/

the requests API is similar enough to the `web.get` API to replace it,
but that is left to another pull request, as other plugins may not
require SNI support because they probably don't encounter the same
variety of sites as `.url`