### PR TITLE
[loader] Properly walk module directories

### DIFF
--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -32,11 +32,33 @@ def get_module_description(path):
 
 def _update_modules_from_dir(modules, directory):
     # Note that this modifies modules in place
-    for path in os.listdir(directory):
-        path = os.path.join(directory, path)
-        result = get_module_description(path)
-        if result:
-            modules[result[0]] = result[1:]
+    for root, dirs, files in os.walk(directory):
+        # Ignore hidden folders/files and __ prefixed (__pycache__)
+        files = [f for f in files if not f[0] == '.']
+        dirs[:] = [d for d in dirs if not d[0] == '.']
+        dirs[:] = [d for d in dirs if not d.startswith('__')]
+
+        # Test if folders are package folders. If they are, we
+        # don't need to walk into them so remove them from the
+        # `dirs` list
+        non_pkg_dirs = []
+        for folder in dirs:
+            path = os.path.join(root, folder)
+            result = get_module_description(path)
+            if result:
+                print(path)
+                modules[result[0]] = result[1:]
+            else:
+                non_pkg_dirs.append(folder)
+        dirs[:] = non_pkg_dirs
+
+        # Assuming all files are modules, try to validate
+        for module in files:
+            path = os.path.join(root, module)
+            result = get_module_description(path)
+            if result:
+                print(path)
+                modules[result[0]] = result[1:]
 
 
 def enumerate_modules(config, show_all=False):

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -46,7 +46,6 @@ def _update_modules_from_dir(modules, directory):
             path = os.path.join(root, folder)
             result = get_module_description(path)
             if result:
-                print(path)
                 modules[result[0]] = result[1:]
             else:
                 non_pkg_dirs.append(folder)
@@ -57,7 +56,6 @@ def _update_modules_from_dir(modules, directory):
             path = os.path.join(root, module)
             result = get_module_description(path)
             if result:
-                print(path)
                 modules[result[0]] = result[1:]
 
 


### PR DESCRIPTION
Tested fairly thoroughly, works with reloading, fresh starts. Should ignore compiled python (`__pycache__`) directories, as well as both hidden files and directories. Works with pypi installed third party modules, ~~should work with third party packaged modules put directly in the modules directory~~. Standalone python files in the modules directory work as before.

Edit: It will currently ignore symlinks, dunno if we should do that or not.

Edit2: It doesn't work if you drop a python package in the modules directory, not really sure what subtlety is messing that up.
