### PR TITLE
Make _ssl_recv always return bytes

### DIFF
--- a/sopel/irc.py
+++ b/sopel/irc.py
@@ -310,7 +310,7 @@ class Bot(asynchat.async_chat):
             data = self.socket.read(buffer_size)
             if not data:
                 self.handle_close()
-                return ''
+                return b''
             return data
         except ssl.SSLError as why:
             if why[0] in (asyncore.ECONNRESET, asyncore.ENOTCONN,
@@ -319,7 +319,7 @@ class Bot(asynchat.async_chat):
                 return ''
             elif why[0] == errno.ENOENT:
                 # Required in order to keep it non-blocking
-                return ''
+                return b''
             else:
                 raise
 


### PR DESCRIPTION
_ssl_recv returned empty strings instead of the empty bytes object if
the socket was closed or upon ENOENT.

This lead to exceptions when running sopel with python3 because
asynchat.handle_read expects byte objects.

This commit fixes #937.

Note - b'' is available from python 2.7 onwards. I tested this change with python 3.5.0 and 2.7.10.