### PR TITLE
Fix for 'USER Not enough parameters'

### DIFF
--- a/sopel/irc.py
+++ b/sopel/irc.py
@@ -227,7 +227,7 @@ class Bot(asynchat.async_chat):
             password = self.config.core.auth_password
             self.write(('PASS', password))
         self.write(('NICK', self.nick))
-        self.write(('USER', self.user, '+iw', self.nick), self.name)
+        self.write(('USER', self.user, '+iw', self.nick, self.name))
 
         stderr('Connected.')
         self.last_ping_time = datetime.now()


### PR DESCRIPTION
When connecting (in cli mode) to at least FreeNode servers, with Sopel 6.2.0 from pip, I kept getting `USER Not enough parameters` no matter whether what I specified in config.

Read [this part of the spec](https://en.wikipedia.org/wiki/List_of_Internet_Relay_Chat_commands#USER) and moved the arguments in the code into the same tuple - and things started working.

I'm not sure whether I just missed something..

$ sopel -v
Sopel 6.2.0 (running on python 3.4.3)
http://sopel.chat/