### PR TITLE
Prevent KeyError when untracked user leaves

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -355,6 +355,7 @@ def track_join(bot, trigger):
     user = bot.users.get(trigger.nick)
     if user is None:
         user = User(trigger.nick, trigger.user, trigger.host)
+        bot.users[trigger.nick] = user
     bot.channels[trigger.sender].add_user(user)
 
     if len(trigger.args) > 1 and trigger.args[1] != '*' and (

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -60,10 +60,10 @@ class Channel(object):
         be compared to appropriate constants from ``sopel.module``."""
 
     def clear_user(self, nick):
-        user = self.users[nick]
-        user.channels.pop(self.name, None)
-        del self.users[nick]
-        del self.privileges[nick]
+        user = self.users.pop(nick, None)
+        self.privileges.pop(nick, None)
+        if user != None:
+            user.channels.pop(self.name, None)
 
     def add_user(self, user):
         assert isinstance(user, User)


### PR DESCRIPTION
Note that untracked users and their privileges are currently horribly handled. See #365 and its derivatives.

Technically fixes #1005, but we really should handle untracked users a lot better. See handle_names in coretasks.py

Before: (5 seconds online time)
```
gracefu:sopel gracefu$ python sopel.py -c test.cfg
Could not open CA certificates file. SSL will not work properly.

Welcome to Sopel. Loading modules...


Error loading ipython: No module named IPython (modules/ipython.py:23)


Registered 42 modules,
1 modules failed to load


Connecting to irc.ppy.sh:6667...
Connected.
Traceback (most recent call last):
  File "/Users/gracefu/sopel/sopel/bot.py", line 441, in call
    exit_code = func(sopel, trigger)
  File "/Users/gracefu/sopel/sopel/coretasks.py", line 375, in track_quit
    channel.clear_user(trigger.nick)
  File "/Users/gracefu/sopel/sopel/tools/target.py", line 63, in clear_user
    user = self.users[nick]
KeyError: Identifier('[GoGri]')

Traceback (most recent call last):
  File "/Users/gracefu/sopel/sopel/bot.py", line 441, in call
    exit_code = func(sopel, trigger)
  File "/Users/gracefu/sopel/sopel/coretasks.py", line 375, in track_quit
    channel.clear_user(trigger.nick)
  File "/Users/gracefu/sopel/sopel/tools/target.py", line 63, in clear_user
    user = self.users[nick]
KeyError: Identifier('Tayzen')

Traceback (most recent call last):
  File "/Users/gracefu/sopel/sopel/bot.py", line 441, in call
    exit_code = func(sopel, trigger)
  File "/Users/gracefu/sopel/sopel/coretasks.py", line 375, in track_quit
    channel.clear_user(trigger.nick)
  File "/Users/gracefu/sopel/sopel/tools/target.py", line 63, in clear_user
    user = self.users[nick]
KeyError: Identifier('darrylshin198')

Traceback (most recent call last):
  File "/Users/gracefu/sopel/sopel/bot.py", line 441, in call
    exit_code = func(sopel, trigger)
  File "/Users/gracefu/sopel/sopel/coretasks.py", line 375, in track_quit
    channel.clear_user(trigger.nick)
  File "/Users/gracefu/sopel/sopel/tools/target.py", line 63, in clear_user
    user = self.users[nick]
KeyError: Identifier('Neke-2001')

^CKeyboardInterrupt
```

After: (5 minutes online time)
```
gracefu:sopel gracefu$ python sopel.py -c test.cfg
Could not open CA certificates file. SSL will not work properly.

Welcome to Sopel. Loading modules...


Error loading ipython: No module named IPython (modules/ipython.py:23)


Registered 42 modules,
1 modules failed to load


Connecting to irc.ppy.sh:6667...
Connected.
^CKeyboardInterrupt
```