### PR TITLE
url: handle capitalized URLs

### DIFF
--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -79,7 +79,7 @@ def setup(bot=None):
         bot.memory['last_seen_url'] = tools.SopelMemory()
 
     url_finder = re.compile(r'(?u)(%s?(?:http|https|ftp)(?:://\S+))' %
-                            (bot.config.url.exclusion_char))
+                            (bot.config.url.exclusion_char), re.IGNORECASE)
 
 
 @commands('title')
@@ -123,6 +123,9 @@ def title_auto(bot, trigger):
             return
 
     urls = re.findall(url_finder, trigger)
+    if len(urls) == 0:
+        return
+
     results = process_urls(bot, trigger, urls)
     bot.memory['last_seen_url'][trigger.sender] = urls[-1]
 


### PR DESCRIPTION
Trigger rules are case-insensitive regexes, so the auto title responder
will be triggered even for capitalized URLs such as "Http://google.com"
(which can happen, for example, when a mobile device attempts to
auto-capitalize the beginning of a sentence).  Match URLs case
insensitively for title lookup purposes and add error handling in case
no URLs could be extracted from the match.