### PR TITLE
Added missing import to xkcd.py

### DIFF
--- a/sopel/modules/xkcd.py
+++ b/sopel/modules/xkcd.py
@@ -8,6 +8,7 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 import json
 import random
 import re
+import requests
 from sopel import web
 from sopel.modules.search import google_search
 from sopel.module import commands


### PR DESCRIPTION
xkcd.py was missing the import for the requests module when it was ported over to requests.

This commit adds that missing import.