### PR TITLE
Make sure we're working with UTF8 string

### DIFF
--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -188,7 +188,10 @@ def find_title(url):
     try:
         content = ''
         for byte in response.iter_content(chunk_size=512, decode_unicode=True):
-            content += str(byte)
+            if not isinstance(byte, bytes):
+                content += byte
+            else:
+                break
             if '</title>' in content or len(content) > max_bytes:
                 break
     except UnicodeDecodeError:


### PR DESCRIPTION
Depending on the URL, response.iter_content() in Python 2/3 will return either:
- `type 'unicode'`/`class 'str'` (for "plain" HTML)
- `type 'str'`/`class 'bytes'` (for binary streams, like file URLs)

To distinguish between the two situations we're checking if we got string or
bytes, and proceed accordingly.

This also fixes #1021