### PR TITLE
[doc] unify grammatical number of `@commands` example

### DIFF
--- a/sopel/module.py
+++ b/sopel/module.py
@@ -131,7 +131,7 @@ def commands(*command_list):
         attribute. If there is no commands attribute, it is added.
 
     Example:
-        @command("hello"):
+        @commands("hello"):
             If the command prefix is "\.", this would trigger on lines starting
             with ".hello".
 


### PR DESCRIPTION
It seems there is no `@command` decorator. 

At any rate, examples for `@commands` should use the same (and correct) grammatical number.

I have only looked at docstring for `@commands`, not at other code nor docstrings.