### PR TITLE
[announce] Confirm when all announces have been sent

### DIFF
--- a/sopel/modules/announce.py
+++ b/sopel/modules/announce.py
@@ -21,3 +21,4 @@ def announce(bot, trigger):
         return
     for channel in bot.channels:
         bot.msg(channel, '[ANNOUNCEMENT] %s' % trigger.group(2))
+    bot.reply('Announce complete.')


### PR DESCRIPTION
Closes #1043

Let me know if there would be a more preferred way to do this. I think `reply` is the most appropriate method, but I am not strongly convinced.