### PR TITLE
fix .set command for non filename attributes

### DIFF
--- a/sopel/modules/admin.py
+++ b/sopel/modules/admin.py
@@ -213,7 +213,7 @@ def set_config(bot, trigger):
             if isinstance(descriptor, FilenameAttribute):
                 value = descriptor.parse(bot.config, descriptor, value)
             else:
-                value = descriptor.parse(descriptor, value)
+                value = descriptor.parse(value)
         except ValueError as exc:
             bot.say("Can't set attribute: " + str(exc))
             return


### PR DESCRIPTION
The parse() method only expects one argument, whereas the .set command gives it two. This is my fix for that.