### PR TITLE
Add nick alias config option for $nick and $nickname in @rule regex

### DIFF
--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -49,6 +49,10 @@ class CoreSection(StaticSection):
     This should not be set for networks that do not support IRCv3 account
     capabilities."""
 
+    alias_nicks = ListAttribute('alias_nicks')
+    """List of alternate names recognized as the bot's nick for $nick and
+    $nickname regex substitutions"""
+
     auth_method = ChoiceAttribute('auth_method', choices=[
         'nickserv', 'authserv', 'Q', 'sasl', 'server'])
     """The method to use to authenticate with the server.

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -115,11 +115,14 @@ def compile_rule(nick, pattern, alias_nicks):
     if isinstance(pattern, _regex_type):
         return pattern
 
-    nick = re.escape(nick)
     if alias_nicks:
-        nicks = alias_nicks
+        nicks = alias_nicks.copy()
         nicks.append(nick)
+        nicks = map(re.escape, nicks)
         nick = '(%s)' % '|'.join(nicks)
+    else:
+        nick = re.escape(nick)
+
     pattern = pattern.replace('$nickname', nick)
     pattern = pattern.replace('$nick', r'{}[,:]\s+'.format(nick))
     flags = re.IGNORECASE

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -117,7 +117,9 @@ def compile_rule(nick, pattern, alias_nicks):
 
     nick = re.escape(nick)
     if alias_nicks:
-        nick = '(%s)' % '|'.join(alias_nicks)
+        nicks = alias_nicks
+        nicks.append(nick)
+        nick = '(%s)' % '|'.join(nicks)
     pattern = pattern.replace('$nickname', nick)
     pattern = pattern.replace('$nick', r'{}[,:]\s+'.format(nick))
     flags = re.IGNORECASE

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -110,12 +110,14 @@ def enumerate_modules(config, show_all=False):
     return modules
 
 
-def compile_rule(nick, pattern):
+def compile_rule(nick, pattern, alias_nicks):
     # Not sure why this happens on reloads, but it shouldn't cause problems…
     if isinstance(pattern, _regex_type):
         return pattern
 
     nick = re.escape(nick)
+    if alias_nicks:
+        nick = '(%s)' % '|'.join(alias_nicks)
     pattern = pattern.replace('$nickname', nick)
     pattern = pattern.replace('$nick', r'{}[,:]\s+'.format(nick))
     flags = re.IGNORECASE
@@ -149,6 +151,7 @@ def clean_callable(func, config):
     """Compiles the regexes, moves commands into func.rule, fixes up docs and
     puts them in func._docs, and sets defaults"""
     nick = config.core.nick
+    alias_nicks = config.core.alias_nicks
     prefix = config.core.prefix
     help_prefix = config.core.help_prefix
     func._docs = {}
@@ -173,7 +176,7 @@ def clean_callable(func, config):
     if hasattr(func, 'rule'):
         if isinstance(func.rule, basestring):
             func.rule = [func.rule]
-        func.rule = [compile_rule(nick, rule) for rule in func.rule]
+        func.rule = [compile_rule(nick, rule, alias_nicks) for rule in func.rule]
 
     if hasattr(func, 'commands'):
         func.rule = getattr(func, 'rule', [])


### PR DESCRIPTION
I have a bot named Pangubot, and sometimes people refer to it as just pangu. With this code, it recognizes its name either way.
