### PR TITLE
Refactor module (un|re)loading

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -280,7 +280,7 @@ class Sopel(irc.Bot):
             self.memory['url_callbacks'].pop(func.url_regex, None)
 
     def unregister_module(self, module):
-        relevant_parts = sopel.loader.clean_module(module, self.config)
+        relevant_parts = sopel.loader.clean_module(module, self.config, modify=False)
         self.unregister(*relevant_parts)
 
         if hasattr(module, "teardown"):

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -213,7 +213,8 @@ class Sopel(irc.Bot):
         if hasattr(obj, 'commands'):
             module_name = obj.__module__.rsplit('.', 1)[-1]
             category = getattr(obj, 'category', module_name)
-            self._command_groups[category].remove(obj.commands)
+            if obj.commands in self._command_groups[category]:
+                self._command_groups[category].remove(obj.commands)
             if len(self._command_groups[category]) is 0:
                 del self._command_groups[category]
             for command, docs in obj._docs.items():
@@ -225,7 +226,8 @@ class Sopel(irc.Bot):
                 if obj in callb_list:
                     callb_list.remove(obj)
         if hasattr(obj, 'interval'):
-                job = sopel.tools.jobs.Job(obj.interval, obj)
+            for interval in obj.interval:
+                job = sopel.tools.jobs.Job(interval, obj)
                 self.scheduler.del_job(job)
         if (getattr(obj, '__name__', None) == 'shutdown'
                 and obj in self.shutdown_methods):

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -269,7 +269,7 @@ class Sopel(irc.Bot):
                 if callbl.commands[0] in self._command_groups[category]:
                     self._command_groups[category].remove(callbl.commands[0])
 
-            for command, docs in callbl._docs.items():
+            for command in callbl._docs:
                 self.doc.pop(command, None)
 
         for func in jobs:

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -253,7 +253,7 @@ def reload_all(top_module, max_depth=20, raise_immediately=False,
     def trace_reload(module, depth):  # recursive
         depth += 1
 
-        if type(module) is ModuleType and depth < max_depth:
+        if isinstance(module, ModuleType) and depth < max_depth:
             # check condition if provided
             if reload_if is not None and not reload_if(module, depth):
                 return
@@ -263,7 +263,7 @@ def reload_all(top_module, max_depth=20, raise_immediately=False,
                 for_reload[module] = depth
 
             # trace through all attributes recursively
-            for name, attr in module.__dict__.items():
+            for attr in module.__dict__.values():
                 trace_reload(attr, depth)
 
     # start tracing

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -211,7 +211,7 @@ def is_triggerable(obj):
     return any(hasattr(obj, attr) for attr in ('rule', 'intents', 'commands', 'nickname_commands'))
 
 
-def clean_module(module, config):
+def clean_module(module, config, modify=True):
     callables = []
     shutdowns = []
     jobs = []
@@ -222,10 +222,12 @@ def clean_module(module, config):
             if getattr(obj, '__name__', None) == 'shutdown':
                 shutdowns.append(obj)
             elif is_triggerable(obj):
-                clean_callable(obj, config)
+                if modify:
+                    clean_callable(obj, config)
                 callables.append(obj)
             elif hasattr(obj, 'interval'):
-                clean_callable(obj, config)
+                if modify:
+                    clean_callable(obj, config)
                 jobs.append(obj)
             elif hasattr(obj, 'url_regex'):
                 urls.append(obj)
@@ -271,10 +273,11 @@ def reload_all(top_module, max_depth=20, raise_immediately=False,
     reload_list = sorted(for_reload, reverse=True, key=lambda k: for_reload[k])
     not_reloaded = dict()
 
-    for module in reload_list:
-        if pre_reload is not None:
+    if pre_reload is not None:
+        for module in reload_list:
             pre_reload(module)
 
+    for module in reload_list:
         try:
             _reload(module)
         except Exception:  # catch and write all errors

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -234,7 +234,8 @@ def clean_module(module, config):
 
 
 # https://github.com/thodnev/reload_all
-def reload_all(top_module, max_depth=20, pre_reload=None, reload_if=None):
+def reload_all(top_module, max_depth=20, raise_immediately=False,
+               pre_reload=None, reload_if=None):
     '''
     A reload function, which recursively traverses through
     all submodules of top_module and reloads them from most-
@@ -250,7 +251,6 @@ def reload_all(top_module, max_depth=20, pre_reload=None, reload_if=None):
     for_reload = dict()
 
     def trace_reload(module, depth):  # recursive
-        nonlocal for_reload
         depth += 1
 
         if type(module) is ModuleType and depth < max_depth:
@@ -278,6 +278,8 @@ def reload_all(top_module, max_depth=20, pre_reload=None, reload_if=None):
         try:
             _reload(module)
         except Exception:  # catch and write all errors
+            if raise_immediately:
+                raise
             not_reloaded[module] = sys.exc_info()[0]
 
     return not_reloaded

--- a/sopel/modules/help.py
+++ b/sopel/modules/help.py
@@ -65,6 +65,7 @@ def help(bot, trigger):
             for category, cmds in collections.OrderedDict(sorted(bot.command_groups.items())).items():
                 category = category.upper().ljust(name_length)
                 cmds = set(cmds)  # remove duplicates
+                cmds = ['|'.join(cg) for cg in cmds]
                 cmds = '  '.join(cmds)
                 msg = category + '  ' + cmds
                 indent = ' ' * (name_length + 2)

--- a/sopel/modules/help.py
+++ b/sopel/modules/help.py
@@ -65,7 +65,6 @@ def help(bot, trigger):
             for category, cmds in collections.OrderedDict(sorted(bot.command_groups.items())).items():
                 category = category.upper().ljust(name_length)
                 cmds = set(cmds)  # remove duplicates
-                cmds = ['|'.join(cg) for cg in cmds]
                 cmds = '  '.join(cmds)
                 msg = category + '  ' + cmds
                 indent = ' ' * (name_length + 2)

--- a/sopel/modules/reload.py
+++ b/sopel/modules/reload.py
@@ -11,10 +11,11 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 import collections
 import sys
 import time
-from sopel.tools import iteritems
+from sopel.tools import iteritems, get_raising_file_and_line
 import sopel.loader
 import sopel.module
 import subprocess
+import os
 
 
 @sopel.module.commands("reload")
@@ -55,7 +56,7 @@ def load_module(bot, name, path, type_):
         module, mtime = sopel.loader.load_module(name, path, type_)
         bot.register_module(module)
     except Exception as e:
-        filename, lineno = tools.get_raising_file_and_line()
+        filename, lineno = get_raising_file_and_line()
         rel_path = os.path.relpath(filename, os.path.dirname(__file__))
         raising_stmt = "%s:%d" % (rel_path, lineno)
         return bot.reply("Error loading %s: %s (%s)" % (name, e, raising_stmt))

--- a/sopel/modules/reload.py
+++ b/sopel/modules/reload.py
@@ -127,7 +127,7 @@ def f_load(bot, trigger):
 
     for name in name.split():
         if name in bot._modules:
-            bot.reply('Module already loaded, use reload')
+            bot.reply("Module '%s' already loaded, use reload" % name)
         elif name not in modules:
             bot.reply("Module '%s' not found." % name)
         else:
@@ -162,7 +162,7 @@ def f_unload(bot, trigger):
     for name in name.split():
         module = bot._modules.get(name)
         if module is None:
-            bot.reply('%s: not loaded, try the `load` command' % name)
+            bot.reply("Module '%s' is not loaded, try the `load` command" % name)
         else:
             try:
                 bot.unregister_module(module)

--- a/sopel/modules/reload.py
+++ b/sopel/modules/reload.py
@@ -55,6 +55,11 @@ def f_reload(bot, trigger):
             if module.__name__ == name or module.__name__.startswith(name + '.'):
                 bot.unregister_module(module)
 
+                try:
+                    del sys.modules[module.__name__]
+                except Exception:
+                    pass
+
         try:
             bot.unregister_module(module)
             reload_all(module, pre_reload=pre_reload, reload_if=reload_check)
@@ -155,7 +160,7 @@ def f_unload(bot, trigger):
     failed_names = []
 
     if not name:
-        return bot.reply('Reload what?')
+        return bot.reply('Unload what?')
     elif name == bot.config.core.owner:
         return bot.reply('What?')
 
@@ -166,6 +171,7 @@ def f_unload(bot, trigger):
         else:
             try:
                 bot.unregister_module(module)
+                ok_names.append(name)
             except Exception as e:
                 filename, lineno = get_raising_file_and_line()
                 rel_path = os.path.relpath(filename, os.path.dirname(__file__))

--- a/sopel/modules/reload.py
+++ b/sopel/modules/reload.py
@@ -17,14 +17,12 @@ import sopel.module
 import subprocess
 
 
-@sopel.module.nickname_commands("reload")
+@sopel.module.commands("reload")
 @sopel.module.priority("low")
 @sopel.module.thread(False)
+@sopel.module.require_admin()
 def f_reload(bot, trigger):
     """Reloads a module, for use by admins only."""
-    if not trigger.admin:
-        return
-
     name = trigger.group(2)
 
     if not name or name == '*' or name.upper() == 'ALL THE THINGS':
@@ -33,6 +31,8 @@ def f_reload(bot, trigger):
             'medium': collections.defaultdict(list),
             'low': collections.defaultdict(list)
         }
+        bot.shutdown_methods.clear()
+        bot.scheduler.clear_jobs()
         bot._command_groups = collections.defaultdict(list)
         bot.setup()
         return bot.reply('done')
@@ -40,21 +40,8 @@ def f_reload(bot, trigger):
     if name not in sys.modules:
         return bot.reply('"%s" not loaded, try the `load` command' % name)
 
-    old_module = sys.modules[name]
-
-    old_callables = {}
-    for obj_name, obj in iteritems(vars(old_module)):
-        bot.unregister(obj)
-
-    # Also remove all references to sopel callables from top level of the
-    # module, so that they will not get loaded again if reloading the
-    # module does not override them.
-    for obj_name in old_callables.keys():
-        delattr(old_module, obj_name)
-
-    # Also delete the setup function
-    if hasattr(old_module, "setup"):
-        delattr(old_module, "setup")
+    old_module = bot._modules[name]
+    bot.unregister_module(old_module)
 
     modules = sopel.loader.enumerate_modules(bot.config)
     if name not in modules:
@@ -64,25 +51,22 @@ def f_reload(bot, trigger):
 
 
 def load_module(bot, name, path, type_):
-    module, mtime = sopel.loader.load_module(name, path, type_)
-    relevant_parts = sopel.loader.clean_module(module, bot.config)
+    try:
+        module, mtime = sopel.loader.load_module(name, path, type_)
+        bot.register_module(module)
+    except Exception as e:
+        filename, lineno = tools.get_raising_file_and_line()
+        rel_path = os.path.relpath(filename, os.path.dirname(__file__))
+        raising_stmt = "%s:%d" % (rel_path, lineno)
+        return bot.reply("Error loading %s: %s (%s)" % (name, e, raising_stmt))
+    else:
+        modified = time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(mtime))
+        bot.reply('%r (version: %s)' % (module, modified))
 
-    bot.register(*relevant_parts)
 
-    # TODO sys.modules[name] = module
-    if hasattr(module, 'setup'):
-        module.setup(bot)
-
-    modified = time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(mtime))
-
-    bot.reply('%r (version: %s)' % (module, modified))
-
-
-@sopel.module.nickname_commands('update')
+@sopel.module.commands('update')
+@sopel.module.require_admin()
 def f_update(bot, trigger):
-    if not trigger.admin:
-        return
-
     """Pulls the latest versions of all modules from Git"""
     proc = subprocess.Popen('/usr/bin/git pull',
                             stdout=subprocess.PIPE,
@@ -92,20 +76,18 @@ def f_update(bot, trigger):
     f_reload(bot, trigger)
 
 
-@sopel.module.nickname_commands("load")
+@sopel.module.commands("load")
 @sopel.module.priority("low")
 @sopel.module.thread(False)
+@sopel.module.require_admin()
 def f_load(bot, trigger):
     """Loads a module, for use by admins only."""
-    if not trigger.admin:
-        return
-
     name = trigger.group(2)
     path = ''
     if not name:
         return bot.reply('Load what?')
 
-    if name in sys.modules:
+    if name in bot._modules:
         return bot.reply('Module already loaded, use reload')
 
     mods = sopel.loader.enumerate_modules(bot.config)
@@ -114,28 +96,20 @@ def f_load(bot, trigger):
     path, type_ = mods[name]
     load_module(bot, name, path, type_)
 
-
-# Catch PM based messages
-@sopel.module.commands("reload")
+@sopel.module.commands("unload")
 @sopel.module.priority("low")
 @sopel.module.thread(False)
-def pm_f_reload(bot, trigger):
-    """Wrapper for allowing delivery of .reload command via PM"""
-    if trigger.is_privmsg:
-        f_reload(bot, trigger)
+@sopel.module.require_admin()
+def f_unload(bot, trigger):
+    """"Unloads" a module, for use by admins only."""
+    name = trigger.group(2)
+    path = ''
+    if name == bot.config.core.owner:
+        return bot.reply('What?')
 
+    if name not in bot._modules:
+        return bot.reply('%s: not loaded, try the `load` command' % name)
 
-@sopel.module.commands('update')
-def pm_f_update(bot, trigger):
-    """Wrapper for allowing delivery of .update command via PM"""
-    if trigger.is_privmsg:
-        f_update(bot, trigger)
-
-
-@sopel.module.commands("load")
-@sopel.module.priority("low")
-@sopel.module.thread(False)
-def pm_f_load(bot, trigger):
-    """Wrapper for allowing delivery of .load command via PM"""
-    if trigger.is_privmsg:
-        f_load(bot, trigger)
+    old_module = bot._modules[name]
+    bot.unregister_module(old_module)
+    bot.reply('done.')

--- a/sopel/tools/jobs.py
+++ b/sopel/tools/jobs.py
@@ -82,13 +82,13 @@ class JobScheduler(threading.Thread):
 
     def del_job(self, del_job):
         """Iterates through the job queue and re-adds all but the given job"""
-        for i in range(self._jobs.qsize()):
+        while self._jobs.qsize():
             job = self._jobs.get()
             if job is not del_job:
                 self._jobs.put(job)
 
     def del_job_by_params(self, interval, func):
-        for i in range(self._jobs.qsize()):
+        while self._jobs.qsize():
             job = self._jobs.get()
             if job.func is not func or job.interval != interval:
                 self._jobs.put(job)

--- a/sopel/tools/jobs.py
+++ b/sopel/tools/jobs.py
@@ -80,6 +80,14 @@ class JobScheduler(threading.Thread):
         """Add a Job to the current job queue."""
         self._jobs.put(job)
 
+    def del_job(self, del_job):
+        newjobs = PriorityQueue()
+        while self._jobs.not_empty:
+            job = self._jobs.get()
+            if job is not del_job:
+                newjobs.put()
+        self._jobs = newjobs
+
     def clear_jobs(self):
         """Clear current Job queue and start fresh."""
         if self._jobs.empty():

--- a/sopel/tools/jobs.py
+++ b/sopel/tools/jobs.py
@@ -81,9 +81,16 @@ class JobScheduler(threading.Thread):
         self._jobs.put(job)
 
     def del_job(self, del_job):
+        """Iterates through the job queue and re-adds all but the given job"""
         for i in range(self._jobs.qsize()):
             job = self._jobs.get()
-            if job and job is not del_job:
+            if job is not del_job:
+                self._jobs.put(job)
+
+    def del_job_by_params(self, interval, func):
+        for i in range(self._jobs.qsize()):
+            job = self._jobs.get()
+            if job.func is not func or job.interval != interval:
                 self._jobs.put(job)
 
     def clear_jobs(self):

--- a/sopel/tools/jobs.py
+++ b/sopel/tools/jobs.py
@@ -81,12 +81,10 @@ class JobScheduler(threading.Thread):
         self._jobs.put(job)
 
     def del_job(self, del_job):
-        newjobs = PriorityQueue()
-        while self._jobs.not_empty:
+        for i in range(self._jobs.qsize()):
             job = self._jobs.get()
-            if job is not del_job:
-                newjobs.put()
-        self._jobs = newjobs
+            if job and job is not del_job:
+                self._jobs.put(job)
 
     def clear_jobs(self):
         """Clear current Job queue and start fresh."""


### PR DESCRIPTION
_Commit summary stolen for use as PR description, since @calebj didn't enter one._ — @dgw

````
Core changes:
Now there's a single place to (un)register modules and keep track of
registered modules, called by both reload.py and bot.setup(). Please
let me know if I forgot to unload/reset something. It hasn't broken
on me yet.

The command categories are structured slightly differently. Instead
of storing only the first command alias, it stores a list of all of
them. I also changed the help.py module to work with this structure.

I added an unload command to the reload module. Since the bot uses a
seperate structure to store loaded modules, the user can't do something
stupid like 'unload sopel'.

Scheduler changes:
Not much here, just added another method that removes a job. Sadly,
PriorityQueue doesn't support this natively, so I just rebuild the
queue, skipping the job in question. This is used in bot.unregister()

Reload module changes:
Since the command is included in trigger.groups(2), making seperate
rules for PM and nick commands that call the same function won't work
without ignoring the first word when triggered by nickname_commands.
It's easier to make it use standalone command syntax, which works in
both PMs and in a channel.
Also, I replaced the admin tests with their decorator counterparts.
````