### PR TITLE
coretasks: remove sticky modifier from account capability requests

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -473,7 +473,7 @@ def recieve_cap_ls_reply(bot, trigger):
     auth_caps = ['account-notify', 'extended-join', 'account-tag']
     for cap in auth_caps:
         if cap not in bot._cap_reqs:
-            bot._cap_reqs[cap] = [_CapReq('=', 'coretasks', acct_warn)]
+            bot._cap_reqs[cap] = [_CapReq('', 'coretasks', acct_warn)]
 
     for cap, reqs in iteritems(bot._cap_reqs):
         # At this point, we know mandatory and prohibited don't co-exist, but


### PR DESCRIPTION
Fixes account tracking on some IRCds that support the caps but not the modifiers. I'd like input on this before merging it in as I'm not fully sure why @embolalia had went for sticky caps initially.

Servers that are known not to support sticky caps:
irc.esper.net
irc.hackint.org
