### PR TITLE
Implement proper extended-join support

### DIFF
--- a/sopel/irc.py
+++ b/sopel/irc.py
@@ -316,7 +316,7 @@ class Bot(asynchat.async_chat):
         self.buffer = ''
         self.last_ping_time = datetime.now()
         pretrigger = PreTrigger(self.nick, line)
-        if 'account-tag' not in self.enabled_capabilities:
+        if all(cap not in self.enabled_capabilities for cap in ['account-tag', 'extended-join']):
             pretrigger.tags.pop('account', None)
 
         if pretrigger.event == 'PING':

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -84,6 +84,11 @@ class PreTrigger(object):
                 self.tags['intent'] = intent
                 self.args[-1] = message or ''
 
+        # Populate account from extended-join messages
+        if self.event == 'JOIN' and len(self.args) == 3:
+            # Account is the second arg `...JOIN #Sopel account :realname`
+            self.tags['account'] = self.args[1]
+
 
 class Trigger(unicode):
     """A line from the server, which has matched a callable's rules.

--- a/test/test_trigger.py
+++ b/test/test_trigger.py
@@ -69,7 +69,7 @@ def test_join_pretrigger(nick):
     assert pretrigger.nick == Identifier('Foo')
     assert pretrigger.user == 'foo'
     assert pretrigger.host == 'example.com'
-    assert pretrigger.sender == Identifier('Foo')
+    assert pretrigger.sender == Identifier('#Sopel')
 
 
 def test_tags_pretrigger(nick):
@@ -143,7 +143,7 @@ def test_ctcp_data_pretrigger(nick):
 def test_ircv3_extended_join_pretrigger(nick):
     line = ':Foo!foo@example.com JOIN #Sopel bar :Real Name'
     pretrigger = PreTrigger(nick, line)
-    assert pretrigger.tags == {}
+    assert pretrigger.tags == {'account': 'bar'}
     assert pretrigger.hostmask == 'Foo!foo@example.com'
     assert pretrigger.line == line
     assert pretrigger.args == ['#Sopel', 'bar', 'Real Name']
@@ -176,7 +176,8 @@ def test_ircv3_extended_join_trigger(nick):
     assert trigger.group == fakematch.group
     assert trigger.groups == fakematch.groups
     assert trigger.args == ['#Sopel', 'bar', 'Real Name']
-    assert trigger.tags == {}
+    assert trigger.account == 'bar'
+    assert trigger.tags == {'account': 'bar'}
     assert trigger.owner is True
     assert trigger.admin is True
 


### PR DESCRIPTION
The check to pop account from the pretrigger if `account-tag` is not in the enabled capabilities really threw me off.