### PR TITLE
Made it so Sopel doesn't automatically message who triggered an error.

### DIFF
--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -178,7 +178,7 @@ class CoreSection(StaticSection):
     It is a regular expression (so the default, ``\.``, means commands start
     with a period), though using capturing groups will create problems."""
 
-    reply_errors = ValidatedAttribute('reply_errors',bool,default=False)
+    reply_errors = ValidatedAttribute('reply_errors', bool, default=True)
     """Whether to message the sender of a message that triggered an error with the exception."""
 
     throttle_join = ValidatedAttribute('throttle_join', int)

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -178,7 +178,7 @@ class CoreSection(StaticSection):
     It is a regular expression (so the default, ``\.``, means commands start
     with a period), though using capturing groups will create problems."""
 
-    reply_errors = ValidatedAttribute('message_logs_sender',bool,default=False)
+    reply_errors = ValidatedAttribute('reply_errors',bool,default=False)
     """Whether to message the sender of a message that triggered an error with the exception."""
 
     throttle_join = ValidatedAttribute('throttle_join', int)

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -131,6 +131,12 @@ class CoreSection(StaticSection):
                                      'DEBUG'],
                                     'WARNING')
     """The lowest severity of logs to display."""
+    
+    message_logs = ValidatedAttribute('log_to_channel',bool,default=True)
+    """Whether to message the logging channel with thrown exceptions."""
+    
+    message_logs_sender = ValidatedAttribute('message_logs_sender',bool,default=False)
+    """Whether to message the sender of a message that triggered an error with the exception."""
 
     modes = ValidatedAttribute('modes', default='B')
     """User modes to be set on connection."""

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -131,12 +131,6 @@ class CoreSection(StaticSection):
                                      'DEBUG'],
                                     'WARNING')
     """The lowest severity of logs to display."""
-    
-    message_logs = ValidatedAttribute('log_to_channel',bool,default=True)
-    """Whether to message the logging channel with thrown exceptions."""
-    
-    message_logs_sender = ValidatedAttribute('message_logs_sender',bool,default=False)
-    """Whether to message the sender of a message that triggered an error with the exception."""
 
     modes = ValidatedAttribute('modes', default='B')
     """User modes to be set on connection."""
@@ -183,6 +177,9 @@ class CoreSection(StaticSection):
 
     It is a regular expression (so the default, ``\.``, means commands start
     with a period), though using capturing groups will create problems."""
+
+    reply_errors = ValidatedAttribute('message_logs_sender',bool,default=False)
+    """Whether to message the sender of a message that triggered an error with the exception."""
 
     throttle_join = ValidatedAttribute('throttle_join', int)
     """Slow down the initial join of channels to prevent getting kicked.

--- a/sopel/irc.py
+++ b/sopel/irc.py
@@ -367,12 +367,18 @@ class Bot(asynchat.async_chat):
             except Exception as e:
                 stderr("Could not save full traceback!")
                 LOGGER.error("Could not save traceback from %s to file: %s", trigger.sender, str(e))
-
-            if trigger and trigger.sender is not None:
-                self.msg(trigger.sender, signature)
+            
+            # Errors will pass silently otherwise, not sure how to handle this
+            if trigger and self.config.core.message_logs and self.config.core.logging_channel is not None:
+                self.msg(self.config.logging_channel, signature)
+                if self.config.core.message_logs_sender:
+                    self.msg(trigger.sender,signature)
         except Exception as e:
-            if trigger and trigger.sender is not None:
-                self.msg(trigger.sender, "Got an error.")
+            if trigger:
+                if self.config.core.message_logs and self.config.core.logging_channel is not None:
+                    self.msg(self.config.core.logging_channel,"Got an error.")
+                    if self.config.core.message_logs_sender:
+                        self.msg(trigger.sender,"Got an error.")
                 LOGGER.error("Exception from %s: %s", trigger.sender, str(e))
 
     def handle_error(self):

--- a/sopel/irc.py
+++ b/sopel/irc.py
@@ -367,12 +367,12 @@ class Bot(asynchat.async_chat):
             except Exception as e:
                 stderr("Could not save full traceback!")
                 LOGGER.error("Could not save traceback from %s to file: %s", trigger.sender, str(e))
-            
+
             if trigger and self.config.core.reply_errors and trigger.sender is not None:
-                    self.msg(trigger.sender,signature)
+                self.msg(trigger.sender,signature)
         except Exception as e:
             if trigger and self.config.core.reply_errors and trigger.sender is not None:
-                        self.msg(trigger.sender,"Got an error.")
+                self.msg(trigger.sender,"Got an error.")
                 LOGGER.error("Exception from %s: %s", trigger.sender, str(e))
 
     def handle_error(self):

--- a/sopel/irc.py
+++ b/sopel/irc.py
@@ -369,10 +369,10 @@ class Bot(asynchat.async_chat):
                 LOGGER.error("Could not save traceback from %s to file: %s", trigger.sender, str(e))
 
             if trigger and self.config.core.reply_errors and trigger.sender is not None:
-                self.msg(trigger.sender,signature)
+                self.msg(trigger.sender, signature)
         except Exception as e:
             if trigger and self.config.core.reply_errors and trigger.sender is not None:
-                self.msg(trigger.sender,"Got an error.")
+                self.msg(trigger.sender, "Got an error.")
                 LOGGER.error("Exception from %s: %s", trigger.sender, str(e))
 
     def handle_error(self):

--- a/sopel/irc.py
+++ b/sopel/irc.py
@@ -368,16 +368,10 @@ class Bot(asynchat.async_chat):
                 stderr("Could not save full traceback!")
                 LOGGER.error("Could not save traceback from %s to file: %s", trigger.sender, str(e))
             
-            # Errors will pass silently otherwise, not sure how to handle this
-            if trigger and self.config.core.message_logs and self.config.core.logging_channel is not None:
-                self.msg(self.config.logging_channel, signature)
-                if self.config.core.message_logs_sender:
+            if trigger and self.config.core.reply_errors and trigger.sender is not None:
                     self.msg(trigger.sender,signature)
         except Exception as e:
-            if trigger:
-                if self.config.core.message_logs and self.config.core.logging_channel is not None:
-                    self.msg(self.config.core.logging_channel,"Got an error.")
-                    if self.config.core.message_logs_sender:
+            if trigger and self.config.core.reply_errors and trigger.sender is not None:
                         self.msg(trigger.sender,"Got an error.")
                 LOGGER.error("Exception from %s: %s", trigger.sender, str(e))
 


### PR DESCRIPTION
Also added core config settings for toggling whether to message the logging channel (if it is set) or to use the original behavior of messaging the sender.

I'm not sure why Sopel automatically messages the sender (as it's a channel most of the time), since it can get pretty disruptive pretty quickly.