### PR TITLE
[weather] catch empty forecast results

### DIFF
--- a/sopel/modules/weather.py
+++ b/sopel/modules/weather.py
@@ -142,6 +142,8 @@ def weather(bot, trigger):
                   dont_decode=True)
     parsed = xmltodict.parse(body).get('query')
     results = parsed.get('results')
+    if results is None:
+        return bot.reply("No forecast available. Try a more specific location.")
     location = results.get('channel').get('title')
     cover = get_cover(results)
     temp = get_temp(results)


### PR DESCRIPTION
e.g. when the user enters a continent for the location.

Since this seems to be triggered by specifying too general a location, I wrote the error message to cover that case.