### PR TITLE
Fixed an issue with extended-join and recognizing accounts

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -357,6 +357,8 @@ def track_join(bot, trigger):
     user = bot.users.get(trigger.nick)
     if user is None:
         user = User(trigger.nick, trigger.user, trigger.host)
+        bot.users[trigger.nick] = user
+
     bot.channels[trigger.sender].add_user(user)
 
     if len(trigger.args) > 1 and trigger.args[1] != '*' and (


### PR DESCRIPTION
Sopel would only add information about the user to the channel and not
the "global" memory which is being used to populate the trigger object
in command handlers.


I'm not very sure this is the right approach to this issue. Would it be better to just check the channel's user list for a valid user/account info?