### PR TITLE
Lint imports

### DIFF
--- a/sopel/modules/calc.py
+++ b/sopel/modules/calc.py
@@ -8,17 +8,12 @@ http://sopel.chat
 """
 from __future__ import unicode_literals, absolute_import, print_function, division
 
-import re
 from sopel import web
 from sopel.module import commands, example
 from sopel.tools.calculation import eval_equation
-from socket import timeout
 import sys
-if sys.version_info.major < 3:
-    import HTMLParser
-else:
+if sys.version_info.major >= 3:
     unichr = chr
-    import html.parser as HTMLParser
 
 
 BASE_TUMBOLIA_URI = 'https://tumbolia-two.appspot.com/'

--- a/sopel/modules/find_updates.py
+++ b/sopel/modules/find_updates.py
@@ -9,8 +9,6 @@ Sopel website.
 # Licensed under the Eiffel Forum License 2.
 from __future__ import unicode_literals, absolute_import, print_function, division
 
-import json
-
 import sopel
 import sopel.module
 import requests

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -8,7 +8,6 @@
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 import re
-from contextlib import closing
 from sopel import web, tools
 from sopel.module import commands, rule, example
 from sopel.config.types import ValidatedAttribute, ListAttribute, StaticSection

--- a/sopel/modules/xkcd.py
+++ b/sopel/modules/xkcd.py
@@ -5,11 +5,9 @@
 # Licensed under the Eiffel Forum License 2.
 from __future__ import unicode_literals, absolute_import, print_function, division
 
-import json
 import random
 import re
 import requests
-from sopel import web
 from sopel.modules.search import google_search
 from sopel.module import commands
 

--- a/sopel/web.py
+++ b/sopel/web.py
@@ -17,7 +17,6 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 import re
 import sys
 import urllib
-import os.path
 import requests
 
 from sopel import __version__


### PR DESCRIPTION
After realizing I'd left a dead import in calc.py after removing the `.wa` command, I decided to go through and clean up any other imports that didn't appear to be in use any more.

Let me know if I've accidentally bollocksed up a module. I double-checked the imports PyCharm said were unused before actually removing them, but I might have made a mistake.