### PR TITLE
[db] Fix group nick count check in unalias_nick()

### DIFF
--- a/sopel/db.py
+++ b/sopel/db.py
@@ -174,7 +174,7 @@ class SopelDB(object):
         nick_id = self.get_nick_id(alias, False)
         count = self.execute('SELECT COUNT(*) FROM nicknames WHERE nick_id = ?',
                              [nick_id]).fetchone()[0]
-        if count == 0:
+        if count <= 1:
             raise ValueError('Given alias is the only entry in its group.')
         self.execute('DELETE FROM nicknames WHERE slug = ?', [alias.lower()])
 


### PR DESCRIPTION
As described in #1101, this DB API call will currently remove even a nickname that is the only member of its group, contrary to what the documentation string says. This fixes the problem.