### PR TITLE
coretasks: tweak topic tracking

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -696,12 +696,16 @@ def track_notify(bot, trigger):
 
 
 @sopel.module.rule('.*')
+@sopel.module.event('TOPIC')
 @sopel.module.event(events.RPL_TOPIC)
 @sopel.module.priority('high')
 @sopel.module.thread(False)
 @sopel.module.unblockable
 def track_topic(bot, trigger):
-    channel = trigger.args[1]
+    if trigger.event != 'TOPIC':
+        channel = trigger.args[1]
+    else:
+        channel = trigger.args[0]
     if channel not in bot.channels:
         return
     bot.channels[channel].topic = trigger.args[-1]


### PR DESCRIPTION
Support different implementation of topic update, RPL_TOPIC appears to only be sent to the user who actually updated the topic.

Resolves #1107 