### PR TITLE
Fixed request.exceptions.SSLError

### DIFF
--- a/sopel/modules/meetbot.py
+++ b/sopel/modules/meetbot.py
@@ -342,7 +342,7 @@ def meetinglink(bot, trigger):
     if not link.startswith("http"):
         link = "http://" + link
     try:
-        title = find_title(link)
+        title = find_title(bot, link)
     except:
         title = ''
     logplain('LINK: %s [%s]' % (link, title), trigger.sender)

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -158,7 +158,7 @@ def process_urls(bot, trigger, urls):
             if matched:
                 continue
             # Finally, actually show the URL
-            title = find_title(url)
+            title = find_title(bot, url)
             if title:
                 results.append((title, get_hostname(url)))
     return results
@@ -182,9 +182,9 @@ def check_callbacks(bot, trigger, url, run=True):
     return matched
 
 
-def find_title(url):
+def find_title(bot, url):
     """Return the title for the given URL."""
-    response = requests.get(url, stream=True)
+    response = requests.get(url, stream=True, verify=bot.config.core.verify_ssl)
     try:
         content = ''
         for byte in response.iter_content(chunk_size=512, decode_unicode=True):


### PR DESCRIPTION
Bot throw SSLerror
---
requests.packages.urllib3.exceptions.SSLError: [SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed (_ssl.c:645)
---

even when 'verify_ssl = False'
The core.verify_ssl was not passed to url.find_title()

Signed-off-by: Sachin Patil <psachin@redhat.com>