### PR TITLE
meetbot/url: fix SSLError

### DIFF
--- a/sopel/modules/meetbot.py
+++ b/sopel/modules/meetbot.py
@@ -342,7 +342,7 @@ def meetinglink(bot, trigger):
     if not link.startswith("http"):
         link = "http://" + link
     try:
-        title = find_title(link)
+        title = find_title(link, verify=bot.config.core.verify_ssl)
     except:
         title = ''
     logplain('LINK: %s [%s]' % (link, title), trigger.sender)

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -158,7 +158,7 @@ def process_urls(bot, trigger, urls):
             if matched:
                 continue
             # Finally, actually show the URL
-            title = find_title(url)
+            title = find_title(url, verify=bot.config.core.verify_ssl)
             if title:
                 results.append((title, get_hostname(url)))
     return results
@@ -182,9 +182,9 @@ def check_callbacks(bot, trigger, url, run=True):
     return matched
 
 
-def find_title(url):
+def find_title(url, verify=True):
     """Return the title for the given URL."""
-    response = requests.get(url, stream=True)
+    response = requests.get(url, stream=True, verify=verify)
     try:
         content = ''
         for byte in response.iter_content(chunk_size=512, decode_unicode=True):


### PR DESCRIPTION
The `core.verify_ssl` was not passed to `url.find_title()`, resulting in SSL errors on sites with invalid certs when `verify_ssl = False`

Slight refactor of @psachin's original code for backwards compatibility. Resolves #1113