### PR TITLE
Notify if Bugzilla is private

### DIFF
--- a/sopel/modules/bugzilla.py
+++ b/sopel/modules/bugzilla.py
@@ -70,7 +70,9 @@ def show_bug(bot, trigger, match=None):
     error = bug.get('@error', None)  # error="NotPermitted"
 
     if error:
-        LOGGER.warning('Bugzilla error: %s', error)
+        LOGGER.warning('Bugzilla error: %s' % error)
+        bot.say('[BUGZILLA] Unable to get infomation for '
+                'linked bug (%s)' % error)
         return
 
     message = ('[BUGZILLA] %s | Product: %s | Component: %s | Version: %s | ' +


### PR DESCRIPTION
Although the primary error no longer exist, but the bot shows nothing if
the bugzilla is private. In the logs, I see the error,

    WARNING:sopel.modules.bugzilla:Bugzilla error: NotPermitted

This commit should notify about private BZ

Closes-Bug: #1112

Signed-off-by: Sachin Patil <psachin@redhat.com>