### PR TITLE
[xkcd] Join sites query without prefix

### DIFF
--- a/sopel/modules/xkcd.py
+++ b/sopel/modules/xkcd.py
@@ -25,7 +25,8 @@ ignored_sites = [
     'wiki.xkcd.com',
     'what-if.xkcd.com',
 ]
-sites_query = ' site:xkcd.com -site:' + ' -site:'.join(ignored_sites)
+sites_query = ' site:xkcd.com ' + ' '.join('-site:{}'.format(ignored_site)
+                                           for ignored_site in ignored_sites)
 
 
 def get_info(number=None):


### PR DESCRIPTION
The sites query can be joined where each element already uses the prefix. That way the prefix doesn't need to be added manually for the first element.