### PR TITLE
Add support for authentication on Quakenet

### DIFF
--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -50,10 +50,10 @@ class CoreSection(StaticSection):
     capabilities."""
 
     auth_method = ChoiceAttribute('auth_method', choices=[
-        'nickserv', 'authserv', 'sasl', 'server'])
+        'nickserv', 'authserv', 'Q','sasl', 'server'])
     """The method to use to authenticate with the server.
 
-    Can be ``nickserv``, ``authserv``, ``q``, ``sasl``, or ``server``."""
+    Can be ``nickserv``, ``authserv``, ``Q``, ``sasl``, or ``server``."""
 
     auth_password = ValidatedAttribute('auth_password')
     """The password to use to authenticate with the server."""

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -53,7 +53,7 @@ class CoreSection(StaticSection):
         'nickserv', 'authserv', 'sasl', 'server'])
     """The method to use to authenticate with the server.
 
-    Can be ``nickserv``, ``authserv``, ``sasl``, or ``server``."""
+    Can be ``nickserv``, ``authserv``, ``q``, ``sasl``, or ``server``."""
 
     auth_password = ValidatedAttribute('auth_password')
     """The password to use to authenticate with the server."""

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -50,7 +50,7 @@ class CoreSection(StaticSection):
     capabilities."""
 
     auth_method = ChoiceAttribute('auth_method', choices=[
-        'nickserv', 'authserv', 'Q','sasl', 'server'])
+        'nickserv', 'authserv', 'Q', 'sasl', 'server'])
     """The method to use to authenticate with the server.
 
     Can be ``nickserv``, ``authserv``, ``Q``, ``sasl``, or ``server``."""

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -50,6 +50,14 @@ def auth_after_register(bot):
             'AUTHSERV auth',
             account + ' ' + password
         ))
+    
+    elif bot.config.core.auth_method.lower() == 'q':
+        account = bot.config.core.auth_username
+        password = bot.config.core.auth_password
+        bot.msg(
+            "q@cserve.quakenet.org",
+            'AUTH %s %s', % (account, password)
+            )
 
 
 @sopel.module.event(events.RPL_WELCOME, events.RPL_LUSERCLIENT)

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -54,10 +54,10 @@ def auth_after_register(bot):
     elif bot.config.core.auth_method.lower() == 'q':
         account = bot.config.core.auth_username
         password = bot.config.core.auth_password
-        bot.msg(
-            "q@cserve.quakenet.org",
-            'AUTH %s %s', % (account, password)
-            )
+        bot.write((
+            'AUTH',
+            account + ' ' + password
+        ))
 
 
 @sopel.module.event(events.RPL_WELCOME, events.RPL_LUSERCLIENT)


### PR DESCRIPTION
I added a couple of rows of simple code which add the support for authenticating your Sopel on Quakenet.

Modified files are `core_tasks.py`, and `core_section.py`. The modifications to the code should be simple enough to understand just by looking at them.

Works on my machine™ (`Sopel v. 6.3.1`, installed via pip).