### PR TITLE
sopel/trigger.py: fix intent_regex

### DIFF
--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -16,7 +16,7 @@ class PreTrigger(object):
     """A parsed message from the server, which has not been matched against
     any rules."""
     component_regex = re.compile(r'([^!]*)!?([^@]*)@?(.*)')
-    intent_regex = re.compile('\x01(\\S+) (.*)\x01')
+    intent_regex = re.compile('\x01(\\S+) ?(.*)\x01')
 
     def __init__(self, own_nick, line):
         """own_nick is the bot's nick, needed to correctly parse sender.


### PR DESCRIPTION
The intent_regex in sopel/trigger.py does not separate "intent" from "args" correctly. The way it was there needed to be a blank after "intent" which caused test_ctcp_intent_pretrigger to fail:

```
test/test_trigger.py:118: in test_ctcp_intent_pretrigger
    assert pretrigger.tags == {'intent': 'VERSION'}
E   assert {} == {'intent': 'VERSION'}
E     Right contains more items:
E     {u'intent': u'VERSION'}
E     Use -v to get the full diff
```

Fixed it by adding a question mark to the regexp after the blank in order to make the blank optional.
