### PR TITLE
url: make find_title more robust

### DIFF
--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -186,16 +186,12 @@ def find_title(url, verify=True):
     """Return the title for the given URL."""
     response = requests.get(url, stream=True, verify=verify)
     try:
-        content = ''
-        for byte in response.iter_content(chunk_size=512, decode_unicode=True):
-            if not isinstance(byte, bytes):
-                content += byte
-            else:
+        content = b''
+        for byte in response.iter_content(chunk_size=512):
+            content += byte
+            if b'</title>' in content or len(content) > max_bytes:
                 break
-            if '</title>' in content or len(content) > max_bytes:
-                break
-    except UnicodeDecodeError:
-        return  # Fail silently when data can't be decoded
+        content = content.decode('utf-8', errors='ignore')
     finally:
         # need to close the connexion because we have not read all the data
         response.close()


### PR DESCRIPTION
Previously, each 512-byte chunk is prone to decoding mishap when a UTF-8 sequence is incomplete. Now we decode all of content at once, ignoring errors.

The old problem appears reliably for pages with many high codepoints:

```
<user> http://www3.nhk.or.jp/news/easy/k10010665021000/k10010665021000.html
<bot-old> [ NEWS WEB EASY|æ±åã¢ã¸ã¢ã§ã¸ã«ç±ã«ãªãäººãå¢ãã ] - www3.nhk.or.jp
```
