### PR TITLE
[weather] Use help_prefix in hint text when no location given

### DIFF
--- a/sopel/modules/weather.py
+++ b/sopel/modules/weather.py
@@ -124,8 +124,10 @@ def weather(bot, trigger):
     if not location:
         woeid = bot.db.get_nick_value(trigger.nick, 'woeid')
         if not woeid:
-            return bot.msg(trigger.sender, "I don't know where you live. " +
-                           'Give me a location, like .weather London, or tell me where you live by saying .setlocation London, for example.')
+            prefix = bot.config.core.help_prefix or '.'
+            return bot.msg(trigger.sender,
+                           "I don't know where you live. Give me a location, like {pfx}weather London, or tell me "
+                           "where you live by saying {pfx}setlocation London, for example.".format(pfx=prefix))
     else:
         location = location.strip()
         woeid = bot.db.get_nick_value(location, 'woeid')


### PR DESCRIPTION
Takes care of #1019 for the weather module. One of my users bumped into this tonight, so I decided to just fix it.