### PR TITLE
[etymology] unescape all known HTML entities

### DIFF
--- a/sopel/modules/etymology.py
+++ b/sopel/modules/etymology.py
@@ -8,6 +8,14 @@ http://sopel.chat
 """
 from __future__ import unicode_literals, absolute_import, print_function, division
 
+try:
+    from html import unescape
+except ImportError:
+    from HTMLParser import HTMLParser
+
+    # pep8 dictates a blank line here...
+    def unescape(s):
+        return HTMLParser.unescape.__func__(HTMLParser, s)
 import re
 from sopel import web
 from sopel.module import commands, example, NOLIMIT
@@ -27,13 +35,6 @@ abbrs = [
 ]
 t_sentence = r'^.*?(?<!%s)(?:\.(?= [A-Z0-9]|\Z)|\Z)'
 r_sentence = re.compile(t_sentence % ')(?<!'.join(abbrs))
-
-
-def unescape(s):
-    s = s.replace('&gt;', '>')
-    s = s.replace('&lt;', '<')
-    s = s.replace('&amp;', '&')
-    return s
 
 
 def text(html):


### PR DESCRIPTION
Replace bespoke implementation of unescape() with stdlib tools; fix #1153.

Uses try/except to maintain compatibility with both Py2 and Py3.