### PR TITLE
wikipedia: retrieve section summaries

### DIFF
--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -8,15 +8,17 @@ from sopel.config.types import StaticSection, ValidatedAttribute
 from sopel.module import NOLIMIT, commands, example, rule
 from requests import get
 import re
-
 import sys
+
 if sys.version_info.major < 3:
     from urllib import quote as _quote
     from urlparse import unquote as _unquote
     quote = lambda s: _quote(s.encode('utf-8')).decode('utf-8')
     unquote = lambda s: _unquote(s.encode('utf-8')).decode('utf-8')
+    import HTMLParser
 else:
     from urllib.parse import quote, unquote
+    from html.parser import HTMLParser
 
 REDIRECT = re.compile(r'^REDIRECT (.*)')
 

--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -22,6 +22,7 @@ else:
 
 REDIRECT = re.compile(r'^REDIRECT (.*)')
 
+
 class WikiParser(HTMLParser):
     def __init__(self, section_name):
         HTMLParser.__init__(self)
@@ -36,7 +37,7 @@ class WikiParser(HTMLParser):
         self.result = ''
 
     def handle_starttag(self, tag, attrs):
-        if tag == 'sup': # don't consume anything in superscript (citation-related tags)
+        if tag == 'sup':    # don't consume anything in superscript (citation-related tags)
             self.consume = False
 
         elif re.match(r'^h\d$', tag):
@@ -173,7 +174,7 @@ def say_section(bot, trigger, server, query, section):
 
 def mw_section(server, query, section):
     """
-    Retrives a snippet from the specified section from the given page 
+    Retrives a snippet from the specified section from the given page
     on the given server.
     """
     sections_url = ('https://{0}/w/api.php?format=json&redirects'
@@ -212,8 +213,9 @@ def mw_section(server, query, section):
 
     return text
 
+
 # Get a wikipedia page (excluding spaces and #, but not /File: links), with a separate optional field for the section
-@rule('.*\/([a-z]+\.wikipedia\.org)\/wiki\/((?!File\:)[^ #]+)#?([^ ]*).*')
+@rule(r'.*\/([a-z]+\.wikipedia\.org)\/wiki\/((?!File\:)[^ #]+)#?([^ ]*).*')
 def mw_info(bot, trigger, found_match=None):
     """
     Retrives a snippet of the specified length from the given page on the given
@@ -221,7 +223,7 @@ def mw_info(bot, trigger, found_match=None):
     """
     match = found_match or trigger
     if match.group(3):
-        if match.group(3).startswith('cite_note-'): # Don't bother trying to retrieve a snippet when cite-note is linked
+        if match.group(3).startswith('cite_note-'):  # Don't bother trying to retrieve a snippet when cite-note is linked
             say_snippet(bot, trigger, match.group(1), unquote(match.group(2)), show_url=False)
         else:
             say_section(bot, trigger, match.group(1), unquote(match.group(2)), unquote(match.group(3)))

--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -15,7 +15,7 @@ if sys.version_info.major < 3:
     from urlparse import unquote as _unquote
     quote = lambda s: _quote(s.encode('utf-8')).decode('utf-8')
     unquote = lambda s: _unquote(s.encode('utf-8')).decode('utf-8')
-    import HTMLParser
+    from HTMLParser import HTMLParser
 else:
     from urllib.parse import quote, unquote
     from html.parser import HTMLParser

--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -65,8 +65,10 @@ class WikiParser(HTMLParser):
                     self.citations = True   # once we hit citations, we can stop
 
     def handle_endtag(self, tag):
-        if not self.consume and tag in ['h2', 'h3', 'sup']:
+        if not self.consume and tag == 'sup':
             self.consume = True
+        if self.is_header and re.match(r'^h\d$', tag):
+            self.is_header = False
         if self.span_depth and tag == 'span':
             self.span_depth -= 1
         if self.div_depth and tag == 'div':

--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -161,14 +161,13 @@ def mw_snippet(server, query):
 def say_section(bot, trigger, server, query, section):
     page_name = query.replace('_', ' ')
     query = quote(query.replace(' ', '_'))
-    section = section.replace('_', ' ')
 
     snippet = mw_section(server, query, section)
     if not snippet:
         bot.say("[WIKIPEDIA] Error fetching section \"{}\" for page \"{}\".".format(section, page_name))
         return
 
-    msg = '[WIKIPEDIA] {} - {} | "{}"'.format(page_name, section, snippet)
+    msg = '[WIKIPEDIA] {} - {} | "{}"'.format(page_name, section.replace('_', ' '), snippet)
     bot.say(msg)
 
 
@@ -185,7 +184,7 @@ def mw_section(server, query, section):
     section_number = None
 
     for entry in sections['parse']['sections']:
-        if entry['line'] == section:
+        if entry['anchor'] == section:
             section_number = entry['index']
             break
 
@@ -198,7 +197,7 @@ def mw_section(server, query, section):
 
     data = get(snippet_url).json()
 
-    parser = WikiParser(section)
+    parser = WikiParser(section.replace('_', ' '))
     parser.feed(data['parse']['text']['*'])
     text = parser.get_result()
     text = ' '.join(text.split())   # collapse multiple whitespace chars


### PR DESCRIPTION
Module will now retrieve text from the relevant section
instead of the beginning of the article irrespective of
section designations in the URL.