### PR TITLE
spellcheck: complete rewrite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ cache:
 addons:
   apt:
     packages:
-      - enchant
+      - aspell
+      - aspell-en
+      - libaspell-dev
 install:
   - pip install -r requirements.txt -r dev-requirements.txt
 script:

--- a/contrib/rpm/sopel.spec.in
+++ b/contrib/rpm/sopel.spec.in
@@ -14,10 +14,13 @@ BuildArch:      noarch
 BuildRequires:  python2-devel
 BuildRequires:  python-sphinx
 BuildRequires:  dos2unix
-BuildRequires: systemd
+BuildRequires:  systemd
+BuildRequires:  aspell
+BuildRequires:  aspell-devel
+BuildRequires:  aspell-en
 
 Requires:       pytz
-Requires:       python-enchant
+Requires:       aspell-python-py2
 Requires:       pyOpenSSL
 Requires:       python-praw
 Requires:       python-backports-ssl_match_hostname

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 xmltodict
 pytz
 praw<6.0.0
-pyenchant; python_version < '3.7'
 geoip2
+aspell-python-py2; python_version < '3'
+aspell-python-py3; python_version >= '3'
 ipython<6.0; python_version < '3.3'
 ipython>=6.0,<7.0; python_version >= '3.3'
 requests>=2.0.0,<3.0.0

--- a/sopel/modules/spellcheck.py
+++ b/sopel/modules/spellcheck.py
@@ -5,27 +5,21 @@ spellcheck.py - Sopel spelling checker module
 Copyright © 2016, Alan Huang
 Licensed under the Eiffel Forum License 2.
 http://sopel.chat
-
-This module relies on aspell-python-py2 or py3, available through pypi or
-https://github.com/WojciechMula/aspell-python
 """
 from __future__ import unicode_literals, absolute_import, print_function, division
 import aspell
-from sopel.module import commands
-
+from sopel.module import commands, example, require_admin
 
 @commands('add')
+@require_admin('I only trust admins to add words.')
 def add_command(bot, trigger):
     """
     Add words to the bot's personal dictionary
     """
-    if(trigger.owner):
-        c = aspell.Speller('lang', 'en')
-        c.addtoPersonal(trigger.group(2))
-        c.saveAllwords()
-        bot.say('Added {0}.'.format(trigger.group(2)))
-    else:
-        bot.say('I only trust {0} to add words >:c'.format(bot.config.core.owner))
+    c = aspell.Speller('lang', 'en')
+    c.addtoPersonal(trigger.group(2))
+    c.saveAllwords()
+    bot.say('Added {0}.'.format(trigger.group(2)))
 
 def check_multiple(bot, words):
     mistakes = []
@@ -54,6 +48,7 @@ def check_one(bot, word):
         bot.say("That doesn't seem to be correct. Try {0}.".format(', '.join(['"{0}"'.format(s) for s in suggestions])))
 
 @commands('spell')
+@example('.spell stuff')
 def spellchecker(bot, trigger):
     """
     Checks if the given word is spelled correctly, and suggests corrections.

--- a/sopel/modules/spellcheck.py
+++ b/sopel/modules/spellcheck.py
@@ -1,10 +1,24 @@
 # coding=utf-8
 
+"""
+spellcheck.py - Sopel spelling checker module
+Copyright © 2016, Alan Huang
+Licensed under the Eiffel Forum License 2.
+http://sopel.chat
+
+This module relies on aspell-python-py2 or py3, available through pypi or
+https://github.com/WojciechMula/aspell-python
+"""
+from __future__ import unicode_literals, absolute_import, print_function, division
 import aspell
 from sopel.module import commands
 
+
 @commands('add')
 def add_command(bot, trigger):
+    """
+    Add words to the bot's personal dictionary
+    """
     if(trigger.owner):
         c = aspell.Speller('lang', 'en')
         c.addtoPersonal(trigger.group(2))
@@ -13,8 +27,12 @@ def add_command(bot, trigger):
     else:
         bot.say('I only trust {0} to add words >:c'.format(bot.config.core.owner))
 
+
 @commands('spell')
 def spellchecker(bot, trigger):
+    """
+    Checks if the given word is spelled correctly, and suggests corrections.
+    """
     if not trigger.group(2):
         bot.say('What word am I checking?')
         return
@@ -39,7 +57,7 @@ def spellchecker(bot, trigger):
         if count < 5:
             suggestion += '"{0}", '.format(word)
             count += 1
-    
+
     if len(suggestion) == 0:
         bot.say("That doesn't seem to be correct.")
     else:

--- a/sopel/modules/spellcheck.py
+++ b/sopel/modules/spellcheck.py
@@ -1,55 +1,46 @@
 # coding=utf-8
-"""
-spellcheck.py - Sopel spell check Module
-Copyright © 2012, Elad Alfassa, <elad@fedoraproject.org>
-Copyright © 2012, Lior Ramati
-Licensed under the Eiffel Forum License 2.
 
-https://sopel.chat
+import aspell
+from sopel.module import commands
 
-This module relies on pyenchant, on Fedora and Red Hat based system, it can be found in the package python-enchant
-"""
-from __future__ import unicode_literals, absolute_import, print_function, division
-
-try:
-    import enchant
-except ImportError:
-    enchant = None
-from sopel.module import commands, example
-
-
-@commands('spellcheck', 'spell')
-@example('.spellcheck stuff')
-def spellcheck(bot, trigger):
-    """
-    Says whether the given word is spelled correctly, and gives suggestions if
-    it's not.
-    """
-    if not enchant:
-        bot.say("Missing pyenchant module.")
-    if not trigger.group(2):
-        return
-    word = trigger.group(2).rstrip()
-    if " " in word:
-        bot.say("One word at a time, please")
-        return
-    dictionary = enchant.Dict("en_US")
-    dictionary_uk = enchant.Dict("en_GB")
-    # I don't want to make anyone angry, so I check both American and British English.
-    if dictionary_uk.check(word):
-        if dictionary.check(word):
-            bot.say(word + " is spelled correctly")
-        else:
-            bot.say(word + " is spelled correctly (British)")
-    elif dictionary.check(word):
-        bot.say(word + " is spelled correctly (American)")
+@commands('add')
+def add_command(bot, trigger):
+    if(trigger.owner):
+        c = aspell.Speller('lang', 'en')
+        c.addtoPersonal(trigger.group(2))
+        c.saveAllwords()
+        bot.say('Added {0}.'.format(trigger.group(2)))
     else:
-        msg = word + " is not spelled correctly. Maybe you want one of these spellings:"
-        sugWords = []
-        for suggested_word in dictionary.suggest(word):
-                sugWords.append(suggested_word)
-        for suggested_word in dictionary_uk.suggest(word):
-                sugWords.append(suggested_word)
-        for suggested_word in sorted(set(sugWords)):  # removes duplicates
-            msg = msg + " '" + suggested_word + "',"
-        bot.say(msg)
+        bot.say('I only trust {0} to add words >:c'.format(bot.config.core.owner))
+
+@commands('spell')
+def spellchecker(bot, trigger):
+    if not trigger.group(2):
+        bot.say('What word am I checking?')
+        return
+
+    if trigger.group(2) == bot.nick:
+        bot.say('Hey, that\'s my name! Nothing wrong with it.')
+        return
+
+    if len(trigger.group(2).split(' ')) > 1:
+        bot.say('One word at a time, please.')
+        return
+
+    c = aspell.Speller('lang', 'en')
+    if c.check(trigger.group(2)):
+        bot.say("I don't see any problems with that word.")
+        return
+
+    suggestions = c.suggest(trigger.group(2))
+    count = 0
+    suggestion = ''
+    for word in suggestions:
+        if count < 5:
+            suggestion += '"{0}", '.format(word)
+            count += 1
+    
+    if len(suggestion) == 0:
+        bot.say("That doesn't seem to be correct.")
+    else:
+        bot.say("That doesn't seem to be correct. Try {0}.".format(suggestion[:-2]))

--- a/sopel/modules/spellcheck.py
+++ b/sopel/modules/spellcheck.py
@@ -27,6 +27,31 @@ def add_command(bot, trigger):
     else:
         bot.say('I only trust {0} to add words >:c'.format(bot.config.core.owner))
 
+def check_multiple(bot, words):
+    mistakes = []
+
+    c = aspell.Speller('lang', 'en')
+    for word in words:
+        if not c.check(word):
+            mistakes.append(word)
+
+    if len(mistakes) == 0:
+        bot.say("Nothing seems to be misspelled.")
+    else:
+        bot.say('The following word(s) seem to be misspelled: {0}'.format(', '.join(['"{0}"'.format(w) for w in mistakes])))
+
+def check_one(bot, word):
+    c = aspell.Speller('lang', 'en')
+    if c.check(word):
+        bot.say("I don't see any problems with that word.")
+        return
+    else:
+        suggestions = c.suggest(word)[:5]
+    
+    if len(suggestions) == 0:
+        bot.say("That doesn't seem to be correct.")
+    else:
+        bot.say("That doesn't seem to be correct. Try {0}.".format(', '.join(['"{0}"'.format(s) for s in suggestions])))
 
 @commands('spell')
 def spellchecker(bot, trigger):
@@ -41,24 +66,9 @@ def spellchecker(bot, trigger):
         bot.say('Hey, that\'s my name! Nothing wrong with it.')
         return
 
-    if len(trigger.group(2).split(' ')) > 1:
-        bot.say('One word at a time, please.')
-        return
+    words = trigger.group(2).split(None)
 
-    c = aspell.Speller('lang', 'en')
-    if c.check(trigger.group(2)):
-        bot.say("I don't see any problems with that word.")
-        return
-
-    suggestions = c.suggest(trigger.group(2))
-    count = 0
-    suggestion = ''
-    for word in suggestions:
-        if count < 5:
-            suggestion += '"{0}", '.format(word)
-            count += 1
-
-    if len(suggestion) == 0:
-        bot.say("That doesn't seem to be correct.")
+    if len(words) > 1:
+        check_multiple(bot, words)
     else:
-        bot.say("That doesn't seem to be correct. Try {0}.".format(suggestion[:-2]))
+        check_one(bot, trigger.group(2))

--- a/sopel/modules/spellcheck.py
+++ b/sopel/modules/spellcheck.py
@@ -10,6 +10,7 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 import aspell
 from sopel.module import commands, example, require_admin
 
+
 @commands('add')
 @require_admin('I only trust admins to add words.')
 def add_command(bot, trigger):
@@ -20,6 +21,7 @@ def add_command(bot, trigger):
     c.addtoPersonal(trigger.group(2))
     c.saveAllwords()
     bot.say('Added {0}.'.format(trigger.group(2)))
+
 
 def check_multiple(bot, words):
     mistakes = []
@@ -34,6 +36,7 @@ def check_multiple(bot, words):
     else:
         bot.say('The following word(s) seem to be misspelled: {0}'.format(', '.join(['"{0}"'.format(w) for w in mistakes])))
 
+
 def check_one(bot, word):
     c = aspell.Speller('lang', 'en')
     if c.check(word):
@@ -41,11 +44,12 @@ def check_one(bot, word):
         return
     else:
         suggestions = c.suggest(word)[:5]
-    
+
     if len(suggestions) == 0:
         bot.say("That doesn't seem to be correct.")
     else:
         bot.say("That doesn't seem to be correct. Try {0}.".format(', '.join(['"{0}"'.format(s) for s in suggestions])))
+
 
 @commands('spell')
 @example('.spell stuff')

--- a/sopel/modules/spellcheck.py
+++ b/sopel/modules/spellcheck.py
@@ -3,24 +3,102 @@
 """
 spellcheck.py - Sopel spelling checker module
 Copyright © 2016, Alan Huang
+Copyright © 2019, dgw
 Licensed under the Eiffel Forum License 2.
-http://sopel.chat
+https://sopel.chat
 """
 from __future__ import unicode_literals, absolute_import, print_function, division
 import aspell
 from sopel.module import commands, example, require_admin
 
 
-@commands('add')
+def setup(bot):
+    bot.memory['spellcheck_pending_adds'] = []
+
+
+def shutdown(bot):
+    try:
+        del bot.memory['spellcheck_pending_adds']
+    except KeyError:
+        pass
+
+
+@commands('scadd')
 @require_admin('I only trust admins to add words.')
 def add_command(bot, trigger):
     """
-    Add words to the bot's personal dictionary
+    Stage a word to be added to the bot's personal dictionary.
     """
+    bot.memory['spellcheck_pending_adds'].append(trigger.group(2))
+    bot.say('Added "{0}". (To review pending words, use {1}scpending. '
+            'To commit changes, use {1}scsave.)'
+            .format(trigger.group(2), bot.config.core.help_prefix))
+
+
+@commands('scpending')
+def pending_command(bot, trigger):
+    """
+    List words that are waiting to be saved to the bot's personal dictionary.
+    """
+    bot.say('Ready to save: "{0}". (To remove a word before saving, use {1}scdel '
+            'word, or clear the list with {1}scclear.)'
+            .format('", "'.join(bot.memory['spellcheck_pending_adds']),
+                    bot.config.core.help_prefix))
+
+
+@commands('scdel')
+@require_admin('Only admins may cancel a word-list addition.')
+def del_command(bot, trigger):
+    """
+    Remove a word from the list of pending personal dictionary additions.
+    """
+    try:
+        bot.memory['spellcheck_pending_adds'].remove(trigger.group(2))
+    except ValueError:
+        bot.say('Not in pending list: "{0}"'.format(trigger.group(2)))
+    else:
+        remaining = len(bot.memory['spellcheck_pending_adds'])
+        if remaining == 0:
+            remaining = 'No words'
+        elif remaining == 1:
+            remaining = 'One word'
+        else:
+            remaining = '{0} words'.format(remaining)
+        bot.say('Removed "{0}". ({1} remaining in pending list.)'
+                .format(trigger.group(2), remaining))
+
+
+@commands('scclear')
+@require_admin('Only admins may clear the pending word list.')
+def clear_command(bot, trigger):
+    """
+    Clear the list of words pending addition to the bot's personal dictionary.
+    """
+    count = len(bot.memory['spellcheck_pending_adds'])
+    del bot.memory['spellcheck_pending_adds'][:]  # list.clear() is py3.3+ only :(
+    bot.say('Cleared pending word list ({0} items).'.format(count))
+
+
+@commands('scsave')
+@require_admin('Only admins may commit word-list changes.')
+def save_command(bot, trigger):
+    """
+    Commit pending changes to the bot's personal dictionary. This action cannot be undone,
+    except by manually editing the aspell dictionary file.
+    """
+    for word in bot.memory['spellcheck_pending_adds']:
+        if word != word.strip() and trigger.group(2) != 'force':
+            bot.say('"{0} contains extra whitespace. Amend the pending list with '
+                    '{1}scdel/{1}scadd, or force saving anyway with {1}scsave force.'
+                    .format(word, bot.config.core.help_prefix))
+            return
     c = aspell.Speller('lang', 'en')
-    c.addtoPersonal(trigger.group(2))
+    for word in bot.memory['spellcheck_pending_adds']:
+        c.addtoPersonal(word)
     c.saveAllwords()
-    bot.say('Added {0}.'.format(trigger.group(2)))
+    bot.say('Saved {0} pending words to my word list.'
+            .format(len(bot.memory['spellcheck_pending_adds'])))
+    del bot.memory['spellcheck_pending_adds'][:]  # list.clear() is py3.3+ only :(
 
 
 def check_multiple(bot, words):
@@ -51,8 +129,8 @@ def check_one(bot, word):
         bot.say("That doesn't seem to be correct. Try {0}.".format(', '.join(['"{0}"'.format(s) for s in suggestions])))
 
 
-@commands('spell')
-@example('.spell stuff')
+@commands('spellcheck', 'spell', 'sc')
+@example('.spellcheck wrod')
 def spellchecker(bot, trigger):
     """
     Checks if the given word is spelled correctly, and suggests corrections.


### PR DESCRIPTION
I had experimented with this module a bit, and had found that I was completely unsatisfied with its performance (namely, the corrections it suggested). As a result, I rewrote the module to use aspell instead of pyenchant. The resulting performance satisfied me.