### PR TITLE
Fixes ConnectionError

### DIFF
--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -186,18 +186,20 @@ def check_callbacks(bot, trigger, url, run=True):
 
 def find_title(url, verify=True):
     """Return the title for the given URL."""
-    response = requests.get(url, stream=True, verify=verify,
-                            headers=default_headers)
     try:
+        response = requests.get(url, stream=True, verify=verify,
+                                headers=default_headers)
         content = b''
         for byte in response.iter_content(chunk_size=512):
             content += byte
             if b'</title>' in content or len(content) > max_bytes:
                 break
         content = content.decode('utf-8', errors='ignore')
-    finally:
-        # need to close the connexion because we have not read all the data
+        # Need to close the connection because we have not read all
+        # the data
         response.close()
+    except requests.exceptions.ConnectionError:
+        return None
 
     # Some cleanup that I don't really grok, but was in the original, so
     # we'll keep it (with the compiled regexes made global) for now.


### PR DESCRIPTION
url.find_title() throws ConnectionError when hostname/IPaddress is not
readable thereby fails to read title

Sample error
```
15:11:05 psachin:     https://10.65.177.15
15:11:09 BB-8:        requests.exceptions.ConnectionError: HTTPSConnectionPool(host='10.65.177.15', port=443): Max retries exceeded with url: / (Caused by NewConnectionError('<requests.packages.urllib3.connection.VerifiedHTTPSConnection object at 0x7feb41b6a2e8>: Failed to establish a new connection: [Errno 113] No route to host',)) (file "/home/tss/virtualenvs/sopel/lib64/python3.5/site-packages/requests/adapters.py", line 487, in send)
```