### PR TITLE
Fix .g giving broken links

### DIFF
--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -39,7 +39,7 @@ r_duck = re.compile(r'nofollow" class="[^"]+" href="(?!https?:\/\/r\.search\.yah
 def duck_search(query):
     query = query.replace('!', '')
     uri = 'http://duckduckgo.com/html/?q=%s&kl=uk-en' % query
-    bytes = web.get(uri)
+    bytes = web.get(uri,headers={"User-Agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36"})
     if 'web-result' in bytes:  # filter out the adds on top of the page
         bytes = bytes.split('web-result')[1]
     m = r_duck.search(bytes)

--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -39,7 +39,7 @@ r_duck = re.compile(r'nofollow" class="[^"]+" href="(?!https?:\/\/r\.search\.yah
 def duck_search(query):
     query = query.replace('!', '')
     uri = 'http://duckduckgo.com/html/?q=%s&kl=uk-en' % query
-    bytes = web.get(uri,headers={"User-Agent":"Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36"})
+    bytes = web.get(uri,headers={'User-Agent':'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36'})
     if 'web-result' in bytes:  # filter out the adds on top of the page
         bytes = bytes.split('web-result')[1]
     m = r_duck.search(bytes)

--- a/sopel/web.py
+++ b/sopel/web.py
@@ -179,7 +179,8 @@ def get_urllib_object(uri, timeout, headers=None, verify_ssl=True, data=None):
         headers = default_headers
     else:
         tmp = default_headers.copy()
-        headers = tmp.update(headers)
+        tmp.update(headers)
+        headers = tmp
     if data is not None:
         response = requests.post(uri, timeout=timeout, verify=verify_ssl,
                                  data=data, headers=headers)

--- a/sopel/web.py
+++ b/sopel/web.py
@@ -86,7 +86,7 @@ def get(uri, timeout=20, headers=None, return_headers=False,
         headers = default_headers
     else:
         tmp = default_headers.copy()
-        headers = tmp.update(headers)
+        tmp.update(headers)
     u = requests.get(uri, timeout=timeout, headers=headers, verify=verify_ssl)
     bytes = u.content
     u.close()

--- a/sopel/web.py
+++ b/sopel/web.py
@@ -87,6 +87,7 @@ def get(uri, timeout=20, headers=None, return_headers=False,
     else:
         tmp = default_headers.copy()
         tmp.update(headers)
+        headers = tmp
     u = requests.get(uri, timeout=timeout, headers=headers, verify=verify_ssl)
     bytes = u.content
     u.close()
@@ -116,7 +117,8 @@ def head(uri, timeout=20, headers=None, verify_ssl=True):
         headers = default_headers
     else:
         tmp = default_headers.copy()
-        headers = tmp.update(headers)
+        tmp.update(headers)
+        headers = tmp
     u = requests.get(uri, timeout=timeout, headers=headers, verify=verify_ssl)
     info = u.headers
     u.close()


### PR DESCRIPTION
This is a two part fix.
1. Fix in web.py for headers being set as blank if they were set in web.get()
2. Use a common user-agent string for duck_search function only.  
Replacing the Sopel version user-string for all web.get calls via web.py would have been a bit too extreme, in my opinion.