### PR TITLE
add physical limit to temperature conversion (units module)

### DIFF
--- a/sopel/modules/units.py
+++ b/sopel/modules/units.py
@@ -60,7 +60,7 @@ def temperature(bot, trigger):
     if kelvin >= 0:
         bot.reply("{:.2f}°C = {:.2f}°F = {:.2f}K".format(celsius, fahrenheit, kelvin))
     else:
-        bot.reply("Physically impossible temperature. Do you live in an imaginary world?")
+        bot.reply("Physically impossible temperature.")
 
 
 @commands('length', 'distance')

--- a/sopel/modules/units.py
+++ b/sopel/modules/units.py
@@ -56,7 +56,11 @@ def temperature(bot, trigger):
 
     kelvin = c_to_k(celsius)
     fahrenheit = c_to_f(celsius)
-    bot.reply("{:.2f}°C = {:.2f}°F = {:.2f}K".format(celsius, fahrenheit, kelvin))
+
+    if kelvin >= 0:
+        bot.reply("{:.2f}°C = {:.2f}°F = {:.2f}K".format(celsius, fahrenheit, kelvin))
+    else:
+        bot.reply("Physically impossible temperature. Do you live in an imaginary world?")
 
 
 @commands('length', 'distance')


### PR DESCRIPTION
There is a bug in the units module (temp sub-module): the user is allowed to convert temperatures below the absolute 0 Kelvin, which is not physically possible. This small code modification allows to return the correct answer to the conversion only if the result if 0 Kelvin or above and will return an error to the user if the resulting temperature for the conversion is below 0 K. 