### PR TITLE
Added key support for movie module

### DIFF
--- a/sopel/modules/movie.py
+++ b/sopel/modules/movie.py
@@ -15,17 +15,18 @@ LOGGER = get_logger(__name__)
 
 
 @sopel.module.commands('movie', 'imdb')
-@sopel.module.example('.movie ThisTitleDoesNotExist', '[MOVIE] Movie not found!')
-@sopel.module.example('.movie Citizen Kane', '[MOVIE] Title: Citizen Kane | Year: 1941 | Rating: 8.4 | Genre: Drama, Mystery | IMDB Link: http://imdb.com/title/tt0033467')
+@sopel.module.example('.movie ThisTitleDoesNotExist', '[MOVIE] Movie not found!', ignore=["[MOVIE] No API key provided."])
+@sopel.module.example('.movie Citizen Kane', '[MOVIE] Title: Citizen Kane | Year: 1941 | Rating: 8.4 | Genre: Drama, Mystery | IMDB Link: http://imdb.com/title/tt0033467', ignore=["[MOVIE] No API key provided."])
 def movie(bot, trigger):
     """
     Returns some information about a movie, like Title, Year, Rating, Genre and IMDB Link.
     """
     if not trigger.group(2):
         return
+    api_key = bot.config.movie.omdb_api_key
     word = trigger.group(2).rstrip()
     uri = "http://www.omdbapi.com/"
-    data = requests.get(uri, params={'t': word}, timeout=30,
+    data = requests.get(uri, params={'t': word, 'apikey': api_key}, timeout=30,
                         verify=bot.config.core.verify_ssl).json()
     if data['Response'] == 'False':
         if 'Error' in data:
@@ -42,6 +43,19 @@ def movie(bot, trigger):
                   ' | Genre: ' + data['Genre'] + \
                   ' | IMDB Link: http://imdb.com/title/' + data['imdbID']
     bot.say(message)
+
+
+class MovieSection(StaticSection):
+    omdb_api_key = ValidatedAttribute('omdb_api_key', default=NO_DEFAULT)
+    """The OMDb API key"""
+
+
+def configure(config):
+    config.define_section('movie', MovieSection, validate=False)
+    config.movie.configure_setting(
+        'omdb_api_key',
+        'Enter your OMDb API key.',
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
As of May 8, 2017, the OMDb API has gone private. From now on it requires a paid API key to function.
This change adds support for an api key in the configuration file.
It also changes the module command examples so that they will not fail the CI tests if there is no API key.