### PR TITLE
Added key support for movie module

### DIFF
--- a/sopel/modules/movie.py
+++ b/sopel/modules/movie.py
@@ -9,9 +9,24 @@ This module relies on omdbapi.com
 from __future__ import unicode_literals, absolute_import, print_function, division
 import requests
 import sopel.module
+from sopel.config.types import StaticSection, ValidatedAttribute, NO_DEFAULT
 from sopel.logger import get_logger
 
 LOGGER = get_logger(__name__)
+
+
+class MovieSection(StaticSection):
+    omdb_api_key = ValidatedAttribute('omdb_api_key', default=NO_DEFAULT)
+    """The OMDb API key"""
+
+
+def configure(config):
+    config.define_section('movie', MovieSection, validate=False)
+    config.movie.configure_setting('omdb_api_key', 'Enter your OMDb API key.')
+    
+    
+def setup(bot):
+    bot.config.define_section('movie', MovieSection)
 
 
 @sopel.module.commands('movie', 'imdb')
@@ -23,9 +38,10 @@ def movie(bot, trigger):
     """
     if not trigger.group(2):
         return
+    api_key = bot.config.movie.omdb_api_key
     word = trigger.group(2).rstrip()
     uri = "http://www.omdbapi.com/"
-    data = requests.get(uri, params={'t': word}, timeout=30,
+    data = requests.get(uri, params={'t': word, 'apikey': api_key}, timeout=30,
                         verify=bot.config.core.verify_ssl).json()
     if data['Response'] == 'False':
         if 'Error' in data:


### PR DESCRIPTION
As of May 8, 2017, the OMDb API has gone private. From now on it requires a paid API key to function.
This change adds support for an api key in the configuration file.
It also changes the module command examples so that they will not fail the CI tests if there is no API key.