### PR TITLE
logger: format arguments for logging channel messages

### DIFF
--- a/sopel/logger.py
+++ b/sopel/logger.py
@@ -23,7 +23,7 @@ class IrcLoggingHandler(logging.Handler):
 class ChannelOutputFormatter(logging.Formatter):
     def __init__(self):
         super(ChannelOutputFormatter, self).__init__(
-            fmt='[%(filename)s] %(msg)s'
+            fmt='[%(filename)s] %(message)s'
         )
 
     def formatException(self, exc_info):


### PR DESCRIPTION
Original code logged the unformatted message string. Something like this:
 [module] Found error while doing %s

Instead of:
 [module] Found error while doing foo

Replacing msg with message fixes this behaviour