### PR TITLE
safety module - catch exception on urllib/parse

### DIFF
--- a/sopel/modules/safety.py
+++ b/sopel/modules/safety.py
@@ -115,7 +115,11 @@ def url_handler(bot, trigger):
     if not check:
         return  # Not overriden by DB, configured default off
 
-    netloc = urlparse(trigger.group(1)).netloc
+    try:
+        netloc = urlparse(trigger.group(1)).netloc
+    except ValueError:
+        return  # Invalid IPv6 URL
+
     if any(regex.search(netloc) for regex in known_good):
         return  # Whitelisted
 


### PR DESCRIPTION
Should ignore exception when checked URL is wrong eg `https://cnn.com]`
Got this error on Python 3.5.2, master release.

not sure this is good solution though...

```
ValueError: Invalid IPv6 URL
  File "sopel/bot.py", line 497, in call
    exit_code = func(sopel, trigger)
  File "modules/safety.py", line 119, in url_handler
    netloc = urlparse(trigger.group(1)).netloc
  File "urllib/parse.py", line 295, in urlparse
    splitresult = urlsplit(url, scheme, allow_fragments)
  File "urllib/parse.py", line 368, in urlsplit
    raise ValueError("Invalid IPv6 URL")
```
