### PR TITLE
Support disabling modules/commands per channel

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -7,6 +7,7 @@
 
 from __future__ import unicode_literals, absolute_import, print_function, division
 
+from ast import literal_eval
 import collections
 import os
 import re
@@ -465,6 +466,28 @@ class Sopel(irc.Bot):
                         func.channel_rate
                     )
                     return
+
+        # if channel has its own config section, check for excluded modules/modules methods
+        if trigger.sender in self.config:
+            channel_config = self.config[trigger.sender]
+
+            # disable listed modules completely on provided channel
+            if 'disable_modules' in channel_config:
+                disabled_modules = channel_config.disable_modules.split(',')
+
+                # if "*" is used, we are disabling all modules on provided channel
+                if '*' in disabled_modules:
+                    return
+                if func.__module__ in disabled_modules:
+                    return
+
+            # disable chosen methods from modules
+            if 'disable_commands' in channel_config:
+                disabled_commands = literal_eval(channel_config.disable_commands)
+
+                if func.__module__ in disabled_commands:
+                    if func.__name__ in disabled_commands[func.__module__]:
+                        return
 
         try:
             exit_code = func(sopel, trigger)

--- a/sopel/config/__init__.py
+++ b/sopel/config/__init__.py
@@ -138,6 +138,9 @@ class Config(object):
         def __getattr__(self, name):
             return None
 
+        def __contains__(self, name):
+            return name in vars(self)
+
         def __setattr__(self, name, value):
             object.__setattr__(self, name, value)
             if type(value) is list:
@@ -163,6 +166,12 @@ class Config(object):
         else:
             raise AttributeError("%r object has no attribute %r"
                                  % (type(self).__name__, name))
+
+    def __getitem__(self, name):
+        return self.__getattr__(name)
+
+    def __contains__(self, name):
+        return name in self.parser.sections()
 
     def option(self, question, default=False):
         """Ask "y/n" and return the corresponding boolean answer.


### PR DESCRIPTION
Ability to disable modules or even methods inside chosen modules for channel name using default configuration file.

In this example we are disabling modules / modules methods on `#example` channel.
`disable_modules` is used to completely disable provided modules on channel for example `choice, weather` won't respond at all.

`disable_commands` is used to disable methods from provided modules for example `event_watcher` from `url` module which means all other methods should work (unless disabled are needed).

Adding other channel excludes is as simple as adding another section named like channel.
```
...

[#example]
disable_modules = choice,weather
disable_commands = {"url": ["event_watcher"]}
```

----

Resolves #64, after many long years and multiple project renames. — @dgw