### PR TITLE
help module - remove duplicates

### DIFF
--- a/sopel/modules/help.py
+++ b/sopel/modules/help.py
@@ -60,6 +60,7 @@ def help(bot, trigger):
             name_length = max(6, max(len(k) for k in bot.command_groups.keys()))
             for category, cmds in collections.OrderedDict(sorted(bot.command_groups.items())).items():
                 category = category.upper().ljust(name_length)
+                cmds = set(cmds)  # remove duplicates
                 cmds = '  '.join(cmds)
                 msg = category + '  ' + cmds
                 indent = ' ' * (name_length + 2)


### PR DESCRIPTION
Remove duplicates in help output. They are showing itself after plugin reload/unload... I don't really remember but worth taking care as well ;-)