### PR TITLE
core, loader, version: Fix intent handling and CTCP replies

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -224,8 +224,11 @@ class Sopel(irc.Bot):
     def register(self, callables, jobs, shutdowns, urls):
         self.shutdown_methods = shutdowns
         for callbl in callables:
-            for rule in callbl.rule:
-                self._callables[callbl.priority][rule].append(callbl)
+            if hasattr(callbl, 'rule'):
+                for rule in callbl.rule:
+                    self._callables[callbl.priority][rule].append(callbl)
+            else:
+                self._callables[callbl.priority][re.compile('.*')].append(callbl)
             if hasattr(callbl, 'commands'):
                 module_name = callbl.__module__.rsplit('.', 1)[-1]
                 # TODO doc and make decorator for this. Not sure if this is how
@@ -513,9 +516,15 @@ class Sopel(irc.Bot):
 
                     if event not in func.event:
                         continue
-                    if (hasattr(func, 'intents') and
-                            trigger.tags.get('intent') not in func.intents):
-                        continue
+                    if hasattr(func, 'intents'):
+                        if not trigger.tags.get('intent'):
+                            continue
+                        match = False
+                        for intent in func.intents:
+                            if intent.match(trigger.tags.get('intent')):
+                                match = True
+                        if not match:
+                            continue
                     if func.thread:
                         targs = (func, wrapper, trigger)
                         t = threading.Thread(target=self.call, args=targs)

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -189,6 +189,8 @@ def clean_callable(func, config):
             for command in func.commands:
                 func._docs[command] = (doc, example)
 
+    if hasattr(func, 'intents'):
+        func.intents = [re.compile(intent, re.IGNORECASE) for intent in func.intents]
 
 def load_module(name, path, type_):
     """Load a module, and sort out the callables and shutdowns"""
@@ -203,7 +205,7 @@ def load_module(name, path, type_):
 
 
 def is_triggerable(obj):
-    return any(hasattr(obj, attr) for attr in ('rule', 'intent', 'commands'))
+    return any(hasattr(obj, attr) for attr in ('rule', 'intents', 'commands'))
 
 
 def clean_module(module, config):

--- a/sopel/modules/version.py
+++ b/sopel/modules/version.py
@@ -10,7 +10,8 @@ http://sopel.chat
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 from datetime import datetime
-import sopel
+from sopel import __version__ as release
+from sopel.module import commands, intent, rate
 import re
 from os import path
 
@@ -31,10 +32,9 @@ def git_info():
                     return sha
 
 
-@sopel.module.commands('version')
+@commands('version')
 def version(bot, trigger):
     """Display the latest commit version, if Sopel is running in a git repo."""
-    release = sopel.__version__
     sha = git_info()
     if not sha:
         msg = 'Sopel v. ' + release
@@ -43,25 +43,25 @@ def version(bot, trigger):
         bot.reply(msg)
         return
 
-    bot.reply("Sopel v. {} at commit: {}".format(sopel.__version__, sha))
+    bot.reply("Sopel v. {} at commit: {}".format(release, sha))
 
 
-@sopel.module.intent('VERSION')
-@sopel.module.rate(20)
+@intent('VERSION')
+@rate(20)
 def ctcp_version(bot, trigger):
     bot.write(('NOTICE', trigger.nick),
-              '\x01VERSION Sopel IRC Bot version %s\x01' % sopel.__version__)
+              '\x01VERSION Sopel IRC Bot version %s\x01' % release)
 
 
-@sopel.module.intent('SOURCE')
-@sopel.module.rate(20)
+@intent('SOURCE')
+@rate(20)
 def ctcp_source(bot, trigger):
     bot.write(('NOTICE', trigger.nick),
               '\x01SOURCE https://github.com/sopel-irc/sopel/\x01')
 
 
-@sopel.module.intent('PING')
-@sopel.module.rate(10)
+@intent('PING')
+@rate(10)
 def ctcp_ping(bot, trigger):
     text = trigger.group()
     text = text.replace("PING ", "")
@@ -70,8 +70,8 @@ def ctcp_ping(bot, trigger):
               '\x01PING {0}\x01'.format(text))
 
 
-@sopel.module.intent('TIME')
-@sopel.module.rate(20)
+@intent('TIME')
+@rate(20)
 def ctcp_time(bot, trigger):
     dt = datetime.now()
     current_time = dt.strftime("%A, %d. %B %Y %I:%M%p")

--- a/sopel/modules/version.py
+++ b/sopel/modules/version.py
@@ -48,21 +48,19 @@ def version(bot, trigger):
 
 @sopel.module.intent('VERSION')
 @sopel.module.rate(20)
-@sopel.module.rule('.*')
 def ctcp_version(bot, trigger):
-    print('wat')
     bot.write(('NOTICE', trigger.nick),
               '\x01VERSION Sopel IRC Bot version %s\x01' % sopel.__version__)
 
 
-@sopel.module.rule('\x01SOURCE\x01')
+@sopel.module.intent('SOURCE')
 @sopel.module.rate(20)
 def ctcp_source(bot, trigger):
     bot.write(('NOTICE', trigger.nick),
               '\x01SOURCE https://github.com/sopel-irc/sopel/\x01')
 
 
-@sopel.module.rule('\x01PING\s(.*)\x01')
+@sopel.module.intent('PING')
 @sopel.module.rate(10)
 def ctcp_ping(bot, trigger):
     text = trigger.group()
@@ -72,7 +70,7 @@ def ctcp_ping(bot, trigger):
               '\x01PING {0}\x01'.format(text))
 
 
-@sopel.module.rule('\x01TIME\x01')
+@sopel.module.intent('TIME')
 @sopel.module.rate(20)
 def ctcp_time(bot, trigger):
     dt = datetime.now()


### PR DESCRIPTION
This PR fixes #1240.
Changes to intents:
- they are now added to _callables for all messages (.*)
- they are now converted to regular expressions, like rules
- they now have more reliable (?) handling in dispatch()