### PR TITLE
Use the stdlib HTMLParser to extract HTML document titles instead of regex

### DIFF
--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -254,7 +254,7 @@ def find_title(url, verify=True):
     except requests.exceptions.RequestException:
         # Unspecified error from requests module, just bail
         return None
-    except Exception as e:
+    except Exception:
         # Something went wrong in parsing the stream, this would be a good place
         # for logging if we had any
         r.close()

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -254,7 +254,7 @@ def find_title(url, verify=True):
         # We're not going to retry since this is isn't very useful if it takes forever
         # and we want to just fail fast
         return None
-    except requests.exceptions.RequestException as e:
+    except requests.exceptions.RequestException:
         # Unspecified error from requests module, just bail
         return None
     except Exception as e:
@@ -268,6 +268,7 @@ def find_title(url, verify=True):
     if len(title) > 200:
         title = title[:200] + '...'
     return title
+
 
 def get_hostname(url):
     idx = 7


### PR DESCRIPTION
Some pages have scripts and other crazy things in their `<head>`, thwarting the module that tries to fetch page titles. I've removed the regex matching and associated kludges, replacing them with a simple title tag parser using the builtin HTMLParser from the stdlib. Downloads a minimum amount of data to find the title.

Closes #1226 and closes #1213.

I think this is a better solution than PR #1215, which only works if the correct title tags are found last.