### PR TITLE
currency: limit precision to two decimal places

### DIFF
--- a/sopel/modules/currency.py
+++ b/sopel/modules/currency.py
@@ -74,7 +74,7 @@ def display(bot, amount, of, to):
         return NOLIMIT
 
     result = amount / of_rate * to_rate
-    bot.say("{} {} ({}) = {} {} ({})".format(amount, of.upper(), of_name,
+    bot.say("{:.2f} {} ({}) = {:.2f} {} ({})".format(amount, of.upper(), of_name,
                                              result, to.upper(), to_name))
 
 


### PR DESCRIPTION
This PR fixes #1253.

Should it be possible to set a custom precision? It'd be an easy addition.