### PR TITLE
Fix IPython requirement

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,2 +1,3 @@
 pytest
-ipython
+ipython<6.0; python_version < '3.3'
+ipython>=6.0; python_version >= '3.3'

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,1 @@
 pytest
-ipython<6.0; python_version < '3.3'
-ipython>=6.0; python_version >= '3.3'

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,5 @@ pytz
 praw
 pyenchant
 pygeoip
+ipython
 requests>=2.0.0,<2.11.0


### PR DESCRIPTION
IPython 6.0+ requires Python 3.3+, so only install that version if we're using Python 3.3+.

This fixes #1194.