### PR TITLE
Allow any 2.x version of requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ praw
 pyenchant
 pygeoip
 ipython
-requests>=2.0.0,<2.11.0
+requests>=2.0.0,<3.0.0


### PR DESCRIPTION
Testing with the latest `requests` (2.18.4 as of writing) showed no issues with all the Sopel modules and functions that I was able to try out.

Newer versions of PRAW (which the `reddit.py` module needs) prefer to be installed with more recent versions of `requests`, and I see no reason not to keep up with `requests` releases unless something breaks.