### PR TITLE
Require PRAW >= 4.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 xmltodict
 pytz
-praw
+praw>=4.0.0,<6.0.0
 pyenchant
 pygeoip
 requests>=2.0.0,<2.11.0


### PR DESCRIPTION
The new `reddit.py` module (updated in December) will not work with PRAW older than 4.0.0. Sopel must therefore require a compatible version.