### PR TITLE
[wikipedia] Return friendly error on missing pages

### DIFF
--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -61,7 +61,12 @@ def mw_search(server, query, num):
 def say_snippet(bot, server, query, show_url=True):
     page_name = query.replace('_', ' ')
     query = query.replace(' ', '_')
-    snippet = mw_snippet(server, query)
+    try:
+        snippet = mw_snippet(server, query)
+    except KeyError:
+        if not show_url:
+            return
+        return bot.say("[WIKIPEDIA] Error fetching snippet for \"{}\".".format(page_name))
     msg = '[WIKIPEDIA] {} | "{}"'.format(page_name, snippet)
     if show_url:
         msg = msg + ' | https://{}/wiki/{}'.format(server, query)

--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -64,9 +64,9 @@ def say_snippet(bot, server, query, show_url=True):
     try:
         snippet = mw_snippet(server, query)
     except KeyError:
-        if not show_url:
-            return
-        return bot.say("[WIKIPEDIA] Error fetching snippet for \"{}\".".format(page_name))
+        if show_url:
+            bot.say("[WIKIPEDIA] Error fetching snippet for \"{}\".".format(page_name))
+        return
     msg = '[WIKIPEDIA] {} | "{}"'.format(page_name, snippet)
     if show_url:
         msg = msg + ' | https://{}/wiki/{}'.format(server, query)


### PR DESCRIPTION
Sopel will now say a human-friendly error message when a Wikipedia link pointing to a non-existent article is posted, instead of a cryptic KeyError.

Fixes #1256