### PR TITLE
Clean up badges in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,4 +1,4 @@
-|version| |downloads| |license| |build| |issues| |forks| |stars| |ages| |works| |badges|
+|version| |build| |issues| |coverage-status| |license|
 
 Introduction
 ------------
@@ -59,24 +59,13 @@ Questions?
 
 Join us in `#sopel <irc://irc.freenode.net/#sopel>`_ on Freenode.
 
-.. |status| image:: https://travis-ci.org/sopel-irc/sopel.svg
-   :target: https://travis-ci.org/sopel-irc/sopel
-.. |coverage-status| image:: https://coveralls.io/repos/sopel-irc/sopel/badge.png
-   :target: https://coveralls.io/r/sopel-irc/sopel
 .. |version| image:: https://img.shields.io/pypi/v/sopel.svg
    :target: https://pypi.python.org/pypi/sopel
-.. |downloads| image:: https://img.shields.io/pypi/dm/sopel.svg
-   :target: https://pypi.python.org/pypi/sopel
+.. |build| image:: https://travis-ci.org/sopel-irc/sopel.svg?branch=master
+   :target: https://travis-ci.org/sopel-irc/sopel
+.. |issues| image:: https://img.shields.io/github/issues/sopel-irc/sopel.svg
+   :target: https://github.com/sopel-irc/issues
+.. |coverage-status| image:: https://coveralls.io/repos/github/sopel-irc/sopel/badge.svg?branch=master
+   :target: https://coveralls.io/github/sopel-irc/sopel?branch=master
 .. |license| image:: https://img.shields.io/pypi/l/sopel.svg
    :target: https://github.com/sopel-irc/sopel/blob/master/COPYING
-.. |build| image:: https://travis-ci.org/sopel-irc/sopel.svg?branch=master
-    :target: https://travis-ci.org/sopel-irc/sopel
-.. |issues| image:: https://img.shields.io/github/issues/sopel-irc/sopel.svg
-   :target: https://github.com/sopel-irc/sopel/issues
-.. |forks| image:: https://img.shields.io/github/forks/sopel-irc/sopel.svg
-   :target: https://github.com/sopel-irc/sopel/network
-.. |stars| image:: https://img.shields.io/github/stars/sopel-irc/sopel.svg
-   :target: https://github.com/sopel-irc/sopel/stargazers
-.. |ages| image:: https://img.shields.io/badge/ages-12%2B-green.svg
-.. |works| image:: https://img.shields.io/badge/works-usually-yellow.svg
-.. |badges| image:: https://img.shields.io/badge/badges-10-green.svg

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,5 @@
-|version| |build| |issues| |coverage-status| |license|
-
-Introduction
-------------
+Introduction |version| |build| |issues| |coverage-status| |license|
+-------------------------------------------------------------------
 
 Sopel is a simple, lightweight, open source, easy-to-use IRC Utility bot,
 written in Python. It's designed to be easy to use, run and extend.


### PR DESCRIPTION
PyPI download count information is no longer available, so that badge is patently useless now (it literally shows "no longer available" as the download count).

I understand the sense of whimsy that comes from saying "works: usually" or "ages: 12+" in badges, but at the same time the badge real estate at the top of a README is for practical information that potential contributors/users need to know. I'm also not sure there's any value in bragging about how many stars/forks the project has in the README. That information isn't really relevant on PyPI, where the README gets the most exposure, and is readily available from GitHub's UI for users visiting the project there.