### PR TITLE
Make __future__ imports consistent

### DIFF
--- a/pytest_run.py
+++ b/pytest_run.py
@@ -11,7 +11,7 @@ Licensed under the Eiffel Forum License 2.
 
 http://sopel.chat
 """
-from __future__ import unicode_literals
+from __future__ import unicode_literals, absolute_import, print_function, division
 
 if __name__ == "__main__":
     import sys

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-from __future__ import unicode_literals, print_function
+from __future__ import unicode_literals, absolute_import, print_function, division
 
 from sopel import __version__
 import sys

--- a/sopel.py
+++ b/sopel.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # coding=utf-8
-from __future__ import absolute_import
+from __future__ import unicode_literals, absolute_import, print_function, division
 # Different from setuptools script, because we want the one in this dir.
 from sopel import run_script
 run_script.main()

--- a/sopel/__init__.py
+++ b/sopel/__init__.py
@@ -11,6 +11,7 @@
 # Licensed under the Eiffel Forum License 2.
 
 from __future__ import unicode_literals, absolute_import, print_function, division
+
 import locale
 import sys
 loc = locale.getlocale()

--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -25,6 +25,7 @@ As an example, if one wanted to define the ``[spam]`` section as having an
 """
 
 from __future__ import unicode_literals, absolute_import, print_function, division
+
 import os.path
 import sys
 from sopel.tools import get_input

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -12,7 +12,6 @@ dispatch function in bot.py and making it easier to maintain.
 # Licensed under the Eiffel Forum License 2.
 from __future__ import unicode_literals, absolute_import, print_function, division
 
-
 from random import randint
 import re
 import sys

--- a/sopel/formatting.py
+++ b/sopel/formatting.py
@@ -6,6 +6,7 @@
 # Copyright 2014, Elsie Powell, embolalia.com
 # Licensed under the Eiffel Forum License 2.
 from __future__ import unicode_literals, absolute_import, print_function, division
+
 import sys
 if sys.version_info.major >= 3:
     unicode = str

--- a/sopel/modules/countdown.py
+++ b/sopel/modules/countdown.py
@@ -7,6 +7,7 @@ Licensed under the Eiffel Forum License 2.
 http://sopel.chat
 """
 from __future__ import unicode_literals, absolute_import, print_function, division
+
 from sopel.module import commands, NOLIMIT
 import datetime
 

--- a/sopel/modules/dice.py
+++ b/sopel/modules/dice.py
@@ -8,6 +8,7 @@ Licensed under the Eiffel Forum License 2.
 http://sopel.chat/
 """
 from __future__ import unicode_literals, absolute_import, print_function, division
+
 import random
 import re
 import operator

--- a/sopel/modules/ipython.py
+++ b/sopel/modules/ipython.py
@@ -7,6 +7,7 @@ Licensed under the Eiffel Forum License 2.
 Sopel: http://sopel.chat/
 """
 from __future__ import unicode_literals, absolute_import, print_function, division
+
 import sopel
 import sys
 if sys.version_info.major >= 3:

--- a/sopel/modules/lmgtfy.py
+++ b/sopel/modules/lmgtfy.py
@@ -7,6 +7,7 @@ Licensed under the Eiffel Forum License 2.
 http://sopel.chat/
 """
 from __future__ import unicode_literals, absolute_import, print_function, division
+
 from sopel.module import commands
 
 

--- a/sopel/modules/meetbot.py
+++ b/sopel/modules/meetbot.py
@@ -7,6 +7,7 @@ Licensed under the Eiffel Forum License 2.
 This module is an attempt to implement at least some of the functionallity of Debian's meetbot
 """
 from __future__ import unicode_literals, absolute_import, print_function, division
+
 import time
 import os
 from sopel.config.types import (

--- a/sopel/modules/movie.py
+++ b/sopel/modules/movie.py
@@ -7,6 +7,7 @@ Licensed under the Eiffel Forum License 2.
 This module relies on omdbapi.com
 """
 from __future__ import unicode_literals, absolute_import, print_function, division
+
 import requests
 import sopel.module
 from sopel.logger import get_logger

--- a/sopel/modules/spellcheck.py
+++ b/sopel/modules/spellcheck.py
@@ -10,6 +10,7 @@ http://sopel.chat
 This module relies on pyenchant, on Fedora and Red Hat based system, it can be found in the package python-enchant
 """
 from __future__ import unicode_literals, absolute_import, print_function, division
+
 try:
     import enchant
 except ImportError:

--- a/sopel/modules/translate.py
+++ b/sopel/modules/translate.py
@@ -7,8 +7,8 @@ Licensed under the Eiffel Forum License 2.
 
 http://sopel.chat
 """
-from __future__ import (unicode_literals, absolute_import,
-                        print_function, division)
+from __future__ import unicode_literals, absolute_import, print_function, division
+
 import json
 import random
 import sys

--- a/sopel/modules/unicode_info.py
+++ b/sopel/modules/unicode_info.py
@@ -4,6 +4,7 @@
 # Copyright 2008, Sean B. Palmer, inamidst.com
 # Licensed under the Eiffel Forum License 2.
 from __future__ import unicode_literals, absolute_import, print_function, division
+
 import unicodedata
 import sys
 from sopel.module import commands, example, NOLIMIT

--- a/sopel/modules/units.py
+++ b/sopel/modules/units.py
@@ -7,6 +7,7 @@ Licensed under the Eiffel Forum License 2.
 
 """
 from __future__ import unicode_literals, absolute_import, print_function, division
+
 from sopel.module import commands, example, NOLIMIT
 import re
 

--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -2,6 +2,7 @@
 # Copyright 2013 Elsie Powell - embolalia.com
 # Licensed under the Eiffel Forum License 2.
 from __future__ import unicode_literals, absolute_import, print_function, division
+
 from sopel import web, tools
 from sopel.config.types import StaticSection, ValidatedAttribute
 from sopel.module import NOLIMIT, commands, example, rule

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -4,8 +4,7 @@
 TODO: Most of these tests assume functionality tested in other tests. This is
 enough to get everything working (and is better than nothing), but best
 practice would probably be not to do that."""
-from __future__ import unicode_literals
-from __future__ import absolute_import
+from __future__ import unicode_literals, absolute_import, print_function, division
 
 import json
 import os

--- a/test/test_irc.py
+++ b/test/test_irc.py
@@ -1,6 +1,6 @@
 # coding=utf8
 """Tests for message formatting"""
-from __future__ import unicode_literals
+from __future__ import unicode_literals, absolute_import, print_function, division
 
 import pytest
 


### PR DESCRIPTION
`CONTRIBUTING` says Python files should always have a specific set of imports from `__future__` as the first line after the docstring. Some were missing or incomplete; others were surrounded by the wrong amount of whitespace. (These were corrected manually, so omissions are accidental.)