### PR TITLE
Start failing builds on style checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - pip install coveralls
   - pip install flake8
 script:
-  - ./checkstyle.sh || true
+  - ./checkstyle.sh
   - coverage run --source sopel -m py.test -v .
   - coverage report --show-missing
 after_success:

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ def read_reqs(path):
     with open(path, 'r') as fil:
         return list(fil.readlines())
 
+
 requires = read_reqs('requirements.txt')
 if sys.version_info[0] < 3:
     requires.append('backports.ssl_match_hostname')

--- a/sopel/__init__.py
+++ b/sopel/__init__.py
@@ -52,6 +52,8 @@ def _version_info(version=__version__):
     version_type = namedtuple('version_info',
                               'major, minor, micro, releaselevel, serial')
     return version_type(major, minor, micro, level, serial)
+
+
 version_info = _version_info()
 
 
@@ -80,11 +82,11 @@ def run(config, pid_file, daemon=False):
             p.run(config.core.host, int(config.core.port))
         except KeyboardInterrupt:
             break
-        except Exception:
+        except Exception:  # TODO: Be specific
             trace = traceback.format_exc()
             try:
                 stderr(trace)
-            except:
+            except Exception:  # TODO: Be specific
                 pass
             logfile = open(os.path.join(config.core.logdir, 'exceptions.log'), 'a')
             logfile.write('Critical exception in core')

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -220,8 +220,8 @@ class Sopel(irc.Bot):
             # TODO this should somehow find the right job to remove, rather than
             # clearing the entire queue. Issue #831
             self.scheduler.clear_jobs()
-        if (getattr(obj, '__name__', None) == 'shutdown'
-                and obj in self.shutdown_methods):
+        if (getattr(obj, '__name__', None) == 'shutdown' and
+                    obj in self.shutdown_methods):
             self.shutdown_methods.remove(obj)
 
     def register(self, callables, jobs, shutdowns, urls):
@@ -473,7 +473,7 @@ class Sopel(irc.Bot):
 
         try:
             exit_code = func(sopel, trigger)
-        except Exception:
+        except Exception:  # TODO: Be specific
             exit_code = None
             self.error(trigger)
 

--- a/sopel/config/__init__.py
+++ b/sopel/config/__init__.py
@@ -109,8 +109,8 @@ class Config(object):
         current = getattr(self, name, None)
         current_name = str(current.__class__)
         new_name = str(cls_)
-        if (current is not None and not isinstance(current, self.ConfigSection)
-                and not current_name == new_name):
+        if (current is not None and not isinstance(current, self.ConfigSection) and
+                not current_name == new_name):
             raise ValueError(
                 "Can not re-define class for section from {} to {}.".format(
                     current_name, new_name)
@@ -255,7 +255,7 @@ def _create_config(configpath):
         ):
             config._modules()
         config.save()
-    except Exception:
+    except Exception:  # TODO: Be specific
         print("Encountered an error while writing the config file." +
               " This shouldn't happen. Check permissions.")
         raise

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -27,7 +27,7 @@ def _find_certs():
         '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem',  # RHEL 7 / CentOS
         '/etc/pki/tls/cacert.pem',  # OpenELEC
         '/etc/ssl/ca-bundle.pem',  # OpenSUSE
-        ]
+    ]
     for certs in locations:
         if os.path.isfile(certs):
             return certs

--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -30,11 +30,6 @@ import os.path
 import sys
 from sopel.tools import get_input
 
-try:
-    import configparser
-except ImportError:
-    import ConfigParser as configparser
-
 if sys.version_info.major >= 3:
     unicode = str
     basestring = (str, bytes)

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -49,7 +49,7 @@ def auth_after_register(bot):
             'AUTHSERV auth',
             account + ' ' + password
         ))
-    
+
     elif bot.config.core.auth_method == 'Q':
         account = bot.config.core.auth_username
         password = bot.config.core.auth_password

--- a/sopel/db.py
+++ b/sopel/db.py
@@ -23,7 +23,7 @@ def _deserialize(value):
     # ignore json parsing errors
     try:
         value = json.loads(value)
-    except:
+    except ValueError:
         pass
     return value
 
@@ -71,7 +71,7 @@ class SopelDB(object):
             self.execute('SELECT * FROM nicknames;')
             self.execute('SELECT * FROM nick_values;')
             self.execute('SELECT * FROM channel_values;')
-        except:
+        except Exception:  # TODO: Be specific
             pass
         else:
             return

--- a/sopel/irc.py
+++ b/sopel/irc.py
@@ -126,8 +126,8 @@ class Bot(asynchat.async_chat):
         if text is not None:
             text = self.safe(text)
         try:
-            self.writing_lock.acquire()  # Blocking lock, can't send two things
-                                         # at a time
+            # Blocking lock, can't send two things at a time
+            self.writing_lock.acquire()
 
             # From RFC2812 Internet Relay Chat: Client Protocol
             # Section 2.3
@@ -304,7 +304,7 @@ class Bot(asynchat.async_chat):
                 # Okay, let's try ISO8859-1
                 try:
                     data = unicode(data, encoding='iso8859-1')
-                except:
+                except UnicodeDecodeError:
                     # Discard line if encoding is unknown
                     return
 

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -16,8 +16,8 @@ _regex_type = type(re.compile(''))
 
 
 def get_module_description(path):
-    good_file = (os.path.isfile(path) and path.endswith('.py')
-                 and not path.startswith('_'))
+    good_file = (os.path.isfile(path) and
+                 path.endswith('.py') and not path.startswith('_'))
     good_dir = (os.path.isdir(path) and
                 os.path.isfile(os.path.join(path, '__init__.py')))
     if good_file:
@@ -68,7 +68,7 @@ def enumerate_modules(config, show_all=False):
     # TODO does this work with all possible install mechanisms?
     try:
         import sopel_modules
-    except:
+    except Exception:  # TODO: Be specific
         pass
     else:
         for directory in sopel_modules.__path__:

--- a/sopel/logger.py
+++ b/sopel/logger.py
@@ -16,7 +16,7 @@ class IrcLoggingHandler(logging.Handler):
             self._bot.msg(self._channel, msg)
         except (KeyboardInterrupt, SystemExit):
             raise
-        except:
+        except Exception:  # TODO: Be specific
             self.handleError(record)
 
 

--- a/sopel/modules/clock.py
+++ b/sopel/modules/clock.py
@@ -133,7 +133,7 @@ def update_user_format(bot, trigger):
 
     try:
         timef = format_time(db=bot.db, zone=tz, nick=trigger.nick)
-    except:
+    except Exception:  # TODO: Be specific
         bot.reply("That format doesn't work. Try using"
                   " http://strftime.net to make one.")
         # New format doesn't work. Revert save in database.
@@ -243,7 +243,7 @@ def update_channel_format(bot, trigger):
 
     try:
         timef = format_time(db=bot.db, zone=tz, channel=trigger.sender)
-    except:
+    except Exception:  # TODO: Be specific
         bot.reply("That format doesn't work. Try using"
                   " http://strftime.net to make one.")
         # New format doesn't work. Revert save in database.

--- a/sopel/modules/countdown.py
+++ b/sopel/modules/countdown.py
@@ -22,19 +22,17 @@ def generic_countdown(bot, trigger):
         bot.say("Please use correct format: .countdown 2012 12 21")
         return NOLIMIT
     text = trigger.group(2).split()
-    if text and (len(text) == 3 and text[0].isdigit() and text[1].isdigit()
-                 and text[2].isdigit()):
+    if text and (len(text) == 3 and text[0].isdigit() and
+                 text[1].isdigit() and text[2].isdigit()):
         try:
-            diff = (datetime.datetime(int(text[0]), int(text[1]), int(text[2]))
-                    - datetime.datetime.today())
-        except:
+            diff = (datetime.datetime(int(text[0]), int(text[1]),
+                    int(text[2])) - datetime.datetime.today())
+        except Exception:  # TODO: Be specific
             bot.say("Please use correct format: .countdown 2012 12 21")
             return NOLIMIT
-        bot.say(str(diff.days) + " days, " + str(diff.seconds // 3600)
-                   + " hours and "
-                   + str(diff.seconds % 3600 // 60)
-                   + " minutes until "
-                   + text[0] + " " + text[1] + " " + text[2])
+        bot.say(str(diff.days) + " days, " + str(diff.seconds // 3600) +
+                " hours and " + str(diff.seconds % 3600 // 60) +
+                " minutes until " + text[0] + " " + text[1] + " " + text[2])
     else:
         bot.say("Please use correct format: .countdown 2012 12 21")
         return NOLIMIT

--- a/sopel/modules/currency.py
+++ b/sopel/modules/currency.py
@@ -52,8 +52,10 @@ def exchange(bot, trigger):
     amount, of, to = match.groups()
     try:
         amount = float(amount)
-    except:
+    except ValueError:
         bot.reply("Sorry, I didn't understand the input.")
+    except OverflowError:
+        bot.reply("Sorry, input amount was out of range.")
     display(bot, amount, of, to)
 
 
@@ -69,7 +71,7 @@ def display(bot, amount, of, to):
         if not to_name:
             bot.reply("Unknown currency: %s" % to)
             return
-    except Exception:
+    except Exception:  # TODO: Be specific
         bot.reply("Something went wrong while I was getting the exchange rate.")
         return NOLIMIT
 
@@ -90,8 +92,11 @@ def bitcoin(bot, trigger):
 
     try:
         amount = float(amount)
-    except:
+    except ValueError:
         bot.reply("Sorry, I didn't understand the input.")
+        return NOLIMIT
+    except OverflowError:
+        bot.reply("Sorry, input amount was out of range.")
         return NOLIMIT
 
     display(bot, amount, 'BTC', to)

--- a/sopel/modules/help.py
+++ b/sopel/modules/help.py
@@ -19,9 +19,11 @@ from sopel.module import commands, rule, example, priority
 
 logger = get_logger(__name__)
 
+
 def setup(bot):
     global help_prefix
     help_prefix = bot.config.core.help_prefix
+
 
 @rule('$nick' '(?i)(help|doc) +([A-Za-z]+)(?:\?+)?$')
 @example('.help tell')
@@ -80,9 +82,9 @@ def help(bot, trigger):
 
 def create_list(bot, msg):
     msg = 'Command listing for {}@{}\n\n'.format(bot.nick, bot.config.core.host) + msg
-    payload = { "content": msg }
+    payload = {"content": msg}
     headers = {'Content-type': 'application/json', 'Accept': 'application/json'}
-    
+
     try:
         result = requests.post('https://ptpb.pw/', json=payload, headers=headers)
     except requests.RequestException:
@@ -104,5 +106,5 @@ def help2(bot, trigger):
         "Hi, I'm a bot. Say {1}commands to me in private for a list "
         "of my commands, or see http://sopel.chat for more "
         "general details. My owner is {0}."
-    .format(bot.config.core.owner, help_prefix))
+        .format(bot.config.core.owner, help_prefix))
     bot.reply(response)

--- a/sopel/modules/isup.py
+++ b/sopel/modules/isup.py
@@ -26,7 +26,7 @@ def isup(bot, trigger):
 
     try:
         response = web.get(site)
-    except Exception:
+    except Exception:  # TODO: Be specific
         bot.say(site + ' looks down from here.')
         return
 

--- a/sopel/modules/meetbot.py
+++ b/sopel/modules/meetbot.py
@@ -128,7 +128,7 @@ def ismeetingrunning(channel):
             return True
         else:
             return False
-    except:
+    except KeyError:
         return False
 
 
@@ -139,7 +139,7 @@ def ischair(nick, channel):
             return True
         else:
             return False
-    except:
+    except KeyError:
         return False
 
 
@@ -178,7 +178,7 @@ def startmeeting(bot, trigger):
     if not os.path.isdir(meeting_log_path + trigger.sender):
         try:
             os.makedirs(meeting_log_path + trigger.sender)
-        except Exception:
+        except Exception:  # TODO: Be specific
             bot.say("Can't create log directory for this channel, meeting not started!")
             meetings_dict[trigger.sender] = Ddict(dict)
             raise
@@ -344,7 +344,7 @@ def meetinglink(bot, trigger):
         link = "http://" + link
     try:
         title = find_title(link, verify=bot.config.core.verify_ssl)
-    except:
+    except Exception:  # TODO: Be specific
         title = ''
     logplain('LINK: %s [%s]' % (link, title), trigger.sender)
     logHTML_listitem('<a href="%s">%s</a>' % (link, title), trigger.sender)

--- a/sopel/modules/pronouns.py
+++ b/sopel/modules/pronouns.py
@@ -71,7 +71,7 @@ def say_pronouns(bot, nick, pronouns):
 @example('.setpronouns they/them/their/theirs/themselves')
 def set_pronouns(bot, trigger):
     if trigger.group(2):
-        pronouns = trigger.group(2)    
+        pronouns = trigger.group(2)
         disambig = ''
         if pronouns == 'they':
             disambig = ' You can also use they/.../themself, if you prefer.'
@@ -83,10 +83,10 @@ def set_pronouns(bot, trigger):
             pronouns = KNOWN_SETS.get(pronouns)
             if not pronouns:
                 bot.say(
-                "I'm sorry, I don't know those pronouns. You can give me a set "
-                "I don't know by formatting it "
-                "subject/object/possessive-determiner/posessive-pronoun/"
-                "reflexive, as in they/them/their/theirs/themselves"
+                    "I'm sorry, I don't know those pronouns. You can give me a set "
+                    "I don't know by formatting it "
+                    "subject/object/possessive-determiner/posessive-pronoun/"
+                    "reflexive, as in they/them/their/theirs/themselves"
                 )
                 return
         bot.db.set_nick_value(trigger.nick, 'pronouns', pronouns)

--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -119,7 +119,7 @@ def redditor_info(bot, trigger, match=None):
     match = match or trigger
     try:
         u = r.get_redditor(match.group(2))
-    except:
+    except Exception:  # TODO: Be specific
         if commanded:
             bot.say('No such Redditor.')
             return NOLIMIT
@@ -151,8 +151,8 @@ def redditor_info(bot, trigger, match=None):
         message = message + ' | 08Gold'
     if u.is_mod:
         message = message + ' | 05Mod'
-    message = message + (' | Link: ' + str(u.link_karma) + ' | Comment: '
-                         + str(u.comment_karma))
+    message = message + (' | Link: ' + str(u.link_karma) +
+                         ' | Comment: ' + str(u.comment_karma))
 
     bot.say(message)
 

--- a/sopel/modules/remind.py
+++ b/sopel/modules/remind.py
@@ -21,7 +21,7 @@ from sopel.tools.time import get_timezone, format_time
 
 try:
     import pytz
-except:
+except ImportError:
     pytz = None
 
 
@@ -79,6 +79,7 @@ def setup(bot):
     targs = (bot,)
     t = threading.Thread(target=monitor, args=targs)
     t.start()
+
 
 scaling = collections.OrderedDict([
     ('years', 365.25 * 24 * 3600),

--- a/sopel/modules/safety.py
+++ b/sopel/modules/safety.py
@@ -147,7 +147,7 @@ def url_handler(bot, trigger):
                 result = bot.memory['safety_cache'][trigger]
             positives = result['positives']
             total = result['total']
-    except Exception:
+    except Exception:  # TODO: Be specific
         LOGGER.debug('Error from checking URL with VT.', exc_info=True)
         pass  # Ignoring exceptions with VT so MalwareDomains will always work
 

--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -23,6 +23,7 @@ def formatnumber(n):
         parts.insert(i, ',')
     return ''.join(parts)
 
+
 r_bing = re.compile(r'<h3><a href="([^"]+)"')
 
 
@@ -33,19 +34,21 @@ def bing_search(query, lang='en-GB'):
     if m:
         return m.group(1)
 
+
 r_duck = re.compile(r'nofollow" class="[^"]+" href="(?!(?:https?:\/\/r\.search\.yahoo)|(?:https?:\/\/duckduckgo\.com\/y\.js))(?:\/l\/\?kh=-1&amp;uddg=)(.*?)">')
 
 
 def duck_search(query):
     query = query.replace('!', '')
     uri = 'http://duckduckgo.com/html/?q=%s&kl=uk-en' % query
-    bytes = web.get(uri,headers={'User-Agent':'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36'})
+    bytes = web.get(uri, headers={'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/55.0.2883.87 Safari/537.36'})
     if 'web-result' in bytes:  # filter out the adds on top of the page
         bytes = bytes.split('web-result')[1]
     m = r_duck.search(bytes)
     if m:
         unquoted_m = unquote(m.group(1))
         return web.decode(unquoted_m)
+
 
 # Alias google_search to duck_search
 google_search = duck_search

--- a/sopel/modules/translate.py
+++ b/sopel/modules/translate.py
@@ -60,7 +60,7 @@ def translate(text, in_lang='auto', out_lang='en', verify_ssl=True):
 
     try:
         language = data[2]  # -2][0][0]
-    except:
+    except IndexError:
         language = '?'
 
     return ''.join(x[0] for x in data[0]), language
@@ -169,7 +169,7 @@ def mangle(bot, trigger):
     if trigger.group(2) is None:
         try:
             phrase = (mangle_lines[trigger.sender.lower()], '')
-        except:
+        except KeyError:
             bot.reply("What do you want me to mangle?")
             return
     else:
@@ -182,7 +182,7 @@ def mangle(bot, trigger):
         try:
             phrase = translate(phrase[0], 'en', lang,
                                verify_ssl=verify_ssl)
-        except:
+        except Exception:  # TODO: Be specific
             phrase = False
         if not phrase:
             phrase = backup
@@ -190,7 +190,7 @@ def mangle(bot, trigger):
 
         try:
             phrase = translate(phrase[0], lang, 'en', verify_ssl=verify_ssl)
-        except:
+        except Exception:  # TODO: Be specific
             phrase = backup
             continue
 

--- a/sopel/modules/unicode_info.py
+++ b/sopel/modules/unicode_info.py
@@ -29,7 +29,7 @@ def codepoint(bot, trigger):
             arg = arg[2:]
         try:
             arg = unichr(int(arg, 16))
-        except:
+        except Exception:  # TODO: Be specific
             bot.reply("That's not a valid code point.")
             return NOLIMIT
 
@@ -47,6 +47,7 @@ def codepoint(bot, trigger):
     else:
         template = 'U+%s %s (\xe2\x97\x8c%s)'
     bot.say(template % (point, name, arg))
+
 
 if __name__ == "__main__":
     from sopel.test_tools import run_example_tests

--- a/sopel/modules/units.py
+++ b/sopel/modules/units.py
@@ -182,6 +182,7 @@ def mass(bot, trigger):
 
     bot.reply('{} = {}'.format(metric_part, stupid_part))
 
+
 if __name__ == "__main__":
     from sopel.test_tools import run_example_tests
     run_example_tests(__file__)

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -152,7 +152,7 @@ def process_urls(bot, trigger, urls):
             # Magic stuff to account for international domain names
             try:
                 url = web.iri_to_uri(url)
-            except:
+            except Exception:  # TODO: Be specific
                 pass
             # First, check that the URL we got doesn't match
             matched = check_callbacks(bot, trigger, url, False)
@@ -232,6 +232,7 @@ def get_hostname(url):
     if slash != -1:
         hostname = hostname[:slash]
     return hostname
+
 
 if __name__ == "__main__":
     from sopel.test_tools import run_example_tests

--- a/sopel/modules/wiktionary.py
+++ b/sopel/modules/wiktionary.py
@@ -62,6 +62,7 @@ def wikt(word):
             break
     return etymology, definitions
 
+
 parts = ('preposition', 'particle', 'noun', 'verb',
     'adjective', 'adverb', 'interjection')
 

--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -201,5 +201,7 @@ def main(argv=None):
     except KeyboardInterrupt:
         print("\n\nInterrupted")
         os._exit(1)
+
+
 if __name__ == '__main__':
     main()

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -229,7 +229,7 @@ class OutputRedirect(object):
                     sys.__stderr__.write(string)
                 else:
                     sys.__stdout__.write(string)
-            except:
+            except Exception:  # TODO: Be specific
                 pass
 
         with codecs.open(self.logpath, 'ab', encoding="utf8",

--- a/sopel/tools/jobs.py
+++ b/sopel/tools/jobs.py
@@ -95,7 +95,7 @@ class JobScheduler(threading.Thread):
         while True:
             try:
                 self._do_next_job()
-            except Exception:
+            except Exception:  # TODO: Be specific
                 # Modules exceptions are caught earlier, so this is a bit
                 # more serious. Options are to either stop the main thread
                 # or continue this thread and hope that it won't happen
@@ -140,7 +140,7 @@ class JobScheduler(threading.Thread):
         # Sopel.bot.call is way too specialized to be used instead.
         try:
             func(self.bot)
-        except Exception:
+        except Exception:  # TODO: Be specific
             self.bot.error()
 
 

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -64,7 +64,7 @@ class Channel(object):
     def clear_user(self, nick):
         user = self.users.pop(nick, None)
         self.privileges.pop(nick, None)
-        if user != None:
+        if user is not None:
             user.channels.pop(self.name, None)
 
     def add_user(self, user):

--- a/sopel/tools/time.py
+++ b/sopel/tools/time.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 import datetime
 try:
     import pytz
-except:
+except ImportError:
     pytz = False
 
 
@@ -45,7 +45,7 @@ def validate_format(tformat):
     try:
         time = datetime.datetime.utcnow()
         time.strftime(tformat)
-    except:
+    except Exception:  # TODO: Be specific
         raise ValueError('Invalid time format')
     return tformat
 

--- a/sopel/web.py
+++ b/sopel/web.py
@@ -148,6 +148,7 @@ def post(uri, query, limit_bytes=None, timeout=20, verify_ssl=True, return_heade
         headers['_http_status'] = u.status_code
         return (bytes, headers)
 
+
 r_entity = re.compile(r'&([^;\s]+);')
 
 

--- a/test/test_irc.py
+++ b/test/test_irc.py
@@ -1,4 +1,4 @@
-# coding=utf8
+# coding=utf-8
 """Tests for message formatting"""
 from __future__ import unicode_literals, absolute_import, print_function, division
 
@@ -8,14 +8,11 @@ import asynchat
 import os
 import shutil
 import socket
-import select
 import tempfile
-import threading
-import time
 import asyncore
 
 from sopel import irc
-from sopel.tools import stderr, Identifier
+from sopel.tools import Identifier
 import sopel.config as conf
 
 
@@ -42,6 +39,7 @@ class BasicServer(asyncore.dispatcher):
 
     def handle_close(self):
         self.close()
+
 
 class BasicHandler(asynchat.async_chat):
     ac_in_buffer_size = 512
@@ -75,7 +73,7 @@ def start_server(rpl_function=None):
     if rpl_function is None:
         rpl_function = rpl_func
 
-    address = ('localhost', 0) # let the kernel give us a port
+    address = ('localhost', 0)  # let the kernel give us a port
     server = BasicServer(address, rpl_function)
     return server
 
@@ -86,6 +84,7 @@ def bot(request):
     print(cfg_dir)
     filename = tempfile.mkstemp(dir=cfg_dir)[1]
     os.mkdir(os.path.join(cfg_dir, 'modules'))
+
     def fin():
         print('teardown config file')
         shutil.rmtree(cfg_dir)
@@ -122,7 +121,7 @@ def basic_irc_replies(server, msg):
         # Quit here because good enough
         server.close()
     elif msg.startswith('PING'):
-        return 'PONG{}'.format(msg.replace('PING','',1))
+        return 'PONG{}'.format(msg.replace('PING', '', 1))
     elif msg.startswith('CAP'):
         return 'CAP * :'
     elif msg.startswith('QUIT'):


### PR DESCRIPTION
With all the little style errors cleaned up in this commit, flake8 will now pass. That means checkstyle.sh can be allowed to fail builds in PRs and enforce all these little things going forward.

No doubt there will be conflicts with some open PRs, but a healthy number of those are either awaiting changes anyway (and can be rebased as part of that) or likely to be closed unmerged for various reasons.

None of these changes should affect functionality, but in a few places I did correct "bare except" with something more specific than `except Exception:` and a `TODO` comment, where I was reasonably sure what exception type might be raised. But with only ~40% test coverage, there's a lot of code that can't be vetted by Travis just yet, and so this is flagged "Needs Review".