### PR TITLE
[config.types] Filter ListAttribute empty values

### DIFF
--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -222,7 +222,7 @@ class ListAttribute(BaseValidated):
         self.strip = strip
 
     def parse(self, value):
-        value = value.split(',')
+        value = list(filter(None, value.split(',')))
         if self.strip:
             return [v.strip() for v in value]
         else:


### PR DESCRIPTION
Might add an optional parameter to the constructor to disable the filtering in the next minor release, similar to the existing `strip` parameter. Don't really want to unless something breaks though (and if anything does, I'd argue that it should be fixed to not rely on empty ListAttribute parsing to `[""]` instead of `[]`).

Merging this should fix #1032 and also close #1173. It will also make #1052 safer, in theory (not tested yet).