### PR TITLE
tell: Catch py2 IOError in setup()

### DIFF
--- a/sopel/modules/tell.py
+++ b/sopel/modules/tell.py
@@ -69,7 +69,7 @@ def setup(self):
     if not os.path.exists(self.tell_filename):
         try:
             f = open(self.tell_filename, 'w')
-        except OSError:
+        except (OSError, IOError):  # Remove IOError when dropping py2 support
             pass
         else:
             f.write('')


### PR DESCRIPTION
If `open()` fails in Python 2, it throws an `IOError`. This was changed to `OSError` in Python 3.3 (but Sopel requires 3.3+, so this change is strictly to safeguard py2 installs).