### PR TITLE
[calc] Switch to Sopel's own tumbolia instance

### DIFF
--- a/sopel/modules/calc.py
+++ b/sopel/modules/calc.py
@@ -16,7 +16,7 @@ if sys.version_info.major >= 3:
     unichr = chr
 
 
-BASE_TUMBOLIA_URI = 'https://tumbolia-two.appspot.com/'
+BASE_TUMBOLIA_URI = 'https://tumbolia-sopel.appspot.com/'
 
 
 @commands('c', 'calc')


### PR DESCRIPTION
tumbolia-two is shared with a number of jenni instances and forks, so it is often over quota for hours at a time. That's inconvenient for users of Sopel, and inconvenient for the development process (because there are tests that rely on the service).

If we run into the same quota issues with our own instance, we can make the URL configurable and provide documentation on setting up your own.