### PR TITLE
Pytest setup shenanigans

### DIFF
--- a/sopel/module.py
+++ b/sopel/module.py
@@ -449,6 +449,9 @@ class example(object):
             sopel.test_tools.insert_into_module(
                 test, func.__module__, func.__name__, 'test_example'
             )
+            sopel.test_tools.insert_into_module(
+                sopel.test_tools.get_disable_setup(), func.__module__, func.__name__, 'disable_setup'
+            )
 
         record = {
             "example": self.msg,

--- a/sopel/modules/ip.py
+++ b/sopel/modules/ip.py
@@ -42,9 +42,6 @@ def configure(config):
 
 
 def setup(bot):
-    if not bot:
-        return  # Because of some weird pytest thing?
-
     bot.config.define_section('ip', GeoipSection)
 
 

--- a/sopel/modules/ip.py
+++ b/sopel/modules/ip.py
@@ -41,7 +41,7 @@ def configure(config):
                                 'Path of the GeoIP db files')
 
 
-def setup(bot=None):
+def setup(bot):
     if not bot:
         return  # Because of some weird pytest thing?
 

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -51,9 +51,6 @@ def configure(config):
 def setup(bot):
     global url_finder
 
-    # TODO figure out why this is needed, and get rid of it, because really?
-    if not bot:
-        return
     bot.config.define_section('url', UrlSection)
 
     if bot.config.url.exclude:

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -48,7 +48,7 @@ def configure(config):
     )
 
 
-def setup(bot=None):
+def setup(bot):
     global url_finder
 
     # TODO figure out why this is needed, and get rid of it, because really?

--- a/sopel/test_tools.py
+++ b/sopel/test_tools.py
@@ -155,6 +155,19 @@ def get_example_test(tested_func, msg, results, privmsg, admin,
     return test
 
 
+def get_disable_setup():
+    import pytest
+    import py
+
+    @pytest.fixture(autouse=True)
+    def disable_setup(request, monkeypatch):
+        setup = getattr(request.module, "setup", None)
+        isfixture = hasattr(setup, "_pytestfixturefunction")
+        if setup is not None and not isfixture and py.builtin.callable(setup):
+            monkeypatch.setattr(setup, "_pytestfixturefunction", pytest.fixture(), raising=False)
+    return disable_setup
+
+
 def insert_into_module(func, module_name, base_name, prefix):
     """Add a function into a module."""
     func.__module__ = module_name


### PR DESCRIPTION
Added monkeypatcher to add properties to setup() functions in modules, so they won't automatically be run by pytest (who thinks they're part of the testing).