### PR TITLE
module: only inject test functions if testing

### DIFF
--- a/sopel/module.py
+++ b/sopel/module.py
@@ -441,7 +441,11 @@ class example(object):
         if not hasattr(func, "example"):
             func.example = []
 
-        if self.result:
+        import sys
+
+        # only inject test-related stuff if we're running tests
+        # see https://stackoverflow.com/a/44595269/5991
+        if 'pytest' in sys.modules and self.result:
             test = sopel.test_tools.get_example_test(
                 func, self.msg, self.result, self.privmsg, self.admin,
                 self.owner, self.repeat, self.use_re, self.ignore


### PR DESCRIPTION
Takes advantage of pytest's test runner always importing `pytest` to detect whether we're running tests.

Alternative to #1295. Fixes #1294.