### PR TITLE
Prune tests from release distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include *requirements.txt
+prune test/


### PR DESCRIPTION
I'd like to exclude `sopel.test_tools` as well, to have as clean a build as possible at release, but since that module is imported in several places that change will take longer to make and validate.

These files aren't even installed, so why are they included in the sdist?