### PR TITLE
search: use regex for example tests

### DIFF
--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -73,7 +73,7 @@ def duck_api(query):
 
 
 @commands('duck', 'ddg', 'g')
-@example('.duck sopel bot', 'https://sopel.chat/')
+@example('.duck sopel bot', r'https?:\/\/sopel\.chat\/?', re=True)
 def duck(bot, trigger):
     """Queries Duck Duck Go for the specified input."""
     query = trigger.group(2)
@@ -98,7 +98,7 @@ def duck(bot, trigger):
 
 
 @commands('bing')
-@example('.bing sopel bot', 'https://sopel.chat/')
+@example('.bing sopel bot', r'https?:\/\/sopel\.chat\/?', re=True)
 def bing(bot, trigger):
     """Queries Bing for the specified input."""
     if not trigger.group(2):
@@ -112,7 +112,7 @@ def bing(bot, trigger):
 
 
 @commands('search')
-@example('.search sopel bot', 'https://sopel.chat/ (b, d)')
+@example('.search sopel bot', r'(https?:\/\/sopel\.chat\/? \(b, d\)|https?:\/\/sopel\.chat\/? \(b\), https?:\/\/sopel\.chat\/? \(d\))', re=True)
 def search(bot, trigger):
     """Searches Bing and Duck Duck Go."""
     if not trigger.group(2):


### PR DESCRIPTION
Sometimes one or the other search engine, depending on source IP, phase of the moon, and/or how many angels are currently dancing on the head of a pin at Travis CI HQ, will return Sopel's website with just 'http://' instead of 'https://'. You can't make this stuff up.

We get a lot fewer random test failures now, but this ought to reduce them even more. Fortunately I recently learned that `@sopel.module.example` has more arguments than just the command & result string.