### PR TITLE
Additional config tests

### DIFF
--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -332,13 +332,13 @@ class FilenameAttribute(BaseValidated):
         if self.directory and not os.path.isdir(value):
             try:
                 os.makedirs(value)
-            except OSError:
+            except (IOError, OSError):
                 raise ValueError(
                     "Value must be an existing or creatable directory.")
         if not self.directory and not os.path.isfile(value):
             try:
                 open(value, 'w').close()
-            except OSError:
+            except (IOError, OSError):
                 raise ValueError("Value must be an existing or creatable file.")
         return value
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -19,8 +19,9 @@ class FakeConfigSection(types.StaticSection):
 
 
 class ConfigFunctionalTest(unittest.TestCase):
-    def read_config(self):
-        configo = config.Config(self.filename)
+    @classmethod
+    def read_config(cls):
+        configo = config.Config(cls.filename)
         configo.define_section('fake', FakeConfigSection)
         return configo
 
@@ -34,7 +35,7 @@ class ConfigFunctionalTest(unittest.TestCase):
                 "homedir={}".format(os.path.expanduser('~/.sopel'))
             )
 
-        cls.config = cls.read_config(cls)
+        cls.config = cls.read_config()
 
         cls.testfile = open(os.path.expanduser('~/.sopel/test.tmp'), 'w+').name
         cls.testdir = os.path.expanduser('~/.sopel/test.d/')

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -24,25 +24,27 @@ class ConfigFunctionalTest(unittest.TestCase):
         configo.define_section('fake', FakeConfigSection)
         return configo
 
-    def setUp(self):
-        self.filename = tempfile.mkstemp()[1]
-        with open(self.filename, 'w') as fileo:
+    @classmethod
+    def setUpClass(cls):
+        cls.filename = tempfile.mkstemp()[1]
+        with open(cls.filename, 'w') as fileo:
             fileo.write(
                 "[core]\n"
                 "owner=dgw\n"
                 "homedir={}".format(os.path.expanduser('~/.sopel'))
             )
 
-        self.config = self.read_config()
+        cls.config = cls.read_config(cls)
 
-        self.testfile = open(os.path.expanduser('~/.sopel/test.tmp'), 'w+').name
-        self.testdir = os.path.expanduser('~/.sopel/test.d/')
-        os.mkdir(self.testdir)
+        cls.testfile = open(os.path.expanduser('~/.sopel/test.tmp'), 'w+').name
+        cls.testdir = os.path.expanduser('~/.sopel/test.d/')
+        os.mkdir(cls.testdir)
 
-    def tearDown(self):
-        os.remove(self.filename)
-        os.remove(self.testfile)
-        os.rmdir(self.testdir)
+    @classmethod
+    def tearDownClass(cls):
+        os.remove(cls.filename)
+        os.remove(cls.testfile)
+        os.rmdir(cls.testdir)
 
     def test_validated_string_when_none(self):
         self.config.fake.valattr = None


### PR DESCRIPTION
I spent some time this morning figuring out more of how the tests actually work, and expanding the test suite to cover all attribute types in `sopel.config.types`. It was a fun exercise, with the added benefit of catching any future breakage due to changes in how the config stuff works.

`test_config` is the only test module that uses `unittest`, apparently. Maybe I'll work on that later.