### PR TITLE
formatting: add italics

### DIFF
--- a/sopel/formatting.py
+++ b/sopel/formatting.py
@@ -19,6 +19,8 @@ CONTROL_COLOR = '\x03'
 """The control code to start or end color formatting"""
 CONTROL_UNDERLINE = '\x1f'
 """The control code to start or end underlining"""
+CONTROL_ITALIC = '\x1d'
+"""The control code to start or end italic formatting"""
 CONTROL_BOLD = '\x02'
 """The control code to start or end bold formatting"""
 
@@ -101,6 +103,11 @@ def color(text, fg=None, bg=None):
 def bold(text):
     """Return the text, with bold IRC formatting."""
     return ''.join([CONTROL_BOLD, text, CONTROL_BOLD])
+
+
+def italic(text):
+    """Return the text, with italic IRC formatting."""
+    return ''.join([CONTROL_ITALIC, text, CONTROL_ITALIC])
 
 
 def underline(text):

--- a/sopel/formatting.py
+++ b/sopel/formatting.py
@@ -17,12 +17,12 @@ CONTROL_NORMAL = '\x0f'
 """The control code to reset formatting"""
 CONTROL_COLOR = '\x03'
 """The control code to start or end color formatting"""
-CONTROL_UNDERLINE = '\x1f'
-"""The control code to start or end underlining"""
-CONTROL_ITALIC = '\x1d'
-"""The control code to start or end italic formatting"""
 CONTROL_BOLD = '\x02'
 """The control code to start or end bold formatting"""
+CONTROL_ITALIC = '\x1d'
+"""The control code to start or end italic formatting"""
+CONTROL_UNDERLINE = '\x1f'
+"""The control code to start or end underlining"""
 
 
 # TODO when we can move to 3.3+ completely, make this an Enum.

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 
 import pytest
 
-from sopel.formatting import colors, color, bold, underline
+from sopel.formatting import colors, color, bold, italic, underline
 
 
 def test_color():
@@ -19,6 +19,11 @@ def test_color():
 def test_bold():
     text = 'Hello World'
     assert bold(text) == '\x02' + text + '\x02'
+
+
+def test_italic():
+    text = 'Hello World'
+    assert italic(text) == '\x1d' + text + '\x1d'
 
 
 def test_underline():


### PR DESCRIPTION
I never noticed before that italics weren't a thing already in `sopel.formatting`, but indeed, the only existing options were colors, bold, and underline. I'm glad I decided to go through and make sure the existing test modules cover as much as possible, because that's how I noticed this.