### PR TITLE
Revert "Prune tests from release distribution"

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,1 @@
 include *requirements.txt
-prune test/


### PR DESCRIPTION
I've learned more about Python packaging conventions today, and have been convinced that the potential benefits of including tests in the source distribution outweigh the small additional file size.

Reverts sopel-irc/sopel#1297