### PR TITLE
Fix IPython requirement for real

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@ pytz
 praw>=4.0.0,<6.0.0
 pyenchant
 pygeoip
-ipython
+ipython<6.0; python_version < '3.3'
+ipython>=6.0,<7.0; python_version >= '3.3'
 requests>=2.0.0,<3.0.0


### PR DESCRIPTION
Either pip isn't smart enough to figure out which Python versions a package version is compatible with and pick one it can use, or IPython is packaged in such a way that it breaks pip's smarts.

Whichever it is, Sopel will have to be the smart one and hold both their hands to avoid breaking things.

Resolves #1308

----

Pinging @alanhuang122 for review — did I do it right? :stuck_out_tongue: