### PR TITLE
Fix bot.channels.privileges

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -230,7 +230,13 @@ def track_modes(bot, trigger):
         else:
             arg = Identifier(arg)
             for mode in modes:
-                priv = bot.privileges[channel].get(arg, 0)
+                priv = bot.channels[channel].privileges.get(arg, 0)
+                # Throw an exception if the two privilege-tracking data
+                # structures get out of sync. That should never happen.
+                # This is a good place to check that bot.channels is doing
+                # what it's supposed to do before ultimately removing the old,
+                # deprecated bot.privileges structure completely.
+                assert priv == bot.privileges[channel].get(arg, 0)
                 value = mapping.get(mode[1])
                 if value is not None:
                     if mode[0] == '+':
@@ -238,6 +244,7 @@ def track_modes(bot, trigger):
                     else:
                         priv = priv & ~value
                     bot.privileges[channel][arg] = priv
+                    bot.channels[channel].privileges[arg] = priv
 
 
 @sopel.module.rule('.*')

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -678,19 +678,18 @@ def _record_who(bot, channel, user, host, nick, account=None, away=None, modes=N
     else:
         user.account = account
     user.away = away
-    if channel not in bot.channels:
-        bot.channels[channel] = Channel(channel)
-    bot.channels[channel].add_user(user)
-    if modes:  # do this after the user is added because add_user() always sets privileges to 0
+    priv = 0
+    if modes:
         mapping = {'+': sopel.module.VOICE,
            '%': sopel.module.HALFOP,
            '@': sopel.module.OP,
            '&': sopel.module.ADMIN,
            '~': sopel.module.OWNER}
-        priv = 0
         for c in modes:
             priv = priv | mapping[c]
-        bot.channels[channel].privileges[user.nick] = priv
+    if channel not in bot.channels:
+        bot.channels[channel] = Channel(channel)
+    bot.channels[channel].add_user(user, privs=priv)
 
 
 @sopel.module.event(events.RPL_WHOREPLY)

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -67,10 +67,10 @@ class Channel(object):
         if user is not None:
             user.channels.pop(self.name, None)
 
-    def add_user(self, user):
+    def add_user(self, user, privs=0):
         assert isinstance(user, User)
         self.users[user.nick] = user
-        self.privileges[user.nick] = 0
+        self.privileges[user.nick] = privs
         user.channels[self.name] = self
 
     def rename_user(self, old, new):


### PR DESCRIPTION
I think I found all the places where `bot.channels` wasn't being updated with privilege info. This should finally resolve #1136, but I would really like another pair of eyes (or three) on this.

Still to do:
- [x] Add tests to verify that `bot.privileges` and `bot.channels.privileges` stay in sync, especially at startup — considering this satisfied by the `assert` added in a21da60.
  - We'll rely on my test instance and early adopters who run Sopel from source on the `master` branch to catch any glaring issues before release.