### PR TITLE
Added tinyurl function with config options

### DIFF
--- a/sopel/__init__.py
+++ b/sopel/__init__.py
@@ -30,7 +30,7 @@ import time
 import traceback
 import signal
 
-__version__ = '6.5.2'
+__version__ = '6.5.3'
 
 
 def _version_info(version=__version__):

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -262,7 +262,10 @@ def get_hostname(url):
 def get_tinyurl(url):
     """ Returns a shortened tinyURL link of the URL. """
     tinyurl = "https://tinyurl.com/api-create.php?url=%s" % url
-    res = requests.get(tinyurl)
+    try:
+        res = requests.get(tinyurl)
+    except requests.exceptions.ConnectionError:
+        return None
     # Replace text output with https instead of http to make the
     # result an HTTPS link.
     return res.text.replace("http://", "https://")


### PR DESCRIPTION
Hi there,

Another channel I was a part of had a bot that would shorten long URLs using TinyURL. I think this is a great feature because I use irssi over SSH so I can't click on links, and copying long links has a tendency of not working out for me.  I've replicated that feature in urls.py as an optional feature; if the user includes a `shorten_url_length` attribute with a value of greater than 0 in the URL section of the config, the bot will call TinyURL's API to shorten a link longer than `shorten_url_length` and then include that result in `title_auto`.

As an example:

```
21:36 <@Casull> https://github.com/sopel-irc/sopel/wiki/Module-Configuration
21:36 < lp0-dev> [ Module Configuration · sopel-irc/sopel Wiki · GitHub ] - github.com 
          ( http://tinyurl.com/ybusdxop )

```