### PR TITLE
Add missing docstring to 'set_channel_value' function

### DIFF
--- a/sopel/db.py
+++ b/sopel/db.py
@@ -97,8 +97,7 @@ class SopelDB(object):
         )
 
     def get_uri(self):
-        """Returns a URL for the database, usable to connect with SQLAlchemy.
-        """
+        """Returns a URL for the database, usable to connect with SQLAlchemy."""
         return 'sqlite://{}'.format(self.filename)
 
     # NICK FUNCTIONS
@@ -179,8 +178,7 @@ class SopelDB(object):
         self.execute('DELETE FROM nicknames WHERE slug = ?', [alias.lower()])
 
     def delete_nick_group(self, nick):
-        """Removes a nickname, and all associated aliases and settings.
-        """
+        """Removes a nickname, and all associated aliases and settings."""
         nick = Identifier(nick)
         nick_id = self.get_nick_id(nick, False)
         self.execute('DELETE FROM nicknames WHERE nick_id = ?', [nick_id])
@@ -209,6 +207,7 @@ class SopelDB(object):
     # CHANNEL FUNCTIONS
 
     def set_channel_value(self, channel, key, value):
+        """Sets the value for a given key to be associated with the channel."""
         channel = Identifier(channel).lower()
         value = json.dumps(value, ensure_ascii=False)
         self.execute('INSERT OR REPLACE INTO channel_values VALUES (?, ?, ?)',
@@ -228,8 +227,7 @@ class SopelDB(object):
     # NICK AND CHANNEL FUNCTIONS
 
     def get_nick_or_channel_value(self, name, key):
-        """Gets the value `key` associated to the nick or channel  `name`.
-        """
+        """Gets the value `key` associated to the nick or channel  `name`."""
         name = Identifier(name)
         if name.is_nick():
             return self.get_nick_value(name, key)


### PR DESCRIPTION
I was reading [Sopel's documentation](https://sopel.chat/docs/db.html) when I noticed that an obvious setter function was missing. I checked the source code and noticed that the function exists but it does not have a docstring. I added it (line 210).
I also put one-liner comments on one line on the same module.