### PR TITLE
bugzilla: handle empty domains setting on shutdown

### DIFF
--- a/sopel/modules/bugzilla.py
+++ b/sopel/modules/bugzilla.py
@@ -52,7 +52,12 @@ def setup(bot):
 
 
 def shutdown(bot):
-    del bot.memory['url_callbacks'][regex]
+    try:
+        del bot.memory['url_callbacks'][regex]
+    except KeyError:
+        # bot.config.bugzilla.domains was probably just empty on startup
+        # everything's daijoubu
+        pass
 
 
 @rule(r'.*https?://(\S+?)'


### PR DESCRIPTION
If `regex` is never added to the bot's URL callback memory, of course trying to remove it with `del` will throw a KeyError. Just catch the exception, everything's fine.

Fixes #1320 (@Helldembez feel free to confirm)