### PR TITLE
web: mark deprecated methods for coverage exclude

### DIFF
--- a/sopel/web.py
+++ b/sopel/web.py
@@ -68,7 +68,7 @@ class MockHttpResponse(httplib.HTTPResponse):
 # HTTP GET
 @deprecated
 def get(uri, timeout=20, headers=None, return_headers=False,
-        limit_bytes=None, verify_ssl=True, dont_decode=False):
+        limit_bytes=None, verify_ssl=True, dont_decode=False):  # pragma: no cover
     """Execute an HTTP GET query on `uri`, and return the result. Deprecated.
 
     `timeout` is an optional argument, which represents how much time we should
@@ -103,7 +103,7 @@ def get(uri, timeout=20, headers=None, return_headers=False,
 
 # Get HTTP headers
 @deprecated
-def head(uri, timeout=20, headers=None, verify_ssl=True):
+def head(uri, timeout=20, headers=None, verify_ssl=True):  # pragma: no cover
     """Execute an HTTP GET query on `uri`, and return the headers. Deprecated.
 
     `timeout` is an optional argument, which represents how much time we should
@@ -127,7 +127,7 @@ def head(uri, timeout=20, headers=None, verify_ssl=True):
 
 # HTTP POST
 @deprecated
-def post(uri, query, limit_bytes=None, timeout=20, verify_ssl=True, return_headers=False):
+def post(uri, query, limit_bytes=None, timeout=20, verify_ssl=True, return_headers=False):  # pragma: no cover
     """Execute an HTTP POST query. Deprecated.
 
     `uri` is the target URI, and `query` is the POST data.
@@ -172,7 +172,7 @@ def decode(html):
 # object they can execute read() on) Both handles redirects and makes sure
 # input URI is UTF-8
 @deprecated
-def get_urllib_object(uri, timeout, headers=None, verify_ssl=True, data=None):
+def get_urllib_object(uri, timeout, headers=None, verify_ssl=True, data=None):  # pragma: no cover
     """Return an HTTPResponse object for `uri` and `timeout` and `headers`. Deprecated
 
     """


### PR DESCRIPTION
It doesn't matter if tests cover the deprecated methods, because, well, they're deprecated. They'll be removed in Sopel 7, and will never have tests added to them.

Doing this is purely cosmetic of course, and I would probably never use `# pragma: no cover` on real code, but for deprecated stuff that is planned to be removed it's OK.