### PR TITLE
Enable testing on Windows with AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,6 +12,9 @@ skip_tags: true
 skip_branch_with_pr: true
 
 environment:
+  appveyor_rdp_password:
+    secure: sgXez5pCWaCHJAgXDENSvg==
+      
   matrix:
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7.x"
@@ -33,6 +36,7 @@ cache:
   - '%LOCALAPPDATA%\pip\Cache'
 
 init:
+  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
   - echo %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%
   - >-
     python -c "import struct; print struct.calcsize('P') * 8"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,45 @@
+build: false
+
+version: "{build}"
+
+branches:
+  only:
+    - master
+    - appveyor  # for testing config changes
+
+skip_tags: true
+
+skip_branch_with_pr: true
+
+environment:
+  matrix:
+    - PYTHON: "C:\\Python27"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python27-x64"
+      PYTHON_VERSION: "2.7.x"
+      PYTHON_ARCH: "64"
+
+    - PYTHON: "C:\\Python34"
+      PYTHON_VERSION: "3.4.x"
+      PYTHON_ARCH: "32"
+
+    - PYTHON: "C:\\Python34-x64"
+      PYTHON_VERSION: "3.4.x"
+      PYTHON_ARCH: "64"
+
+cache:
+  - '%LOCALAPPDATA%\pip\Cache'
+
+init:
+  - echo %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%
+  - >-
+    python -c "import struct; print struct.calcsize('P') * 8"
+
+install:
+  - "python -m pip install --upgrade pip"  # to avoid pip warning that it's outdated
+  - "python -m pip install -r requirements.txt -r dev-requirements.txt"
+
+test_script:
+  - "coverage run -m py.test -v ."

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -27,7 +27,8 @@ class ConfigFunctionalTest(unittest.TestCase):
 
     @classmethod
     def setUpClass(cls):
-        cls.filename = tempfile.mkstemp()[1]
+        _handle, cls.filename = tempfile.mkstemp()
+        os.close(_handle)  # Tests fail on AppVeyor without doing this
         with open(cls.filename, 'w') as fileo:
             fileo.write(
                 "[core]\n"

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -18,7 +18,8 @@ from sopel.db import SopelDB
 from sopel.test_tools import MockConfig
 from sopel.tools import Identifier
 
-db_filename = tempfile.mkstemp()[1]
+_handle, db_filename = tempfile.mkstemp()
+os.close(_handle)  # Tests fail on AppVeyor without doing this
 if sys.version_info.major >= 3:
     unicode = str
     basestring = str

--- a/test/test_irc.py
+++ b/test/test_irc.py
@@ -82,7 +82,8 @@ def start_server(rpl_function=None):
 def bot(request):
     cfg_dir = tempfile.mkdtemp()
     print(cfg_dir)
-    filename = tempfile.mkstemp(dir=cfg_dir)[1]
+    _handle, filename = tempfile.mkstemp(dir=cfg_dir)
+    os.close(_handle)  # Tests fail on AppVeyor without doing this
     os.mkdir(os.path.join(cfg_dir, 'modules'))
 
     def fin():


### PR DESCRIPTION
Adds AppVeyor configuration file and tweaks the use of temp files in tests so they run properly in the AppVeyor environment.

I'm still working on the configuration via test builds attached to my fork, and there have already been several force-pushes to this branch to fix the actual tests (because of how `tempfile` works on Windows vs. Linux) and tweak the build matrix. Expect more before this is ready to merge—especially since AppVeyor has stopped actually running jobs for me, making it impossible to finish testing the config.

When complete, this will resolve #1330. (Though I didn't expect to get around to it so soon, which I why I even made the tracking issue. Could be worse.)