### PR TITLE
wiktionary: Decode HTML entities

### DIFF
--- a/sopel/modules/wiktionary.py
+++ b/sopel/modules/wiktionary.py
@@ -24,6 +24,7 @@ def text(html):
     text = text.replace('\r', '')
     text = text.replace('(intransitive', '(intr.')
     text = text.replace('(transitive', '(trans.')
+    text = web.decode(text)
     return text
 
 


### PR DESCRIPTION
I only noticed this because someone looked up a word that happened to contain an entity escape sequence… Maybe Sopel needs an `html2text()` function in its library? (Or maybe that would be too much like reinventing the wheel.)