### PR TITLE
[translate] Fail graciously when the API does not respond

### DIFF
--- a/sopel/modules/translate.py
+++ b/sopel/modules/translate.py
@@ -53,7 +53,10 @@ def translate(text, in_lang='auto', out_lang='en', verify_ssl=True):
         result = result.replace(',,', ',null,')
         result = result.replace('[,', '[null,')
 
-    data = json.loads(result)
+    try:
+        data = json.loads(result)
+    except json.decoder.JSONDecodeError:
+        return None, None
 
     if raw:
         return str(data), 'en-raw'
@@ -85,6 +88,8 @@ def tr(bot, trigger):
     if in_lang != out_lang:
         msg, in_lang = translate(phrase, in_lang, out_lang,
                                  verify_ssl=bot.config.core.verify_ssl)
+        if not in_lang:
+            return bot.say("Translation failed, probably because of a rate-limit.")
         if sys.version_info.major < 3 and isinstance(msg, str):
             msg = msg.decode('utf-8')
         if msg:
@@ -133,6 +138,8 @@ def tr2(bot, trigger):
     if src != dest:
         msg, src = translate(phrase, src, dest,
                              verify_ssl=bot.config.core.verify_ssl)
+        if not src:
+            return bot.say("Translation failed, probably because of a rate-limit.")
         if sys.version_info.major < 3 and isinstance(msg, str):
             msg = msg.decode('utf-8')
         if msg:


### PR DESCRIPTION
When Google decides that a CAPTCHA needs to be solved before using their translation service, the module will break and throw a JSONDecodeError.