### PR TITLE
lmgtfy: update URLs to HTTPS

### DIFF
--- a/sopel/modules/lmgtfy.py
+++ b/sopel/modules/lmgtfy.py
@@ -16,5 +16,5 @@ def googleit(bot, trigger):
     """Let me just... google that for you."""
     # No input
     if not trigger.group(2):
-        return bot.say('http://google.com/')
-    bot.say('http://lmgtfy.com/?q=' + trigger.group(2).replace(' ', '+'))
+        return bot.say('https://www.google.com/')
+    bot.say('https://lmgtfy.com/?q=' + trigger.group(2).replace(' ', '+'))


### PR DESCRIPTION
Google's URL is also always given with `www.` prefix, so include that. It's not like the bot is ever in danger of overflowing the IRC line by sending a link to Google's homepage…