### PR TITLE
search: remove tests that hit Bing

### DIFF
--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -105,7 +105,7 @@ def duck(bot, trigger):
 
 
 @commands('bing')
-@example('.bing sopel irc bot', r'https?:\/\/sopel\.chat\/?', re=True)
+@example('.bing sopel irc bot')
 def bing(bot, trigger):
     """Queries Bing for the specified input."""
     if not trigger.group(2):
@@ -119,7 +119,7 @@ def bing(bot, trigger):
 
 
 @commands('search')
-@example('.search sopel irc bot', r'(https?:\/\/sopel\.chat\/? \(b, d\)|https?:\/\/sopel\.chat\/? \(b\), https?:\/\/sopel\.chat\/? \(d\))', re=True)
+@example('.search sopel irc bot')
 def search(bot, trigger):
     """Searches Bing and Duck Duck Go."""
     if not trigger.group(2):


### PR DESCRIPTION
Bing returning inconsistent results has been the number-one cause of CI failures for the last several months. Basically the only cause, in fact.

Kicking the CI occasionally to re-run a failed job was tolerable, but it's reached a point where seemingly no number of job restarts will get a successful test run out of Bing, so away the tests will go.

Coveralls will probably yell at me because this reduces coverage, but I don't care. I'm tired of seeing red X's on pull requests because of this. (**Edit:** "Coverage increased (+0.2%) to 42.833%"? What?)