### PR TITLE
lmgtfy: urlencode query

### DIFF
--- a/sopel/modules/lmgtfy.py
+++ b/sopel/modules/lmgtfy.py
@@ -9,6 +9,7 @@ https://sopel.chat/
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 from sopel.module import commands
+from sopel.web import quote
 
 
 @commands('lmgtfy', 'lmgify', 'gify', 'gtfy')
@@ -17,4 +18,4 @@ def googleit(bot, trigger):
     # No input
     if not trigger.group(2):
         return bot.say('https://www.google.com/')
-    bot.say('https://lmgtfy.com/?q=' + trigger.group(2).replace(' ', '+'))
+    bot.say('https://lmgtfy.com/?q=' + quote(trigger.group(2).replace(' ', '+'), '+'))


### PR DESCRIPTION
Use `web.quote()` to encode the query so it's safe to use as a GET param.

Will merge-conflict with #1363 because they both touch the same line.