### PR TITLE
pronouns: use HTTPS in output links

### DIFF
--- a/sopel/modules/pronouns.py
+++ b/sopel/modules/pronouns.py
@@ -50,7 +50,7 @@ def pronouns(bot, trigger):
             # gender, but like… it's a bot.
             bot.say(
                 "I am a bot. Beep boop. My pronouns are it/it/its/its/itself. "
-                "See http://pronoun.is/it for examples."
+                "See https://pronoun.is/it for examples."
             )
         else:
             bot.say("I don't know {}'s pronouns. They can set them with "
@@ -63,7 +63,7 @@ def say_pronouns(bot, nick, pronouns):
             break
         short = pronouns
 
-    bot.say("{}'s pronouns are {}. See http://pronoun.is/{} for "
+    bot.say("{}'s pronouns are {}. See https://pronoun.is/{} for "
             "examples.".format(nick, pronouns, short))
 
 


### PR DESCRIPTION
I don't know how long `pronoun.is` has supported HTTPS, but it's never too soon to default secure.