### PR TITLE
safety: retrieve MalwareDomains list over HTTPS

### DIFF
--- a/sopel/modules/safety.py
+++ b/sopel/modules/safety.py
@@ -90,7 +90,7 @@ def setup(bot):
 
 def _download_malwaredomains_db(path):
     print('Downloading malwaredomains db...')
-    urlretrieve('http://mirror1.malwaredomains.com/files/justdomains', path)
+    urlretrieve('https://mirror1.malwaredomains.com/files/justdomains', path)
 
 
 @sopel.module.rule('(?u).*(https?://\S+).*')


### PR DESCRIPTION
HTTPS support for the mirror we've been using is officially listed on their site at time of writing: https://www.malwaredomains.com/?page_id=29