### PR TITLE
url: Say something on .title command failure

### DIFF
--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -104,6 +104,13 @@ def title_command(bot, trigger):
     for title, domain in results[:4]:
         bot.reply('[ %s ] - %s' % (title, domain))
 
+    # Nice to have different failure messages for one-and-only requested URL
+    # failed vs. one-of-many failed.
+    if len(urls) == 1 and not results:
+        bot.reply('Sorry, fetching that title failed. Make sure the site is working.')
+    elif len(urls) > len(results):
+        bot.reply('I couldn\'t get all of the titles, but I fetched what I could!')
+
 
 @rule('(?u).*(https?://\S+).*')
 def title_auto(bot, trigger):


### PR DESCRIPTION
Bit weird in its handling of failure when multiple URLs were passed in, admittedly, but figuring out which URL failed would require a refactor.

Fixes #1340.

@antdude what do you think of this solution?