### PR TITLE
dice: invalid dice rolls now gives a more friendly error

### DIFF
--- a/sopel/modules/dice.py
+++ b/sopel/modules/dice.py
@@ -218,12 +218,20 @@ def roll(bot, trigger):
     eval_str = arg_str % (tuple(map(_get_eval_str, dice)))
     pretty_str = arg_str % (tuple(map(_get_pretty_str, dice)))
 
-    # Showing the actual error will hopefully give a better hint of what is
-    # wrong with the syntax than a generic error message.
     try:
         result = eval_equation(eval_str)
-    except SyntaxError:
-        bot.reply("What a weird dice you gave me. How do I throw it?")
+    except TypeError:
+        bot.reply("The type of this equation is, apparently, not a string. " +
+            "How did you do that, anyway?")
+    except ValueError:
+        # As it seems that ValueError is raised if the resulting equation would
+        # be too big, give a semi-serious answer to reflect on this.
+        bot.reply("You roll %s: %s = very big" % (
+            trigger.group(2), pretty_str))
+        return
+    except (SyntaxError, eval_equation.Error):
+        bot.reply("I don't know how to process that. " +
+            "Are the dice as well as the algorithms correct?")
         return
 
     bot.reply("You roll %s: %s = %d" % (

--- a/sopel/modules/dice.py
+++ b/sopel/modules/dice.py
@@ -222,8 +222,8 @@ def roll(bot, trigger):
     # wrong with the syntax than a generic error message.
     try:
         result = eval_equation(eval_str)
-    except Exception as e:
-        bot.reply("SyntaxError, eval(%s), %s" % (eval_str, e))
+    except SyntaxError:
+        bot.reply("What a weird dice you gave me. How do I throw it?")
         return
 
     bot.reply("You roll %s: %s = %d" % (


### PR DESCRIPTION
Another side note is that i used `SyntaxError` rather than the all-encompassing `Exception`, as some exceptions should be handled different. As far as I know, though, `eval_equation()` only throws `SyntaxError`.
Fixes #1189 