### PR TITLE
irc: sopel now runs shutdown routines on connection error

### DIFF
--- a/sopel/irc.py
+++ b/sopel/irc.py
@@ -155,6 +155,7 @@ class Bot(asynchat.async_chat):
             self.initiate_connect(host, port)
         except socket.error as e:
             stderr('Connection error: %s' % e)
+            self.handle_close()
 
     def initiate_connect(self, host, port):
         stderr('Connecting to %s:%s...' % (host, port))


### PR DESCRIPTION
After grinding the code for a while, I noticed that the shutdown routines (function `handle_close()`) doesn't run if `socket.error` is thrown.

There is a simple way of reproducing the issue: target Sopel towards an IP address that doesn't host an IRC server. 127.0.0.1 should do fine, as long as you aren't running an IRC server on your system.

Fixes #1378 