### PR TITLE
reload: fix to handle removed callables + cleanly remove intervals + missing `priority` error

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -217,9 +217,7 @@ class Sopel(irc.Bot):
                 if obj in callb_list:
                     callb_list.remove(obj)
         if hasattr(obj, 'interval'):
-            # TODO this should somehow find the right job to remove, rather than
-            # clearing the entire queue. Issue #831
-            self.scheduler.clear_jobs()
+            self.scheduler.remove_callable_job(obj)
         if (getattr(obj, '__name__', None) == 'shutdown' and
                     obj in self.shutdown_methods):
             self.shutdown_methods.remove(obj)

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -167,7 +167,8 @@ def clean_callable(func, config):
         func.rule = getattr(func, 'rule', [])
         for command in getattr(func, 'commands', []):
             regexp = get_command_regexp(prefix, command)
-            func.rule.append(regexp)
+            if regexp not in func.rule:
+                func.rule.append(regexp)
         for command in getattr(func, 'nickname_commands', []):
             regexp = get_nickname_command_regexp(nick, command, alias_nicks)
             func.rule.append(regexp)

--- a/sopel/modules/reload.py
+++ b/sopel/modules/reload.py
@@ -66,7 +66,7 @@ def reload_module_tree(bot, name, seen=None, silent=False):
 
     old_callables = {}
     for obj_name, obj in iteritems(vars(old_module)):
-        if callable(obj):
+        if callable(obj) and '.' not in name:
             bot.unregister(obj)
         elif (type(obj) is ModuleType and
               obj.__name__.startswith(name + '.') and

--- a/sopel/tools/jobs.py
+++ b/sopel/tools/jobs.py
@@ -90,6 +90,19 @@ class JobScheduler(threading.Thread):
             self._cleared = True
             self._jobs = PriorityQueue()
 
+    def remove_callable_job(self, callable):
+        """Removes specific callable from job queue"""
+        with self._mutex:
+            new_queue = PriorityQueue()
+            while True:
+                try:
+                    job = self._jobs.get(False)
+                    if job.func != callable:
+                        new_queue.put(job)
+                except Queue.Empty:
+                    break
+            self._jobs = new_queue
+
     def run(self):
         """Run forever."""
         while True:


### PR DESCRIPTION
**EDIT**: rebased; some comments no longer apply.

Attempt #2 (see #1398)

This commit attempts to address #1056 . @dgw did most of the work here. ~~, as I am working off his fork. @dgw has two branches for #1056 (one for reloading with recursion, and one for preventing duplicates). Since they both address reloading issues, I combined the changes from both branches into one. On top of that,~~ I don't think the fix submitted in #1314 works completely for all cases. For example, when a module is defined with callables from a submodule imported into the init, additional issues arise.  

For example, 
my_sopel_module/some_submodule.py
```
...
__all__ = ['callable1', 'callable2']
...
```

my_sopel_module/\_\_init\_\_.py
```
...
from .some_submodule import *
...
```
leads to issues in the recursion, where the same module is found as `my_sopel_module.some_submodule`, and `some_submodule`. I added a condition to check for `.` in the module name, and ignore if that is the case. This should still work under all previously passing tests.