### PR TITLE
help: support multiple examples

### DIFF
--- a/sopel/module.py
+++ b/sopel/module.py
@@ -457,9 +457,12 @@ class example(object):
         ignore:
             List of outputs to ignore. Strings in this list are always
             interpreted as regular expressions.
+        user_help:
+            Whether this example should be displayed in user-facing help output
+            such as `.help command`.
     """
     def __init__(self, msg, result=None, privmsg=False, admin=False,
-                 owner=False, repeat=1, re=False, ignore=None):
+                 owner=False, repeat=1, re=False, ignore=None, user_help=False):
         # Wrap result into a list for get_example_test
         if isinstance(result, list):
             self.result = result
@@ -480,6 +483,8 @@ class example(object):
             self.ignore = [ignore]
         else:
             self.ignore = []
+
+        self.user_help = user_help
 
     def __call__(self, func):
         if not hasattr(func, "example"):
@@ -508,6 +513,7 @@ class example(object):
             "result": self.result,
             "privmsg": self.privmsg,
             "admin": self.admin,
+            "help": self.user_help,
         }
         func.example.append(record)
         return func

--- a/sopel/modules/admin.py
+++ b/sopel/modules/admin.py
@@ -92,7 +92,8 @@ def _part(bot, channel, msg=None, save=True):
 @sopel.module.require_admin
 @sopel.module.commands('join')
 @sopel.module.priority('low')
-@sopel.module.example('.join #example or .join #example key')
+@sopel.module.example('.join #example key', user_help=True)
+@sopel.module.example('.join #example', user_help=True)
 def join(bot, trigger):
     """Join the specified channel. This is an admin-only command."""
     channel, key = trigger.group(3), trigger.group(4)

--- a/sopel/modules/help.py
+++ b/sopel/modules/help.py
@@ -40,7 +40,9 @@ def help(bot, trigger):
         threshold = 3
 
         if name in bot.doc:
-            if len(bot.doc[name][0]) + (1 if bot.doc[name][1] else 0) > threshold:
+            # count lines we're going to send
+            # lines in command docstring, plus one line for example(s) if present (they're sent all on one line)
+            if len(bot.doc[name][0]) + int(bool(bot.doc[name][1])) > threshold:
                 if trigger.nick != trigger.sender:  # don't say that if asked in private
                     bot.reply('The documentation for this command is too long; I\'m sending it to you in a private message.')
 
@@ -52,7 +54,9 @@ def help(bot, trigger):
             for line in bot.doc[name][0]:
                 msgfun(line)
             if bot.doc[name][1]:
-                msgfun('e.g. ' + bot.doc[name][1])
+                # Build a nice, grammatically-correct list of examples
+                examples = ', '.join(bot.doc[name][1][:-2] + [' or '.join(bot.doc[name][1][-2:])])
+                msgfun('e.g. ' + examples)
     else:
         # This'll probably catch most cases, without having to spend the time
         # actually creating the list first. Maybe worth storing the link and a

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -323,7 +323,7 @@ def test_clean_callable_example(tmpconfig, func):
     docs = func._docs['test']
     assert len(docs) == 2
     assert docs[0] == inspect.cleandoc(func.__doc__).splitlines()
-    assert docs[1] == '.test hello'
+    assert docs[1] == ['.test hello']
 
 
 def test_clean_callable_example_multi_commands(tmpconfig, func):
@@ -344,7 +344,7 @@ def test_clean_callable_example_multi_commands(tmpconfig, func):
     assert test_docs == unit_docs
 
     assert test_docs[0] == inspect.cleandoc(func.__doc__).splitlines()
-    assert test_docs[1] == '.test hello'
+    assert test_docs[1] == ['.test hello']
 
 
 def test_clean_callable_example_first_only(tmpconfig, func):
@@ -360,7 +360,7 @@ def test_clean_callable_example_first_only(tmpconfig, func):
     docs = func._docs['test']
     assert len(docs) == 2
     assert docs[0] == inspect.cleandoc(func.__doc__).splitlines()
-    assert docs[1] == '.test hello'
+    assert docs[1] == ['.test hello']
 
 
 def test_clean_callable_example_first_only_multi_commands(tmpconfig, func):
@@ -382,7 +382,7 @@ def test_clean_callable_example_first_only_multi_commands(tmpconfig, func):
     assert test_docs == unit_docs
 
     assert test_docs[0] == inspect.cleandoc(func.__doc__).splitlines()
-    assert test_docs[1] == '.test hello'
+    assert test_docs[1] == ['.test hello']
 
 
 def test_clean_callable_example_default_prefix(tmpconfig, func):
@@ -398,7 +398,7 @@ def test_clean_callable_example_default_prefix(tmpconfig, func):
     docs = func._docs['test']
     assert len(docs) == 2
     assert docs[0] == inspect.cleandoc(func.__doc__).splitlines()
-    assert docs[1] == '!test hello'
+    assert docs[1] == ['!test hello']
 
 
 def test_clean_callable_example_nickname(tmpconfig, func):
@@ -413,7 +413,7 @@ def test_clean_callable_example_nickname(tmpconfig, func):
     docs = func._docs['test']
     assert len(docs) == 2
     assert docs[0] == inspect.cleandoc(func.__doc__).splitlines()
-    assert docs[1] == 'TestBot: hello'
+    assert docs[1] == ['TestBot: hello']
 
 
 def test_clean_callable_intents(tmpconfig, func):

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -326,6 +326,21 @@ def test_clean_callable_example(tmpconfig, func):
     assert docs[1] == ['.test hello']
 
 
+def test_clean_callable_example_not_set(tmpconfig, func):
+    module.commands('test')(func)
+
+    loader.clean_callable(func, tmpconfig)
+
+    assert hasattr(func, '_docs')
+    assert len(func._docs) == 1
+    assert 'test' in func._docs
+
+    docs = func._docs['test']
+    assert len(docs) == 2
+    assert docs[0] == inspect.cleandoc(func.__doc__).splitlines()
+    assert docs[1] == []
+
+
 def test_clean_callable_example_multi_commands(tmpconfig, func):
     module.commands('test')(func)
     module.commands('unit')(func)
@@ -385,6 +400,53 @@ def test_clean_callable_example_first_only_multi_commands(tmpconfig, func):
     assert test_docs[1] == ['.test hello']
 
 
+def test_clean_callable_example_user_help(tmpconfig, func):
+    module.commands('test')(func)
+    module.example('.test hello', user_help=True)(func)
+
+    loader.clean_callable(func, tmpconfig)
+
+    assert len(func._docs) == 1
+    assert 'test' in func._docs
+
+    docs = func._docs['test']
+    assert len(docs) == 2
+    assert docs[0] == inspect.cleandoc(func.__doc__).splitlines()
+    assert docs[1] == ['.test hello']
+
+
+def test_clean_callable_example_user_help_multi(tmpconfig, func):
+    module.commands('test')(func)
+    module.example('.test hello', user_help=True)(func)
+    module.example('.test bonjour', user_help=True)(func)
+
+    loader.clean_callable(func, tmpconfig)
+
+    assert len(func._docs) == 1
+    assert 'test' in func._docs
+
+    docs = func._docs['test']
+    assert len(docs) == 2
+    assert docs[0] == inspect.cleandoc(func.__doc__).splitlines()
+    assert docs[1] == ['.test hello', '.test bonjour']
+
+
+def test_clean_callable_example_user_help_mixed(tmpconfig, func):
+    module.commands('test')(func)
+    module.example('.test hello')(func)
+    module.example('.test bonjour', user_help=True)(func)
+
+    loader.clean_callable(func, tmpconfig)
+
+    assert len(func._docs) == 1
+    assert 'test' in func._docs
+
+    docs = func._docs['test']
+    assert len(docs) == 2
+    assert docs[0] == inspect.cleandoc(func.__doc__).splitlines()
+    assert docs[1] == ['.test bonjour']
+
+
 def test_clean_callable_example_default_prefix(tmpconfig, func):
     module.commands('test')(func)
     module.example('.test hello')(func)
@@ -405,6 +467,22 @@ def test_clean_callable_example_nickname(tmpconfig, func):
     module.commands('test')(func)
     module.example('$nickname: hello')(func)
 
+    loader.clean_callable(func, tmpconfig)
+
+    assert len(func._docs) == 1
+    assert 'test' in func._docs
+
+    docs = func._docs['test']
+    assert len(docs) == 2
+    assert docs[0] == inspect.cleandoc(func.__doc__).splitlines()
+    assert docs[1] == ['TestBot: hello']
+
+
+def test_clean_callable_example_nickname_custom_prefix(tmpconfig, func):
+    module.commands('test')(func)
+    module.example('$nickname: hello')(func)
+
+    tmpconfig.core.help_prefix = '!'
     loader.clean_callable(func, tmpconfig)
 
     assert len(func._docs) == 1


### PR DESCRIPTION
Should behave the same as before for modules that don't use the new parameter to `@sopel.module.example()` to declare multiple help examples.

Updated `admin.py` module as a proof of concept. Going through other modules and updating them with multiple examples is a separate project.

Output is still tweakable, but I'm happy enough without worrying about splitting lines just yet.

----

This is WIP code I based off of #1303. Between the length of time between when I last looked at this and the present, and the fact that I had to manually rebase it on `master`, I'm definitely leaving it labeled WIP until I get back to working on it (probably after 6.6.0 releases).

Because this changes the module API (a new argument to `@sopel.module.example()` is introduced), this will be a Sopel 7 project.