### PR TITLE
url: added optional shortening of long URLs

### DIFF
--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -34,6 +34,8 @@ class UrlSection(StaticSection):
     # TODO some validation rules maybe?
     exclude = ListAttribute('exclude')
     exclusion_char = ValidatedAttribute('exclusion_char', default='!')
+    shorten_url_length = ValidatedAttribute(
+        'shorten_url_length', int, default=0)
 
 
 def configure(config):
@@ -45,6 +47,12 @@ def configure(config):
     config.url.configure_setting(
         'exclusion_char',
         'Enter a character which can be prefixed to suppress URL titling'
+    )
+    config.url.configure_setting(
+        'shorten_url_length',
+        'Enter how many characters a URL should be before the bot puts a'
+        ' shorter version of the URL in the title as a TinyURL link'
+        ' (0 to disable)'
     )
 
 
@@ -101,8 +109,11 @@ def title_command(bot, trigger):
         urls = re.findall(url_finder, trigger)
 
     results = process_urls(bot, trigger, urls)
-    for title, domain in results[:4]:
-        bot.reply('[ %s ] - %s' % (title, domain))
+    for title, domain, tinyurl in results[:4]:
+        message = '[ %s ] - %s' % (title, domain)
+        if tinyurl:
+            message += ' ( %s )' % tinyurl
+        bot.reply(message)
 
 
 @rule(r'(?u).*(https?://\S+).*')
@@ -127,8 +138,10 @@ def title_auto(bot, trigger):
     results = process_urls(bot, trigger, urls)
     bot.memory['last_seen_url'][trigger.sender] = urls[-1]
 
-    for title, domain in results[:4]:
+    for title, domain, tinyurl in results[:4]:
         message = '[ %s ] - %s' % (title, domain)
+        if tinyurl:
+            message += ' ( %s )' % tinyurl
         # Guard against responding to other instances of this bot.
         if message != trigger:
             bot.say(message)
@@ -144,6 +157,7 @@ def process_urls(bot, trigger, urls):
     """
 
     results = []
+    shorten_url_length = bot.config.url.shorten_url_length
     for url in urls:
         if not url.startswith(bot.config.url.exclusion_char):
             # Magic stuff to account for international domain names
@@ -155,10 +169,24 @@ def process_urls(bot, trigger, urls):
             matched = check_callbacks(bot, trigger, url, False)
             if matched:
                 continue
+            # If the URL is over bot.config.url.shorten_url_length,
+            # shorten the URL
+            tinyurl = None
+            if (shorten_url_length > 0) and (len(url) > shorten_url_length):
+                # Check bot memory to see if the shortened URL is already in
+                # memory
+                if not bot.memory.contains('shortened_urls'):
+                    # Initialize shortened_urls as a dict if it doesn't exist.
+                    bot.memory['shortened_urls'] = tools.SopelMemory()
+                if bot.memory['shortened_urls'].contains(url):
+                    tinyurl = bot.memory['shortened_urls'][url]
+                else:
+                    tinyurl = get_tinyurl(url)
+                    bot.memory['shortened_urls'][url] = tinyurl
             # Finally, actually show the URL
             title = find_title(url, verify=bot.config.core.verify_ssl)
             if title:
-                results.append((title, get_hostname(url)))
+                results.append((title, get_hostname(url), tinyurl))
     return results
 
 
@@ -229,6 +257,19 @@ def get_hostname(url):
     if slash != -1:
         hostname = hostname[:slash]
     return hostname
+
+
+def get_tinyurl(url):
+    """ Returns a shortened tinyURL link of the URL. """
+    tinyurl = "https://tinyurl.com/api-create.php?url=%s" % url
+    try:
+        res = requests.get(tinyurl)
+        res.raise_for_status()
+    except requests.exceptions.RequestException:
+        return None
+    # Replace text output with https instead of http to make the
+    # result an HTTPS link.
+    return res.text.replace("http://", "https://")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Continuation of #1317; this time, I've separated out the request from my own `master` branch to my own `tinyurl-rebase` branch so any changes I make to my own master don't pollute my pull requests. (I'm learning a lot from this.)

I've incorporated all suggestions from #1317 into this pull request.

New function `get_tinyurl` in URL module
`title` and `title_auto` can now shorten long URLs using TinyURL. The length of a long URL is definable by the user in the config and is optional; the user can disable this functionality by setting
`shorten_url_length` in the config's `[url]` section to `0` or leaving it out entirely.