### PR TITLE
reload: fix shutdown routines not called on .reload

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -580,6 +580,8 @@ class Sopel(irc.Bot):
                         shutdown_method.__module__, e
                     )
                 )
+        # Avoid calling shutdown methods if we already have.
+        self.shutdown_methods = []
 
     def cap_req(self, module_name, capability, arg=None, failure_callback=None,
                 success_callback=None):

--- a/sopel/modules/reload.py
+++ b/sopel/modules/reload.py
@@ -41,7 +41,6 @@ def f_reload(bot, trigger):
             'medium': collections.defaultdict(list),
             'low': collections.defaultdict(list)
         }
-        bot._shutdown()
         bot._command_groups = collections.defaultdict(list)
 
         for m in sopel.loader.enumerate_modules(bot.config):

--- a/sopel/modules/reload.py
+++ b/sopel/modules/reload.py
@@ -11,7 +11,7 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 import collections
 import sys
 import time
-from sopel.tools import iteritems
+from sopel.tools import stderr, iteritems
 import sopel.loader
 import sopel.module
 import subprocess
@@ -41,6 +41,7 @@ def f_reload(bot, trigger):
             'medium': collections.defaultdict(list),
             'low': collections.defaultdict(list)
         }
+        bot._shutdown()
         bot._command_groups = collections.defaultdict(list)
 
         for m in sopel.loader.enumerate_modules(bot.config):
@@ -67,6 +68,22 @@ def reload_module_tree(bot, name, seen=None, silent=False):
     old_callables = {}
     for obj_name, obj in iteritems(vars(old_module)):
         if callable(obj):
+            if (getattr(obj, '__name__', None) == 'shutdown' and
+                        obj in bot.shutdown_methods):
+                # If this is a shutdown method, call it first.
+                try:
+                    stderr(
+                        "calling %s.%s" % (
+                            obj.__module__, obj.__name__,
+                        )
+                    )
+                    obj(bot)
+                except Exception as e:
+                    stderr(
+                        "Error calling shutdown method for module %s:%s" % (
+                            obj.__module__, e
+                        )
+                    )
             bot.unregister(obj)
         elif (type(obj) is ModuleType and
               obj.__name__.startswith(name + '.') and


### PR DESCRIPTION
Similar to #1381, `.reload` didn't call any shutdown methods. This pull request addresses this by simply calling the shutdown method(s) before unloading the resources.
Fixes #1395 