### PR TITLE
reddit: match more subdomains

### DIFF
--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -22,7 +22,7 @@ else:
     unescape = HTMLParser().unescape
 
 
-domain = r'https?://(?:www\.|np\.|old\.)?reddit\.com'
+domain = r'https?://(?:www\.|old\.|pay\.|ssl\.|[a-z]{2}\.)?reddit\.com'
 post_url = r'%s/r/(.*?)/comments/([\w-]+)' % domain
 user_url = r'%s/u(ser)?/([\w-]+)' % domain
 post_regex = re.compile(post_url)


### PR DESCRIPTION
Fix for #1411 

- **Current Fix:** Wildcard subdomain for reddit.com
- **Changes:** sopel/modules/reddit.py --> regexp for url with wildcard subdomain

**Background:**

I think it would be better to have wildcards rather than calling out specific subdomains in the regex. (unless we scope the subdomains to support)

Based on the examples in the issue. I initially preferred to allow 2 char or 3 char length subdomain wildcards as `https?://(?:[a-z0-9]{2}\.|[a-z0-9]{3}\.)?reddit\.com`

Digging further, based on a initial vague subdomain scanning (summary below)
```
park1.reddit.com
glee.reddit.com
devel.reddit.com
edin.reddit.com
divms.reddit.com
eriogerg.reddit.com
gogo0.reddit.com
hofmystery.reddit.com
hq.reddit.com
maoliworld.reddit.com
aniwthoi.reddit.com
portableappz.reddit.com
uspeh-v-tebe.reddit.com
iheartfaces.reddit.com
glitterbox.reddit.com
iwanbanaran.reddit.com
realestalker.reddit.com
planet-social.reddit.com
server101.reddit.com
optimalmediagroup.reddit.com
statsperso.reddit.com
avtosaltanat.reddit.com
filmekaneten.reddit.com
mga.reddit.com
oviclub.reddit.comR
tweetdeck.reddit.com
secretebase.reddit.com
indiabooks.reddit.com
hoffmann.reddit.com
movidreams.reddit.com
to-gamato.reddit.com
permaculturaportugal.reddit.com
pica.reddit.com
atlantic-pacific.reddit.com
thetannerbrigade.reddit.com
metin58.reddit.com
creationsci.reddit.com
psychiatriinfirmiere.reddit.com
kinlb.reddit.com
primmoroz.reddit.com
plaqueta.reddit.com
...
...
```
Also, Most of the subdomains of reddit redirects to subreddits. 

I think it would be better to use a wildcard match `*.reddit.com` or to limit particular length of the subdomain. Suggestions?




