### PR TITLE
search: add contextual warning for 'site:' in DDG query

### DIFF
--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -101,7 +101,12 @@ def duck(bot, trigger):
         if 'last_seen_url' in bot.memory:
             bot.memory['last_seen_url'][trigger.sender] = uri
     else:
-        bot.reply("No results found for '%s'." % query)
+        msg = "No results found for '%s'." % query
+        if query.count('site:') >= 2:
+            # This check exists because of issue #1415. The git.io link will take the user there.
+            # (Better a sopel.chat link, but it's not set up to do that. This is shorter anyway.)
+            msg += " Try again with at most one 'site:' operator. See https://git.io/fpKtP for why."
+        bot.reply(msg)
 
 
 @commands('bing')


### PR DESCRIPTION
The simple way to deal with #1415.

A rewrite isn't in the cards this late in the release cycle for 6.6.0, so the next best option is to detect when a query is affected by the bug and advise the user to modify it.