### PR TITLE
target: nick property are now updated properly on NICK events

### DIFF
--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -76,6 +76,7 @@ class Channel(object):
     def rename_user(self, old, new):
         if old in self.users:
             self.users[new] = self.users.pop(old)
+            self.users[new].nick = new
         if old in self.privileges:
             self.privileges[new] = self.privileges.pop(old)
 


### PR DESCRIPTION
In `rename_user()`, in class `Channel`, the nick property of users was not updated on NICK events, but the keys for the dictionary were. This pull request addresses this.

Fixes #1358