### PR TITLE
loader: test coverage

### DIFF
--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -2,7 +2,20 @@
 """Test for the ``sopel.loader`` module."""
 import imp
 
-from sopel import loader
+import pytest
+
+from sopel import loader, config
+
+
+@pytest.fixture
+def tmpconfig(tmpdir):
+    conf_file = tmpdir.join('conf.ini')
+    conf_file.write("\n".join([
+        "[core]",
+        "owner=testnick",
+        ""
+    ]))
+    return config.Config(conf_file.strpath)
 
 
 def test_get_module_description_good_file(tmpdir):
@@ -60,3 +73,68 @@ def test_get_module_description_bad_dir_no_init(tmpdir):
 
     filename = test_dir.strpath
     assert loader.get_module_description(filename) is None
+
+
+def test_clean_module_commands(tmpdir, tmpconfig):
+    root = tmpdir.mkdir('loader_mods')
+    mod_file = root.join('file_mod.py')
+    mod_file.write("""
+# coding=utf-8
+
+import sopel.module
+
+
+@sopel.module.commands("first")
+def first_command(bot, trigger):
+    pass
+
+
+@sopel.module.commands("second")
+def second_command(bot, trigger):
+    pass
+
+
+@sopel.module.interval(5)
+def interval5s(bot):
+    pass
+
+
+@sopel.module.interval(10)
+def interval10s(bot):
+    pass
+
+
+@sopel.module.url(r'.\\.example\\.com')
+def example_url(bot):
+    pass
+
+
+def shutdown():
+    pass
+
+
+def ignored():
+    pass
+
+""")
+
+    test_mod, _ = loader.load_module('file_mod', mod_file.strpath, imp.PY_SOURCE)
+    callables, jobs, shutdowns, urls = loader.clean_module(
+        test_mod, tmpconfig)
+
+    assert len(callables) == 2
+    assert test_mod.first_command in callables
+    assert test_mod.second_command in callables
+    assert len(jobs) == 2
+    assert test_mod.interval5s in jobs
+    assert test_mod.interval10s in jobs
+    assert len(shutdowns)
+    assert test_mod.shutdown in shutdowns
+    assert len(urls) == 1
+    assert test_mod.example_url in urls
+
+    # ignored function is ignored
+    assert test_mod.ignored not in callables
+    assert test_mod.ignored not in jobs
+    assert test_mod.ignored not in shutdowns
+    assert test_mod.ignored not in urls

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -68,6 +68,7 @@ def tmpconfig(tmpdir):
     conf_file.write("\n".join([
         "[core]",
         "owner=testnick",
+        "nick = TestBot",
         ""
     ]))
     return config.Config(conf_file.strpath)
@@ -228,7 +229,7 @@ def test_clean_callable_rule_string(tmpconfig, func):
 
 
 def test_clean_callable_rule_nick(tmpconfig, func):
-    """Assert ``$nick`` in a rule will match ``Sopel: `` or ``Sopel, ``."""
+    """Assert ``$nick`` in a rule will match ``TestBot: `` or ``TestBot, ``."""
     setattr(func, 'rule', [r'$nickhello'])
     loader.clean_callable(func, tmpconfig)
 
@@ -237,13 +238,13 @@ def test_clean_callable_rule_nick(tmpconfig, func):
 
     # Test the regex is compiled properly
     regex = func.rule[0]
-    assert regex.match('Sopel: hello')
-    assert regex.match('Sopel, hello')
-    assert not regex.match('Sopel not hello')
+    assert regex.match('TestBot: hello')
+    assert regex.match('TestBot, hello')
+    assert not regex.match('TestBot not hello')
 
 
 def test_clean_callable_rule_nickname(tmpconfig, func):
-    """Assert ``$nick`` in a rule will match ``Sopel``."""
+    """Assert ``$nick`` in a rule will match ``TestBot``."""
     setattr(func, 'rule', [r'$nickname\s+hello'])
     loader.clean_callable(func, tmpconfig)
 
@@ -252,8 +253,8 @@ def test_clean_callable_rule_nickname(tmpconfig, func):
 
     # Test the regex is compiled properly
     regex = func.rule[0]
-    assert regex.match('Sopel hello')
-    assert not regex.match('Sopel not hello')
+    assert regex.match('TestBot hello')
+    assert not regex.match('TestBot not hello')
 
 
 def test_clean_callable_nickname_command(tmpconfig, func):
@@ -267,10 +268,10 @@ def test_clean_callable_nickname_command(tmpconfig, func):
     assert len(func.rule) == 1
 
     regex = func.rule[0]
-    assert regex.match('Sopel hello!')
-    assert regex.match('Sopel, hello!')
-    assert regex.match('Sopel: hello!')
-    assert not regex.match('Sopel not hello')
+    assert regex.match('TestBot hello!')
+    assert regex.match('TestBot, hello!')
+    assert regex.match('TestBot: hello!')
+    assert not regex.match('TestBot not hello')
 
 
 def test_clean_callable_events(tmpconfig, func):
@@ -410,7 +411,7 @@ def test_clean_callable_example_nickname(tmpconfig, func):
     docs = func._docs['test']
     assert len(docs) == 2
     assert docs[0] == inspect.cleandoc(func.__doc__).splitlines()
-    assert docs[1] == 'Sopel: hello'
+    assert docs[1] == 'TestBot: hello'
 
 
 def test_clean_callable_intents(tmpconfig, func):

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -1,0 +1,62 @@
+# coding=utf-8
+"""Test for the ``sopel.loader`` module."""
+import imp
+
+from sopel import loader
+
+
+def test_get_module_description_good_file(tmpdir):
+    root = tmpdir.mkdir('loader_mods')
+    test_file = root.join('file_module.py')
+    test_file.write('')
+
+    filename = test_file.strpath
+    assert loader.get_module_description(filename) == (
+        'file_module', filename, imp.PY_SOURCE
+    )
+
+
+def test_get_module_description_bad_file_pyc(tmpdir):
+    root = tmpdir.mkdir('loader_mods')
+    test_file = root.join('file_module.pyc')
+    test_file.write('')
+
+    filename = test_file.strpath
+    assert loader.get_module_description(filename) is None
+
+
+def test_get_module_description_bad_file_no_ext(tmpdir):
+    root = tmpdir.mkdir('loader_mods')
+    test_file = root.join('file_module')
+    test_file.write('')
+
+    filename = test_file.strpath
+    assert loader.get_module_description(filename) is None
+
+
+def test_get_module_description_good_dir(tmpdir):
+    root = tmpdir.mkdir('loader_mods')
+    test_dir = root.mkdir('dir_package')
+    test_dir.join('__init__.py').write('')
+
+    filename = test_dir.strpath
+    assert loader.get_module_description(filename) == (
+        'dir_package', filename, imp.PKG_DIRECTORY
+    )
+
+
+def test_get_module_description_bad_dir_empty(tmpdir):
+    root = tmpdir.mkdir('loader_mods')
+    test_dir = root.mkdir('dir_package')
+
+    filename = test_dir.strpath
+    assert loader.get_module_description(filename) is None
+
+
+def test_get_module_description_bad_dir_no_init(tmpdir):
+    root = tmpdir.mkdir('loader_mods')
+    test_dir = root.mkdir('dir_package')
+    test_dir.join('no_init.py').write('')
+
+    filename = test_dir.strpath
+    assert loader.get_module_description(filename) is None

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -413,6 +413,22 @@ def test_clean_callable_example_nickname(tmpconfig, func):
     assert docs[1] == 'Sopel: hello'
 
 
+def test_clean_callable_intents(tmpconfig, func):
+    setattr(func, 'intents', [r'abc'])
+    loader.clean_callable(func, tmpconfig)
+
+    assert hasattr(func, 'intents')
+    assert len(func.intents) == 1
+
+    # Test the regex is compiled properly
+    regex = func.intents[0]
+    assert regex.match('abc')
+    assert regex.match('abcd')
+    assert regex.match('ABC')
+    assert regex.match('AbCdE')
+    assert not regex.match('efg')
+
+
 def test_load_module_pymod(tmpdir):
     root = tmpdir.mkdir('loader_mods')
     mod_file = root.join('file_mod.py')


### PR DESCRIPTION
The `sopel.loader` module is responsible for loading Sopel Module (as in, "plugins" for Sopel), so it's quite critical.

So I added unit-tests, and change as few code as possible.

There is one function that I didn't test, because I want to rework it later: `enumerate_modules`. This function does too many things, and relies on too many global or hard-coded variables. This must be changed.

So, for now, here is a good increase in coverage for the project.

---

**Initial description**:

> Hi! It's a WIP and I don't expect it to be merged "as-is". I wanted to dive into Sopel's code, just to give it a try, and found that I could help on the test side of thing.
>
> I think I can do plenty more on the `sopel.loader` module, but I wanted to share this as soon as possible, to see if it would help and/or was in the right direction, code-style wise in particular.
>
> I'll work on this in the following days, but don't hesitate to stop me, ask question, make remarks, etc. feedback is very welcome!