### PR TITLE
dice: clean up the dice "choose" command output (fix #1420)

### DIFF
--- a/sopel/modules/dice.py
+++ b/sopel/modules/dice.py
@@ -242,6 +242,14 @@ def roll(bot, trigger):
 @sopel.module.commands("ch")
 @sopel.module.commands("choose")
 @sopel.module.priority("medium")
+@sopel.module.example(".choose a, b, c", r'Your options: a, b, c. My choice: (a|b|c)', re=True)
+@sopel.module.example(".choose a | b | c", r'Your options: a, b, c. My choice: (a|b|c)', re=True)
+@sopel.module.example(".choose a,b,c", r'Your options: a, b, c. My choice: (a|b|c)', re=True)
+@sopel.module.example(".choose a|b|c", r'Your options: a, b, c. My choice: (a|b|c)', re=True)
+@sopel.module.example(".choose a, b | just a",
+                      r'Your options: "a, b", just a. My choice: ((a, b)|(just a))',
+                      re=True)
+@sopel.module.example(".choose a", 'Your options: a. My choice: a')
 def choose(bot, trigger):
     """
     .choice option1|option2|option3 - Makes a difficult choice easy.
@@ -254,14 +262,14 @@ def choose(bot, trigger):
         if len(choices) > 1:
             break
     choices = [choice.strip() for choice in choices]
-    # Use a different delimiter in the output, to prevent ambiguity.
-    for show_delim in ',|/\\':
-        if show_delim not in trigger.group(2):
-            show_delim += ' '
-            break
-
     pick = random.choice(choices)
-    return bot.reply('Your options: %s. My choice: %s' % (show_delim.join(choices), pick))
+
+    # Always use a comma in the output
+    display_options = ', '.join(
+        choice if ',' not in choice else '"%s"' % choice
+        for choice in choices
+    )
+    return bot.reply('Your options: %s. My choice: %s' % (display_options, pick))
 
 
 if __name__ == "__main__":

--- a/sopel/modules/dice.py
+++ b/sopel/modules/dice.py
@@ -246,6 +246,7 @@ def roll(bot, trigger):
 @sopel.module.example(".choose a | b | c", r'Your options: a, b, c. My choice: (a|b|c)', re=True)
 @sopel.module.example(".choose a,b,c", r'Your options: a, b, c. My choice: (a|b|c)', re=True)
 @sopel.module.example(".choose a|b|c", r'Your options: a, b, c. My choice: (a|b|c)', re=True)
+@sopel.module.example(".choose a b c", r'Your options: a, b, c. My choice: (a|b|c)', re=True)
 @sopel.module.example(".choose a, b | just a",
                       r'Your options: "a, b", just a. My choice: ((a, b)|(just a))',
                       re=True)
@@ -257,7 +258,7 @@ def choose(bot, trigger):
     if not trigger.group(2):
         return bot.reply('I\'d choose an option, but you didn\'t give me any.')
     choices = [trigger.group(2)]
-    for delim in '|\\/,':
+    for delim in '|\\/, ':
         choices = trigger.group(2).split(delim)
         if len(choices) > 1:
             break


### PR DESCRIPTION
See issue #1420 and PR #1421 that I used as my starting point.

Following my comment on #1420 I decided to go with a PR that:

* strip the space from the input,
* properly format delimiter in the ouput,
* add some test example while I was at it,
* and use the space `\s` as a last-resort delimiter, because why not,

which improve coverage and make for a better output.

**EDIT**: we discussed another option, which I implemented afterward, to use comma as an output delimiter in all cases and to add quotation marks when needed.

Example with comma `,`:

    [nick] .choose a, b, c
    [Sopel] Your options: a, b, c. My choice: b

Example with comma `,` (without spaces):

    [nick] .choose a,b,c
    [Sopel] Your options: a, b, c. My choice: b

Example with pipe `|`:

    [nick] .choose a | b | c
    [Sopel] Your options: a, b, c. My choice: b

Example with pipe `|` (without spaces):

    [nick] .choose a|b|c
    [Sopel] Your options: a, b, c. My choice: b

Example with space `\s`:

    [nick] .choose a b c
    [Sopel] Your options: a, b, c. My choice: b

Example with pipe `|` but there are comma in some options:

    [nick] .choose a, b and c | a, b | just a
    [Sopel] Your options: "a, b and c", "a, b", just a. My choice: a, b
