### PR TITLE
test: add coverage_html_report dir to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,9 +26,11 @@ sopel.egg-info/*
 .project
 .pydevproject
 
+# Test/Coverage
 .cache
 .pytest_cache
 .coverage
+coverage_html_report/
 
 # macOS
 *.DS_Store


### PR DESCRIPTION
Since the `.coveragerc` configuration file defines `coverage_html_report` as the HTML report folder, we can add it to the `.gitignore` file.

I guess few people use the `coverage html` command line, but since I do it *a lot*, and since it's configured in `.coveragerc`, it's fair enough to add it to the project's `.gitignore` file.