### PR TITLE
run_script: clean up & reorganize code

### DIFF
--- a/sopel.py
+++ b/sopel.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # coding=utf-8
 from __future__ import unicode_literals, absolute_import, print_function, division
+import sys
 # Different from setuptools script, because we want the one in this dir.
 from sopel import run_script
-run_script.main()
+sys.exit(run_script.main())

--- a/sopel/config/__init__.py
+++ b/sopel/config/__init__.py
@@ -262,5 +262,6 @@ def _create_config(configpath):
         print("Encountered an error while writing the config file." +
               " This shouldn't happen. Check permissions.")
         raise
-        sys.exit(1)
+
     print("Config file written successfully!")
+    return config.filename

--- a/sopel/config/__init__.py
+++ b/sopel/config/__init__.py
@@ -34,6 +34,9 @@ import sopel.config.core_section
 from sopel.config.types import StaticSection
 
 
+DEFAULT_HOMEDIR = os.path.join(os.path.expanduser('~'), '.sopel')
+
+
 class ConfigurationError(Exception):
     """ Exception type for configuration errors """
 

--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -62,15 +62,45 @@ def enumerate_configs(config_dir, extension='.cfg'):
     return configfiles
 
 
-def find_config(name, extension='.cfg'):
+def find_config(config_dir, name, extension='.cfg'):
+    """Build the absolute path for the given configuration file ``name``
+
+    :param str config_dir: path to the configuration directory
+    :param str name: configuration file ``name``
+    :param str extension: configuration file's extension (default to ``.cfg``)
+    :return: the path of the configuration file, either in the current
+             directory or from the ``config_dir`` directory
+
+    This function tries different locations:
+
+    * the current directory
+    * the ``config_dir`` directory with the ``extension`` suffix
+    * the ``config_dir`` directory without a suffix
+
+    Example::
+
+        >>> from sopel import run_script
+        >>> os.listdir()
+        ['local.cfg', 'extra.ini']
+        >>> os.listdir(run_script.homedir)
+        ['config.cfg', 'extra.ini', 'module.cfg', 'README']
+        >>> run_script.find_config(run_script.homedir, 'local.cfg')
+        'local.cfg'
+        >>> run_script.find_config(run_script.homedir, 'local')
+        '/home/username/.sopel/local'
+        >>> run_script.find_config(run_script.homedir, 'config')
+        '/home/username/.sopel/config.cfg'
+        >>> run_script.find_config(run_script.homedir, 'extra', '.ini')
+        '/home/username/.sopel/extra.ini'
+
+    """
     if os.path.isfile(name):
         return name
-    configs = enumerate_configs(homedir, extension)
-    if name in configs or name + extension in configs:
-        if name + extension in configs:
-            name = name + extension
+    configs = enumerate_configs(config_dir, extension)
+    if name + extension in configs:
+        name = name + extension
 
-    return os.path.join(homedir, name)
+    return os.path.join(config_dir, name)
 
 
 def main(argv=None):
@@ -147,13 +177,13 @@ def main(argv=None):
 
         config_name = opts.config or 'default'
 
-        configpath = find_config(config_name)
+        configpath = find_config(homedir, config_name)
         if not os.path.isfile(configpath):
             print("Welcome to Sopel!\nI can't seem to find the configuration file, so let's generate it!\n")
             if not configpath.endswith('.cfg'):
                 configpath = configpath + '.cfg'
             _create_config(configpath)
-            configpath = find_config(config_name)
+            configpath = find_config(homedir, config_name)
         try:
             config_module = Config(configpath)
         except ConfigurationError as e:

--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -151,6 +151,15 @@ def check_not_root():
             raise RuntimeError('Error: Do not run Sopel as Administrator.')
 
 
+def print_version():
+    """Print Python version and Sopel version on stdout."""
+    py_ver = '%s.%s.%s' % (sys.version_info.major,
+                           sys.version_info.minor,
+                           sys.version_info.micro)
+    print('Sopel %s (running on python %s)' % (__version__, py_ver))
+    print('https://sopel.chat/')
+
+
 def main(argv=None):
     try:
         # Step One: Parse The Command Line
@@ -165,16 +174,14 @@ def main(argv=None):
             return 1
 
         if opts.version:
-            py_ver = '%s.%s.%s' % (sys.version_info.major,
-                                   sys.version_info.minor,
-                                   sys.version_info.micro)
-            print('Sopel %s (running on python %s)' % (__version__, py_ver))
-            print('https://sopel.chat/')
+            print_version()
             return
-        elif opts.wizard:
+
+        if opts.wizard:
             _wizard('all', opts.config)
             return
-        elif opts.mod_wizard:
+
+        if opts.mod_wizard:
             _wizard('mod', opts.config)
             return
 

--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -31,13 +31,33 @@ import sopel.tools as tools
 homedir = os.path.join(os.path.expanduser('~'), '.sopel')
 
 
-def enumerate_configs(extension='.cfg'):
+def enumerate_configs(config_dir, extension='.cfg'):
+    """List configuration file from ``config_dir`` with ``extension``
+
+    :param str config_dir: path to the configuration directory
+    :param str extension: configuration file's extension (default to ``.cfg``)
+    :return: a list of configuration filename found in ``config_dir`` with
+             the correct ``extension``
+    :rtype: list
+
+    Example::
+
+        >>> from sopel import run_script
+        >>> os.listdir(run_script.homedir)
+        ['config.cfg', 'extra.ini', 'module.cfg', 'README']
+        >>> run_script.enumerate_configs(run_script.homedir)
+        ['config.cfg', 'module.cfg']
+        >>> run_script.enumerate_configs(run_script.homedir, '.ini')
+        ['extra.ini']
+
+    """
     configfiles = []
-    if os.path.isdir(homedir):
-        sopel_dotdirfiles = os.listdir(homedir)  # Preferred
-        for item in sopel_dotdirfiles:
-            if item.endswith(extension):
-                configfiles.append(item)
+    if not os.path.isdir(config_dir):
+        return configfiles
+
+    for item in os.listdir(config_dir):
+        if item.endswith(extension):
+            configfiles.append(item)
 
     return configfiles
 
@@ -45,7 +65,7 @@ def enumerate_configs(extension='.cfg'):
 def find_config(name, extension='.cfg'):
     if os.path.isfile(name):
         return name
-    configs = enumerate_configs(extension)
+    configs = enumerate_configs(homedir, extension)
     if name in configs or name + extension in configs:
         if name + extension in configs:
             name = name + extension
@@ -115,7 +135,7 @@ def main(argv=None):
             return
 
         if opts.list_configs:
-            configs = enumerate_configs()
+            configs = enumerate_configs(homedir)
             print('Config files in ~/.sopel:')
             if len(configs) is 0:
                 print('\tNone found')

--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -51,15 +51,12 @@ def enumerate_configs(config_dir, extension='.cfg'):
         ['extra.ini']
 
     """
-    configfiles = []
     if not os.path.isdir(config_dir):
-        return configfiles
+        return
 
     for item in os.listdir(config_dir):
         if item.endswith(extension):
-            configfiles.append(item)
-
-    return configfiles
+            yield item
 
 
 def find_config(config_dir, name, extension='.cfg'):
@@ -96,9 +93,10 @@ def find_config(config_dir, name, extension='.cfg'):
     """
     if os.path.isfile(name):
         return name
-    configs = enumerate_configs(config_dir, extension)
-    if name + extension in configs:
-        name = name + extension
+    name_ext = name + extension
+    for config in enumerate_configs(config_dir, extension):
+        if name_ext == config:
+            return os.path.join(config_dir, name_ext)
 
     return os.path.join(config_dir, name)
 
@@ -167,11 +165,12 @@ def main(argv=None):
         if opts.list_configs:
             configs = enumerate_configs(homedir)
             print('Config files in ~/.sopel:')
-            if len(configs) is 0:
+            config = None
+            for config in configs:
+                print('\t%s' % config)
+            if not config:
                 print('\tNone found')
-            else:
-                for config in configs:
-                    print('\t%s' % config)
+
             print('-------------------------')
             return
 

--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -160,6 +160,19 @@ def print_version():
     print('https://sopel.chat/')
 
 
+def print_config():
+    """Print list of available configurations from default homedir."""
+    configs = enumerate_configs(DEFAULT_HOMEDIR)
+    print('Config files in %s:' % DEFAULT_HOMEDIR)
+    config = None
+    for config in configs:
+        print('\t%s' % config)
+    if not config:
+        print('\tNone found')
+
+    print('-------------------------')
+
+
 def main(argv=None):
     try:
         # Step One: Parse The Command Line
@@ -186,15 +199,7 @@ def main(argv=None):
             return
 
         if opts.list_configs:
-            configs = enumerate_configs(DEFAULT_HOMEDIR)
-            print('Config files in ~/.sopel:')
-            config = None
-            for config in configs:
-                print('\t%s' % config)
-            if not config:
-                print('\tNone found')
-
-            print('-------------------------')
+            print_config()
             return
 
         config_name = opts.config or 'default'

--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -220,6 +220,27 @@ def get_pid_filename(options, pid_dir):
     return os.path.abspath(os.path.join(pid_dir, name))
 
 
+def get_running_pid(filename):
+    """Retrieve the PID number from the given ``filename``.
+
+    :param str filename: path to file to read the PID from
+    :return: the PID number of a Sopel instance if running, ``None`` otherwise
+    :rtype: integer
+
+    This function tries to retrieve a PID number from the given ``filename``,
+    as an integer, and returns ``None`` if the file is not found or if the
+    content is not an integer.
+    """
+    if not os.path.isfile(filename):
+        return
+
+    with open(filename, 'r') as pid_file:
+        try:
+            return int(pid_file.read())
+        except ValueError:
+            pass
+
+
 def main(argv=None):
     try:
         # Step One: Parse The Command Line
@@ -270,14 +291,7 @@ def main(argv=None):
         # Step Six: Handle process-lifecycle options and manage the PID file
         pid_dir = config_module.core.pid_dir
         pid_file_path = get_pid_filename(opts, pid_dir)
-
-        old_pid = None
-        if os.path.isfile(pid_file_path):
-            with open(pid_file_path, 'r') as pid_file:
-                try:
-                    old_pid = int(pid_file.read())
-                except ValueError:
-                    pass
+        old_pid = get_running_pid(pid_file_path)
 
         if old_pid is not None and tools.check_pid(old_pid):
             if not opts.quit and not opts.kill:

--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -25,10 +25,14 @@ import argparse
 import signal
 
 from sopel.__init__ import run, __version__
-from sopel.config import Config, _create_config, ConfigurationError, _wizard
+from sopel.config import (
+    Config,
+    _create_config,
+    ConfigurationError,
+    DEFAULT_HOMEDIR,
+    _wizard
+)
 import sopel.tools as tools
-
-homedir = os.path.join(os.path.expanduser('~'), '.sopel')
 
 
 def enumerate_configs(config_dir, extension='.cfg'):
@@ -42,12 +46,12 @@ def enumerate_configs(config_dir, extension='.cfg'):
 
     Example::
 
-        >>> from sopel import run_script
-        >>> os.listdir(run_script.homedir)
+        >>> from sopel import run_script, config
+        >>> os.listdir(config.DEFAULT_HOMEDIR)
         ['config.cfg', 'extra.ini', 'module.cfg', 'README']
-        >>> run_script.enumerate_configs(run_script.homedir)
+        >>> run_script.enumerate_configs(config.DEFAULT_HOMEDIR)
         ['config.cfg', 'module.cfg']
-        >>> run_script.enumerate_configs(run_script.homedir, '.ini')
+        >>> run_script.enumerate_configs(config.DEFAULT_HOMEDIR, '.ini')
         ['extra.ini']
 
     """
@@ -79,15 +83,15 @@ def find_config(config_dir, name, extension='.cfg'):
         >>> from sopel import run_script
         >>> os.listdir()
         ['local.cfg', 'extra.ini']
-        >>> os.listdir(run_script.homedir)
+        >>> os.listdir(config.DEFAULT_HOMEDIR)
         ['config.cfg', 'extra.ini', 'module.cfg', 'README']
-        >>> run_script.find_config(run_script.homedir, 'local.cfg')
+        >>> run_script.find_config(config.DEFAULT_HOMEDIR, 'local.cfg')
         'local.cfg'
-        >>> run_script.find_config(run_script.homedir, 'local')
+        >>> run_script.find_config(config.DEFAULT_HOMEDIR, 'local')
         '/home/username/.sopel/local'
-        >>> run_script.find_config(run_script.homedir, 'config')
+        >>> run_script.find_config(config.DEFAULT_HOMEDIR, 'config')
         '/home/username/.sopel/config.cfg'
-        >>> run_script.find_config(run_script.homedir, 'extra', '.ini')
+        >>> run_script.find_config(config.DEFAULT_HOMEDIR, 'extra', '.ini')
         '/home/username/.sopel/extra.ini'
 
     """
@@ -102,7 +106,6 @@ def find_config(config_dir, name, extension='.cfg'):
 
 
 def main(argv=None):
-    global homedir
     # Step One: Parse The Command Line
     try:
         parser = argparse.ArgumentParser(description='Sopel IRC Bot',
@@ -163,7 +166,7 @@ def main(argv=None):
             return
 
         if opts.list_configs:
-            configs = enumerate_configs(homedir)
+            configs = enumerate_configs(DEFAULT_HOMEDIR)
             print('Config files in ~/.sopel:')
             config = None
             for config in configs:
@@ -176,13 +179,13 @@ def main(argv=None):
 
         config_name = opts.config or 'default'
 
-        configpath = find_config(homedir, config_name)
+        configpath = find_config(DEFAULT_HOMEDIR, config_name)
         if not os.path.isfile(configpath):
             print("Welcome to Sopel!\nI can't seem to find the configuration file, so let's generate it!\n")
             if not configpath.endswith('.cfg'):
                 configpath = configpath + '.cfg'
             _create_config(configpath)
-            configpath = find_config(homedir, config_name)
+            configpath = find_config(DEFAULT_HOMEDIR, config_name)
         try:
             config_module = Config(configpath)
         except ConfigurationError as e:

--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -104,39 +104,42 @@ def find_config(config_dir, name, extension='.cfg'):
     return os.path.join(config_dir, name)
 
 
+def build_parser():
+    """Build an ``argparse.ArgumentParser`` for the bot"""
+    parser = argparse.ArgumentParser(description='Sopel IRC Bot',
+                                        usage='%(prog)s [options]')
+    parser.add_argument('-c', '--config', metavar='filename',
+                        help='use a specific configuration file')
+    parser.add_argument("-d", '--fork', action="store_true",
+                        dest="daemonize", help="Daemonize Sopel")
+    parser.add_argument("-q", '--quit', action="store_true", dest="quit",
+                        help="Gracefully quit Sopel")
+    parser.add_argument("-k", '--kill', action="store_true", dest="kill",
+                        help="Kill Sopel")
+    parser.add_argument("-l", '--list', action="store_true",
+                        dest="list_configs",
+                        help="List all config files found")
+    parser.add_argument("-m", '--migrate', action="store_true",
+                        dest="migrate_configs",
+                        help="Migrate config files to the new format")
+    parser.add_argument('--quiet', action="store_true", dest="quiet",
+                        help="Suppress all output")
+    parser.add_argument('-w', '--configure-all', action='store_true',
+                        dest='wizard', help='Run the configuration wizard.')
+    parser.add_argument('--configure-modules', action='store_true',
+                        dest='mod_wizard', help=(
+                            'Run the configuration wizard, but only for the '
+                            'module configuration options.'))
+    parser.add_argument('-v', '--version', action="store_true",
+                        dest="version", help="Show version number and exit")
+    return parser
+
+
 def main(argv=None):
     # Step One: Parse The Command Line
     try:
-        parser = argparse.ArgumentParser(description='Sopel IRC Bot',
-                                         usage='%(prog)s [options]')
-        parser.add_argument('-c', '--config', metavar='filename',
-                            help='use a specific configuration file')
-        parser.add_argument("-d", '--fork', action="store_true",
-                            dest="daemonize", help="Daemonize sopel")
-        parser.add_argument("-q", '--quit', action="store_true", dest="quit",
-                            help="Gracefully quit Sopel")
-        parser.add_argument("-k", '--kill', action="store_true", dest="kill",
-                            help="Kill Sopel")
-        parser.add_argument("-l", '--list', action="store_true",
-                            dest="list_configs",
-                            help="List all config files found")
-        parser.add_argument("-m", '--migrate', action="store_true",
-                            dest="migrate_configs",
-                            help="Migrate config files to the new format")
-        parser.add_argument('--quiet', action="store_true", dest="quiet",
-                            help="Suppress all output")
-        parser.add_argument('-w', '--configure-all', action='store_true',
-                            dest='wizard', help='Run the configuration wizard.')
-        parser.add_argument('--configure-modules', action='store_true',
-                            dest='mod_wizard', help=(
-                                'Run the configuration wizard, but only for the '
-                                'module configuration options.'))
-        parser.add_argument('-v', '--version', action="store_true",
-                            dest="version", help="Show version number and exit")
-        if argv:
-            opts = parser.parse_args(argv)
-        else:
-            opts = parser.parse_args()
+        parser = build_parser()
+        opts = parser.parse_args(argv or None)
 
         # Step Two: "Do not run as root" checks.
         try:

--- a/test/test_run_script.py
+++ b/test/test_run_script.py
@@ -1,0 +1,37 @@
+# coding=utf-8
+"""Tests for command handling"""
+from __future__ import unicode_literals, absolute_import, print_function, division
+
+from sopel import run_script
+
+
+def test_enumerate_configs(tmpdir):
+    """Assert function retrieves only .cfg files by default"""
+    config_dir = tmpdir.mkdir("config")
+    config_dir.join('config.cfg').write('')
+    config_dir.join('extra.ini').write('')
+    config_dir.join('module.cfg').write('')
+    config_dir.join('README').write('')
+    results = list(run_script.enumerate_configs(config_dir.strpath))
+
+    assert 'config.cfg' in results
+    assert 'module.cfg' in results
+    assert 'extra.ini' not in results
+    assert 'README' not in results
+    assert len(results) == 2
+
+
+def test_enumerate_configs_extension(tmpdir):
+    """Assert function retrieves only files with the given extension"""
+    config_dir = tmpdir.mkdir("config")
+    config_dir.join('config.cfg').write('')
+    config_dir.join('extra.ini').write('')
+    config_dir.join('module.cfg').write('')
+    config_dir.join('README').write('')
+    results = list(run_script.enumerate_configs(config_dir.strpath, '.ini'))
+
+    assert 'config.cfg' not in results
+    assert 'module.cfg' not in results
+    assert 'extra.ini' in results
+    assert 'README' not in results
+    assert len(results) == 1

--- a/test/test_run_script.py
+++ b/test/test_run_script.py
@@ -113,3 +113,41 @@ def test_get_configuration(tmpdir):
         result = run_script.get_configuration(options)
         assert isinstance(result, config.Config)
         assert result.core.owner == 'TestName'
+
+
+def test_get_pid_filename_default():
+    """Assert function returns the default filename from given ``pid_dir``"""
+    pid_dir = '/pid'
+    parser = run_script.build_parser()
+    options = parser.parse_args([])
+
+    result = run_script.get_pid_filename(options, pid_dir)
+    assert result == pid_dir + '/sopel.pid'
+
+
+def test_get_pid_filename_named():
+    """Assert function returns a specific filename when config (with extension) is set"""
+    pid_dir = '/pid'
+    parser = run_script.build_parser()
+
+    # With extension
+    options = parser.parse_args(['-c', 'test.cfg'])
+
+    result = run_script.get_pid_filename(options, pid_dir)
+    assert result == pid_dir + '/sopel-test.pid'
+
+    # Without extension
+    options = parser.parse_args(['-c', 'test'])
+
+    result = run_script.get_pid_filename(options, pid_dir)
+    assert result == pid_dir + '/sopel-test.pid'
+
+
+def test_get_pid_filename_ext_not_cfg():
+    """Assert function keeps the config file extension when it is not cfg"""
+    pid_dir = '/pid'
+    parser = run_script.build_parser()
+    options = parser.parse_args(['-c', 'test.ini'])
+
+    result = run_script.get_pid_filename(options, pid_dir)
+    assert result == pid_dir + '/sopel-test.ini.pid'

--- a/test/test_run_script.py
+++ b/test/test_run_script.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 from contextlib import contextmanager
 import os
 
-from sopel import run_script
+from sopel import run_script, config
 
 
 @contextmanager
@@ -96,3 +96,20 @@ def test_find_config_extension(tmpdir):
         found_config = run_script.find_config(
             config_dir.strpath, 'extra', '.ini')
         assert found_config == config_dir.join('extra.ini').strpath
+
+
+def test_get_configuration(tmpdir):
+    """Assert function returns a Sopel ``Config`` object"""
+    working_dir = tmpdir.mkdir("working")
+    working_dir.join('default.cfg').write('\n'.join([
+        '[core]',
+        'owner = TestName'
+    ]))
+
+    parser = run_script.build_parser()
+    options = parser.parse_args(['-c', 'default.cfg'])
+
+    with cd(working_dir.strpath):
+        result = run_script.get_configuration(options)
+        assert isinstance(result, config.Config)
+        assert result.core.owner == 'TestName'

--- a/test/test_run_script.py
+++ b/test/test_run_script.py
@@ -151,3 +151,34 @@ def test_get_pid_filename_ext_not_cfg():
 
     result = run_script.get_pid_filename(options, pid_dir)
     assert result == pid_dir + '/sopel-test.ini.pid'
+
+
+def test_get_running_pid(tmpdir):
+    """Assert function retrieves an integer from a given filename"""
+    pid_file = tmpdir.join('sopel.pid')
+    pid_file.write('7814')
+
+    result = run_script.get_running_pid(pid_file.strpath)
+    assert result == 7814
+
+
+def test_get_running_pid_not_integer(tmpdir):
+    """Assert function returns None when the content is not an Integer"""
+    pid_file = tmpdir.join('sopel.pid')
+    pid_file.write('')
+
+    result = run_script.get_running_pid(pid_file.strpath)
+    assert result is None
+
+    pid_file.write('abcdefg')
+
+    result = run_script.get_running_pid(pid_file.strpath)
+    assert result is None
+
+
+def test_get_running_pid_no_file(tmpdir):
+    """Assert function returns None when there is no such file"""
+    pid_file = tmpdir.join('sopel.pid')
+
+    result = run_script.get_running_pid(pid_file.strpath)
+    assert result is None


### PR DESCRIPTION
My end goal is to address issues like #1243 or #1175 and for that the code must allow it, either by being more modular, or more reusable, or more testable - not mentioning documentation, which is not an easy task at all.

In this PR:

* I extracted bit of code from `sopel.run_script` into separated and testable functions,
* I removed the usage of a global variable in these functions, as it is an hard-coded value, so it could be replaced at a higher level of the application,
* I replaced as much as I could any `sys.exit` and `os._exit` call, while keeping the exit value for the command line,

so it still lacks proper unit-testing and documentation, but in my opinion it is a good starting point.

That being said, I think this is a good topic for Sopel 7.0.0 or another future version.