### PR TITLE
cli: sopel-module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,5 +72,10 @@ setup(
     platforms='Linux x86, x86-64',
     install_requires=requires,
     extras_require={'dev': dev_requires},
-    entry_points={'console_scripts': ['sopel = sopel.run_script:main']},
+    entry_points={
+        'console_scripts': [
+            'sopel = sopel.run_script:main',
+            'sopel-module = sopel.cli.modules:main',
+        ],
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     # Distutils is shit, and doesn't check if it's a list of basestring
     # but instead requires str.
     packages=[str('sopel'), str('sopel.modules'),
-              str('sopel.config'), str('sopel.tools')],
+              str('sopel.config'), str('sopel.tools'), str('sopel.cli')],
     classifiers=classifiers,
     license='Eiffel Forum License, version 2',
     platforms='Linux x86, x86-64',

--- a/sopel/cli/__init__.py
+++ b/sopel/cli/__init__.py
@@ -1,0 +1,2 @@
+# coding=utf-8
+"""Sopel Command Line Interfaces (CLI)"""

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -11,8 +11,8 @@ from sopel import loader, run_script, config, tools
 
 
 DISPLAY_ENABLE = {
-    True: 'E',
-    False: 'X',
+    True: 'e',
+    False: 'x',
 }
 
 DISPLAY_TYPE = {
@@ -107,11 +107,6 @@ def handle_list(options, settings):
     show_all = options.show_all or options.show_excluded
     modules = loader.enumerate_modules(settings, show_all=show_all).items()
 
-    # Show All
-    if show_all:
-        # If all are shown, add the "enabled" column
-        template = col_sep.join([template, '{enabled}'])
-
     # Show Excluded Only
     if options.show_excluded:
         if settings.core.enable:
@@ -137,12 +132,19 @@ def handle_list(options, settings):
         modules,
         key=lambda arg: arg[0])
 
+    # Get the maximum length of module names for display purpose
+    max_length = 0
+    if modules:
+        max_length = max(len(info[0]) for info in modules)
+
+    # Show All
+    if show_all:
+        name_template = '{name:<' + str(max_length) + '}'
+        # If all are shown, add the "enabled" column
+        template = col_sep.join(['{enabled}', template])
+
     # Show Module Path
     if options.show_path:
-        # Get the maximum length of module names for display purpose
-        max_length = 0
-        if modules:
-            max_length = max(len(info[0]) for info in modules)
         name_template = '{name:<' + str(max_length) + '}'
         # Add the path at the end of the line
         template = col_sep.join([template, '{path}'])

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -69,6 +69,13 @@ def build_parser():
         default=False,
         help='Show only excluded module')
 
+    # Configure DISABLE action
+    disable_parser = subparsers.add_parser(
+        'disable',
+        help='Disable a sopel module',
+        description='Disable a sopel module')
+    disable_parser.add_argument('module')
+
     return parser
 
 
@@ -220,6 +227,25 @@ def handle_show(options, settings):
             print('\t%s' % url.url_regex.pattern)
 
 
+def handle_disable(options, settings):
+    module_name = options.module
+    modules = loader.enumerate_modules(settings, show_all=True)
+
+    if module_name not in modules:
+        tools.stderr('No module named %s' % module_name)
+        return 1
+
+    disabled = settings.core.exclude
+    if module_name in disabled:
+        tools.stderr('Module %s already disabled' % module_name)
+        return 0
+
+    settings.core.exclude = disabled + [module_name]
+    settings.save()
+
+    print('Module %s disabled' % module_name)
+
+
 def main():
     """Console entry point for ``sopel-module``"""
     parser = build_parser()
@@ -233,3 +259,6 @@ def main():
 
     if action == 'show':
         return handle_show(options, settings)
+
+    if action == 'disable':
+        return handle_disable(options, settings)

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -314,7 +314,11 @@ def main():
             'Unable to find the configuration file %s' % config_filename)
         return 2
 
-    settings = config.Config(config_filename)
+    try:
+        settings = config.Config(config_filename)
+    except config.ConfigurationError as error:
+        tools.stderr(error)
+        return 2
 
     if action == 'list':
         return handle_list(options, settings)

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -12,12 +12,20 @@ def main():
     parser = argparse.ArgumentParser(
         description='Experimental Sopel Module tool')
     subparsers = parser.add_subparsers(
-        help='Actions to perform, default to list',
+        help='Actions to perform (default to list)',
         dest='action')
 
     # Configure LIST action
-    subparsers.add_parser(
-        'list', help='List availables sopel modules')
+    list_parser = subparsers.add_parser(
+        'list',
+        help='List availables sopel modules',
+        description='List availables sopel modules')
+    list_parser.add_argument(
+        '-p', '--path',
+        action='store_true',
+        dest='show_path',
+        default=False,
+        help='Show the path to the module file')
 
     options = parser.parse_args()
     action = options.action or 'list'
@@ -25,11 +33,27 @@ def main():
     if action == 'list':
         config_filename = run_script.find_config('default')
         settings = config.Config(config_filename)
+        modules = loader.enumerate_modules(settings)
         modules = sorted(
-            tools.iteritems(loader.enumerate_modules(settings)),
+            modules.items(),
             key=lambda arg: arg[0])
 
+        template = '{name}'
+        if options.show_path:
+            # Get the maximum length of module names for display purpose
+            max_length = max(len(info[0]) for info in modules)
+
+            template = '\t'.join([
+                '{name:<' + str(max_length) +'}',
+                '{path}',
+            ])
+
         for name, info in modules:
-            print(name)
+            path, module_type = info
+            print(template.format(
+                name=name,
+                path=path,
+                module_type=module_type,
+            ))
 
         return

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -113,8 +113,7 @@ def handle_list(options, settings):
                 if name in settings.core.exclude or
                 name not in settings.core.enable
             ]
-
-        if settings.core.exclude:
+        else:
             # Get only excluded
             modules = [
                 (name, info)
@@ -130,7 +129,9 @@ def handle_list(options, settings):
     # Show Module Path
     if options.show_path:
         # Get the maximum length of module names for display purpose
-        max_length = max(len(info[0]) for info in modules)
+        max_length = 0
+        if modules:
+            max_length = max(len(info[0]) for info in modules)
         name_template = '{name:<' + str(max_length) + '}'
         # Add the path at the end of the line
         template = col_sep.join([template, '{path}'])

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -1,0 +1,35 @@
+# coding=utf-8
+"""Sopel Modules Command Line Interfaces (CLI): ``sopel-module``"""
+from __future__ import unicode_literals, absolute_import, print_function, division
+
+import argparse
+
+from sopel import loader, run_script, config, tools
+
+
+def main():
+    """Console entry point for ``sopel-module``"""
+    parser = argparse.ArgumentParser(
+        description='Experimental Sopel Module tool')
+    subparsers = parser.add_subparsers(
+        help='Actions to perform, default to list',
+        dest='action')
+
+    # Configure LIST action
+    subparsers.add_parser(
+        'list', help='List availables sopel modules')
+
+    options = parser.parse_args()
+    action = options.action or 'list'
+
+    if action == 'list':
+        config_filename = run_script.find_config('default')
+        settings = config.Config(config_filename)
+        modules = sorted(
+            tools.iteritems(loader.enumerate_modules(settings)),
+            key=lambda arg: arg[0])
+
+        for name, info in modules:
+            print(name)
+
+        return

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -3,8 +3,15 @@
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 import argparse
+import imp
 
-from sopel import loader, run_script, config, tools
+from sopel import loader, run_script, config
+
+
+DISPLAY_TYPE = {
+    imp.PKG_DIRECTORY: 'p',
+    imp.PY_SOURCE: 'm'
+}
 
 
 def main():
@@ -26,6 +33,15 @@ def main():
         dest='show_path',
         default=False,
         help='Show the path to the module file')
+    list_parser.add_argument(
+        '-t', '--type',
+        action='store_true',
+        dest='show_type',
+        default=False,
+        help=('Show the type to the module file: '
+              '`p` for package directory, '
+              '`m` for module file, '
+              '`?` for unknown'))
 
     options = parser.parse_args()
     action = options.action or 'list'
@@ -38,22 +54,26 @@ def main():
             modules.items(),
             key=lambda arg: arg[0])
 
+        col_sep = '\t'
         template = '{name}'
         if options.show_path:
             # Get the maximum length of module names for display purpose
             max_length = max(len(info[0]) for info in modules)
 
-            template = '\t'.join([
-                '{name:<' + str(max_length) +'}',
+            template = col_sep.join([
+                '{name:<' + str(max_length) + '}',
                 '{path}',
             ])
+
+        if options.show_type:
+            template = col_sep.join(['{module_type}', template])
 
         for name, info in modules:
             path, module_type = info
             print(template.format(
                 name=name,
                 path=path,
-                module_type=module_type,
+                module_type=DISPLAY_TYPE.get(module_type, '?'),
             ))
 
         return

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -175,13 +175,18 @@ def handle_show(options, settings):
         print('')
         print('# Module Commands')
         for command in callables:
-            print('')
-
             if command._docs.keys():
+                print('')
                 print('## %s' % ', '.join(command._docs.keys()))
-            elif command.rule:
+            elif getattr(command, 'rule', None):
                 # display rules afters normal commands
                 rule_callables.append(command)
+                continue
+            elif getattr(command, 'intents', None):
+                rule_callables.append(command)
+                continue
+            else:
+                # nothing to display right now
                 continue
 
             docstring = inspect.cleandoc(
@@ -196,7 +201,9 @@ def handle_show(options, settings):
 
             for command in rule_callables:
                 print('')
-                for rule in command.rule:
+                for intent in getattr(command, 'intents', []):
+                    print('[INTENT]', intent.pattern)
+                for rule in getattr(command, 'rule', []):
                     print(rule.pattern)
 
                 docstring = inspect.cleandoc(

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 import argparse
 import imp
 import inspect
+import os
 
 from sopel import loader, run_script, config, tools
 
@@ -20,6 +21,12 @@ DISPLAY_TYPE = {
 }
 
 
+def add_config_option(subparser):
+    subparser.add_argument(
+        '-c', '--config', default=None, metavar='filename', dest='config',
+        help='Use a specific configuration file')
+
+
 def build_parser():
     parser = argparse.ArgumentParser(
         description='Experimental Sopel Module tool')
@@ -32,6 +39,7 @@ def build_parser():
         'show',
         help='Show a sopel module\'s details',
         description='Show a sopel module\'s details')
+    add_config_option(show_parser)
     show_parser.add_argument('module')
 
     # Configure LIST action
@@ -39,6 +47,7 @@ def build_parser():
         'list',
         help='List availables sopel modules',
         description='List availables sopel modules')
+    add_config_option(list_parser)
     list_parser.add_argument(
         '-p', '--path',
         action='store_true',
@@ -74,6 +83,7 @@ def build_parser():
         'enable',
         help='Enable a sopel module',
         description='Enable a sopel module')
+    add_config_option(enable_parser)
     enable_parser.add_argument('module')
 
     # Configure DISABLE action
@@ -81,6 +91,7 @@ def build_parser():
         'disable',
         help='Disable a sopel module',
         description='Disable a sopel module')
+    add_config_option(disable_parser)
     disable_parser.add_argument('module')
 
     return parser
@@ -296,7 +307,13 @@ def main():
     parser = build_parser()
     options = parser.parse_args()
     action = options.action or 'list'
-    config_filename = run_script.find_config('default')
+    config_filename = run_script.find_config(options.config or 'default')
+
+    if not os.path.isfile(config_filename):
+        tools.stderr(
+            'Unable to find the configuration file %s' % config_filename)
+        return 2
+
     settings = config.Config(config_filename)
 
     if action == 'list':

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -97,7 +97,10 @@ def main():
                 modules = [
                     (name, info)
                     for name, info in modules
-                    if name not in settings.core.enable
+                    # Remove enabled modules...
+                    # ... unless they are in the excluded list.
+                    if name in settings.core.exclude or
+                    name not in settings.core.enable
                 ]
 
             if settings.core.exclude:

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -42,6 +42,12 @@ def main():
               '`p` for package directory, '
               '`m` for module file, '
               '`?` for unknown'))
+    list_parser.add_argument(
+        '-a', '--all',
+        action='store_true',
+        dest='show_all',
+        default=False,
+        help='Show all available module, enabled or not')
 
     options = parser.parse_args()
     action = options.action or 'list'
@@ -49,7 +55,7 @@ def main():
     if action == 'list':
         config_filename = run_script.find_config('default')
         settings = config.Config(config_filename)
-        modules = loader.enumerate_modules(settings)
+        modules = loader.enumerate_modules(settings, show_all=options.show_all)
         modules = sorted(
             modules.items(),
             key=lambda arg: arg[0])

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -55,18 +55,20 @@ def main():
               '`p` for package directory, '
               '`m` for module file, '
               '`?` for unknown'))
-    list_parser.add_argument(
+
+    list_group = list_parser.add_mutually_exclusive_group()
+    list_group.add_argument(
         '-a', '--all',
         action='store_true',
         dest='show_all',
         default=False,
         help='Show all available module, enabled or not')
-    list_parser.add_argument(
+    list_group.add_argument(
         '-e', '--excluded',
         action='store_true',
         dest='show_excluded',
         default=False,
-        help='Show only excluded module (incompatible with -a/--all)')
+        help='Show only excluded module')
 
     options = parser.parse_args()
     action = options.action or 'list'


### PR DESCRIPTION
**Disclaimer**:  this is an experimental command line tool. I suggest to merge it as-is, and to iterate in further PR if we need to. I've been working on that for few days, and I think now it is in a good enough shape to work properly.

---

So last day I was working on #1424 and #1429 and I was wondering: how can I get the list of available/enabled modules for Sopel? So I look up the CLI (`sopel` or `python sopel.py`) with no result.

So... maybe I could do something about that? After all, there is an old issue about module enabled/excluded (#244), and maybe I can suggest a solution.

And here it is: a Pull Request that adds a new command line interface: `sopel-module`.

---

## Entry point

At the moment, I added a `sopel-module` entry point in the `setup.py` configuration.
Maybe later we'll need to add a `.py` file at the root of this repository, like there is to launch `python sopel.py` from the source.

That'll be for later.

## Code organization

I don't like having a `sopel.run_script` module. I think, if we want to add multiple CLI for sopel, we should have a proper sub-package for that.

So I put all my code into `sopel.cli`, and the function used as entry point is `main`.

I think this structure could be use for the `run_script` code too, but I don't want to change that in *that* PR: it'll be for another one, once this is merged.

## CLI

To test it from the source:

    python setup.py develop

This will install both entry point `sopel` and `sopel-module` in your virtualenv, and then you can do:

    sopel-module list
    sopel-module show xkcd
    sopel-module disable xkcd
    sopel-module enable xkcd

Good luck with the review!

### list

The command `sopel-module list` enumerate modules, as Sopel does when looking for modules.

```
usage: sopel-module list [-h] [-c filename] [-p] [-t] [-a | -e]

List availables sopel modules

optional arguments:
  -h, --help            show this help message and exit
  -c filename, --config filename
                        Use a specific configuration file
  -p, --path            Show the path to the module file
  -t, --type            Show the type to the module file: `p` for package
                        directory, `m` for module file, `?` for unknown
  -a, --all             Show all available module, enabled or not
  -e, --excluded        Show only excluded module
```

### show

The `sopel-module show <module>` command display various information about the module (if found): it tries to list commands, rules pattern, events and intents, that will be loaded by the module.

```
usage: sopel-module show [-h] [-c filename] module

Show a sopel module's details

positional arguments:
  module

optional arguments:
  -h, --help            show this help message and exit
  -c filename, --config filename
                        Use a specific configuration file
```

### enable

The `sopel-module enable <module>` tries to enable a module:

* if there is a whitelist, it adds the module to it,
* it always try to remove it from excluded,

```
usage: sopel-module enable [-h] [-c filename] module

Enable a sopel module

positional arguments:
  module

optional arguments:
  -h, --help            show this help message and exit
  -c filename, --config filename
                        Use a specific configuration file
```

If there is no whitelist yet, this command won't use it. Maybe an option could be added later for that - I suggest to keep it simple for now, and to iterate in further PRs.

### disable

The `sopel-module disable <module>` tries to disable a module by adding it to the list of excluded.

```
usage: sopel-module disable [-h] [-c filename] module

Disable a sopel module

positional arguments:
  module

optional arguments:
  -h, --help            show this help message and exit
  -c filename, --config filename
                        Use a specific configuration file
```
