### PR TITLE
config: Add default value of 'UTC' to core.default_timezone

### DIFF
--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -103,7 +103,7 @@ class CoreSection(StaticSection):
                                              default='%Y-%m-%d - %T%Z')
     """The default format to use for time in messages."""
 
-    default_timezone = ValidatedAttribute('default_timezone')
+    default_timezone = ValidatedAttribute('default_timezone', default='UTC')
     """The default timezone to use for time in messages."""
 
     enable = ListAttribute('enable')


### PR DESCRIPTION
Resolves #1426, and some potential oddities in time handling on fresh Sopel installs.