### PR TITLE
wiktionary: fix query logic

### DIFF
--- a/sopel/modules/wiktionary.py
+++ b/sopel/modules/wiktionary.py
@@ -99,8 +99,11 @@ def wiktionary(bot, trigger):
 
     _etymology, definitions = wikt(word)
     if not definitions:
-        bot.say("Couldn't get any definitions for %s." % word)
-        return
+        # Cast word to lower to check in case of mismatched user input
+        _etymology, definitions = wikt(word.lower())
+        if not definitions:
+            bot.say("Couldn't get any definitions for %s." % word)
+            return
 
     result = format(word, definitions)
     if len(result) < 150:


### PR DESCRIPTION
Looking at the wiktionary results so far, it appears that all (or nearly all) of the words are lowercase when querying. I believe it is safe to cast our query to lower().

Should fix #1214 