### PR TITLE
wiktionary: refactor/bugfix parsing all possible parts of speech

### DIFF
--- a/sopel/modules/wiktionary.py
+++ b/sopel/modules/wiktionary.py
@@ -18,6 +18,25 @@ r_sup = re.compile(r'<sup[^>]+>.+</sup>')  # Superscripts that are references on
 r_tag = re.compile(r'<[^>]+>')
 r_ul = re.compile(r'(?ims)<ul>.*?</ul>')
 
+# From https://en.wiktionary.org/wiki/Wiktionary:Entry_layout#Part_of_speech
+PARTS_OF_SPEECH = [
+    # Parts of speech
+    'Adjective', 'Adverb', 'Ambiposition', 'Article', 'Circumposition',
+    'Classifier', 'Conjunction', 'Contraction', 'Counter', 'Determiner',
+    'Ideophone', 'Interjection', 'Noun', 'Numeral', 'Participle', 'Particle',
+    'Postposition', 'Preposition', 'Pronoun', 'Proper noun', 'Verb',
+    # Morphemes
+    'Circumfix', 'Combining form', 'Infix', 'Interfix', 'Prefix', 'Root', 'Suffix',
+    # Symbols and characters
+    'Diacritical mark', 'Letter', 'Ligature', 'Number', 'Punctuation mark', 'Syllable', 'Symbol',
+    # Phrases
+    'Phrase', 'Proverb', 'Prepositional phrase',
+    # Han characters and language-specific varieties
+    'Han character', 'Hanzi', 'Kanji', 'Hanja',
+    # Other
+    'Romanization',
+]
+
 
 def text(html):
     text = r_sup.sub('', html)  # Remove superscripts that are references from definition
@@ -38,35 +57,26 @@ def wikt(word):
     etymology = None
     definitions = {}
     for line in bytes.splitlines():
+        is_new_mode = False
         if 'id="Etymology"' in line:
             mode = 'etymology'
-        elif 'id="Noun"' in line:
-            mode = 'noun'
-        elif 'id="Verb"' in line:
-            mode = 'verb'
-        elif 'id="Adjective"' in line:
-            mode = 'adjective'
-        elif 'id="Adverb"' in line:
-            mode = 'adverb'
-        elif 'id="Interjection"' in line:
-            mode = 'interjection'
-        elif 'id="Particle"' in line:
-            mode = 'particle'
-        elif 'id="Preposition"' in line:
-            mode = 'preposition'
-        elif 'id="Prefix"' in line:
-            mode = 'prefix'
-        elif 'id="Suffix"' in line:
-            mode = 'suffix'
-        # 'id="' can occur in definition lines <li> when <sup> tag is used for references;
-        # make sure those are not excluded (see e.g., abecedarian).
-        elif ('id="' in line) and ('<li>' not in line):
-            mode = None
+            is_new_mode = True
+        else:
+            for pos in PARTS_OF_SPEECH:
+                if 'id="{}"'.format(pos.replace(' ', '_')) in line:
+                    mode = pos.lower()
+                    is_new_mode = True
+                    break
 
-        elif (mode == 'etmyology') and ('<p>' in line):
-            etymology = text(line)
-        elif (mode is not None) and ('<li>' in line):
-            definitions.setdefault(mode, []).append(text(line))
+        if not is_new_mode:
+            # 'id="' can occur in definition lines <li> when <sup> tag is used for references;
+            # make sure those are not excluded (see e.g., abecedarian).
+            if ('id="' in line) and ('<li>' not in line):
+                mode = None
+            elif (mode == 'etmyology') and ('<p>' in line):
+                etymology = text(line)
+            elif (mode is not None) and ('<li>' in line):
+                definitions.setdefault(mode, []).append(text(line))
 
         if '<hr' in line:
             break

--- a/sopel/modules/wiktionary.py
+++ b/sopel/modules/wiktionary.py
@@ -58,7 +58,7 @@ def wikt(word):
     definitions = {}
     for line in bytes.splitlines():
         is_new_mode = False
-        if 'id="Etymology"' in line:
+        if 'id="Etymology' in line:
             mode = 'etymology'
             is_new_mode = True
         else:
@@ -83,9 +83,7 @@ def wikt(word):
     return etymology, definitions
 
 
-parts = ('preposition', 'particle', 'noun', 'verb',
-         'adjective', 'adverb', 'interjection',
-         'prefix', 'suffix')
+parts = [pos.lower() for pos in PARTS_OF_SPEECH]
 
 
 def format(result, definitions, number=2):


### PR DESCRIPTION
The _refactor_ comes from changing the control flow, and the _bugfix_ is the ability of the module to parse more parts of speech. While this may not be a _bug_ per se, I'd think not being able to get definitions for a word/term that is actually in Wiktionary is not a preferred behavior (pardon the double negative :sweat_smile:).

Regardless, this PR is opened to address the points that came up in #1405:
- [x] parse all parts of speech
- ~~give subdefinitions like those for [`-able`](https://en.wiktionary.org/wiki/-able) their own sub-number (e.g., 1a., 1b., ...)~~


- ~~update formatting algo to be smarter about sub-definitions and such~~
- ~~re-order parts of speech list so that definitions can be prioritized... it would be a shame if some obscure _circumposition_ (A circumposition is a discontinuous adposition... _um wat?_) definition led to the more common _verb_ definition being truncated.~~

I'll put the commit messages as comments below to get a prettified output of what was done (and since I'll probably overwrite/summarize them in a squash, if/when it is time)

**EDIT**: The removed (strikethrough) enhancements will be moved to another issue. 