### PR TITLE
cli: use ENV variable to load configuration

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,5 +72,10 @@ setup(
     platforms='Linux x86, x86-64',
     install_requires=requires,
     extras_require={'dev': dev_requires},
-    entry_points={'console_scripts': ['sopel = sopel.run_script:main']},
+    entry_points={
+        'console_scripts': [
+            'sopel = sopel.run_script:main',
+            'sopel-module = sopel.cli.modules:main',
+        ],
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     # Distutils is shit, and doesn't check if it's a list of basestring
     # but instead requires str.
     packages=[str('sopel'), str('sopel.modules'),
-              str('sopel.config'), str('sopel.tools')],
+              str('sopel.config'), str('sopel.tools'), str('sopel.cli')],
     classifiers=classifiers,
     license='Eiffel Forum License, version 2',
     platforms='Linux x86, x86-64',

--- a/sopel/cli/__init__.py
+++ b/sopel/cli/__init__.py
@@ -1,0 +1,2 @@
+# coding=utf-8
+"""Sopel Command Line Interfaces (CLI)"""

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -11,8 +11,8 @@ from sopel import loader, run_script, config, tools
 
 
 DISPLAY_ENABLE = {
-    True: 'E',
-    False: 'X',
+    True: 'e',
+    False: 'x',
 }
 
 DISPLAY_TYPE = {
@@ -107,11 +107,6 @@ def handle_list(options, settings):
     show_all = options.show_all or options.show_excluded
     modules = loader.enumerate_modules(settings, show_all=show_all).items()
 
-    # Show All
-    if show_all:
-        # If all are shown, add the "enabled" column
-        template = col_sep.join([template, '{enabled}'])
-
     # Show Excluded Only
     if options.show_excluded:
         if settings.core.enable:
@@ -137,12 +132,19 @@ def handle_list(options, settings):
         modules,
         key=lambda arg: arg[0])
 
+    # Get the maximum length of module names for display purpose
+    max_length = 0
+    if modules:
+        max_length = max(len(info[0]) for info in modules)
+
+    # Show All
+    if show_all:
+        name_template = '{name:<' + str(max_length) + '}'
+        # If all are shown, add the "enabled" column
+        template = col_sep.join(['{enabled}', template])
+
     # Show Module Path
     if options.show_path:
-        # Get the maximum length of module names for display purpose
-        max_length = 0
-        if modules:
-            max_length = max(len(info[0]) for info in modules)
         name_template = '{name:<' + str(max_length) + '}'
         # Add the path at the end of the line
         template = col_sep.join([template, '{path}'])

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -69,6 +69,13 @@ def build_parser():
         default=False,
         help='Show only excluded module')
 
+    # Configure DISABLE action
+    disable_parser = subparsers.add_parser(
+        'disable',
+        help='Disable a sopel module',
+        description='Disable a sopel module')
+    disable_parser.add_argument('module')
+
     return parser
 
 
@@ -220,6 +227,25 @@ def handle_show(options, settings):
             print('\t%s' % url.url_regex.pattern)
 
 
+def handle_disable(options, settings):
+    module_name = options.module
+    modules = loader.enumerate_modules(settings, show_all=True)
+
+    if module_name not in modules:
+        tools.stderr('No module named %s' % module_name)
+        return 1
+
+    disabled = settings.core.exclude
+    if module_name in disabled:
+        tools.stderr('Module %s already disabled' % module_name)
+        return 0
+
+    settings.core.exclude = disabled + [module_name]
+    settings.save()
+
+    print('Module %s disabled' % module_name)
+
+
 def main():
     """Console entry point for ``sopel-module``"""
     parser = build_parser()
@@ -233,3 +259,6 @@ def main():
 
     if action == 'show':
         return handle_show(options, settings)
+
+    if action == 'disable':
+        return handle_disable(options, settings)

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -9,6 +9,7 @@ import inspect
 import os
 
 from sopel import loader, run_script, config, tools
+from sopel.cli import utils
 
 
 DISPLAY_ENABLE = {
@@ -20,12 +21,6 @@ DISPLAY_TYPE = {
     imp.PKG_DIRECTORY: 'p',
     imp.PY_SOURCE: 'm'
 }
-
-
-def add_config_option(subparser):
-    subparser.add_argument(
-        '-c', '--config', default=None, metavar='filename', dest='config',
-        help='Use a specific configuration file')
 
 
 def build_parser():
@@ -40,7 +35,7 @@ def build_parser():
         'show',
         help='Show a sopel module\'s details',
         description='Show a sopel module\'s details')
-    add_config_option(show_parser)
+    utils.add_config_arguments(show_parser)
     show_parser.add_argument('module')
 
     # Configure LIST action
@@ -48,7 +43,7 @@ def build_parser():
         'list',
         help='List availables sopel modules',
         description='List availables sopel modules')
-    add_config_option(list_parser)
+    utils.add_config_arguments(list_parser)
     list_parser.add_argument(
         '-p', '--path',
         action='store_true',
@@ -84,7 +79,7 @@ def build_parser():
         'enable',
         help='Enable a sopel module',
         description='Enable a sopel module')
-    add_config_option(enable_parser)
+    utils.add_config_arguments(enable_parser)
     enable_parser.add_argument('module')
 
     # Configure DISABLE action
@@ -92,7 +87,7 @@ def build_parser():
         'disable',
         help='Disable a sopel module',
         description='Disable a sopel module')
-    add_config_option(disable_parser)
+    utils.add_config_arguments(disable_parser)
     disable_parser.add_argument('module')
 
     return parser
@@ -318,15 +313,9 @@ def main():
     parser = build_parser()
     options = parser.parse_args()
     action = options.action or 'list'
-    config_filename = run_script.find_config(options.config or 'default')
-
-    if not os.path.isfile(config_filename):
-        tools.stderr(
-            'Unable to find the configuration file %s' % config_filename)
-        return 2
 
     try:
-        settings = config.Config(config_filename)
+        settings = utils.load_settings(options)
     except config.ConfigurationError as error:
         tools.stderr(error)
         return 2

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -314,7 +314,11 @@ def main():
             'Unable to find the configuration file %s' % config_filename)
         return 2
 
-    settings = config.Config(config_filename)
+    try:
+        settings = config.Config(config_filename)
+    except config.ConfigurationError as error:
+        tools.stderr(error)
+        return 2
 
     if action == 'list':
         return handle_list(options, settings)

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -12,12 +12,20 @@ def main():
     parser = argparse.ArgumentParser(
         description='Experimental Sopel Module tool')
     subparsers = parser.add_subparsers(
-        help='Actions to perform, default to list',
+        help='Actions to perform (default to list)',
         dest='action')
 
     # Configure LIST action
-    subparsers.add_parser(
-        'list', help='List availables sopel modules')
+    list_parser = subparsers.add_parser(
+        'list',
+        help='List availables sopel modules',
+        description='List availables sopel modules')
+    list_parser.add_argument(
+        '-p', '--path',
+        action='store_true',
+        dest='show_path',
+        default=False,
+        help='Show the path to the module file')
 
     options = parser.parse_args()
     action = options.action or 'list'
@@ -25,11 +33,27 @@ def main():
     if action == 'list':
         config_filename = run_script.find_config('default')
         settings = config.Config(config_filename)
+        modules = loader.enumerate_modules(settings)
         modules = sorted(
-            tools.iteritems(loader.enumerate_modules(settings)),
+            modules.items(),
             key=lambda arg: arg[0])
 
+        template = '{name}'
+        if options.show_path:
+            # Get the maximum length of module names for display purpose
+            max_length = max(len(info[0]) for info in modules)
+
+            template = '\t'.join([
+                '{name:<' + str(max_length) +'}',
+                '{path}',
+            ])
+
         for name, info in modules:
-            print(name)
+            path, module_type = info
+            print(template.format(
+                name=name,
+                path=path,
+                module_type=module_type,
+            ))
 
         return

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -113,8 +113,7 @@ def handle_list(options, settings):
                 if name in settings.core.exclude or
                 name not in settings.core.enable
             ]
-
-        if settings.core.exclude:
+        else:
             # Get only excluded
             modules = [
                 (name, info)
@@ -130,7 +129,9 @@ def handle_list(options, settings):
     # Show Module Path
     if options.show_path:
         # Get the maximum length of module names for display purpose
-        max_length = max(len(info[0]) for info in modules)
+        max_length = 0
+        if modules:
+            max_length = max(len(info[0]) for info in modules)
         name_template = '{name:<' + str(max_length) + '}'
         # Add the path at the end of the line
         template = col_sep.join([template, '{path}'])

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -1,0 +1,35 @@
+# coding=utf-8
+"""Sopel Modules Command Line Interfaces (CLI): ``sopel-module``"""
+from __future__ import unicode_literals, absolute_import, print_function, division
+
+import argparse
+
+from sopel import loader, run_script, config, tools
+
+
+def main():
+    """Console entry point for ``sopel-module``"""
+    parser = argparse.ArgumentParser(
+        description='Experimental Sopel Module tool')
+    subparsers = parser.add_subparsers(
+        help='Actions to perform, default to list',
+        dest='action')
+
+    # Configure LIST action
+    subparsers.add_parser(
+        'list', help='List availables sopel modules')
+
+    options = parser.parse_args()
+    action = options.action or 'list'
+
+    if action == 'list':
+        config_filename = run_script.find_config('default')
+        settings = config.Config(config_filename)
+        modules = sorted(
+            tools.iteritems(loader.enumerate_modules(settings)),
+            key=lambda arg: arg[0])
+
+        for name, info in modules:
+            print(name)
+
+        return

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -3,8 +3,15 @@
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 import argparse
+import imp
 
-from sopel import loader, run_script, config, tools
+from sopel import loader, run_script, config
+
+
+DISPLAY_TYPE = {
+    imp.PKG_DIRECTORY: 'p',
+    imp.PY_SOURCE: 'm'
+}
 
 
 def main():
@@ -26,6 +33,15 @@ def main():
         dest='show_path',
         default=False,
         help='Show the path to the module file')
+    list_parser.add_argument(
+        '-t', '--type',
+        action='store_true',
+        dest='show_type',
+        default=False,
+        help=('Show the type to the module file: '
+              '`p` for package directory, '
+              '`m` for module file, '
+              '`?` for unknown'))
 
     options = parser.parse_args()
     action = options.action or 'list'
@@ -38,22 +54,26 @@ def main():
             modules.items(),
             key=lambda arg: arg[0])
 
+        col_sep = '\t'
         template = '{name}'
         if options.show_path:
             # Get the maximum length of module names for display purpose
             max_length = max(len(info[0]) for info in modules)
 
-            template = '\t'.join([
-                '{name:<' + str(max_length) +'}',
+            template = col_sep.join([
+                '{name:<' + str(max_length) + '}',
                 '{path}',
             ])
+
+        if options.show_type:
+            template = col_sep.join(['{module_type}', template])
 
         for name, info in modules:
             path, module_type = info
             print(template.format(
                 name=name,
                 path=path,
-                module_type=module_type,
+                module_type=DISPLAY_TYPE.get(module_type, '?'),
             ))
 
         return

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -6,9 +6,8 @@ import argparse
 import datetime
 import imp
 import inspect
-import os
 
-from sopel import loader, run_script, config, tools
+from sopel import loader, config, tools
 from sopel.cli import utils
 
 

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -175,13 +175,18 @@ def handle_show(options, settings):
         print('')
         print('# Module Commands')
         for command in callables:
-            print('')
-
             if command._docs.keys():
+                print('')
                 print('## %s' % ', '.join(command._docs.keys()))
-            elif command.rule:
+            elif getattr(command, 'rule', None):
                 # display rules afters normal commands
                 rule_callables.append(command)
+                continue
+            elif getattr(command, 'intents', None):
+                rule_callables.append(command)
+                continue
+            else:
+                # nothing to display right now
                 continue
 
             docstring = inspect.cleandoc(
@@ -196,7 +201,9 @@ def handle_show(options, settings):
 
             for command in rule_callables:
                 print('')
-                for rule in command.rule:
+                for intent in getattr(command, 'intents', []):
+                    print('[INTENT]', intent.pattern)
+                for rule in getattr(command, 'rule', []):
                     print(rule.pattern)
 
                 docstring = inspect.cleandoc(

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 import argparse
 import imp
 import inspect
+import os
 
 from sopel import loader, run_script, config, tools
 
@@ -20,6 +21,12 @@ DISPLAY_TYPE = {
 }
 
 
+def add_config_option(subparser):
+    subparser.add_argument(
+        '-c', '--config', default=None, metavar='filename', dest='config',
+        help='Use a specific configuration file')
+
+
 def build_parser():
     parser = argparse.ArgumentParser(
         description='Experimental Sopel Module tool')
@@ -32,6 +39,7 @@ def build_parser():
         'show',
         help='Show a sopel module\'s details',
         description='Show a sopel module\'s details')
+    add_config_option(show_parser)
     show_parser.add_argument('module')
 
     # Configure LIST action
@@ -39,6 +47,7 @@ def build_parser():
         'list',
         help='List availables sopel modules',
         description='List availables sopel modules')
+    add_config_option(list_parser)
     list_parser.add_argument(
         '-p', '--path',
         action='store_true',
@@ -74,6 +83,7 @@ def build_parser():
         'enable',
         help='Enable a sopel module',
         description='Enable a sopel module')
+    add_config_option(enable_parser)
     enable_parser.add_argument('module')
 
     # Configure DISABLE action
@@ -81,6 +91,7 @@ def build_parser():
         'disable',
         help='Disable a sopel module',
         description='Disable a sopel module')
+    add_config_option(disable_parser)
     disable_parser.add_argument('module')
 
     return parser
@@ -296,7 +307,13 @@ def main():
     parser = build_parser()
     options = parser.parse_args()
     action = options.action or 'list'
-    config_filename = run_script.find_config('default')
+    config_filename = run_script.find_config(options.config or 'default')
+
+    if not os.path.isfile(config_filename):
+        tools.stderr(
+            'Unable to find the configuration file %s' % config_filename)
+        return 2
+
     settings = config.Config(config_filename)
 
     if action == 'list':

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -97,7 +97,10 @@ def main():
                 modules = [
                     (name, info)
                     for name, info in modules
-                    if name not in settings.core.enable
+                    # Remove enabled modules...
+                    # ... unless they are in the excluded list.
+                    if name in settings.core.exclude or
+                    name not in settings.core.enable
                 ]
 
             if settings.core.exclude:

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -42,6 +42,12 @@ def main():
               '`p` for package directory, '
               '`m` for module file, '
               '`?` for unknown'))
+    list_parser.add_argument(
+        '-a', '--all',
+        action='store_true',
+        dest='show_all',
+        default=False,
+        help='Show all available module, enabled or not')
 
     options = parser.parse_args()
     action = options.action or 'list'
@@ -49,7 +55,7 @@ def main():
     if action == 'list':
         config_filename = run_script.find_config('default')
         settings = config.Config(config_filename)
-        modules = loader.enumerate_modules(settings)
+        modules = loader.enumerate_modules(settings, show_all=options.show_all)
         modules = sorted(
             modules.items(),
             key=lambda arg: arg[0])

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -55,18 +55,20 @@ def main():
               '`p` for package directory, '
               '`m` for module file, '
               '`?` for unknown'))
-    list_parser.add_argument(
+
+    list_group = list_parser.add_mutually_exclusive_group()
+    list_group.add_argument(
         '-a', '--all',
         action='store_true',
         dest='show_all',
         default=False,
         help='Show all available module, enabled or not')
-    list_parser.add_argument(
+    list_group.add_argument(
         '-e', '--excluded',
         action='store_true',
         dest='show_excluded',
         default=False,
-        help='Show only excluded module (incompatible with -a/--all)')
+        help='Show only excluded module')
 
     options = parser.parse_args()
     action = options.action or 'list'

--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -1,0 +1,42 @@
+# coding=utf-8
+"""Sopel Command Line Interfaces (CLI) utils"""
+from __future__ import unicode_literals, absolute_import, print_function, division
+import os
+
+from sopel import config, run_script
+
+
+def add_config_arguments(parser):
+    """Add configuration related argument to a given ``parser``.
+
+    :param parser: Argument parser (or sub-parser)
+    :type parser: argparse.ArgumentParser
+
+    This function adds the proper argument to a given ``parser`` in order to
+    have a standard way to define a configuration filename in all of Sopel's
+    command line interfaces.
+    """
+    parser.add_argument(
+        '-c', '--config',
+        default=None,
+        metavar='filename',
+        dest='config',
+        help='Use a specific configuration file')
+
+
+def load_settings(options):
+    """Load Sopel settings from command line's ``options``.
+
+    :param options: parsed arguments
+    :return: sopel configuration loaded from the options, or the default one
+    :rtype: :class:`sopel.config.Config`
+    :raise sopel.config.NotFound: raised when configuration file is not found
+    :raise sopel.config.ConfigurationError: raised when configuration is
+                                            invalid
+    """
+    config_filename = run_script.find_config(options.config or 'default')
+
+    if not os.path.isfile(config_filename):
+        raise config.NotFound(filename=config_filename)
+
+    return config.Config(config_filename)

--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -25,16 +25,41 @@ def add_config_arguments(parser):
 
 
 def load_settings(options):
-    """Load Sopel settings from command line's ``options``.
+    """Load Sopel settings given a command line's ``options``.
 
     :param options: parsed arguments
-    :return: sopel configuration loaded from the options, or the default one
+    :return: sopel configuration
     :rtype: :class:`sopel.config.Config`
     :raise sopel.config.NotFound: raised when configuration file is not found
     :raise sopel.config.ConfigurationError: raised when configuration is
                                             invalid
+
+    This function load Sopel settings from one of these sources:
+
+    * value of ``options.config``, if given,
+    * ``SOPEL_CONFIG`` environ variable, if no option is given,
+    * otherwise the ``default`` configuration is loaded,
+
+    then loads the settings and returns it as a :class:`~sopel.config.Config`
+    object.
+
+    If the configuration file can not be found, a :exc:`sopel.config.NotFound`
+    error will be raised.
+
+    .. note::
+
+        To use this function effectively, the
+        :func:`sopel.cli.utils.add_config_arguments` should be used to add the
+        proper option to the argument parser.
     """
-    config_filename = run_script.find_config(options.config or 'default')
+    # Default if no options.config or no env var or if they are empty
+    name = 'default'
+    if options.config:
+        name = options.config
+    elif 'SOPEL_CONFIG' in os.environ:
+        name = os.environ['SOPEL_CONFIG'] or name
+
+    config_filename = run_script.find_config(name)
 
     if not os.path.isfile(config_filename):
         raise config.NotFound(filename=config_filename)

--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -3,7 +3,32 @@
 from __future__ import unicode_literals, absolute_import, print_function, division
 import os
 
-from sopel import config, run_script
+from sopel import config
+
+
+homedir = os.path.join(os.path.expanduser('~'), '.sopel')
+
+
+def enumerate_configs(extension='.cfg'):
+    configfiles = []
+    if os.path.isdir(homedir):
+        sopel_dotdirfiles = os.listdir(homedir)  # Preferred
+        for item in sopel_dotdirfiles:
+            if item.endswith(extension):
+                configfiles.append(item)
+
+    return configfiles
+
+
+def find_config(name, extension='.cfg'):
+    if os.path.isfile(name):
+        return name
+    configs = enumerate_configs(extension)
+    if name in configs or name + extension in configs:
+        if name + extension in configs:
+            name = name + extension
+
+    return os.path.join(homedir, name)
 
 
 def add_config_arguments(parser):
@@ -59,7 +84,7 @@ def load_settings(options):
     elif 'SOPEL_CONFIG' in os.environ:
         name = os.environ['SOPEL_CONFIG'] or name
 
-    config_filename = run_script.find_config(name)
+    config_filename = find_config(name)
 
     if not os.path.isfile(config_filename):
         raise config.NotFound(filename=config_filename)

--- a/sopel/config/__init__.py
+++ b/sopel/config/__init__.py
@@ -48,6 +48,7 @@ class NotFound(ConfigurationError):
     """Configuration file not found."""
     def __init__(self, filename):
         self.filename = filename
+        """Path to the configuration file not found"""
 
     def __str__(self):
         return 'Unable to find the configuration file %s' % self.filename

--- a/sopel/config/__init__.py
+++ b/sopel/config/__init__.py
@@ -44,6 +44,15 @@ class ConfigurationError(Exception):
         return 'ConfigurationError: %s' % self.value
 
 
+class NotFound(ConfigurationError):
+    """Configuration file not found."""
+    def __init__(self, filename):
+        self.filename = filename
+
+    def __str__(self):
+        return 'Unable to find the configuration file %s' % self.filename
+
+
 class Config(object):
     def __init__(self, filename, validate=True):
         """The bot's configuration.


### PR DESCRIPTION
Remember #1434 I did to work on a new cli interface for Sopel? Well, it gets better and better!

**TL;DR**: I use `SOPEL_CONFIG` env var to load the configuration, using a `sopel.cli.utils` module

## The core of this PR

The core of this PR is to add a `SOPEL_CONFIG` env var to load configuration.

What happens is that:

* first, we try to get the config from the command line argument, like `-c filename`
* then, if the `-c` is not used, we try to look at `SOPEL_CONFIG` env var,
* if nothing is set, we fall back on the `default` config file,

If the `-c` option is used or the `SOPEL_CONFIG` is defined, then it tries to load it, and it won't fall back to the default, ie. if the user decided to use a wrong config file, then Sopel will warn them.

## About the state of the project

To really understand what's going on here, you need to have a look at #1434 because I based this branch from it. Then, here are the good bits of this PR:

* In 614a730 I added `sopel.cli.utils` to store cli-related tools,
* In 3324ca3 I introduce the usage of a `SOPEL_CONFIG` env var,
* In eea0863 I use the 2 previous commit's work to improve the `sopel.run_script` module.

Note: both #1434 and this PR should be rebased after #1429 is merged into master, because the clean-up and the unit-test are very valuable!

**The end goal is to move** both `sopel` and `sopel-module` command line `main` functions into `sopel.cli`.
