### PR TITLE
db: adding multi database support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -44,6 +44,16 @@ In the source directory (whether cloned or from the tarball) run
 bot. Alternately, you can just run the ``sopel.py`` file in the source
 directory.
 
+Database Support
+----------------
+Sopel leverages SQLAlchemy to support the following database types: SQLite,
+MySQL, PostgreSQL, MSSQL, Oracle, Firebird, and Sybase. By default Sopel will
+use a SQLite database in the current configuration directory, but alternative
+databases can be configured with the following config options: ``db_type``,
+``db_filename`` (SQLite only), ``db_driver``, ``db_user``, ``db_pass``,
+``db_host``, ``db_port``, and ``db_name``. You will need to manually install
+any packages (system or ``pip``) needed to make your chosen database work.
+
 Adding modules
 --------------
 The easiest place to put new modules is in ``~/.sopel/modules``. Some newer

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,5 @@ requests>=2.0.0,<3.0.0
 dnspython<2.0; python_version >= '2.7' and python_version < '3.0'
 dnspython<1.16.0; python_version == '3.3'
 dnspython<3.0; python_version >= '3.4'
+sqlalchemy<1.3; python_version == '3.3'
+sqlalchemy<1.4; python_version != '3.3'

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -108,8 +108,38 @@ class CoreSection(StaticSection):
     channels = ListAttribute('channels')
     """List of channels for the bot to join when it connects"""
 
+    db_type = ChoiceAttribute('db_type', choices=[
+        'sqlite', 'mysql', 'postgres', 'mssql', 'oracle', 'firebird', 'sybase'], default='sqlite')
+    """The type of database to use for Sopel's database.
+
+    mysql - pip install mysql-python (Python 2) or pip install mysqlclient (Python 3)
+    postgres - pip install psycopg2
+    mssql - pip install pymssql
+
+    See https://docs.sqlalchemy.org/en/latest/dialects/ for a full list of dialects"""
+
     db_filename = ValidatedAttribute('db_filename')
-    """The filename for Sopel's database."""
+    """The filename for Sopel's database. (SQLite only)"""
+
+    db_driver = ValidatedAttribute('db_driver')
+    """The driver for Sopel's database.
+    This is optional, but can be specified if user wants to use a different driver
+    https://docs.sqlalchemy.org/en/latest/core/engines.html"""
+
+    db_user = ValidatedAttribute('db_user')
+    """The user for Sopel's database."""
+
+    db_pass = ValidatedAttribute('db_pass')
+    """The password for Sopel's database."""
+
+    db_host = ValidatedAttribute('db_host')
+    """The host for Sopel's database."""
+
+    db_port = ValidatedAttribute('db_port')
+    """The port for Sopel's database."""
+
+    db_name = ValidatedAttribute('db_name')
+    """The name of Sopel's database."""
 
     default_time_format = ValidatedAttribute('default_time_format',
                                              default='%Y-%m-%d - %T%Z')


### PR DESCRIPTION
This should fix #736.

This PR migrates from direct SQLite SQL statements to using the SQLAlchemy ORM. This will allow users to choose whether they want to stick with SQLite (Default), or leverage another database engine.

I've added a few more variables to core to handle non-SQLite databases: db_type, db_user, db_pass, db_host, and db_name. If db_type is not specified, or is specified with sqlite, the other values do not need to be specified. If db_type is specified with MySQL, users will need to specify the other parameters.

We could probably move the Models into their own model.py to clean things up a bit, but I will leave that to your discretion @dgw  