### PR TITLE
core: properly truncate long messages with 2-byte characters

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -290,27 +290,15 @@ class Sopel(irc.Bot):
         message will contain the entire remainder, which may be truncated by
         the server.
         """
-        # We're arbitrarily saying that the max is 400 bytes of text when
-        # messages will be split. Otherwise, we'd have to acocunt for the bot's
-        # hostmask, which is hard.
-        max_text_length = 400
-        # Encode to bytes, for propper length calculation
-        if isinstance(text, unicode):
-            encoded_text = text.encode('utf-8')
-        else:
-            encoded_text = text
         excess = ''
-        if max_messages > 1 and len(encoded_text) > max_text_length:
-            last_space = encoded_text.rfind(' '.encode('utf-8'), 0, max_text_length)
-            if last_space == -1:
-                excess = encoded_text[max_text_length:]
-                encoded_text = encoded_text[:max_text_length]
-            else:
-                excess = encoded_text[last_space + 1:]
-                encoded_text = encoded_text[:last_space]
-        # We'll then send the excess at the end
-        # Back to unicode again, so we don't screw things up later.
-        text = encoded_text.decode('utf-8')
+        if not isinstance(text, unicode):
+            # Make sure we are dealing with unicode string
+            text = text.decode('utf-8')
+
+        if max_messages > 1:
+            # Manage multi-line only when needed
+            text, excess = tools.get_sendable_message(text)
+
         try:
             self.sending.acquire()
 

--- a/sopel/irc.py
+++ b/sopel/irc.py
@@ -138,13 +138,24 @@ class Bot(asynchat.async_chat):
             # CR-LF (Carriage Return - Line Feed) pair, and these messages SHALL
             # NOT exceed 512 characters in length, counting all characters
             # including the trailing CR-LF. Thus, there are 510 characters
-            # maximum allowed for the command and its parameters.  There is no
+            # maximum allowed for the command and its parameters. There is no
             # provision for continuation of message lines.
 
+            max_length = unicode_max_length = 510
             if text is not None:
-                temp = (' '.join(args) + ' :' + text)[:510] + '\r\n'
+                temp = (' '.join(args) + ' :' + text)
             else:
-                temp = ' '.join(args)[:510] + '\r\n'
+                temp = ' '.join(args)
+
+            # The max length of 512 is in bytes, not unicode
+            while len(temp.encode('utf-8')) > max_length:
+                temp = temp[:unicode_max_length]
+                unicode_max_length = unicode_max_length - 1
+
+            # Ends the message with CR-LF
+            temp = temp + '\r\n'
+
+            # Log and output the message
             self.log_raw(temp, '>>')
             self.send(temp.encode('utf-8'))
         finally:

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -152,6 +152,40 @@ def get_nickname_command_pattern(command):
         """.format(command=command)
 
 
+def get_sendable_message(text, max_length=400):
+    """Get a sendable ``text`` message, with its excess when needed.
+
+    :param str txt: unicode string of text to send
+    :param int max_length: maximum length of the message to be sendable
+    :return: a tuple of two values, the sendable text and its excess text
+
+    We're arbitrarily saying that the max is 400 bytes of text when
+    messages will be split. Otherwise, we'd have to account for the bot's
+    hostmask, which is hard.
+
+    The `max_length` is the max length of text in **bytes**, but we take
+    care of unicode 2-bytes characters, by working on the unicode string,
+    then making sure the bytes version is smaller than the max length.
+    """
+    unicode_max_length = max_length
+    excess = ''
+
+    while len(text.encode('utf-8')) > max_length:
+        last_space = text.rfind(' ', 0, unicode_max_length)
+        if last_space == -1:
+            # No last space, just split where it is possible
+            excess = text[unicode_max_length:] + excess
+            text = text[:unicode_max_length]
+            # Decrease max length for the unicode string
+            unicode_max_length = unicode_max_length - 1
+        else:
+            # Split at the last best space found
+            excess = text[last_space:]
+            text = text[:last_space]
+
+    return text, excess.lstrip()
+
+
 def deprecated(old):
     def new(*args, **kwargs):
         print('Function %s is deprecated.' % old.__name__, file=sys.stderr)

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -1,0 +1,93 @@
+# coding=utf-8
+"""Tests sopel.tools"""
+from __future__ import unicode_literals, absolute_import, print_function, division
+
+
+from sopel import tools
+
+
+def test_get_sendable_message_default():
+    initial = 'aaaa'
+    text, excess = tools.get_sendable_message(initial)
+
+    assert text == initial
+    assert excess == ''
+
+
+def test_get_sendable_message_limit():
+    initial = 'a' * 400
+    text, excess = tools.get_sendable_message(initial)
+
+    assert text == initial
+    assert excess == ''
+
+
+def test_get_sendable_message_excess():
+    initial = 'a' * 401
+    text, excess = tools.get_sendable_message(initial)
+
+    assert text == 'a' * 400
+    assert excess == 'a'
+
+
+def test_get_sendable_message_excess_space():
+    # aaa...aaa bbb...bbb
+    initial = ' '.join(['a' * 200, 'b' * 200])
+    text, excess = tools.get_sendable_message(initial)
+
+    assert text == 'a' * 200
+    assert excess == 'b' * 200
+
+
+def test_get_sendable_message_excess_space_limit():
+    # aaa...aaa bbb...bbb
+    initial = ' '.join(['a' * 400, 'b' * 200])
+    text, excess = tools.get_sendable_message(initial)
+
+    assert text == 'a' * 400
+    assert excess == 'b' * 200
+
+
+def test_get_sendable_message_excess_bigger():
+    # aaa...aaa bbb...bbb
+    initial = ' '.join(['a' * 401, 'b' * 1000])
+    text, excess = tools.get_sendable_message(initial)
+
+    assert text == 'a' * 400
+    assert excess == 'a ' + 'b' * 1000
+
+
+def test_get_sendable_message_optional():
+    text, excess = tools.get_sendable_message('aaaa', 3)
+    assert text == 'aaa'
+    assert excess == 'a'
+
+    text, excess = tools.get_sendable_message('aaa bbb', 3)
+    assert text == 'aaa'
+    assert excess == 'bbb'
+
+    text, excess = tools.get_sendable_message('aa bb cc', 3)
+    assert text == 'aa'
+    assert excess == 'bb cc'
+
+
+def test_get_sendable_message_two_bytes():
+    text, excess = tools.get_sendable_message('αααα', 4)
+    assert text == 'αα'
+    assert excess == 'αα'
+
+    text, excess = tools.get_sendable_message('αααα', 5)
+    assert text == 'αα'
+    assert excess == 'αα'
+
+    text, excess = tools.get_sendable_message('α ααα', 4)
+    assert text == 'α'
+    assert excess == 'ααα'
+
+    text, excess = tools.get_sendable_message('αα αα', 4)
+    assert text == 'αα'
+    assert excess == 'αα'
+
+    text, excess = tools.get_sendable_message('ααα α', 4)
+    assert text == 'αα'
+    assert excess == 'α α'


### PR DESCRIPTION
When a module wants to send a multi-line message, the `Bot.say` method can be used with a `max_messages` parameter to do so. The low-level `write` method on the other hand, will truncate and discard the excess no matter what.

In both case, we must not truncate unicode character composed of 2 bytes in half: we must remove the whole unicode character, then check the size again, until the encoded message's length is lower or equal to the maximum length.

It won't solve the case where the bot can send a valid message, but the server won't be able to propagate it properly to other clients because it has to add extra information (such as the bot's hostmask and all) and such a way that it generates a message too long.

But it's a good start to fix #467 