### PR TITLE
help: choose pastebin service for .help output

### DIFF
--- a/sopel/modules/help.py
+++ b/sopel/modules/help.py
@@ -130,7 +130,11 @@ def help(bot, trigger):
         # actually creating the list first. Maybe worth storing the link and a
         # heuristic in the DB, too, so it persists across restarts. Would need a
         # command to regenerate, too...
-        if 'command-list' in bot.memory and bot.memory['command-list'][0] == len(bot.command_groups):
+        if (
+                'command-list' in bot.memory and
+                bot.memory['command-list'][0] == len(bot.command_groups) and
+                bot.memory['command-list'][2] == bot.config.help.output
+        ):
             url = bot.memory['command-list'][1]
         else:
             bot.say("Hang on, I'm creating a list.")
@@ -149,7 +153,9 @@ def help(bot, trigger):
             url = create_list(bot, '\n\n'.join(msgs))
             if not url:
                 return
-            bot.memory['command-list'] = (len(bot.command_groups), url)
+            bot.memory['command-list'] = (len(bot.command_groups),
+                                          url,
+                                          bot.config.help.output)
         bot.say("I've posted a list of my commands at {0} - You can see "
                 "more info about any of these commands by doing {1}help "
                 "<command> (e.g. {1}help time)".format(url, help_prefix))

--- a/sopel/modules/help.py
+++ b/sopel/modules/help.py
@@ -25,6 +25,14 @@ from sopel.config.types import (
 )
 
 
+LOGGER = get_logger(__name__)
+
+
+class PostingException(Exception):
+    """Custom exception type for errors posting help to the chosen pastebin."""
+    pass
+
+
 # Pastebin handlers
 
 
@@ -118,14 +126,14 @@ def post_to_termbin(msg):
 
     # find/replace just in case the site tries to be sneaky and save on SSL overhead,
     # though it will probably send us an HTTPS link without any tricks.
-    return response.strip(u'\x00\n').replace('http://', 'https://', 1)
+    return response.strip('\x00\n').replace('http://', 'https://', 1)
 
 
 PASTEBIN_PROVIDERS = {
     'clbin': post_to_clbin,
     '0x0': post_to_0x0,
     'hastebin': post_to_hastebin,
-    'termbin': post_to_termbin
+    'termbin': post_to_termbin,
 }
 
 
@@ -144,9 +152,6 @@ def configure(config):
         'output',
         'Pick a pastebin provider: {}: '.format(provider_list)
     )
-
-
-LOGGER = get_logger(__name__)
 
 
 def setup(bot):
@@ -232,11 +237,6 @@ def create_list(bot, msg):
         LOGGER.exception("Error posting commands")
         return
     return result
-
-
-class PostingException(Exception):
-    """Custom exception type for errors posting help to the chosen pastebin."""
-    pass
 
 
 @rule('$nick' r'(?i)help(?:[?!]+)?$')

--- a/sopel/modules/help.py
+++ b/sopel/modules/help.py
@@ -25,7 +25,7 @@ from sopel.config.types import (
 # Pastebin handlers
 
 
-def post_to_clbin(bot, msg):
+def post_to_clbin(msg):
     result = requests.post('https://clbin.com/', data={'clbin': msg})
     result = result.text
 
@@ -36,13 +36,13 @@ def post_to_clbin(bot, msg):
         raise PostingException()
 
 
-def post_to_0x0(bot, msg):
+def post_to_0x0(msg):
     payload = {'file': msg}
     result = requests.post('https://0x0.st', files=payload)
     return result.text
 
 
-def post_to_hastebin(bot, msg):
+def post_to_hastebin(msg):
     result = requests.post('https://hastebin.com/documents', data=msg)
     result = result.json()
     if 'key' not in result:
@@ -51,7 +51,7 @@ def post_to_hastebin(bot, msg):
     return "https://hastebin.com/" + result['key']
 
 
-def post_to_termbin(bot, msg):
+def post_to_termbin(msg):
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
     s.connect(('termbin.com', 9999))
     s.sendall(msg)
@@ -165,7 +165,7 @@ def create_list(bot, msg):
     msg = 'Command listing for {}@{}\n\n'.format(bot.nick, bot.config.core.host) + msg
 
     try:
-        result = _pastebin_providers[bot.config.help.output](bot, msg)
+        result = _pastebin_providers[bot.config.help.output](msg)
     except (requests.RequestException, PostingException):
         bot.say("Sorry! Something went wrong.")
         LOGGER.exception("Error posting commands")

--- a/sopel/modules/help.py
+++ b/sopel/modules/help.py
@@ -55,8 +55,10 @@ def post_to_clbin(msg):
         raise
 
     result = result.text
-    if 'https://clbin.com/' in result:
-        return result
+    if '://clbin.com/' in result:
+        # find/replace just in case the site tries to be sneaky and save on SSL overhead,
+        # though it will probably send us an HTTPS link without any tricks.
+        return result.replace('http://', 'https://', 1)
     else:
         LOGGER.error("Invalid result %s", result)
         raise PostingException('clbin result did not contain expected URL base.')
@@ -69,8 +71,10 @@ def post_to_0x0(msg):
         raise
 
     result = result.text
-    if 'https://0x0.st' in result:
-        return result
+    if '://0x0.st' in result:
+        # find/replace just in case the site tries to be sneaky and save on SSL overhead,
+        # though it will probably send us an HTTPS link without any tricks.
+        return result.replace('http://', 'https://', 1)
     else:
         LOGGER.error('Invalid result %s', result)
         raise PostingException('0x0.st result did not contain expected URL base.')
@@ -112,7 +116,9 @@ def post_to_termbin(msg):
         LOGGER.exception('Error during communication with termbin')
         raise PostingException('Error uploading to termbin')
 
-    return response.strip(u'\x00\n')
+    # find/replace just in case the site tries to be sneaky and save on SSL overhead,
+    # though it will probably send us an HTTPS link without any tricks.
+    return response.strip(u'\x00\n').replace('http://', 'https://', 1)
 
 
 _pastebin_providers = {

--- a/sopel/modules/help.py
+++ b/sopel/modules/help.py
@@ -130,9 +130,11 @@ _pastebin_providers = {
 
 
 class HelpSection(StaticSection):
+    """Configuration section for this module."""
     output = ChoiceAttribute('output',
                              list(_pastebin_providers),
                              default='clbin')
+    """The pastebin provider to use for help output."""
 
 
 def configure(config):
@@ -158,7 +160,7 @@ def setup(bot):
 @commands('help', 'commands')
 @priority('low')
 def help(bot, trigger):
-    """Shows a command's documentation, and possibly an example."""
+    """Shows a command's documentation, and an example if available. With no arguments, lists all commands."""
     if trigger.group(2):
         name = trigger.group(2)
         name = name.lower()
@@ -217,6 +219,10 @@ def help(bot, trigger):
 
 
 def create_list(bot, msg):
+    """Creates & uploads the command list.
+
+    Returns the URL from the chosen pastebin provider.
+    """
     msg = 'Command listing for {}@{}\n\n'.format(bot.nick, bot.config.core.host) + msg
 
     try:
@@ -229,6 +235,7 @@ def create_list(bot, msg):
 
 
 class PostingException(Exception):
+    """Custom exception type for errors posting help to the chosen pastebin."""
     pass
 
 

--- a/sopel/modules/help.py
+++ b/sopel/modules/help.py
@@ -82,6 +82,11 @@ class HelpSection(StaticSection):
 
 def configure(config):
     config.define_section('help', HelpSection)
+    provider_list = ', '.join(_pastebin_providers)
+    config.help.configure_setting(
+        'output',
+        'Pick a pastebin provider: {}: '.format(provider_list)
+    )
 
 
 LOGGER = get_logger(__name__)

--- a/sopel/modules/help.py
+++ b/sopel/modules/help.py
@@ -4,6 +4,8 @@ help.py - Sopel Help Module
 Copyright 2008, Sean B. Palmer, inamidst.com
 Copyright © 2013, Elad Alfassa, <elad@fedoraproject.org>
 Copyright © 2018, Adam Erdman, pandorah.org
+Copyright © 2019, Tomasz Kurcz, github.com/uint
+Copyright © 2019, dgw, technobabbl.es
 Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
@@ -11,9 +13,10 @@ https://sopel.chat
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 import collections
-import requests
 import socket
 import textwrap
+
+import requests
 
 from sopel.logger import get_logger
 from sopel.module import commands, rule, example, priority


### PR DESCRIPTION
# Description
I've created a new config section `help` with the `output` setting. `output` can currently be set to:
* `"ptpb"`
* `"0x0"`
* `"hastebin"`
* `"termbin"`

This resolves #1416.

# Example
```
19:42 <uint> .set help.output termbin
19:42 <uint> .help
19:43 <uint-bot> Hang on, I'm creating a list.
19:43 <uint-bot> I've posted a list of my commands at https://termbin.com/3tyx2 - You can see more
                 info about any of these commands by doing .help <command> (e.g. .help time)
```

# Potential problems
It seems that if I use `.help`, the bot will cache the url. If I then change the `output` option to something else, the bot won't let me use the new service since it still has the old link cached. This could lead to problems if the old link is erroneous and the user can't get a new one until they restart the bot.

@dgw Is it possible to make it so that changing the config option also triggers the cached data to be cleared? I think that would be the simplest solution.

# Next steps?
* We probably really should add an option for the bot to simply "say" the command list, either in the channel or a private message. Should I work on that too?

# Version
```
19:51 <uint> .version
19:51 <uint-bot> uint: Sopel v. 6.5.3
```