### PR TITLE
Don't require pyenchant on Python 3.7 or above

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 xmltodict
 pytz
 praw<6.0.0
-pyenchant
+pyenchant; python_version < '3.7'
 geoip2
 ipython<6.0; python_version < '3.3'
 ipython>=6.0,<7.0; python_version >= '3.3'


### PR DESCRIPTION
pyenchant is broken on newer distributions, and has been unmaintained for quite a while. Since only the spellcheck module needs it, and a rewrite of that module to switch libraries is coming Soon™, we might as
well make Sopel installable in the mean time on systems that can't pull down a working pyenchant build.

See #1452. Alternative to #1453.

Note that this change is intended to make `master` installable, and there is no release planned between now and Sopel 7 (which will include the rewritten spellcheck module and drop pyenchant completely).