### PR TITLE
modules: use @require_admin instead of if trigger.admin

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -596,15 +596,13 @@ def sasl_success(bot, trigger):
 @sopel.module.priority('low')
 @sopel.module.thread(False)
 @sopel.module.unblockable
+@sopel.module.require_admin
 def blocks(bot, trigger):
     """
     Manage Sopel's blocking features.\
     See [ignore system documentation]({% link _usage/ignoring-people.md %}).
 
     """
-    if not trigger.admin:
-        return
-
     STRINGS = {
         "success_del": "Successfully deleted block: %s",
         "success_add": "Successfully added block: %s",

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -341,22 +341,33 @@ def require_privilege(level, message=None):
     return actual_decorator
 
 
-def require_admin(message=None):
+def require_admin(message=None, reply=False):
     """Decorate a function to require the triggering user to be a bot admin.
 
-    If they are not, `message` will be said if given."""
+    :param str message: optional message said to non-admin user
+    :param bool reply: use `reply` instead of `say` when true, default to false
+
+    When the triggering user is not an admin, the command is not run, and the
+    bot will say the ``message`` if given. By default, it uses ``bot.say``,
+    but when ``reply`` is true, then it uses ``bot.reply`` instead.
+    """
     def actual_decorator(function):
         @functools.wraps(function)
         def guarded(bot, trigger, *args, **kwargs):
             if not trigger.admin:
                 if message and not callable(message):
-                    bot.say(message)
+                    if reply:
+                        bot.reply(message)
+                    else:
+                        bot.say(message)
             else:
                 return function(bot, trigger, *args, **kwargs)
         return guarded
+
     # Hack to allow decorator without parens
     if callable(message):
         return actual_decorator(message)
+
     return actual_decorator
 
 

--- a/sopel/modules/announce.py
+++ b/sopel/modules/announce.py
@@ -7,18 +7,16 @@ Licensed under the Eiffel Forum License 2.
 """
 from __future__ import unicode_literals, absolute_import, print_function, division
 
-from sopel.module import commands, example
+from sopel.module import commands, example, require_admin
 
 
 @commands('announce')
 @example('.announce Some important message here')
+@require_admin('Sorry, I can\'t let you do that', reply=True)
 def announce(bot, trigger):
     """
     Send an announcement to all channels the bot is in
     """
-    if not trigger.admin:
-        bot.reply('Sorry, I can\'t let you do that')
-        return
     for channel in bot.channels:
         bot.msg(channel, '[ANNOUNCEMENT] %s' % trigger.group(2))
     bot.reply('Announce complete.')

--- a/sopel/modules/ipython.py
+++ b/sopel/modules/ipython.py
@@ -36,14 +36,12 @@ console = None
 
 
 @sopel.module.commands('console')
+@sopel.module.require_admin('Only admins can start the interactive console')
 def interactive_shell(bot, trigger):
     """
     Starts an interactive IPython console
     """
     global console
-    if not trigger.admin:
-        bot.say('Only admins can start the interactive console')
-        return
     if 'iconsole_running' in bot.memory and bot.memory['iconsole_running']:
         bot.say('Console already running')
         return

--- a/sopel/modules/reload.py
+++ b/sopel/modules/reload.py
@@ -28,11 +28,9 @@ except ImportError:
 @sopel.module.nickname_commands("reload")
 @sopel.module.priority("low")
 @sopel.module.thread(False)
+@sopel.module.require_admin
 def f_reload(bot, trigger):
     """Reloads a module, for use by admins only."""
-    if not trigger.admin:
-        return
-
     name = trigger.group(2)
 
     if not name or name == '*' or name.upper() == 'ALL THE THINGS':
@@ -113,10 +111,8 @@ def load_module(bot, name, path, type_, silent=False):
 
 
 @sopel.module.nickname_commands('update')
+@sopel.module.require_admin
 def f_update(bot, trigger):
-    if not trigger.admin:
-        return
-
     """Pulls the latest versions of all modules from Git"""
     proc = subprocess.Popen('/usr/bin/git pull',
                             stdout=subprocess.PIPE,
@@ -129,11 +125,9 @@ def f_update(bot, trigger):
 @sopel.module.nickname_commands("load")
 @sopel.module.priority("low")
 @sopel.module.thread(False)
+@sopel.module.require_admin
 def f_load(bot, trigger):
     """Loads a module, for use by admins only."""
-    if not trigger.admin:
-        return
-
     name = trigger.group(2)
     path = ''
     if not name:


### PR DESCRIPTION
There is a decorator in `sopel.module.require_admin` that check for `trigger.admin`, but it wasn't used everywhere!

So I fixed this, and added a `reply=False` optional argument, that, when `True`, uses `bot.reply` instead of `bot.say`.

It's a very small improvement.