### PR TITLE
config: support comma in config ListAttribute item

### DIFF
--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -266,17 +266,22 @@ class ListAttribute(BaseValidated):
             prompt = prompt[0]
 
         if default is not NO_DEFAULT:
-            default = ','.join(default)
-            prompt = '{} [{}]'.format(prompt, default)
+            default_prompt = ','.join(['"{}"'.format(item) for item in default])
+            prompt = '{} [{}]'.format(prompt, default_prompt)
         else:
-            default = ''
+            default = []
         print(prompt)
         values = []
         value = get_input(each_prompt + ' ') or default
+        if (value == default) and not default:
+            value = ''
         while value:
-            values.append(value)
+            if value == default:
+                values.extend(value)
+            else:
+                values.append(value)
             value = get_input(each_prompt + ' ')
-        return self.parse(','.join(values))
+        return self.parse(self.serialize(values))
 
 
 class ChoiceAttribute(BaseValidated):

--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -212,13 +212,34 @@ class ListAttribute(BaseValidated):
     currently support commas within items in the list. By default, the spaces
     before and after each item are stripped; you can override this by passing
     ``strip=False``."""
+
+    ESCAPE_CHARACTER = '\\'
+    DELIMITER = ','
+
     def __init__(self, name, strip=True, default=None):
         default = default or []
         super(ListAttribute, self).__init__(name, default=default)
         self.strip = strip
 
     def parse(self, value):
-        value = list(filter(None, value.split(',')))
+        items = []
+        is_escape_on = False
+        current_token = []
+        for char in value:
+            if not is_escape_on:
+                if char == ListAttribute.ESCAPE_CHARACTER:
+                    is_escape_on = True
+                elif char == ListAttribute.DELIMITER:
+                    items.append(''.join(current_token))
+                    current_token = []
+                else:
+                    current_token.append(char)
+            else:
+                current_token.append(char)
+                is_escape_on = False
+        items.append(''.join(current_token))
+
+        value = list(filter(None, items))
         if self.strip:
             return [v.strip() for v in value]
         else:
@@ -227,7 +248,16 @@ class ListAttribute(BaseValidated):
     def serialize(self, value):
         if not isinstance(value, (list, set)):
             raise ValueError('ListAttribute value must be a list.')
-        return ','.join(value)
+
+        items = []
+        for item in value:
+            current_token = []
+            for char in item:
+                if char in [ListAttribute.ESCAPE_CHARACTER, ListAttribute.DELIMITER]:
+                    current_token.append(ListAttribute.ESCAPE_CHARACTER)
+                current_token.append(char)
+            items.append(''.join(current_token))
+        return ','.join(items)
 
     def configure(self, prompt, default, parent, section_name):
         each_prompt = '?'

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -65,7 +65,50 @@ class ConfigFunctionalTest(unittest.TestCase):
 
     def test_listattribute_with_value_containing_comma(self):
         self.config.fake.listattr = ['spam, egg, sausage', 'bacon']
-        self.assertEqual(self.config.fake.listattr, ['spam', 'egg', 'sausage', 'bacon'])
+        self.assertEqual(self.config.fake.listattr, ['spam, egg, sausage', 'bacon'])
+
+    def test_listattribute_with_value_containing_nonescape_backslash(self):
+        self.config.fake.listattr = ['spam', r'egg\sausage', 'bacon']
+        self.assertEqual(self.config.fake.listattr, ['spam', r'egg\sausage', 'bacon'])
+
+        self.config.fake.listattr = ['spam', r'egg\tacos', 'bacon']
+        self.assertEqual(self.config.fake.listattr, ['spam', r'egg\tacos', 'bacon'])
+
+    def test_listattribute_with_value_containing_standard_escape_sequence(self):
+        self.config.fake.listattr = ['spam', 'egg\tsausage', 'bacon']
+        self.assertEqual(self.config.fake.listattr, ['spam', 'egg\tsausage', 'bacon'])
+
+        self.config.fake.listattr = ['spam', 'egg\nsausage', 'bacon']
+        self.assertEqual(self.config.fake.listattr, ['spam', 'egg\nsausage', 'bacon'])
+
+        self.config.fake.listattr = ['spam', 'egg\\sausage', 'bacon']
+        self.assertEqual(self.config.fake.listattr, ['spam', 'egg\\sausage', 'bacon'])
+
+    def test_listattribute_with_value_ending_in_special_chars(self):
+        self.config.fake.listattr = ['spam', 'egg', 'sausage\\', 'bacon']
+        self.assertEqual(self.config.fake.listattr, ['spam', 'egg', 'sausage\\', 'bacon'])
+
+        self.config.fake.listattr = ['spam', 'egg', 'sausage,', 'bacon']
+        self.assertEqual(self.config.fake.listattr, ['spam', 'egg', 'sausage,', 'bacon'])
+
+        self.config.fake.listattr = ['spam', 'egg', 'sausage,,', 'bacon']
+        self.assertEqual(self.config.fake.listattr, ['spam', 'egg', 'sausage,,', 'bacon'])
+
+    def test_listattribute_with_value_containing_adjacent_special_chars(self):
+        self.config.fake.listattr = ['spam', r'egg\,sausage', 'bacon']
+        self.assertEqual(self.config.fake.listattr, ['spam', r'egg\,sausage', 'bacon'])
+
+        self.config.fake.listattr = ['spam', r'egg\,\sausage', 'bacon']
+        self.assertEqual(self.config.fake.listattr, ['spam', r'egg\,\sausage', 'bacon'])
+
+        self.config.fake.listattr = ['spam', r'egg,\,sausage', 'bacon']
+        self.assertEqual(self.config.fake.listattr, ['spam', r'egg,\,sausage', 'bacon'])
+
+        self.config.fake.listattr = ['spam', 'egg,,sausage', 'bacon']
+        self.assertEqual(self.config.fake.listattr, ['spam', 'egg,,sausage', 'bacon'])
+
+        self.config.fake.listattr = ['spam', r'egg\\sausage', 'bacon']
+        self.assertEqual(self.config.fake.listattr, ['spam', r'egg\\sausage', 'bacon'])
 
     def test_choiceattribute_when_none(self):
         self.config.fake.choiceattr = None


### PR DESCRIPTION
This is a first step towards completing #1455, since, as @dgw mentioned, to do so would require accepting commas in a single entry of `ListAttribute`.

Items entered through the wizard do not need to be escaped manually. Items configured in the `.cfg` file manually require an escape sequence, like `\,` or `\\`. The prompt has also been changed such that the items are now surrounded by quotes so that one can differentiate items that may contain commas.

Relevant tests were added/updated (see commit messages).