### PR TITLE
version: include python version

### DIFF
--- a/sopel/modules/version.py
+++ b/sopel/modules/version.py
@@ -14,6 +14,8 @@ from sopel import __version__ as release
 from sopel.module import commands, intent, rate
 import re
 from os import path
+import platform
+
 
 log_line = re.compile(r'\S+ (\S+) (.*? <.*?>) (\d+) (\S+)\tcommit[^:]*: (.+)')
 
@@ -37,13 +39,13 @@ def version(bot, trigger):
     """Display the latest commit version, if Sopel is running in a git repo."""
     sha = git_info()
     if not sha:
-        msg = 'Sopel v. ' + release
+        msg = 'Sopel v. ' + release + ' (Python {})'.format(platform.python_version())
         if release[-4:] == '-git':
             msg += ' at unknown commit.'
         bot.reply(msg)
         return
 
-    bot.reply("Sopel v. {} at commit: {}".format(release, sha))
+    bot.reply("Sopel v. {} (Python {}) at commit: {}".format(release, platform.python_version(), sha))
 
 
 @intent('VERSION')


### PR DESCRIPTION
Last unsolicited PR until I dig into `.reload` more, _I PROMISE_ :grin:

Sometimes I forget which version of python I am using :sweat_smile:.  Really though, this stemmed from testing issues/code across multiple versions of Python. I could _quickly_ check the Sopel version from the bot, but not the python version it was running on. This commit simply appends the Python version to the `.version` response.


I don't think it shouldn't really be a security issue to show the Python version of the bot... _right??_