### PR TITLE
cli: fix configpath issue for wizard

### DIFF
--- a/sopel/config/__init__.py
+++ b/sopel/config/__init__.py
@@ -212,7 +212,7 @@ class Config(object):
 
 def _wizard(section, config=None):
     dotdir = os.path.expanduser('~/.sopel')
-    configpath = os.path.join(dotdir, (config or 'default') + '.cfg')
+    configpath = os.path.join(dotdir, ((config or 'default.cfg') + ('.cfg' if config and not config.endswith('.cfg') else '')))
     if section == 'all':
         _create_config(configpath)
     elif section == 'mod':


### PR DESCRIPTION
Now checks if the config file passed to `-c` already has a `.cfg` extensions before appending one.

Fixes #1463