### PR TITLE
cli: sopel-config

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,6 +76,7 @@ setup(
         'console_scripts': [
             'sopel = sopel.run_script:main',
             'sopel-module = sopel.cli.modules:main',
+            'sopel-config = sopel.cli.config:main',
         ],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -72,5 +72,10 @@ setup(
     platforms='Linux x86, x86-64',
     install_requires=requires,
     extras_require={'dev': dev_requires},
-    entry_points={'console_scripts': ['sopel = sopel.run_script:main']},
+    entry_points={
+        'console_scripts': [
+            'sopel = sopel.run_script:main',
+            'sopel-module = sopel.cli.modules:main',
+        ],
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     # Distutils is shit, and doesn't check if it's a list of basestring
     # but instead requires str.
     packages=[str('sopel'), str('sopel.modules'),
-              str('sopel.config'), str('sopel.tools')],
+              str('sopel.config'), str('sopel.tools'), str('sopel.cli')],
     classifiers=classifiers,
     license='Eiffel Forum License, version 2',
     platforms='Linux x86, x86-64',

--- a/sopel/cli/__init__.py
+++ b/sopel/cli/__init__.py
@@ -1,0 +1,2 @@
+# coding=utf-8
+"""Sopel Command Line Interfaces (CLI)"""

--- a/sopel/cli/config.py
+++ b/sopel/cli/config.py
@@ -1,0 +1,95 @@
+# coding=utf-8
+"""Sopel Config Command Line Interfaces (CLI): ``sopel-config``"""
+from __future__ import unicode_literals, absolute_import, print_function, division
+
+import argparse
+import os
+
+from sopel import run_script, tools, config
+
+
+def add_config_option(subparser):
+    """FIXME: Duplicate from sopel.cli.modules"""
+    subparser.add_argument(
+        '-c', '--config', default=None, metavar='filename', dest='config',
+        help='Use a specific configuration file')
+
+
+def build_parser():
+    """Configure an argument parser for ``sopel-config``."""
+    parser = argparse.ArgumentParser(
+        description='Experimental Sopel Config tool')
+    add_config_option(parser)  # global configuration
+
+    # Subparser: sopel-config <subparser> <sub-options>
+    subparsers = parser.add_subparsers(
+        help='Actions to perform (default to list)',
+        dest='action')
+
+    init_parser = subparsers.add_parser(
+        'init',
+        help='Initialize sopel configuration file',
+        description='Initialize sopel configuration file')
+    add_config_option(init_parser)
+
+    return parser
+
+
+def load_settings(options):
+    """FIXME: Duplicate from sopel.cli.modules."""
+    config_filename = run_script.find_config(
+        getattr(options, 'config', None) or 'default')
+
+    if not os.path.isfile(config_filename):
+        raise Exception(
+            'Unable to find the configuration file %s' % config_filename)
+
+    return config.Config(config_filename)
+
+
+def handle_init(options):
+    """Use config's wizard to initialize a new configuration file for the bot
+
+    :param options: argument parser's parsed options
+
+    .. note::
+
+       Due to how the config's wizard works, the configuration filename's
+       extension will be ignored and replaced by ``.cfg``.
+
+    """
+    config_filename = run_script.find_config(
+        getattr(options, 'config', None) or 'default')
+    config_name, ext = os.path.splitext(config_filename)
+
+    if ext and ext != '.cfg':
+        tools.stderr('Configuration wizard accepts .cfg file only')
+        return 2
+    elif not ext:
+        config_filename = config_name + '.cfg'
+
+    if os.path.isfile(config_filename):
+        tools.stderr('Configuration file %s already exists' % config_filename)
+        return 2
+
+    print('Starting Sopel config wizard for: %s' % config_filename)
+    config._wizard('all', config_name)
+
+
+def main():
+    """Console entry point for ``sopel-config``"""
+    parser = build_parser()
+    options = parser.parse_args()
+
+    # init command does not require existing settings
+    if options.action == 'init':
+        return handle_init(options)
+
+    # to manage other action, existing settings are required
+    try:
+        settings = load_settings(options)
+    except Exception as error:
+        tools.stderr(error)
+        return 2
+
+    print('Configuration file at: %s' % settings.filename)

--- a/sopel/cli/config.py
+++ b/sopel/cli/config.py
@@ -32,6 +32,14 @@ def build_parser():
         description='Initialize sopel configuration file')
     add_config_option(init_parser)
 
+    get_parser = subparsers.add_parser(
+        'get',
+        help='Get a configuration option\'s value',
+        description='Get a configuration option\'s value',
+    )
+    get_parser.add_argument('section')
+    get_parser.add_argument('key')
+
     return parser
 
 
@@ -76,6 +84,24 @@ def handle_init(options):
     config._wizard('all', config_name)
 
 
+def handle_get(options, settings):
+    """Read the settings to display the value of <section> <key>"""
+    section = options.section
+    option = options.option
+
+    # Making sure the section.option exists
+    if not settings.parser.has_section(section):
+        tools.stderr('Section %s does not exist' % section)
+        return 1
+    if not settings.parser.has_option(section, option):
+        tools.stderr(
+            'Section %s does not have a %s option' % (section, option))
+        return 1
+
+    # Display the value
+    print(settings.get(section, option))
+
+
 def main():
     """Console entry point for ``sopel-config``"""
     parser = build_parser()
@@ -91,5 +117,8 @@ def main():
     except Exception as error:
         tools.stderr(error)
         return 2
+
+    if options.action == 'get':
+        return handle_get(options, settings)
 
     print('Configuration file at: %s' % settings.filename)

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -11,8 +11,8 @@ from sopel import loader, run_script, config, tools
 
 
 DISPLAY_ENABLE = {
-    True: 'E',
-    False: 'X',
+    True: 'e',
+    False: 'x',
 }
 
 DISPLAY_TYPE = {
@@ -107,11 +107,6 @@ def handle_list(options, settings):
     show_all = options.show_all or options.show_excluded
     modules = loader.enumerate_modules(settings, show_all=show_all).items()
 
-    # Show All
-    if show_all:
-        # If all are shown, add the "enabled" column
-        template = col_sep.join([template, '{enabled}'])
-
     # Show Excluded Only
     if options.show_excluded:
         if settings.core.enable:
@@ -137,12 +132,19 @@ def handle_list(options, settings):
         modules,
         key=lambda arg: arg[0])
 
+    # Get the maximum length of module names for display purpose
+    max_length = 0
+    if modules:
+        max_length = max(len(info[0]) for info in modules)
+
+    # Show All
+    if show_all:
+        name_template = '{name:<' + str(max_length) + '}'
+        # If all are shown, add the "enabled" column
+        template = col_sep.join(['{enabled}', template])
+
     # Show Module Path
     if options.show_path:
-        # Get the maximum length of module names for display purpose
-        max_length = 0
-        if modules:
-            max_length = max(len(info[0]) for info in modules)
         name_template = '{name:<' + str(max_length) + '}'
         # Add the path at the end of the line
         template = col_sep.join([template, '{path}'])

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -69,6 +69,13 @@ def build_parser():
         default=False,
         help='Show only excluded module')
 
+    # Configure DISABLE action
+    disable_parser = subparsers.add_parser(
+        'disable',
+        help='Disable a sopel module',
+        description='Disable a sopel module')
+    disable_parser.add_argument('module')
+
     return parser
 
 
@@ -220,6 +227,25 @@ def handle_show(options, settings):
             print('\t%s' % url.url_regex.pattern)
 
 
+def handle_disable(options, settings):
+    module_name = options.module
+    modules = loader.enumerate_modules(settings, show_all=True)
+
+    if module_name not in modules:
+        tools.stderr('No module named %s' % module_name)
+        return 1
+
+    disabled = settings.core.exclude
+    if module_name in disabled:
+        tools.stderr('Module %s already disabled' % module_name)
+        return 0
+
+    settings.core.exclude = disabled + [module_name]
+    settings.save()
+
+    print('Module %s disabled' % module_name)
+
+
 def main():
     """Console entry point for ``sopel-module``"""
     parser = build_parser()
@@ -233,3 +259,6 @@ def main():
 
     if action == 'show':
         return handle_show(options, settings)
+
+    if action == 'disable':
+        return handle_disable(options, settings)

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -314,7 +314,11 @@ def main():
             'Unable to find the configuration file %s' % config_filename)
         return 2
 
-    settings = config.Config(config_filename)
+    try:
+        settings = config.Config(config_filename)
+    except config.ConfigurationError as error:
+        tools.stderr(error)
+        return 2
 
     if action == 'list':
         return handle_list(options, settings)

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -12,12 +12,20 @@ def main():
     parser = argparse.ArgumentParser(
         description='Experimental Sopel Module tool')
     subparsers = parser.add_subparsers(
-        help='Actions to perform, default to list',
+        help='Actions to perform (default to list)',
         dest='action')
 
     # Configure LIST action
-    subparsers.add_parser(
-        'list', help='List availables sopel modules')
+    list_parser = subparsers.add_parser(
+        'list',
+        help='List availables sopel modules',
+        description='List availables sopel modules')
+    list_parser.add_argument(
+        '-p', '--path',
+        action='store_true',
+        dest='show_path',
+        default=False,
+        help='Show the path to the module file')
 
     options = parser.parse_args()
     action = options.action or 'list'
@@ -25,11 +33,27 @@ def main():
     if action == 'list':
         config_filename = run_script.find_config('default')
         settings = config.Config(config_filename)
+        modules = loader.enumerate_modules(settings)
         modules = sorted(
-            tools.iteritems(loader.enumerate_modules(settings)),
+            modules.items(),
             key=lambda arg: arg[0])
 
+        template = '{name}'
+        if options.show_path:
+            # Get the maximum length of module names for display purpose
+            max_length = max(len(info[0]) for info in modules)
+
+            template = '\t'.join([
+                '{name:<' + str(max_length) +'}',
+                '{path}',
+            ])
+
         for name, info in modules:
-            print(name)
+            path, module_type = info
+            print(template.format(
+                name=name,
+                path=path,
+                module_type=module_type,
+            ))
 
         return

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -113,8 +113,7 @@ def handle_list(options, settings):
                 if name in settings.core.exclude or
                 name not in settings.core.enable
             ]
-
-        if settings.core.exclude:
+        else:
             # Get only excluded
             modules = [
                 (name, info)
@@ -130,7 +129,9 @@ def handle_list(options, settings):
     # Show Module Path
     if options.show_path:
         # Get the maximum length of module names for display purpose
-        max_length = max(len(info[0]) for info in modules)
+        max_length = 0
+        if modules:
+            max_length = max(len(info[0]) for info in modules)
         name_template = '{name:<' + str(max_length) + '}'
         # Add the path at the end of the line
         template = col_sep.join([template, '{path}'])

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -1,0 +1,35 @@
+# coding=utf-8
+"""Sopel Modules Command Line Interfaces (CLI): ``sopel-module``"""
+from __future__ import unicode_literals, absolute_import, print_function, division
+
+import argparse
+
+from sopel import loader, run_script, config, tools
+
+
+def main():
+    """Console entry point for ``sopel-module``"""
+    parser = argparse.ArgumentParser(
+        description='Experimental Sopel Module tool')
+    subparsers = parser.add_subparsers(
+        help='Actions to perform, default to list',
+        dest='action')
+
+    # Configure LIST action
+    subparsers.add_parser(
+        'list', help='List availables sopel modules')
+
+    options = parser.parse_args()
+    action = options.action or 'list'
+
+    if action == 'list':
+        config_filename = run_script.find_config('default')
+        settings = config.Config(config_filename)
+        modules = sorted(
+            tools.iteritems(loader.enumerate_modules(settings)),
+            key=lambda arg: arg[0])
+
+        for name, info in modules:
+            print(name)
+
+        return

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -3,8 +3,15 @@
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 import argparse
+import imp
 
-from sopel import loader, run_script, config, tools
+from sopel import loader, run_script, config
+
+
+DISPLAY_TYPE = {
+    imp.PKG_DIRECTORY: 'p',
+    imp.PY_SOURCE: 'm'
+}
 
 
 def main():
@@ -26,6 +33,15 @@ def main():
         dest='show_path',
         default=False,
         help='Show the path to the module file')
+    list_parser.add_argument(
+        '-t', '--type',
+        action='store_true',
+        dest='show_type',
+        default=False,
+        help=('Show the type to the module file: '
+              '`p` for package directory, '
+              '`m` for module file, '
+              '`?` for unknown'))
 
     options = parser.parse_args()
     action = options.action or 'list'
@@ -38,22 +54,26 @@ def main():
             modules.items(),
             key=lambda arg: arg[0])
 
+        col_sep = '\t'
         template = '{name}'
         if options.show_path:
             # Get the maximum length of module names for display purpose
             max_length = max(len(info[0]) for info in modules)
 
-            template = '\t'.join([
-                '{name:<' + str(max_length) +'}',
+            template = col_sep.join([
+                '{name:<' + str(max_length) + '}',
                 '{path}',
             ])
+
+        if options.show_type:
+            template = col_sep.join(['{module_type}', template])
 
         for name, info in modules:
             path, module_type = info
             print(template.format(
                 name=name,
                 path=path,
-                module_type=module_type,
+                module_type=DISPLAY_TYPE.get(module_type, '?'),
             ))
 
         return

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -175,13 +175,18 @@ def handle_show(options, settings):
         print('')
         print('# Module Commands')
         for command in callables:
-            print('')
-
             if command._docs.keys():
+                print('')
                 print('## %s' % ', '.join(command._docs.keys()))
-            elif command.rule:
+            elif getattr(command, 'rule', None):
                 # display rules afters normal commands
                 rule_callables.append(command)
+                continue
+            elif getattr(command, 'intents', None):
+                rule_callables.append(command)
+                continue
+            else:
+                # nothing to display right now
                 continue
 
             docstring = inspect.cleandoc(
@@ -196,7 +201,9 @@ def handle_show(options, settings):
 
             for command in rule_callables:
                 print('')
-                for rule in command.rule:
+                for intent in getattr(command, 'intents', []):
+                    print('[INTENT]', intent.pattern)
+                for rule in getattr(command, 'rule', []):
                     print(rule.pattern)
 
                 docstring = inspect.cleandoc(

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -5,6 +5,7 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 import argparse
 import imp
 import inspect
+import os
 
 from sopel import loader, run_script, config, tools
 
@@ -20,6 +21,12 @@ DISPLAY_TYPE = {
 }
 
 
+def add_config_option(subparser):
+    subparser.add_argument(
+        '-c', '--config', default=None, metavar='filename', dest='config',
+        help='Use a specific configuration file')
+
+
 def build_parser():
     parser = argparse.ArgumentParser(
         description='Experimental Sopel Module tool')
@@ -32,6 +39,7 @@ def build_parser():
         'show',
         help='Show a sopel module\'s details',
         description='Show a sopel module\'s details')
+    add_config_option(show_parser)
     show_parser.add_argument('module')
 
     # Configure LIST action
@@ -39,6 +47,7 @@ def build_parser():
         'list',
         help='List availables sopel modules',
         description='List availables sopel modules')
+    add_config_option(list_parser)
     list_parser.add_argument(
         '-p', '--path',
         action='store_true',
@@ -74,6 +83,7 @@ def build_parser():
         'enable',
         help='Enable a sopel module',
         description='Enable a sopel module')
+    add_config_option(enable_parser)
     enable_parser.add_argument('module')
 
     # Configure DISABLE action
@@ -81,6 +91,7 @@ def build_parser():
         'disable',
         help='Disable a sopel module',
         description='Disable a sopel module')
+    add_config_option(disable_parser)
     disable_parser.add_argument('module')
 
     return parser
@@ -296,7 +307,13 @@ def main():
     parser = build_parser()
     options = parser.parse_args()
     action = options.action or 'list'
-    config_filename = run_script.find_config('default')
+    config_filename = run_script.find_config(options.config or 'default')
+
+    if not os.path.isfile(config_filename):
+        tools.stderr(
+            'Unable to find the configuration file %s' % config_filename)
+        return 2
+
     settings = config.Config(config_filename)
 
     if action == 'list':

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -97,7 +97,10 @@ def main():
                 modules = [
                     (name, info)
                     for name, info in modules
-                    if name not in settings.core.enable
+                    # Remove enabled modules...
+                    # ... unless they are in the excluded list.
+                    if name in settings.core.exclude or
+                    name not in settings.core.enable
                 ]
 
             if settings.core.exclude:

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -42,6 +42,12 @@ def main():
               '`p` for package directory, '
               '`m` for module file, '
               '`?` for unknown'))
+    list_parser.add_argument(
+        '-a', '--all',
+        action='store_true',
+        dest='show_all',
+        default=False,
+        help='Show all available module, enabled or not')
 
     options = parser.parse_args()
     action = options.action or 'list'
@@ -49,7 +55,7 @@ def main():
     if action == 'list':
         config_filename = run_script.find_config('default')
         settings = config.Config(config_filename)
-        modules = loader.enumerate_modules(settings)
+        modules = loader.enumerate_modules(settings, show_all=options.show_all)
         modules = sorted(
             modules.items(),
             key=lambda arg: arg[0])

--- a/sopel/cli/modules.py
+++ b/sopel/cli/modules.py
@@ -55,18 +55,20 @@ def main():
               '`p` for package directory, '
               '`m` for module file, '
               '`?` for unknown'))
-    list_parser.add_argument(
+
+    list_group = list_parser.add_mutually_exclusive_group()
+    list_group.add_argument(
         '-a', '--all',
         action='store_true',
         dest='show_all',
         default=False,
         help='Show all available module, enabled or not')
-    list_parser.add_argument(
+    list_group.add_argument(
         '-e', '--excluded',
         action='store_true',
         dest='show_excluded',
         default=False,
-        help='Show only excluded module (incompatible with -a/--all)')
+        help='Show only excluded module')
 
     options = parser.parse_args()
     action = options.action or 'list'


### PR DESCRIPTION
Yet another PR related to #1434 (and to #1445).

The goal, this time, is to be able to do this:

```
$ sopel-config init -c config_name
... wizard ...
$ sopel-config get -c config_name core nick
Sopel
$ sopel-config set -c config_name core nick GoodBot
$ sopel-config get -c config_name core nick
GoodBot
```

So far, both `init` and `get <section> <option>` work fine, but I'm not sure about the syntax yet: maybe `<section>.<option>` would be better, as in `core.nick` instead of `core nick`.

Anyway, this is just me doing experimental things and trying to make quality of life improvement for Sopel's sysadmin.