### PR TITLE
Update supported IPython versions again

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ praw<6.0.0
 pyenchant; python_version < '3.7'
 geoip2
 ipython<6.0; python_version < '3.3'
-ipython>=6.0,<7.0; python_version >= '3.3'
+ipython>=6.0,<7.0; python_version >= '3.3' and python_version < '3.5'
+ipython>=7.0,<8.0; python_version >= '3.5'
 requests>=2.0.0,<3.0.0
 dnspython


### PR DESCRIPTION
I can't WAIT to drop the ipython module from core.

Less than a year after dropping py2 support, upstream has also dumped support for Python below 3.5. They're moving too fast for our slow-ass release cycle (and it's not even an important dependency).

Shout-out to `eagle` on IRC for kick-starting this one. Yes, it appears Sopel works just fine with IPython 7.x.