### PR TITLE
Get specific about dnspython requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,6 @@ geoip2
 ipython<6.0; python_version < '3.3'
 ipython>=6.0,<7.0; python_version >= '3.3'
 requests>=2.0.0,<3.0.0
-dnspython
+dnspython<2.0; python_version >= '2.7' and python_version < '3.0'
+dnspython<1.16.0; python_version == '3.3'
+dnspython<3.0; python_version >= '3.4'


### PR DESCRIPTION
dnspython dropped support for Python 3.3 in version 1.16.0, so we have to special-case that. Otherwise, py2.7 and 3.4+ are supported until version 2.0 comes out.

This is the part where I maybe come to regret adding this dependency, isn't it? Might be worth trying to make dnspython optional later.

Closes #1461.