### PR TITLE
irc/bot: implement echo-message

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -530,8 +530,8 @@ class Sopel(irc.Bot):
                                 match = True
                         if not match:
                             continue
-                    if (not (hasattr(func, 'echo') and func.echo is True) and
-                            trigger.nick.lower() == self.nick.lower()):
+                    if (trigger.nick.lower() == self.nick.lower() and
+                            not func.echo):
                         continue
                     if func.thread:
                         targs = (func, wrapper, trigger)

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -530,6 +530,9 @@ class Sopel(irc.Bot):
                                 match = True
                         if not match:
                             continue
+                    if (not (hasattr(func, 'echo') and func.echo is True) and
+                            trigger.nick.lower() == self.nick.lower()):
+                        continue
                     if func.thread:
                         targs = (func, wrapper, trigger)
                         t = threading.Thread(target=self.call, args=targs)

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -407,11 +407,11 @@ def track_quit(bot, trigger):
 @sopel.module.thread(False)
 @sopel.module.priority('high')
 @sopel.module.unblockable
-def recieve_cap_list(bot, trigger):
+def receive_cap_list(bot, trigger):
     cap = trigger.strip('-=~')
     # Server is listing capabilites
     if trigger.args[1] == 'LS':
-        recieve_cap_ls_reply(bot, trigger)
+        receive_cap_ls_reply(bot, trigger)
     # Server denied CAP REQ
     elif trigger.args[1] == 'NAK':
         entry = bot._cap_reqs.get(cap, None)
@@ -455,10 +455,10 @@ def recieve_cap_list(bot, trigger):
                 if req.success:
                     req.success(bot, req.prefix + trigger)
             if cap == 'sasl':  # TODO why is this not done with bot.cap_req?
-                recieve_cap_ack_sasl(bot)
+                receive_cap_ack_sasl(bot)
 
 
-def recieve_cap_ls_reply(bot, trigger):
+def receive_cap_ls_reply(bot, trigger):
     if bot.server_capabilities:
         # We've already seen the results, so someone sent CAP LS from a module.
         # We're too late to do SASL, and we don't want to send CAP END before
@@ -480,7 +480,13 @@ def recieve_cap_ls_reply(bot, trigger):
 
     # If some other module requests it, we don't need to add another request.
     # If some other module prohibits it, we shouldn't request it.
-    core_caps = ['multi-prefix', 'away-notify', 'cap-notify', 'server-time']
+    core_caps = [
+        'echo-message',
+        'multi-prefix',
+        'away-notify',
+        'cap-notify',
+        'server-time',
+    ]
     for cap in core_caps:
         if cap not in bot._cap_reqs:
             bot._cap_reqs[cap] = [_CapReq('', 'coretasks')]
@@ -529,7 +535,7 @@ def recieve_cap_ls_reply(bot, trigger):
         bot.write(('CAP', 'END'))
 
 
-def recieve_cap_ack_sasl(bot):
+def receive_cap_ack_sasl(bot):
     # Presumably we're only here if we said we actually *want* sasl, but still
     # check anyway.
     password = bot.config.core.auth_password

--- a/sopel/irc.py
+++ b/sopel/irc.py
@@ -149,14 +149,21 @@ class Bot(asynchat.async_chat):
             self.send(temp.encode('utf-8'))
         finally:
             self.writing_lock.release()
+
         # Simulate echo-message
         if ('echo-message' not in self.enabled_capabilities and
                 args[0].upper() in ['PRIVMSG', 'NOTICE']):
-            # Since we have no way of knowing the hostmask the IRC server uses
-            # for us, we'll just use something reasonable
+            # Use the hostmask we think the IRC server is using for us,
+            # or something reasonable if that's not available
             host = 'localhost'
             if self.config.core.bind_host:
                 host = self.config.core.bind_host
+            else:
+                try:
+                    host = self.hostmask
+                except KeyError:
+                    pass  # we tried, and that's good enough
+
             pretrigger = PreTrigger(self.nick, ':{0}!{1}@{2} {3}'
                 .format(self.nick, self.user, host, temp))
             self.dispatch(pretrigger)

--- a/sopel/irc.py
+++ b/sopel/irc.py
@@ -150,7 +150,8 @@ class Bot(asynchat.async_chat):
         finally:
             self.writing_lock.release()
         # Simulate echo-message
-        if 'echo-message' not in self.enabled_capabilities:
+        if ('echo-message' not in self.enabled_capabilities and
+                args[0].upper() in ['PRIVMSG', 'NOTICE']):
             # Since we have no way of knowing the hostmask the IRC server uses
             # for us, we'll just use something reasonable
             host = 'localhost'

--- a/sopel/irc.py
+++ b/sopel/irc.py
@@ -149,6 +149,16 @@ class Bot(asynchat.async_chat):
             self.send(temp.encode('utf-8'))
         finally:
             self.writing_lock.release()
+        # Simulate echo-message
+        if 'echo-message' not in self.enabled_capabilities:
+            # Since we have no way of knowing the hostmask the IRC server uses
+            # for us, we'll just use something reasonable
+            host = 'localhost'
+            if self.config.core.bind_host:
+                host = self.config.core.bind_host
+            pretrigger = PreTrigger(self.nick, ':{0}!{1}@{2} {3}'
+                .format(self.nick, self.user, host, temp))
+            self.dispatch(pretrigger)
 
     def run(self, host, port=6667):
         try:

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -144,6 +144,7 @@ def clean_callable(func, config):
     example = None
 
     func.unblockable = getattr(func, 'unblockable', False)
+    func.echo = getattr(func, 'echo', False)
     func.priority = getattr(func, 'priority', 'medium')
     func.thread = getattr(func, 'thread', True)
     func.rate = getattr(func, 'rate', 0)

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -116,7 +116,7 @@ def thread(value):
     return add_attribute
 
 
-def echo(value=True):
+def echo(value):
     """Decorate a function to specify if it should receive echo messages.
 
     This decorator can be used to listen in on the messages that Sopel is

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -116,6 +116,23 @@ def thread(value):
     return add_attribute
 
 
+def echo(value=True):
+    """Decorate a function to specify if it should receive echo messages.
+
+    This decorator can be used to listen in on the messages that Sopel is
+    sending and react accordingly.
+
+    Args:
+        value: Either True or False. If True the function will receive echo
+            messages, and if False only messages received from other users.
+
+    """
+    def add_attribute(function):
+        function.echo = value
+        return function
+    return add_attribute
+
+
 def commands(*command_list):
     """Decorate a function to set one or more commands to trigger it.
 

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -116,20 +116,19 @@ def thread(value):
     return add_attribute
 
 
-def echo(value):
+def echo(function=None):
     """Decorate a function to specify if it should receive echo messages.
 
     This decorator can be used to listen in on the messages that Sopel is
     sending and react accordingly.
-
-    Args:
-        value: Either True or False. If True the function will receive echo
-            messages, and if False only messages received from other users.
-
     """
     def add_attribute(function):
-        function.echo = value
+        function.echo = True
         return function
+
+    # hack to allow both @echo and @echo() to work
+    if callable(function):
+        return add_attribute(function)
     return add_attribute
 
 

--- a/sopel/modules/find.py
+++ b/sopel/modules/find.py
@@ -12,7 +12,7 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 
 import re
 from sopel.tools import Identifier, SopelMemory
-from sopel.module import rule, priority
+from sopel.module import rule, priority, echo
 from sopel.formatting import bold
 
 
@@ -20,6 +20,7 @@ def setup(bot):
     bot.memory['find_lines'] = SopelMemory()
 
 
+@echo
 @rule('.*')
 @priority('low')
 def collectlines(bot, trigger):

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -83,10 +83,14 @@ def test_thread():
 
 
 def test_echo():
-    @module.echo(False)
+    @module.echo()
     def mock(bot, trigger, match):
         return True
-    assert mock.echo is False
+    assert mock.echo is True
+
+    def mock(bot, trigger, match):
+        return True
+    assert not hasattr(mock, 'echo')
 
 
 def test_commands():

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -83,13 +83,23 @@ def test_thread():
 
 
 def test_echo():
+    # test decorator with parentheses
     @module.echo()
     def mock(bot, trigger, match):
         return True
     assert mock.echo is True
 
+    # test decorator without parentheses
+    @module.echo
     def mock(bot, trigger, match):
         return True
+    assert mock.echo is True
+
+    # test without decorator
+    def mock(bot, trigger, match):
+        return True
+    # on undecorated callables, the attr only exists after the loader loads them
+    # so this cannot `assert mock.echo is False` here
     assert not hasattr(mock, 'echo')
 
 

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -82,6 +82,13 @@ def test_thread():
     assert mock.thread is True
 
 
+def test_echo():
+    @module.echo(False)
+    def mock(bot, trigger, match):
+        return True
+    assert mock.echo is False
+
+
 def test_commands():
     @module.commands('sopel')
     def mock(bot, trigger, match):


### PR DESCRIPTION
Rebased & tweaked version of #1072, which stalled. Resolves #526. Original PR description by @maxpowa follows; see #1072 for the earlier evolution of this patch.

----

Allows modules to listen in on what's being sent by Sopel. Compatible with all the other decorators, as it goes through all the same logic. If `echo-message` is supported on the server and is toggled on by a module, only functions with the `@sopel.module.echo(True)` decorator will receive those echo messages. If `echo-message` isn't enabled, the same behavior still exists but the hostmask will not be as accurate.