### PR TITLE
sopel.cli.utils

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ setup(
     # Distutils is shit, and doesn't check if it's a list of basestring
     # but instead requires str.
     packages=[str('sopel'), str('sopel.modules'),
-              str('sopel.config'), str('sopel.tools')],
+              str('sopel.cli'), str('sopel.config'), str('sopel.tools')],
     classifiers=classifiers,
     license='Eiffel Forum License, version 2',
     platforms='Linux x86, x86-64',

--- a/sopel/cli/__init__.py
+++ b/sopel/cli/__init__.py
@@ -1,0 +1,5 @@
+# coding=utf-8
+from __future__ import unicode_literals, absolute_import, print_function, division
+
+# Shortcut imports
+from .utils import enumerate_configs  # noqa

--- a/sopel/cli/__init__.py
+++ b/sopel/cli/__init__.py
@@ -2,4 +2,4 @@
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 # Shortcut imports
-from .utils import enumerate_configs  # noqa
+from .utils import enumerate_configs, find_config  # noqa

--- a/sopel/cli/__init__.py
+++ b/sopel/cli/__init__.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 
 # Shortcut imports
 from .utils import (  # noqa
-    add_config_arguments,
+    add_common_arguments,
     enumerate_configs,
     find_config,
     load_settings

--- a/sopel/cli/__init__.py
+++ b/sopel/cli/__init__.py
@@ -2,4 +2,4 @@
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 # Shortcut imports
-from .utils import enumerate_configs, find_config  # noqa
+from .utils import enumerate_configs, find_config, load_settings  # noqa

--- a/sopel/cli/__init__.py
+++ b/sopel/cli/__init__.py
@@ -2,4 +2,9 @@
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 # Shortcut imports
-from .utils import enumerate_configs, find_config, load_settings  # noqa
+from .utils import (  # noqa
+    add_config_arguments,
+    enumerate_configs,
+    find_config,
+    load_settings
+)

--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -5,6 +5,14 @@ import os
 
 from sopel import config
 
+# Allow clean import *
+__all__ = [
+    'enumerate_configs',
+    'find_config',
+    'add_config_arguments',
+    'load_settings',
+]
+
 
 def enumerate_configs(config_dir, extension='.cfg'):
     """List configuration files from ``config_dir`` with ``extension``

--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -1,0 +1,32 @@
+# coding=utf-8
+from __future__ import unicode_literals, absolute_import, print_function, division
+
+import os
+
+
+def enumerate_configs(config_dir, extension='.cfg'):
+    """List configuration files from ``config_dir`` with ``extension``
+
+    :param str config_dir: path to the configuration directory
+    :param str extension: configuration file's extension (default to ``.cfg``)
+    :return: a list of configuration filenames found in ``config_dir`` with
+             the correct ``extension``
+    :rtype: list
+
+    Example::
+
+        >>> from sopel import cli, config
+        >>> os.listdir(config.DEFAULT_HOMEDIR)
+        ['config.cfg', 'extra.ini', 'module.cfg', 'README']
+        >>> cli.enumerate_configs(config.DEFAULT_HOMEDIR)
+        ['config.cfg', 'module.cfg']
+        >>> cli.enumerate_configs(config.DEFAULT_HOMEDIR, '.ini')
+        ['extra.ini']
+
+    """
+    if not os.path.isdir(config_dir):
+        return
+
+    for item in os.listdir(config_dir):
+        if item.endswith(extension):
+            yield item

--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -30,3 +30,45 @@ def enumerate_configs(config_dir, extension='.cfg'):
     for item in os.listdir(config_dir):
         if item.endswith(extension):
             yield item
+
+
+def find_config(config_dir, name, extension='.cfg'):
+    """Build the absolute path for the given configuration file ``name``
+
+    :param str config_dir: path to the configuration directory
+    :param str name: configuration file ``name``
+    :param str extension: configuration file's extension (default to ``.cfg``)
+    :return: the path of the configuration file, either in the current
+             directory or from the ``config_dir`` directory
+
+    This function tries different locations:
+
+    * the current directory
+    * the ``config_dir`` directory with the ``extension`` suffix
+    * the ``config_dir`` directory without a suffix
+
+    Example::
+
+        >>> from sopel import run_script
+        >>> os.listdir()
+        ['local.cfg', 'extra.ini']
+        >>> os.listdir(config.DEFAULT_HOMEDIR)
+        ['config.cfg', 'extra.ini', 'module.cfg', 'README']
+        >>> run_script.find_config(config.DEFAULT_HOMEDIR, 'local.cfg')
+        'local.cfg'
+        >>> run_script.find_config(config.DEFAULT_HOMEDIR, 'local')
+        '/home/username/.sopel/local'
+        >>> run_script.find_config(config.DEFAULT_HOMEDIR, 'config')
+        '/home/username/.sopel/config.cfg'
+        >>> run_script.find_config(config.DEFAULT_HOMEDIR, 'extra', '.ini')
+        '/home/username/.sopel/extra.ini'
+
+    """
+    if os.path.isfile(name):
+        return name
+    name_ext = name + extension
+    for config in enumerate_configs(config_dir, extension):
+        if name_ext == config:
+            return os.path.join(config_dir, name_ext)
+
+    return os.path.join(config_dir, name)

--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -9,7 +9,7 @@ from sopel import config
 __all__ = [
     'enumerate_configs',
     'find_config',
-    'add_config_arguments',
+    'add_common_arguments',
     'load_settings',
 ]
 
@@ -84,15 +84,15 @@ def find_config(config_dir, name, extension='.cfg'):
     return os.path.join(config_dir, name)
 
 
-def add_config_arguments(parser):
-    """Add configuration-related argument to a ``parser``.
+def add_common_arguments(parser):
+    """Add common and configuration-related arguments to a ``parser``.
 
     :param parser: Argument parser (or subparser)
     :type parser: argparse.ArgumentParser
 
-    This function adds the proper argument to the ``parser`` given in order to
-    have a standard way to define a configuration filename in all of Sopel's
-    command line interfaces.
+    This functions adds the common arguments for Sopel's command line tools.
+    At the moment, this functions adds only one argument to the parser: the
+    argument used as the standard way to define a configuration filename.
 
     This can be used on an argument parser, or an argument subparser, to handle
     these cases::
@@ -102,6 +102,12 @@ def add_config_arguments(parser):
 
     Then, when the parser parses the command line arguments, it will expose
     a ``config`` option to be used to find and load Sopel's settings.
+
+    .. seealso::
+
+        The :func:`sopel.cli.utils.load_settings` function uses an ``options``
+        object from a parser configured with such arguments.
+
     """
     parser.add_argument(
         '-c', '--config',
@@ -136,7 +142,7 @@ def load_settings(options):
     .. note::
 
         To use this function effectively, the
-        :func:`sopel.cli.utils.add_config_arguments` function should be used to
+        :func:`sopel.cli.utils.add_common_arguments` function should be used to
         add the proper option to the argument parser.
 
     """

--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 
 import os
 
+from sopel import config
+
 
 def enumerate_configs(config_dir, extension='.cfg'):
     """List configuration files from ``config_dir`` with ``extension``
@@ -67,8 +69,8 @@ def find_config(config_dir, name, extension='.cfg'):
     if os.path.isfile(name):
         return name
     name_ext = name + extension
-    for config in enumerate_configs(config_dir, extension):
-        if name_ext == config:
+    for filename in enumerate_configs(config_dir, extension):
+        if name_ext == filename:
             return os.path.join(config_dir, name_ext)
 
     return os.path.join(config_dir, name)
@@ -99,3 +101,41 @@ def add_config_arguments(parser):
         metavar='filename',
         dest='config',
         help='Use a specific configuration file')
+
+
+def load_settings(options):
+    """Load Sopel's settings using the command line's ``options``.
+
+    :param options: parsed arguments
+    :return: sopel configuration
+    :rtype: :class:`sopel.config.Config`
+    :raise sopel.config.ConfigurationNotFound: raised when configuration file
+                                               is not found
+    :raise sopel.config.ConfigurationError: raised when configuration is
+                                            invalid
+
+    This function loads Sopel's settings from one of these sources:
+
+    * value of ``options.config``, if given,
+    * or the ``default`` configuration is loaded,
+
+    then loads the settings and returns it as a :class:`~sopel.config.Config`
+    object.
+
+    If the configuration file can not be found, a
+    :exc:`sopel.config.ConfigurationNotFound` error will be raised.
+
+    .. note::
+
+        To use this function effectively, the
+        :func:`sopel.cli.utils.add_config_arguments` function should be used to
+        add the proper option to the argument parser.
+
+    """
+    name = options.config or 'default'
+    filename = find_config(config.DEFAULT_HOMEDIR, name)
+
+    if not os.path.isfile(filename):
+        raise config.ConfigurationNotFound(filename=filename)
+
+    return config.Config(filename)

--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -72,3 +72,30 @@ def find_config(config_dir, name, extension='.cfg'):
             return os.path.join(config_dir, name_ext)
 
     return os.path.join(config_dir, name)
+
+
+def add_config_arguments(parser):
+    """Add configuration-related argument to a ``parser``.
+
+    :param parser: Argument parser (or subparser)
+    :type parser: argparse.ArgumentParser
+
+    This function adds the proper argument to the ``parser`` given in order to
+    have a standard way to define a configuration filename in all of Sopel's
+    command line interfaces.
+
+    This can be used on an argument parser, or an argument subparser, to handle
+    these cases::
+
+        [sopel-command] -c [filename]
+        [sopel-command] [action] -c [filename]
+
+    Then, when the parser parses the command line arguments, it will expose
+    a ``config`` option to be used to find and load Sopel's settings.
+    """
+    parser.add_argument(
+        '-c', '--config',
+        default=None,
+        metavar='filename',
+        dest='config',
+        help='Use a specific configuration file')

--- a/sopel/config/__init__.py
+++ b/sopel/config/__init__.py
@@ -38,13 +38,22 @@ DEFAULT_HOMEDIR = os.path.join(os.path.expanduser('~'), '.sopel')
 
 
 class ConfigurationError(Exception):
-    """ Exception type for configuration errors """
-
+    """Exception type for configuration errors"""
     def __init__(self, value):
         self.value = value
 
     def __str__(self):
         return 'ConfigurationError: %s' % self.value
+
+
+class ConfigurationNotFound(ConfigurationError):
+    """Configuration file not found."""
+    def __init__(self, filename):
+        self.filename = filename
+        """Path to the configuration file not found"""
+
+    def __str__(self):
+        return 'Unable to find the configuration file %s' % self.filename
 
 
 class Config(object):

--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -46,48 +46,6 @@ encounter such error case.
 """
 
 
-def find_config(config_dir, name, extension='.cfg'):
-    """Build the absolute path for the given configuration file ``name``
-
-    :param str config_dir: path to the configuration directory
-    :param str name: configuration file ``name``
-    :param str extension: configuration file's extension (default to ``.cfg``)
-    :return: the path of the configuration file, either in the current
-             directory or from the ``config_dir`` directory
-
-    This function tries different locations:
-
-    * the current directory
-    * the ``config_dir`` directory with the ``extension`` suffix
-    * the ``config_dir`` directory without a suffix
-
-    Example::
-
-        >>> from sopel import run_script
-        >>> os.listdir()
-        ['local.cfg', 'extra.ini']
-        >>> os.listdir(config.DEFAULT_HOMEDIR)
-        ['config.cfg', 'extra.ini', 'module.cfg', 'README']
-        >>> run_script.find_config(config.DEFAULT_HOMEDIR, 'local.cfg')
-        'local.cfg'
-        >>> run_script.find_config(config.DEFAULT_HOMEDIR, 'local')
-        '/home/username/.sopel/local'
-        >>> run_script.find_config(config.DEFAULT_HOMEDIR, 'config')
-        '/home/username/.sopel/config.cfg'
-        >>> run_script.find_config(config.DEFAULT_HOMEDIR, 'extra', '.ini')
-        '/home/username/.sopel/extra.ini'
-
-    """
-    if os.path.isfile(name):
-        return name
-    name_ext = name + extension
-    for config in utils.enumerate_configs(config_dir, extension):
-        if name_ext == config:
-            return os.path.join(config_dir, name_ext)
-
-    return os.path.join(config_dir, name)
-
-
 def build_parser():
     """Build an ``argparse.ArgumentParser`` for the bot"""
     parser = argparse.ArgumentParser(description='Sopel IRC Bot',
@@ -166,7 +124,7 @@ def get_configuration(options):
     invalid configuration file.
     """
     config_name = options.config or 'default'
-    config_path = find_config(DEFAULT_HOMEDIR, config_name)
+    config_path = utils.find_config(DEFAULT_HOMEDIR, config_name)
 
     if not os.path.isfile(config_path):
         print(

--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -50,8 +50,7 @@ def build_parser():
     """Build an ``argparse.ArgumentParser`` for the bot"""
     parser = argparse.ArgumentParser(description='Sopel IRC Bot',
                                      usage='%(prog)s [options]')
-    parser.add_argument('-c', '--config', metavar='filename',
-                        help='use a specific configuration file')
+    utils.add_config_arguments(parser)
     parser.add_argument("-d", '--fork', action="store_true",
                         dest="daemonize", help="Daemonize Sopel")
     parser.add_argument("-q", '--quit', action="store_true", dest="quit",

--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -11,6 +11,8 @@ https://sopel.chat
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 import sys
+
+from sopel.cli import utils
 from sopel.tools import stderr
 
 if sys.version_info < (2, 7):
@@ -42,34 +44,6 @@ ERR_CODE_NO_RESTART = 2
 This error code is used to prevent systemd from restarting the bot when it
 encounter such error case.
 """
-
-
-def enumerate_configs(config_dir, extension='.cfg'):
-    """List configuration file from ``config_dir`` with ``extension``
-
-    :param str config_dir: path to the configuration directory
-    :param str extension: configuration file's extension (default to ``.cfg``)
-    :return: a list of configuration filename found in ``config_dir`` with
-             the correct ``extension``
-    :rtype: list
-
-    Example::
-
-        >>> from sopel import run_script, config
-        >>> os.listdir(config.DEFAULT_HOMEDIR)
-        ['config.cfg', 'extra.ini', 'module.cfg', 'README']
-        >>> run_script.enumerate_configs(config.DEFAULT_HOMEDIR)
-        ['config.cfg', 'module.cfg']
-        >>> run_script.enumerate_configs(config.DEFAULT_HOMEDIR, '.ini')
-        ['extra.ini']
-
-    """
-    if not os.path.isdir(config_dir):
-        return
-
-    for item in os.listdir(config_dir):
-        if item.endswith(extension):
-            yield item
 
 
 def find_config(config_dir, name, extension='.cfg'):
@@ -107,7 +81,7 @@ def find_config(config_dir, name, extension='.cfg'):
     if os.path.isfile(name):
         return name
     name_ext = name + extension
-    for config in enumerate_configs(config_dir, extension):
+    for config in utils.enumerate_configs(config_dir, extension):
         if name_ext == config:
             return os.path.join(config_dir, name_ext)
 
@@ -174,7 +148,7 @@ def print_version():
 
 def print_config():
     """Print list of available configurations from default homedir."""
-    configs = enumerate_configs(DEFAULT_HOMEDIR)
+    configs = utils.enumerate_configs(DEFAULT_HOMEDIR)
     print('Config files in %s:' % DEFAULT_HOMEDIR)
     config = None
     for config in configs:

--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -31,6 +31,7 @@ from sopel.config import (
     Config,
     _create_config,
     ConfigurationError,
+    ConfigurationNotFound,
     DEFAULT_HOMEDIR,
     _wizard
 )
@@ -122,23 +123,23 @@ def get_configuration(options):
     This may raise a ``sopel.config.ConfigurationError`` if the file is an
     invalid configuration file.
     """
-    config_name = options.config or 'default'
-    config_path = utils.find_config(DEFAULT_HOMEDIR, config_name)
-
-    if not os.path.isfile(config_path):
+    try:
+        bot_config = utils.load_settings(options)
+    except ConfigurationNotFound as error:
         print(
             "Welcome to Sopel!\n"
             "I can't seem to find the configuration file, "
             "so let's generate it!\n")
 
+        config_path = error.filename
         if not config_path.endswith('.cfg'):
             config_path = config_path + '.cfg'
 
         config_path = _create_config(config_path)
+        # try to reload it now that it's created
+        bot_config = Config(config_path)
 
-    bot_config = Config(config_path)
     bot_config._is_daemonized = options.daemonize
-
     return bot_config
 
 

--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -51,7 +51,7 @@ def build_parser():
     """Build an ``argparse.ArgumentParser`` for the bot"""
     parser = argparse.ArgumentParser(description='Sopel IRC Bot',
                                      usage='%(prog)s [options]')
-    utils.add_config_arguments(parser)
+    utils.add_common_arguments(parser)
     parser.add_argument("-d", '--fork', action="store_true",
                         dest="daemonize", help="Daemonize Sopel")
     parser.add_argument("-q", '--quit', action="store_true", dest="quit",

--- a/test/cli/test_cli_utils.py
+++ b/test/cli/test_cli_utils.py
@@ -1,0 +1,41 @@
+# coding=utf-8
+"""Tests for sopel.cli.utils"""
+from __future__ import unicode_literals, absolute_import, print_function, division
+
+import pytest
+
+from sopel.cli.utils import enumerate_configs
+
+
+@pytest.fixture
+def config_dir(tmpdir):
+    """Pytest fixture used to generate a temporary configuration directory"""
+    test_dir = tmpdir.mkdir("config")
+    test_dir.join('config.cfg').write('')
+    test_dir.join('extra.ini').write('')
+    test_dir.join('module.cfg').write('')
+    test_dir.join('README').write('')
+
+    return test_dir
+
+
+def test_enumerate_configs(config_dir):
+    """Assert function retrieves only .cfg files by default"""
+    results = list(enumerate_configs(config_dir.strpath))
+
+    assert 'config.cfg' in results
+    assert 'module.cfg' in results
+    assert 'extra.ini' not in results
+    assert 'README' not in results
+    assert len(results) == 2
+
+
+def test_enumerate_configs_extension(config_dir):
+    """Assert function retrieves only files with the given extension"""
+    results = list(enumerate_configs(config_dir.strpath, '.ini'))
+
+    assert 'config.cfg' not in results
+    assert 'module.cfg' not in results
+    assert 'extra.ini' in results
+    assert 'README' not in results
+    assert len(results) == 1

--- a/test/cli/test_cli_utils.py
+++ b/test/cli/test_cli_utils.py
@@ -2,12 +2,13 @@
 """Tests for sopel.cli.utils"""
 from __future__ import unicode_literals, absolute_import, print_function, division
 
+import argparse
 from contextlib import contextmanager
 import os
 
 import pytest
 
-from sopel.cli.utils import enumerate_configs, find_config
+from sopel.cli.utils import enumerate_configs, find_config, add_config_arguments
 
 
 @contextmanager
@@ -89,3 +90,37 @@ def test_find_config_extension(tmpdir, config_dir):
         found_config = find_config(
             config_dir.strpath, 'extra', '.ini')
         assert found_config == config_dir.join('extra.ini').strpath
+
+
+def test_add_config_arguments():
+    """Assert function adds the -c/--config option."""
+    parser = argparse.ArgumentParser()
+    add_config_arguments(parser)
+
+    options = parser.parse_args([])
+    assert hasattr(options, 'config')
+    assert options.config is None
+
+    options = parser.parse_args(['-c', 'test-short'])
+    assert options.config == 'test-short'
+
+    options = parser.parse_args(['--config', 'test-long'])
+    assert options.config == 'test-long'
+
+
+def test_add_config_arguments_subparser():
+    """Assert function adds the -c/--config option on a subparser."""
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest='action')
+    sub = subparsers.add_parser('sub')
+    add_config_arguments(sub)
+
+    options = parser.parse_args(['sub'])
+    assert hasattr(options, 'config')
+    assert options.config is None
+
+    options = parser.parse_args(['sub', '-c', 'test-short'])
+    assert options.config == 'test-short'
+
+    options = parser.parse_args(['sub', '--config', 'test-long'])
+    assert options.config == 'test-long'

--- a/test/cli/test_cli_utils.py
+++ b/test/cli/test_cli_utils.py
@@ -2,9 +2,22 @@
 """Tests for sopel.cli.utils"""
 from __future__ import unicode_literals, absolute_import, print_function, division
 
+from contextlib import contextmanager
+import os
+
 import pytest
 
-from sopel.cli.utils import enumerate_configs
+from sopel.cli.utils import enumerate_configs, find_config
+
+
+@contextmanager
+def cd(newdir):
+    prevdir = os.getcwd()
+    os.chdir(os.path.expanduser(newdir))
+    try:
+        yield
+    finally:
+        os.chdir(prevdir)
 
 
 @pytest.fixture
@@ -39,3 +52,40 @@ def test_enumerate_configs_extension(config_dir):
     assert 'extra.ini' in results
     assert 'README' not in results
     assert len(results) == 1
+
+
+def test_find_config_local(tmpdir, config_dir):
+    """Assert function retrieves configuration file from working dir first"""
+    working_dir = tmpdir.mkdir("working")
+    working_dir.join('local.cfg').write('')
+
+    with cd(working_dir.strpath):
+        found_config = find_config(config_dir.strpath, 'local.cfg')
+        assert found_config == 'local.cfg'
+
+        found_config = find_config(config_dir.strpath, 'local')
+        assert found_config == config_dir.join('local').strpath
+
+
+def test_find_config_default(tmpdir, config_dir):
+    """Assert function retrieves configuration file from given config dir"""
+    working_dir = tmpdir.mkdir("working")
+    working_dir.join('local.cfg').write('')
+
+    with cd(working_dir.strpath):
+        found_config = find_config(config_dir.strpath, 'config')
+        assert found_config == config_dir.join('config.cfg').strpath
+
+        found_config = find_config(config_dir.strpath, 'config.cfg')
+        assert found_config == config_dir.join('config.cfg').strpath
+
+
+def test_find_config_extension(tmpdir, config_dir):
+    """Assert function retrieves configuration file with the given extension"""
+    working_dir = tmpdir.mkdir("working")
+    working_dir.join('local.cfg').write('')
+
+    with cd(working_dir.strpath):
+        found_config = find_config(
+            config_dir.strpath, 'extra', '.ini')
+        assert found_config == config_dir.join('extra.ini').strpath

--- a/test/cli/test_cli_utils.py
+++ b/test/cli/test_cli_utils.py
@@ -8,7 +8,7 @@ import os
 
 import pytest
 
-from sopel.cli.utils import enumerate_configs, find_config, add_config_arguments
+from sopel.cli.utils import enumerate_configs, find_config, add_common_arguments
 
 
 @contextmanager
@@ -92,10 +92,10 @@ def test_find_config_extension(tmpdir, config_dir):
         assert found_config == config_dir.join('extra.ini').strpath
 
 
-def test_add_config_arguments():
+def test_add_common_arguments():
     """Assert function adds the -c/--config option."""
     parser = argparse.ArgumentParser()
-    add_config_arguments(parser)
+    add_common_arguments(parser)
 
     options = parser.parse_args([])
     assert hasattr(options, 'config')
@@ -108,12 +108,12 @@ def test_add_config_arguments():
     assert options.config == 'test-long'
 
 
-def test_add_config_arguments_subparser():
+def test_add_common_arguments_subparser():
     """Assert function adds the -c/--config option on a subparser."""
     parser = argparse.ArgumentParser()
     subparsers = parser.add_subparsers(dest='action')
     sub = subparsers.add_parser('sub')
-    add_config_arguments(sub)
+    add_common_arguments(sub)
 
     options = parser.parse_args(['sub'])
     assert hasattr(options, 'config')

--- a/test/test_run_script.py
+++ b/test/test_run_script.py
@@ -32,28 +32,6 @@ def config_dir(tmpdir):
     return test_dir
 
 
-def test_enumerate_configs(config_dir):
-    """Assert function retrieves only .cfg files by default"""
-    results = list(run_script.enumerate_configs(config_dir.strpath))
-
-    assert 'config.cfg' in results
-    assert 'module.cfg' in results
-    assert 'extra.ini' not in results
-    assert 'README' not in results
-    assert len(results) == 2
-
-
-def test_enumerate_configs_extension(config_dir):
-    """Assert function retrieves only files with the given extension"""
-    results = list(run_script.enumerate_configs(config_dir.strpath, '.ini'))
-
-    assert 'config.cfg' not in results
-    assert 'module.cfg' not in results
-    assert 'extra.ini' in results
-    assert 'README' not in results
-    assert len(results) == 1
-
-
 def test_find_config_local(tmpdir, config_dir):
     """Assert function retrieves configuration file from working dir first"""
     working_dir = tmpdir.mkdir("working")

--- a/test/test_run_script.py
+++ b/test/test_run_script.py
@@ -32,43 +32,6 @@ def config_dir(tmpdir):
     return test_dir
 
 
-def test_find_config_local(tmpdir, config_dir):
-    """Assert function retrieves configuration file from working dir first"""
-    working_dir = tmpdir.mkdir("working")
-    working_dir.join('local.cfg').write('')
-
-    with cd(working_dir.strpath):
-        found_config = run_script.find_config(config_dir.strpath, 'local.cfg')
-        assert found_config == 'local.cfg'
-
-        found_config = run_script.find_config(config_dir.strpath, 'local')
-        assert found_config == config_dir.join('local').strpath
-
-
-def test_find_config_default(tmpdir, config_dir):
-    """Assert function retrieves configuration file from given config dir"""
-    working_dir = tmpdir.mkdir("working")
-    working_dir.join('local.cfg').write('')
-
-    with cd(working_dir.strpath):
-        found_config = run_script.find_config(config_dir.strpath, 'config')
-        assert found_config == config_dir.join('config.cfg').strpath
-
-        found_config = run_script.find_config(config_dir.strpath, 'config.cfg')
-        assert found_config == config_dir.join('config.cfg').strpath
-
-
-def test_find_config_extension(tmpdir, config_dir):
-    """Assert function retrieves configuration file with the given extension"""
-    working_dir = tmpdir.mkdir("working")
-    working_dir.join('local.cfg').write('')
-
-    with cd(working_dir.strpath):
-        found_config = run_script.find_config(
-            config_dir.strpath, 'extra', '.ini')
-        assert found_config == config_dir.join('extra.ini').strpath
-
-
 def test_get_configuration(tmpdir):
     """Assert function returns a Sopel ``Config`` object"""
     working_dir = tmpdir.mkdir("working")


### PR DESCRIPTION
Related to #1471:

* create a `sopel.cli.utils` modules,
* functions from `sopel.cli.utils` are available from `sopel.cli` as shortcuts,
* find, enumerate, and load configurations functions are now in `sopel.cli.utils`,
* `sopel.run_script` now uses `sopel.cli.utils` for these functions,
* existing tests are moved around into `test/cli/test_cli_utils.py` for consistency,

and there is no new feature, only internal changes: everything is backward compatible.

From this PR, it is possible to change how settings are loaded (which files, from where, etc.), and there is one single place to load a Sopel's configuration.
