### PR TITLE
cli: allow config loading from env (SOPEL_CONFIG)

### DIFF
--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -131,7 +131,8 @@ def load_settings(options):
     This function loads Sopel's settings from one of these sources:
 
     * value of ``options.config``, if given,
-    * or the ``default`` configuration is loaded,
+    * ``SOPEL_CONFIG`` environment variable, if no option is given,
+    * otherwise the ``default`` configuration is loaded,
 
     then loads the settings and returns it as a :class:`~sopel.config.Config`
     object.
@@ -146,7 +147,13 @@ def load_settings(options):
         add the proper option to the argument parser.
 
     """
-    name = options.config or 'default'
+    # Default if no options.config or no env var or if they are empty
+    name = 'default'
+    if options.config:
+        name = options.config
+    elif 'SOPEL_CONFIG' in os.environ:
+        name = os.environ['SOPEL_CONFIG'] or name  # use default if empty
+
     filename = find_config(config.DEFAULT_HOMEDIR, name)
 
     if not os.path.isfile(filename):


### PR DESCRIPTION
**Related** to #1471
**Replace** #1445, based on #1472 

This PR adds one commit to #1472 to load the configuration file from the environment variable `SOPEL_CONFIG`.

Sopel will now try to load the configuration from:

* `-c <filename>` or `--config <filename>` if used,
* then look at `SOPEL_CONFIG` env var, and use it if not empty,
* and default to use `default`,

but it does not try to load one and fallback on other: it'll stop at the first option available, and raise an error if the configuration is invalid and/or not found.