### PR TITLE
etymology: fix py3.3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: python
 python:
   - "2.7"
+  - "3.3"
   - "3.4"
 git:
   submodules: false

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,5 @@
 pytest
 coveralls
-flake8>=3.6.0,<3.7.0
+flake8<3.6.0; python_version == '3.3'
+flake8>=3.6.0,<3.7.0; python_version != '3.3'
+setuptools<40.0; python_version == '3.3'

--- a/sopel/modules/etymology.py
+++ b/sopel/modules/etymology.py
@@ -13,13 +13,19 @@ from re import sub
 from requests import get
 from sopel.module import commands, example, NOLIMIT
 try:
-    # Python 2.6-2.7
+    # Python 2.7
     from HTMLParser import HTMLParser
     h = HTMLParser()
     unescape = h.unescape
 except ImportError:
-    # Python 3
-    from html import unescape  # https://stackoverflow.com/a/2087433
+    try:
+        # Python 3.4+
+        from html import unescape  # https://stackoverflow.com/a/2087433
+    except ImportError:
+        # Python 3.3... sigh
+        from html.parser import HTMLParser
+        h = HTMLParser()
+        unescape = h.unescape
 
 
 ETYURI = 'https://www.etymonline.com/word/%s'


### PR DESCRIPTION
Travis wasn't testing on 3.3, so this slipped in with the rewrite for Sopel 6.6.0 (#1432). Hopefully Travis will just work without any additional tweaking, and we'll have tests for Python 3.3 until we eventually do drop support for it (since it's already EOL).