### PR TITLE
Add docstrings for privilege levels

### DIFF
--- a/sopel/module.py
+++ b/sopel/module.py
@@ -23,19 +23,34 @@ be used, for example, to allow a user to retry a failed command immediately.
 """
 
 VOICE = 1
-"""Privilege level for the +v channel permission"""
+"""Privilege level for the +v channel permission
+
+.. versionadded:: 4.1
+"""
 
 HALFOP = 2
-"""Privilege level for the +h channel permission"""
+"""Privilege level for the +h channel permission
+
+.. versionadded:: 4.1
+"""
 
 OP = 4
-"""Privilege level for the +o channel permission"""
+"""Privilege level for the +o channel permission
+
+.. versionadded:: 4.1
+"""
 
 ADMIN = 8
-"""Privilege level for the +a channel permission"""
+"""Privilege level for the +a channel permission
+
+.. versionadded:: 4.1
+"""
 
 OWNER = 16
-"""Privilege level for the +q channel permission"""
+"""Privilege level for the +q channel permission
+
+.. versionadded:: 4.1
+"""
 
 
 def unblockable(function):

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -23,10 +23,19 @@ be used, for example, to allow a user to retry a failed command immediately.
 """
 
 VOICE = 1
+"""Privilege level for the +v channel permission"""
+
 HALFOP = 2
+"""Privilege level for the +h channel permission"""
+
 OP = 4
+"""Privilege level for the +o channel permission"""
+
 ADMIN = 8
+"""Privilege level for the +a channel permission"""
+
 OWNER = 16
+"""Privilege level for the +q channel permission"""
 
 
 def unblockable(function):


### PR DESCRIPTION
At present, the privilege level constants (VOICE, OP, HALFOP, ...) aren't included in the [documentation](https://sopel.chat/docs/plugin.html?highlight=unblockable#module-sopel.module) because they lack docstrings. Docs `make html` appears correct with this patch, though ordered alphabetically with the other constant (NOLIMIT).

