### PR TITLE
use platform to check OS name instead of try, except

### DIFF
--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -164,7 +164,7 @@ def check_not_root():
         if os.environ.get("USERNAME") == "Administrator":
             raise RuntimeError('Error: Do not run Sopel as Administrator.')
     else:
-        raise RuntimeError('Error: Could not detect Operating Sytem Type, or it is unsupported.')
+        stderr('Warning: Operating System is uncommon. Contact Sopel Devs.')
 
 
 def print_version():

--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -23,6 +23,7 @@ if sys.version_info.major == 3 and sys.version_info.minor < 3:
 import os
 import argparse
 import signal
+import platform
 
 from sopel import run, tools, __version__
 from sopel.config import (
@@ -148,19 +149,22 @@ def build_parser():
 
 
 def check_not_root():
+
     """Check if root is running the bot.
 
     It raises a ``RuntimeError`` if the user has root privileges on Linux or
     if it is the ``Administrator`` account on Windows.
     """
-    try:
+    if platform.system() in ["Linux", "Darwin"]:
         # Linux/Mac
         if os.getuid() == 0 or os.geteuid() == 0:
             raise RuntimeError('Error: Do not run Sopel with root privileges.')
-    except AttributeError:
+    elif platform.system() in ["Windows"]:
         # Windows
         if os.environ.get("USERNAME") == "Administrator":
             raise RuntimeError('Error: Do not run Sopel as Administrator.')
+    else:
+        raise RuntimeError('Error: Could not detect Operating Sytem Type, or it is unsupported.')
 
 
 def print_version():

--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -165,7 +165,7 @@ def check_not_root():
         if os.environ.get("USERNAME") == "Administrator":
             raise RuntimeError('Error: Do not run Sopel as Administrator.')
     else:
-        warnings.warn('Warning: Operating System is uncommon. Contact Sopel Devs regarding %s' % name, warnings.RuntimeWarning)
+        warnings.warn('Warning: Operating System is uncommon. Contact Sopel Devs regarding %s' % opersystem, warnings.RuntimeWarning)
 
 
 def print_version():

--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -165,7 +165,7 @@ def check_not_root():
         if os.environ.get("USERNAME") == "Administrator":
             raise RuntimeError('Error: Do not run Sopel as Administrator.')
     else:
-        warning.warn('Warning: Operating System is uncommon. Contact Sopel Devs.', warning.RuntimeWarning)
+        warnings.warn('Warning: Operating System is uncommon. Contact Sopel Devs.', warnings.RuntimeWarning)
 
 
 def print_version():

--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -154,11 +154,12 @@ def check_not_root():
     It raises a ``RuntimeError`` if the user has root privileges on Linux or
     if it is the ``Administrator`` account on Windows.
     """
-    if platform.system() in ["Linux", "Darwin"]:
+    opersystem = platform.system()
+    if opersystem in ["Linux", "Darwin"]:
         # Linux/Mac
         if os.getuid() == 0 or os.geteuid() == 0:
             raise RuntimeError('Error: Do not run Sopel with root privileges.')
-    elif platform.system() in ["Windows"]:
+    elif opersystem in ["Windows"]:
         # Windows
         if os.environ.get("USERNAME") == "Administrator":
             raise RuntimeError('Error: Do not run Sopel as Administrator.')

--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -24,6 +24,7 @@ import os
 import argparse
 import signal
 import platform
+import warning
 
 from sopel import run, tools, __version__
 from sopel.config import (
@@ -164,7 +165,7 @@ def check_not_root():
         if os.environ.get("USERNAME") == "Administrator":
             raise RuntimeError('Error: Do not run Sopel as Administrator.')
     else:
-        stderr('Warning: Operating System is uncommon. Contact Sopel Devs.')
+        warning.warn('Warning: Operating System is uncommon. Contact Sopel Devs.', warning.RuntimeWarning)
 
 
 def print_version():

--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -165,7 +165,7 @@ def check_not_root():
         if os.environ.get("USERNAME") == "Administrator":
             raise RuntimeError('Error: Do not run Sopel as Administrator.')
     else:
-        warnings.warn('Warning: Operating System is uncommon. Contact Sopel Devs.', warnings.RuntimeWarning)
+        warnings.warn('Warning: Operating System is uncommon. Contact Sopel Devs regarding %s' % name, warnings.RuntimeWarning)
 
 
 def print_version():

--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -24,7 +24,7 @@ import os
 import argparse
 import signal
 import platform
-import warning
+import warnings
 
 from sopel import run, tools, __version__
 from sopel.config import (

--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -165,7 +165,7 @@ def check_not_root():
         if os.environ.get("USERNAME") == "Administrator":
             raise RuntimeError('Error: Do not run Sopel as Administrator.')
     else:
-        warnings.warn('Warning: Operating System is uncommon. Contact Sopel Devs regarding %s' % opersystem, warnings.RuntimeWarning)
+        warnings.warn('Warning: Operating System is uncommon. Contact Sopel Devs regarding %s' % opersystem, RuntimeWarning)
 
 
 def print_version():

--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -149,7 +149,6 @@ def build_parser():
 
 
 def check_not_root():
-
     """Check if root is running the bot.
 
     It raises a ``RuntimeError`` if the user has root privileges on Linux or


### PR DESCRIPTION
Removed the try/except method for a method to detect operating system.

os.name works fairly similar as well.

Testing on win10, and linux works great,,, don't have Mac to test "darwin"