### PR TITLE
etymology: quote URL parameters

### DIFF
--- a/sopel/modules/etymology.py
+++ b/sopel/modules/etymology.py
@@ -11,6 +11,7 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 
 from re import sub
 from requests import get
+from sopel import web
 from sopel.module import commands, example, NOLIMIT
 try:
     # Python 2.7
@@ -39,7 +40,7 @@ def etymology(word):
     if len(word) > 25:
         raise ValueError("Word too long: %s[…]" % word[:10])
 
-    ety = get(ETYURI % word)
+    ety = get(ETYURI % web.quote(word))
     if ety.status_code != 200:
         return None
 
@@ -60,7 +61,7 @@ def etymology(word):
         sentence = ' '.join(words) + ' […]'
 
     sentence = '"' + sentence.replace('"', "'") + '"'
-    return sentence + ' - ' + (ETYURI % word)
+    return sentence + ' - ' + (ETYURI % web.quote(word))
 
 
 @commands('ety')
@@ -72,7 +73,7 @@ def f_etymology(bot, trigger):
     try:
         result = etymology(word)
     except IOError:
-        msg = "Can't connect to etymonline.com (%s)" % (ETYURI % word)
+        msg = "Can't connect to etymonline.com (%s)" % (ETYURI % web.quote(word))
         bot.msg(trigger.sender, msg)
         return NOLIMIT
     except (AttributeError, TypeError):
@@ -83,7 +84,7 @@ def f_etymology(bot, trigger):
     if result is not None:
         bot.msg(trigger.sender, result)
     else:
-        uri = ETYSEARCH % word
+        uri = ETYSEARCH % web.quote(word)
         msg = 'Can\'t find the etymology for "%s". Try %s' % (word, uri)
         bot.msg(trigger.sender, msg)
         return NOLIMIT


### PR DESCRIPTION
**Note**: quick fix for 6.6.x

The `ety` command now properly encodes the search term used in the URL
to request www.etymonline.com.

This way, the command `.ety coup d'etat` returns something like:

> "1640s, from French coup d'étate, literally 'stroke of the state'
> (see coup). […]" - https://www.etymonline.com/word/coup%20d%27etat

Instead of this:

> Can't find the etymology for "coup d'etat".
> Try https://www.etymonline.com/search?q=coup d'etat

Which was very unfortunate, because a) it didn't find the answer
and b) it gave an invalid URL to search for an answer.

It also encodes the search URL when it does not found a result:

    <me> .ety not found
    <Sopel> Can't find the etymology for "not found".
            Try https://www.etymonline.com/search?q=not%20found

So that the user can copy and paste the URL.

**Edit**: fix grammar