### PR TITLE
search: quote URL parameters

### DIFF
--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -30,9 +30,13 @@ r_bing = re.compile(r'<h2(?: class=" b_topTitle")?><a href="([^"]+)"')
 
 
 def bing_search(query, lang='en-US'):
-    base = 'https://www.bing.com/search?mkt=%s&q=' % lang
-    bytes = requests.get(base + query).text
-    m = r_bing.search(bytes)
+    base = 'https://www.bing.com/search'
+    parameters = {
+        'mkt': lang,
+        'q': query,
+    }
+    response = requests.get(base, parameters)
+    m = r_bing.search(response.text)
     if m:
         return m.group(1)
 

--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -5,10 +5,6 @@
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 import re
-from sopel import web
-from sopel.module import commands, example
-import requests
-import xmltodict
 import sys
 
 if sys.version_info.major < 3:
@@ -16,6 +12,12 @@ if sys.version_info.major < 3:
     unquote = lambda s: _unquote(s.encode('utf-8')).decode('utf-8')
 else:
     from urllib.parse import unquote
+
+import requests
+import xmltodict
+
+from sopel import web
+from sopel.module import commands, example
 
 
 def formatnumber(n):

--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -162,8 +162,14 @@ def suggest(bot, trigger):
     # a composite profile of all users on a given instance, not a profile of any
     # single user. This can be switched out as soon as someone finds (or builds)
     # an alternative suggestion API.
-    uri = 'https://suggestqueries.google.com/complete/search?output=toolbar&hl=en&q='
-    answer = xmltodict.parse(requests.get(uri + query.replace('+', '%2B')).text)['toplevel']
+    base = 'https://suggestqueries.google.com/complete/search'
+    parameters = {
+        'output': 'toolbar',
+        'hl': 'en',
+        'q': query,
+    }
+    response = requests.get(base, parameters)
+    answer = xmltodict.parse(response.text)['toplevel']
     try:
         answer = answer['CompleteSuggestion'][0]['suggestion']['@data']
     except TypeError:


### PR DESCRIPTION
**Note**: quick fix for 6.6.x

Following #1480 my eyes turned to the search module, and they found the same kind of problems.

So I applied the same solution, and it works fine:

    <@Exirel> .suggest 2+2
    <Sopel> 4
    <@Exirel> .suggest coup d'ét
    <Sopel> coup d'état

_(also yes, I'm so French that I can't resi**s**t to use "coup d'état" in my example)_