### PR TITLE
unicode: remove `u` prefix (and other cleanups)

### DIFF
--- a/sopel/modules/unicode_info.py
+++ b/sopel/modules/unicode_info.py
@@ -5,9 +5,10 @@
 # Licensed under the Eiffel Forum License 2.
 from __future__ import unicode_literals, absolute_import, print_function, division
 
-import unicodedata
 import sys
-from sopel.module import commands, example, NOLIMIT
+import unicodedata
+
+from sopel import module
 
 if sys.version_info.major >= 3:
     # Note on unicode and str (required for py2 compatibility)
@@ -38,14 +39,14 @@ def get_codepoint_name(char):
     return point, name
 
 
-@commands('u')
-@example('.u ‽', 'U+203D INTERROBANG (‽)')
-@example('.u 203D', 'U+203D INTERROBANG (‽)')
+@module.commands('u')
+@module.example('.u ‽', 'U+203D INTERROBANG (‽)')
+@module.example('.u 203D', 'U+203D INTERROBANG (‽)')
 def codepoint(bot, trigger):
     arg = trigger.group(2)
     if not arg:
         bot.reply('What code point do you want me to look up?')
-        return NOLIMIT
+        return module.NOLIMIT
     stripped = arg.strip()
     if len(stripped) > 0:
         arg = stripped
@@ -56,7 +57,7 @@ def codepoint(bot, trigger):
             arg = unichr(int(arg, 16))
         except (ValueError, TypeError):
             bot.reply("That's not a valid code point.")
-            return NOLIMIT
+            return module.NOLIMIT
 
     point, name = get_codepoint_name(arg)
     if name is None:

--- a/sopel/modules/unicode_info.py
+++ b/sopel/modules/unicode_info.py
@@ -10,7 +10,32 @@ import sys
 from sopel.module import commands, example, NOLIMIT
 
 if sys.version_info.major >= 3:
+    # Note on unicode and str (required for py2 compatibility)
+    # the `hex` function returns a `str`, both in py2 and py3
+    # however, a `str` is a unicode string in py3, but a bytestring in py2
+    # in order to prevent that, we encode the return from `hex` as `unicode`
+    # and since this class does not exist anymore on py3, we create an alias
+    # for `str` in py3
     unichr = chr
+    unicode = str
+
+
+def get_codepoint_name(char):
+    """Retrieve the codepoint and name if possible from a character"""
+    # Get the hex value for the code point, and drop the 0x from the front
+    point = unicode(hex(ord(char)))[2:]
+
+    # Make the hex 4 characters long with preceding 0s, and all upper case
+    point = point.rjust(4, '0').upper()
+
+    # get codepoint's name
+    name = None
+    try:
+        name = unicodedata.name(char)
+    except ValueError:
+        pass
+
+    return point, name
 
 
 @commands('u')
@@ -33,19 +58,14 @@ def codepoint(bot, trigger):
             bot.reply("That's not a valid code point.")
             return NOLIMIT
 
-    # Get the hex value for the code point, and drop the 0x from the front
-    point = str(hex(ord(u'' + arg)))[2:]
-    # Make the hex 4 characters long with preceding 0s, and all upper case
-    point = point.rjust(4, str('0')).upper()
-    try:
-        name = unicodedata.name(arg)
-    except ValueError:
-        return 'U+%s (No name found)' % point
+    point, name = get_codepoint_name(arg)
+    if name is None:
+        name = '(No name found)'
 
+    template = 'U+%s %s (\xe2\x97\x8c%s)'
     if not unicodedata.combining(arg):
         template = 'U+%s %s (%s)'
-    else:
-        template = 'U+%s %s (\xe2\x97\x8c%s)'
+
     bot.say(template % (point, name, arg))
 
 

--- a/sopel/modules/unicode_info.py
+++ b/sopel/modules/unicode_info.py
@@ -29,7 +29,7 @@ def codepoint(bot, trigger):
             arg = arg[2:]
         try:
             arg = unichr(int(arg, 16))
-        except Exception:  # TODO: Be specific
+        except (ValueError, TypeError):
             bot.reply("That's not a valid code point.")
             return NOLIMIT
 


### PR DESCRIPTION
**Note**: based on 6.6.x (and yes, this looks like #1483 a lot - but it's a different plugin!)

The `hex` function returns a `str` object, and you can not use a bytestring object when you need a unicode one. Which is a problem, because py2's str is py3's bytestring, and the py3's str is
py2's unicode.

The previous implementation used to convert everything into `str` and to call it a day. It "works", but requires some hack, for instance:

    ord(u'' + arg)
    point.rjust(4, str('0')

Which can be quite confusing. To make things easier to read, the new implementation defines `unicode` for py3 as an alias for `str`, and uses it in the code once. From that line:

    unicode(hex(ord(char)))[2:]

Everything is working with unicode strings (which is more consistent) instead of working with bytestrings in py2, and unicode in py3.

That being said, I'm amazed by the hack that was in place before, because it shows how complex the situation trully is. **Unicode is hard!**