### PR TITLE
Replace deprecated bot.privileges accesses

### DIFF
--- a/sopel/module.py
+++ b/sopel/module.py
@@ -330,7 +330,7 @@ def require_privilege(level, message=None):
             # If this is a privmsg, ignore privilege requirements
             if trigger.is_privmsg:
                 return function(bot, trigger, *args, **kwargs)
-            channel_privs = bot.privileges[trigger.sender]
+            channel_privs = bot.channels[trigger.sender].privileges
             allowed = channel_privs.get(trigger.nick, 0) >= level
             if not trigger.is_privmsg and not allowed:
                 if message and not callable(message):

--- a/sopel/modules/adminchannel.py
+++ b/sopel/modules/adminchannel.py
@@ -27,7 +27,7 @@ def kick(bot, trigger):
     """
     Kick a user from the channel.
     """
-    if bot.privileges[trigger.sender][bot.nick] < HALFOP:
+    if bot.channels[trigger.sender].privileges[bot.nick] < HALFOP:
         return bot.reply("I'm not a channel operator!")
     text = trigger.group().split()
     argc = len(text)
@@ -79,7 +79,7 @@ def ban(bot, trigger):
     This give admins the ability to ban a user.
     The bot must be a Channel Operator for this command to work.
     """
-    if bot.privileges[trigger.sender][bot.nick] < HALFOP:
+    if bot.channels[trigger.sender].privileges[bot.nick] < HALFOP:
         return bot.reply("I'm not a channel operator!")
     text = trigger.group().split()
     argc = len(text)
@@ -107,7 +107,7 @@ def unban(bot, trigger):
     This give admins the ability to unban a user.
     The bot must be a Channel Operator for this command to work.
     """
-    if bot.privileges[trigger.sender][bot.nick] < HALFOP:
+    if bot.channels[trigger.sender].privileges[bot.nick] < HALFOP:
         return bot.reply("I'm not a channel operator!")
     text = trigger.group().split()
     argc = len(text)
@@ -135,7 +135,7 @@ def quiet(bot, trigger):
     This gives admins the ability to quiet a user.
     The bot must be a Channel Operator for this command to work.
     """
-    if bot.privileges[trigger.sender][bot.nick] < OP:
+    if bot.channels[trigger.sender].privileges[bot.nick] < OP:
         return bot.reply("I'm not a channel operator!")
     text = trigger.group().split()
     argc = len(text)
@@ -163,7 +163,7 @@ def unquiet(bot, trigger):
     This gives admins the ability to unquiet a user.
     The bot must be a Channel Operator for this command to work.
     """
-    if bot.privileges[trigger.sender][bot.nick] < OP:
+    if bot.channels[trigger.sender].privileges[bot.nick] < OP:
         return bot.reply("I'm not a channel operator!")
     text = trigger.group().split()
     argc = len(text)
@@ -193,7 +193,7 @@ def kickban(bot, trigger):
     The bot must be a Channel Operator for this command to work.
     .kickban [#chan] user1 user!*@* get out of here
     """
-    if bot.privileges[trigger.sender][bot.nick] < HALFOP:
+    if bot.channels[trigger.sender].privileges[bot.nick] < HALFOP:
         return bot.reply("I'm not a channel operator!")
     text = trigger.group().split()
     argc = len(text)
@@ -227,7 +227,7 @@ def topic(bot, trigger):
     This gives ops the ability to change the topic.
     The bot must be a Channel Operator for this command to work.
     """
-    if bot.privileges[trigger.sender][bot.nick] < HALFOP:
+    if bot.channels[trigger.sender].privileges[bot.nick] < HALFOP:
         return bot.reply("I'm not a channel operator!")
     if not trigger.group(2):
         return

--- a/sopel/modules/clock.py
+++ b/sopel/modules/clock.py
@@ -177,7 +177,7 @@ def update_channel(bot, trigger):
     """
     Set the preferred timezone for the channel.
     """
-    if bot.privileges[trigger.sender][trigger.nick] < OP:
+    if bot.channels[trigger.sender].privileges[trigger.nick] < OP:
         return
     elif not pytz:
         bot.reply("Sorry, I don't have timezone support installed.")
@@ -231,7 +231,7 @@ def update_channel_format(bot, trigger):
     Sets your preferred format for time. Uses the standard strftime format. You
     can use <http://strftime.net> or your favorite search engine to learn more.
     """
-    if bot.privileges[trigger.sender][trigger.nick] < OP:
+    if bot.channels[trigger.sender].privileges[trigger.nick] < OP:
         return
 
     tformat = trigger.group(2)

--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -176,7 +176,7 @@ def update_channel(bot, trigger):
     Sets the Safe for Work status (true or false) for the current
     channel. Defaults to false.
     """
-    if bot.privileges[trigger.sender][trigger.nick] < OP:
+    if bot.channels[trigger.sender].privileges[trigger.nick] < OP:
         return
     else:
         param = 'true'

--- a/sopel/modules/safety.py
+++ b/sopel/modules/safety.py
@@ -186,7 +186,7 @@ def url_handler(bot, trigger):
 @sopel.module.commands('safety')
 def toggle_safety(bot, trigger):
     """ Set safety setting for channel """
-    if not trigger.admin and bot.privileges[trigger.sender][trigger.nick] < OP:
+    if not trigger.admin and bot.channels[trigger.sender].privileges[trigger.nick] < OP:
         bot.reply('Only channel operators can change safety settings')
         return
     allowed_states = ['strict', 'on', 'off', 'local', 'local strict']

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -20,9 +20,7 @@ def sopel():
 @pytest.fixture
 def bot(sopel, pretrigger):
     bot = MockSopelWrapper(sopel, pretrigger)
-    bot.privileges = dict()
-    bot.privileges[Identifier('#Sopel')] = dict()
-    bot.privileges[Identifier('#Sopel')][Identifier('Foo')] = module.VOICE
+    bot.channels[Identifier('#Sopel')].privileges[Identifier('Foo')] = module.VOICE
     return bot
 
 


### PR DESCRIPTION
`bot.privileges[channel][user]` -> `bot.channels[channel].privileges[user]`. Smoke tested.