### PR TITLE
Py2 warning

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,8 @@ Sopel requires ``backports.ssl_match_hostname`` to be installed. Use
 ``yum install python-backports.ssl_match_hostname`` to install it, or download
 and install it manually `from PyPI <https://pypi.org/project/backports.ssl_match_hostname>`_.
 
+Note: Python 2.x is near end of life. Sopel support at that point is TBD.
+
 In the source directory (whether cloned or from the tarball) run
 ``setup.py install``. You can then run ``sopel`` to configure and start the
 bot. Alternately, you can just run the ``sopel.py`` file in the source

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,8 @@ if sys.version_info < (2, 7) or (
     # Maybe not the cleanest or best way to do this, but I'm tired of answering
     # this fucking question, and if you get here you should go RTGDMFM.
     raise ImportError('Sopel requires Python 2.7+ or 3.3+.')
+if sys.version_info.major == 2:
+    print('Warning: Python 2.x is near end of life. Sopel support at that point is TBD.', file=sys.stderr)
 
 
 def read_reqs(path):

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -17,6 +17,8 @@ from sopel import tools
 if sys.version_info < (2, 7):
     tools.stderr('Error: Requires Python 2.7 or later. Try python2.7 sopel')
     sys.exit(1)
+if sys.version_info.major == 2:
+    tools.stderr('Warning: Python 2.x is near end of life. Sopel support at that point is TBD.')
 if sys.version_info.major == 3 and sys.version_info.minor < 3:
     tools.stderr('Error: When running on Python 3, Python 3.3 is required.')
     sys.exit(1)


### PR DESCRIPTION
This will simply display a warning about py2.x EOL

It won't exit, but gives people most of a year to straighten out their python versions.

Not saying Sopel should/will drop py2.7 support Jan 1st 2020, but we shouldn't tie our hands with this either.