### PR TITLE
plugin: reload using new interface

### DIFF
--- a/docs/source/plugin.rst
+++ b/docs/source/plugin.rst
@@ -5,7 +5,12 @@ A Sopel plugin consists of a Python module containing one or more
 ``callable``\s. It may optionally also contain ``configure``, ``setup``, and
 ``shutdown`` hooks.
 
-.. py:method:: callable(bot, trigger)
+.. py:function:: callable(bot, trigger)
+
+    :param bot: the bot's instance
+    :type bot: :class:`sopel.bot.Sopel`
+    :param trigger: the object that triggered the call
+    :type trigger: :class:`sopel.trigger.Trigger`
 
     A callable is any function which takes as its arguments a
     :class:`sopel.bot.Sopel` object and a :class:`sopel.trigger.Trigger`
@@ -21,7 +26,10 @@ A Sopel plugin consists of a Python module containing one or more
     Note that the name can, and should, be anything - it doesn't need to be
     called "callable".
 
-.. py:method:: setup(bot)
+.. py:function:: setup(bot)
+
+    :param bot: the bot's instance
+    :type bot: :class:`sopel.bot.Sopel`
 
     This is an optional function of a plugin, which will be called while the
     module is being loaded. The purpose of this function is to perform whatever
@@ -41,7 +49,10 @@ A Sopel plugin consists of a Python module containing one or more
     execution of this function. As such, an infinite loop (such as an
     unthreaded polling loop) will cause the bot to hang.
 
-.. py:method:: shutdown(bot)
+.. py:function:: shutdown(bot)
+
+    :param bot: the bot's instance
+    :type bot: :class:`sopel.bot.Sopel`
 
     This is an optional function of a module, which will be called while the
     bot is quitting. Note that this normally occurs after closing connection
@@ -57,7 +68,10 @@ A Sopel plugin consists of a Python module containing one or more
 
     .. versionadded:: 4.1
 
-.. py:method:: configure(config)
+.. py:function:: configure(config)
+
+    :param bot: the bot's configuration object
+    :type bot: :class:`sopel.config.Config`
 
     This is an optional function of a module, which will be called during the
     user's setup of the bot. It's intended purpose is to use the methods of the
@@ -71,3 +85,12 @@ sopel.module
 .. automodule:: sopel.module
    :members:
 
+sopel.plugins
+-------------
+.. automodule:: sopel.plugins
+   :members:
+
+sopel.plugins.handlers
+----------------------
+.. automodule:: sopel.plugins.handlers
+   :members:

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
     ),
     # Distutils is shit, and doesn't check if it's a list of basestring
     # but instead requires str.
-    packages=[str('sopel'), str('sopel.modules'),
+    packages=[str('sopel'), str('sopel.modules'), str('sopel.plugins'),
               str('sopel.config'), str('sopel.tools')],
     classifiers=classifiers,
     license='Eiffel Forum License, version 2',

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -14,8 +14,7 @@ import sys
 import threading
 import time
 
-from sopel import tools
-from sopel import irc
+from sopel import irc, plugins, tools
 from sopel.db import SopelDB
 from sopel.tools import stderr, Identifier
 import sopel.tools.jobs
@@ -167,44 +166,48 @@ class Sopel(irc.Bot):
 
     def setup(self):
         stderr("\nWelcome to Sopel. Loading modules...\n\n")
+        plugins_info = plugins.enumerate_plugins(self.config)
 
-        modules = sopel.loader.enumerate_modules(self.config)
-
-        error_count = 0
-        success_count = 0
-        for name in modules:
-            path, type_ = modules[name]
+        load_success = 0
+        load_error = 0
+        load_disabled = 0
+        for plugin, is_enabled in plugins_info:
+            name = plugin.name
+            if not is_enabled:
+                load_disabled = load_disabled + 1
+                continue
 
             try:
-                module, _ = sopel.loader.load_module(name, path, type_)
+                plugin.load()
             except Exception as e:
-                error_count = error_count + 1
+                load_error = load_error + 1
                 filename, lineno = tools.get_raising_file_and_line()
                 rel_path = os.path.relpath(filename, os.path.dirname(__file__))
                 raising_stmt = "%s:%d" % (rel_path, lineno)
                 stderr("Error loading %s: %s (%s)" % (name, e, raising_stmt))
             else:
                 try:
-                    if hasattr(module, 'setup'):
-                        module.setup(self)
-                    relevant_parts = sopel.loader.clean_module(
-                        module, self.config)
+                    if plugin.has_setup():
+                        plugin.setup(self)
+                    plugin.register(self)
                 except Exception as e:
-                    error_count = error_count + 1
+                    load_error = load_error + 1
                     filename, lineno = tools.get_raising_file_and_line()
                     rel_path = os.path.relpath(
                         filename, os.path.dirname(__file__)
                     )
                     raising_stmt = "%s:%d" % (rel_path, lineno)
                     stderr("Error in %s setup procedure: %s (%s)"
-                           % (name, e, raising_stmt))
+                        % (name, e, raising_stmt))
                 else:
-                    self.register(*relevant_parts)
-                    success_count += 1
+                    load_success = load_success + 1
+                    print('Loaded: %s' % name)
 
-        if len(modules) > 1:  # coretasks is counted
-            stderr('\n\nRegistered %d modules,' % (success_count - 1))
-            stderr('%d modules failed to load\n\n' % error_count)
+        total = sum([load_success, load_error, load_disabled])
+        if total and load_success:
+            stderr('\n\nRegistered %d modules,' % (load_success - 1))
+            stderr('%d modules failed to load\n\n' % load_error)
+            stderr('%d modules disabled\n\n' % load_disabled)
         else:
             stderr("Warning: Couldn't load any modules")
 

--- a/sopel/config/__init__.py
+++ b/sopel/config/__init__.py
@@ -19,10 +19,6 @@ object is initialized.
 
 from __future__ import unicode_literals, absolute_import, print_function, division
 
-from sopel.tools import stderr
-import sopel.tools
-from sopel.tools import get_input
-import sopel.loader
 import os
 import sys
 if sys.version_info.major < 3:
@@ -30,9 +26,9 @@ if sys.version_info.major < 3:
 else:
     basestring = str
     import configparser as ConfigParser
-from sopel import plugins
-import sopel.config.core_section
-from sopel.config.types import StaticSection
+
+from sopel import tools
+from . import core_section, types
 
 
 DEFAULT_HOMEDIR = os.path.join(os.path.expanduser('~'), '.sopel')
@@ -64,7 +60,7 @@ class Config(object):
         """The config object's associated file, as noted above."""
         self.parser = ConfigParser.RawConfigParser(allow_no_value=True)
         self.parser.read(self.filename)
-        self.define_section('core', sopel.config.core_section.CoreSection,
+        self.define_section('core', core_section.CoreSection,
                             validate=validate)
         self.get = self.parser.get
 
@@ -108,7 +104,7 @@ class Config(object):
         exception raised if they are invalid. This is desirable in a module's
         setup function, for example, but might not be in the configure function.
         """
-        if not issubclass(cls_, StaticSection):
+        if not issubclass(cls_, types.StaticSection):
             raise ValueError("Class must be a subclass of StaticSection.")
         current = getattr(self, name, None)
         current_name = str(current.__class__)
@@ -180,12 +176,20 @@ class Config(object):
         d = 'n'
         if default:
             d = 'y'
-        ans = get_input(question + ' (y/n)? [' + d + '] ')
+        ans = tools.get_input(question + ' (y/n)? [' + d + '] ')
         if not ans:
             ans = d
         return ans.lower() == 'y'
 
     def _modules(self):
+        # Avoid circular import:
+        # - sopel.plugins use sopel.loader
+        # - sopel.config use sopel.plugins
+        # - sopel.loader use sopel.config
+        # TODO: Module configuration should not be in sopel.config
+        # removing module configuration from sopel.config would also remove
+        # the unecessary circular import
+        from sopel import plugins
         for plugin, is_enabled in plugins.enumerate_plugins(self):
             if not is_enabled:
                 # Do not configure non-enabled modules
@@ -195,15 +199,15 @@ class Config(object):
             try:
                 plugin.load()
             except Exception as e:
-                filename, lineno = sopel.tools.get_raising_file_and_line()
+                filename, lineno = tools.get_raising_file_and_line()
                 rel_path = os.path.relpath(filename, os.path.dirname(__file__))
                 raising_stmt = "%s:%d" % (rel_path, lineno)
-                stderr("Error loading %s: %s (%s)" % (name, e, raising_stmt))
+                tools.stderr("Error loading %s: %s (%s)" % (name, e, raising_stmt))
             else:
                 if plugin.has_configure():
                     prompt = 'Configure {} (y/n)? [n]'.format(
                         plugin.get_label())
-                    do_configure = get_input(prompt)
+                    do_configure = tools.get_input(prompt)
                     do_configure = do_configure and do_configure.lower() == 'y'
                     if do_configure:
                         plugin.configure(self)
@@ -248,7 +252,7 @@ def _create_config(configpath):
           " to create your configuration file:\n")
     try:
         config = Config(configpath, validate=False)
-        sopel.config.core_section.configure(config)
+        core_section.configure(config)
         if config.option(
             'Would you like to see if there are any modules'
             ' that need configuring'

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -167,10 +167,12 @@ def clean_callable(func, config):
         func.rule = getattr(func, 'rule', [])
         for command in getattr(func, 'commands', []):
             regexp = get_command_regexp(prefix, command)
-            func.rule.append(regexp)
+            if regexp not in func.rule:
+                func.rule.append(regexp)
         for command in getattr(func, 'nickname_commands', []):
             regexp = get_nickname_command_regexp(nick, command, alias_nicks)
-            func.rule.append(regexp)
+            if regexp not in func.rule:
+                func.rule.append(regexp)
         if hasattr(func, 'example'):
             example = func.example[0]["example"]
             example = example.replace('$nickname', nick)
@@ -184,7 +186,14 @@ def clean_callable(func, config):
                 func._docs[command] = (doc, example)
 
     if hasattr(func, 'intents'):
-        func.intents = [re.compile(intent, re.IGNORECASE) for intent in func.intents]
+        # Can be implementation-dependent
+        _regex_type = type(re.compile(''))
+        func.intents = [
+            (intent
+                if isinstance(intent, _regex_type)
+                else re.compile(intent, re.IGNORECASE))
+            for intent in func.intents
+        ]
 
 
 def load_module(name, path, type_):

--- a/sopel/modules/reload.py
+++ b/sopel/modules/reload.py
@@ -8,21 +8,27 @@ https://sopel.chat
 """
 from __future__ import unicode_literals, absolute_import, print_function, division
 
-import collections
-import sys
-import time
-from sopel.tools import iteritems
-import sopel.loader
-import sopel.module
+import os
 import subprocess
 
-try:
-    from importlib import reload
-except ImportError:
+import sopel.module
+from sopel import plugins, tools
+
+
+def _load(bot, plugin):
+    # handle loading's errors (if any)
     try:
-        from imp import reload
-    except ImportError:
-        pass  # fallback to builtin if neither module is available
+        plugin.load()
+        if plugin.has_setup():
+            plugin.setup(bot)
+        plugin.register(bot)
+    except Exception as e:
+        filename, lineno = tools.get_raising_file_and_line()
+        rel_path = os.path.relpath(filename, os.path.dirname(__file__))
+        raising_stmt = "%s:%d" % (rel_path, lineno)
+        tools.stderr(
+            "Error loading %s: %s (%s)" % (plugin.name, e, raising_stmt))
+        raise
 
 
 @sopel.module.nickname_commands("reload")
@@ -36,80 +42,14 @@ def f_reload(bot, trigger):
     name = trigger.group(2)
 
     if not name or name == '*' or name.upper() == 'ALL THE THINGS':
-        bot._callables = {
-            'high': collections.defaultdict(list),
-            'medium': collections.defaultdict(list),
-            'low': collections.defaultdict(list)
-        }
-        bot._command_groups = collections.defaultdict(list)
-
-        for m in sopel.loader.enumerate_modules(bot.config):
-            reload_module_tree(bot, m, silent=True)
-
+        bot.reload_plugins()
         return bot.reply('done')
 
-    if (name not in sys.modules and name not in sopel.loader.enumerate_modules(bot.config)):
+    if not bot.has_plugin(name):
         return bot.reply('"%s" not loaded, try the `load` command' % name)
 
-    reload_module_tree(bot, name)
-
-
-def reload_module_tree(bot, name, seen=None, silent=False):
-    from types import ModuleType
-
-    old_module = sys.modules[name]
-
-    if seen is None:
-        seen = {}
-    if name not in seen:
-        seen[name] = []
-
-    old_callables = {}
-    for obj_name, obj in iteritems(vars(old_module)):
-        if callable(obj):
-            bot.unregister(obj)
-        elif (type(obj) is ModuleType and
-              obj.__name__.startswith(name + '.') and
-              obj.__name__ not in sys.builtin_module_names):
-            # recurse into submodules, see issue 1056
-            if obj not in seen[name]:
-                seen[name].append(obj)
-                reload(obj)
-                reload_module_tree(bot, obj.__name__, seen, silent)
-
-    modules = sopel.loader.enumerate_modules(bot.config)
-    if name not in modules:
-        return  # Only reload the top-level module, once recursion is finished
-
-    # Also remove all references to sopel callables from top level of the
-    # module, so that they will not get loaded again if reloading the
-    # module does not override them.
-    for obj_name in old_callables.keys():
-        delattr(old_module, obj_name)
-
-    # Also delete the setup function
-    # Sub-modules shouldn't have setup functions, so do after the recursion check
-    if hasattr(old_module, "setup"):
-        delattr(old_module, "setup")
-
-    path, type_ = modules[name]
-    load_module(bot, name, path, type_, silent)
-
-
-def load_module(bot, name, path, type_, silent=False):
-    module, mtime = sopel.loader.load_module(name, path, type_)
-    relevant_parts = sopel.loader.clean_module(module, bot.config)
-
-    bot.register(*relevant_parts)
-
-    # TODO sys.modules[name] = module
-    if hasattr(module, 'setup'):
-        module.setup(bot)
-
-    modified = time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime(mtime))
-
-    if not silent:
-        bot.reply('%r (version: %s)' % (module, modified))
+    bot.reload_plugin(name)
+    return bot.reply('done: %s reloaded' % name)
 
 
 @sopel.module.nickname_commands('update')
@@ -135,18 +75,28 @@ def f_load(bot, trigger):
         return
 
     name = trigger.group(2)
-    path = ''
     if not name:
         return bot.reply('Load what?')
 
-    if name in sys.modules:
+    if bot.has_plugin(name):
         return bot.reply('Module already loaded, use reload')
 
-    mods = sopel.loader.enumerate_modules(bot.config)
-    if name not in mods:
-        return bot.reply('Module %s not found' % name)
-    path, type_ = mods[name]
-    load_module(bot, name, path, type_)
+    for plugin, is_enabled in plugins.enumerate_plugins(bot.config):
+        if plugin.name == name:
+            if is_enabled:
+                try:
+                    _load(bot, plugin)
+                    bot.reply('Module %s loaded' % name)
+                except Exception as error:
+                    bot.reply(
+                        'Module %s can not be loaded: %s' % (name, error))
+            else:
+                bot.reply('Module %s is disabled' % name)
+
+            break
+    else:
+        # Will be triggered only if "break" is not found
+        bot.reply('Module %s not found' % name)
 
 
 # Catch PM based messages

--- a/sopel/plugins/__init__.py
+++ b/sopel/plugins/__init__.py
@@ -1,4 +1,16 @@
 # coding=utf-8
+"""Sopel's plugins interface
+
+.. versionadded:: 7.0
+
+Sopel uses plugins (also called "modules") and uses what are called
+Plugin Handlers as an interface between the bot and its plugins. This interface
+is defined by the :class:`~.handlers.AbstractPluginHandler` abstract class.
+
+To find all available plugins, the :func:`~.enumerate_plugins` function can be
+used. For a more fine-grained search, ``find_*`` functions exists for each
+type of plugins.
+"""
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 import imp
@@ -27,7 +39,7 @@ def _list_plugin_filenames(directory):
 def find_internal_plugins():
     """List internal plugins
 
-    :return: Yield instance of :class:`sopel.plugins.handlers.PyModulePlugin`
+    :return: Yield instance of :class:`~.handlers.PyModulePlugin`
              configured for ``sopel.modules.*``
     """
     plugin_dir = imp.find_module(
@@ -42,7 +54,7 @@ def find_internal_plugins():
 def find_sopel_modules_plugins():
     """List plugins from ``sopel_modules.*``
 
-    :return: Yield instance of :class:`sopel.plugins.handlers.PyModulePlugin`
+    :return: Yield instance of :class:`~.handlers.PyModulePlugin`
              configured for ``sopel_modules.*``
     """
     try:
@@ -58,7 +70,7 @@ def find_sopel_modules_plugins():
 def find_directory_plugins(directory):
     """List plugins from a ``directory``
 
-    :return: Yield instance of :class:`sopel.plugins.handlers.PyFilePlugin`
+    :return: Yield instance of :class:`~.handlers.PyFilePlugin`
              found in ``directory``
     """
     for _, abspath in _list_plugin_filenames(directory):
@@ -71,8 +83,8 @@ def enumerate_plugins(settings):
     :param settings: Sopel's configuration
     :type settings: :class:`sopel.config.Config`
     :return: yield 2-values tuple: an instance of
-             :class:`sopel.plugins.handlers.AbstractPluginHandler`, and
-             if the plugin is active or not
+             :class:`~.handlers.AbstractPluginHandler`, and if the plugin is
+             active or not
 
     This function uses the find functions to find all the available Sopel's
     plugins. It uses the bot's ``settings`` to determine if the plugin is

--- a/sopel/plugins/__init__.py
+++ b/sopel/plugins/__init__.py
@@ -1,4 +1,120 @@
 # coding=utf-8
 from __future__ import unicode_literals, absolute_import, print_function, division
 
+import imp
+import itertools
+import os
+
 from . import handlers  # noqa
+
+
+def _list_plugin_filenames(directory):
+    # list plugin filenames from a directory
+    # yield 2-values tuples: (name, absolute path)
+    base = os.path.abspath(directory)
+    for filename in os.listdir(base):
+        abspath = os.path.join(base, filename)
+
+        if os.path.isdir(abspath):
+            if os.path.isfile(os.path.join(abspath, '__init__.py')):
+                yield os.path.basename(filename), abspath
+        else:
+            name, ext = os.path.splitext(filename)
+            if ext == '.py' and name != '__init__':
+                yield name, abspath
+
+
+def find_internal_plugins():
+    """List internal plugins
+
+    :return: Yield instance of :class:`sopel.plugins.handlers.PyModulePlugin`
+             configured for ``sopel.modules.*``
+    """
+    plugin_dir = imp.find_module(
+        'modules',
+        [imp.find_module('sopel')[1]]
+    )[1]
+
+    for name, _ in _list_plugin_filenames(plugin_dir):
+        yield handlers.PyModulePlugin(name, 'sopel.modules')
+
+
+def find_sopel_modules_plugins():
+    """List plugins from ``sopel_modules.*``
+
+    :return: Yield instance of :class:`sopel.plugins.handlers.PyModulePlugin`
+             configured for ``sopel_modules.*``
+    """
+    try:
+        import sopel_modules
+    except:  # noqa
+        return
+
+    for plugin_dir in set(sopel_modules.__path__):
+        for name, _ in _list_plugin_filenames(plugin_dir):
+            yield handlers.PyModulePlugin(name, 'sopel_modules')
+
+
+def find_directory_plugins(directory):
+    """List plugins from a ``directory``
+
+    :return: Yield instance of :class:`sopel.plugins.handlers.PyFilePlugin`
+             found in ``directory``
+    """
+    for _, abspath in _list_plugin_filenames(directory):
+        yield handlers.PyFilePlugin(abspath)
+
+
+def enumerate_plugins(settings):
+    """Yield Sopel's plugins
+
+    :param settings: Sopel's configuration
+    :type settings: :class:`sopel.config.Config`
+    :return: yield 2-values tuple: an instance of
+             :class:`sopel.plugins.handlers.AbstractPluginHandler`, and
+             if the plugin is active or not
+
+    This function uses the find functions to find all the available Sopel's
+    plugins. It uses the bot's ``settings`` to determine if the plugin is
+    enabled or disabled.
+
+    .. seealso::
+
+       The find functions used are:
+
+       * :func:`find_internal_plugins` for internal plugins
+       * :func:`find_sopel_modules_plugins` for sopel_modules.* plugins
+       * :func:`find_directory_plugins` for modules in ``$homedir/modules``
+
+    """
+    from_internals = find_internal_plugins()
+    from_sopel_modules = find_sopel_modules_plugins()
+    # load from directories
+    source_dirs = [os.path.join(settings.homedir, 'modules')]
+    if settings.core.extra:
+        source_dirs = source_dirs + list(settings.core.extra)
+
+    from_directories = [
+        find_directory_plugins(source_dir)
+        for source_dir in source_dirs
+        if os.path.isdir(source_dir)
+    ]
+
+    # Retrieve all plugins
+    all_plugins = itertools.chain(
+        from_internals,
+        from_sopel_modules,
+        *from_directories)
+
+    # Get setting's details
+    enabled = settings.core.enable
+    disabled = settings.core.exclude
+
+    # Yield all found plugins with their enable status (yes/no)
+    for plugin in all_plugins:
+        name = plugin.name
+        is_enabled = name not in disabled and (not enabled or name in enabled)
+        yield plugin, is_enabled
+
+    # And always yield coretasks
+    yield handlers.PyModulePlugin('coretasks', 'sopel'), True

--- a/sopel/plugins/__init__.py
+++ b/sopel/plugins/__init__.py
@@ -1,0 +1,4 @@
+# coding=utf-8
+from __future__ import unicode_literals, absolute_import, print_function, division
+
+from . import handlers  # noqa

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -118,6 +118,14 @@ class AbstractPluginHandler(object):
         """
         raise NotImplementedError
 
+    def unregister(self, bot):
+        """Unregister the plugin from the ``bot``
+
+        :param bot: instance of Sopel
+        :type bot: :class:`sopel.bot.Sopel`
+        """
+        raise NotImplementedError
+
     def shutdown(self, bot):
         """Take action on bot's shutdown
 
@@ -216,7 +224,11 @@ class PyModulePlugin(AbstractPluginHandler):
 
     def register(self, bot):
         relevant_parts = loader.clean_module(self._module, bot.config)
-        bot.register(*relevant_parts)
+        bot.add_plugin(self, *relevant_parts)
+
+    def unregister(self, bot):
+        relevant_parts = loader.clean_module(self._module, bot.config)
+        bot.remove_plugin(self, *relevant_parts)
 
     def shutdown(self, bot):
         if self.has_shutdown():

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -152,3 +152,38 @@ class PyModulePlugin(AbstractPluginHandler):
 
     def has_configure(self):
         return hasattr(self._module, 'configure')
+
+
+class PyFilePlugin(PyModulePlugin):
+    """Sopel's Plugin loaded from the filesystem outside of the Python Path
+
+    This plugin handler can be used to load a Sopel's Plugin from the
+    filesystem, being a Python ``.py`` file or a directory containing an
+    ``__init__.py`` file, and behaves like a :class:`PyModulePlugin`::
+
+        >>> from sopel.plugins.handlers import PyFilePlugin
+        >>> plugin = PyFilePlugin('/home/sopel/.sopel/modules/custom.py')
+        >>> plugin.load()
+        >>> plugin.name
+        'custom'
+
+    In this example, the plugin ``custom`` is loaded from its filename albeit
+    it is not in the Python path.
+    """
+    def __init__(self, filename):
+        result = loader.get_module_description(filename)
+        if result is None:
+            # TODO: throw more specific exception
+            raise Exception('Invalid Sopel plugin: %s' % filename)
+
+        name, path, module_type = result
+        self.filename = filename
+        self.path = path
+        self.module_type = module_type
+
+        super(PyFilePlugin, self).__init__(name)
+
+    def load(self):
+        self._module, _ = loader.load_module(
+            self.name, self.path, self.module_type
+        )

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -1,4 +1,33 @@
 # coding=utf-8
+"""Sopel's plugin handlers
+
+.. versionadded:: 7.0
+
+Between a plugin and Sopel's core, Plugin Handlers are used. It is an interface
+(defined by the :class:`AbstractPluginHandler` abstract class), that acts as a
+proxy between Sopel and the plugin, making a clear separation between
+how the bot behave and how the plugins works.
+
+From the :class:`~sopel.bot.Sopel` class, a plugin must be:
+
+* loaded, using :meth:`~AbstractPluginHandler.load`
+* setup (if required), using :meth:`~AbstractPluginHandler.setup`
+* and eventually registered using :meth:`~AbstractPluginHandler.register`
+
+Each subclass of :class:`AbstractPluginHandler` must implement its methods in
+order to be used in the application.
+
+At the moment, only two types of plugin are handled:
+
+* :class:`PyModulePlugin`: manage plugins that can be imported as Python
+  module from a python package, ie. where ``from package import name`` works
+* :class:`PyFilePlugin`: manage plugins that are Python files on the filesystem
+  or Python directory (with an ``__init__.py`` file inside), that can not be
+  directly imported and extra steps are necessary
+
+Both exposes the same interface and hide the internal implementation to the
+rest of the application.
+"""
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 import inspect
@@ -14,8 +43,8 @@ class AbstractPluginHandler(object):
     configure, load, shutdown, etc. a Sopel's plugin (or "module").
 
     It is through this interface that Sopel will interact with its plugin,
-    being internals (from `sopel.modules`) or externals (from the python files
-    in a directory, to ``sopel_modules.*` subpackages).
+    being internals (from ``sopel.modules``) or externals (from the python
+    files in a directory, to ``sopel_modules.*`` subpackages).
 
     A "Plugin Handler" will be created by Sopel's loader for each plugin it
     finds, and it'll delegate it to load the plugin, to list its functions
@@ -52,7 +81,11 @@ class AbstractPluginHandler(object):
         raise NotImplementedError
 
     def setup(self, bot):
-        """Setup the plugin with the ``bot``"""
+        """Setup the plugin with the ``bot``
+
+        :param bot: instance of Sopel
+        :type bot: :class:`sopel.bot.Sopel`
+        """
         raise NotImplementedError
 
     def has_setup(self):
@@ -64,11 +97,19 @@ class AbstractPluginHandler(object):
         raise NotImplementedError
 
     def register(self, bot):
-        """Register the plugin with the ``bot``"""
+        """Register the plugin with the ``bot``
+
+        :param bot: instance of Sopel
+        :type bot: :class:`sopel.bot.Sopel`
+        """
         raise NotImplementedError
 
     def shutdown(self, bot):
-        """Take action on bot's shutdown"""
+        """Take action on bot's shutdown
+
+        :param bot: instance of Sopel
+        :type bot: :class:`sopel.bot.Sopel`
+        """
         raise NotImplementedError
 
     def has_shutdown(self):
@@ -101,8 +142,8 @@ class AbstractPluginHandler(object):
 class PyModulePlugin(AbstractPluginHandler):
     """Sopel's Plugin loaded from a Python module or package
 
-    A :class:`sopel.plugins.handlers.PyModulePlugin` represents a Sopel's
-    Plugin that is a Python module (or package) that can be imported directly.
+    A :class:`PyModulePlugin` represents a Sopel's Plugin that is a Python
+    module (or package) that can be imported directly.
 
     This::
 

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -1,0 +1,83 @@
+# coding=utf-8
+from __future__ import unicode_literals, absolute_import, print_function, division
+
+
+class AbstractPluginHandler(object):
+    """Base class for plugin handlers.
+
+    This abstract class defines the Sopel's interface to handle plugins to:
+    configure, load, shutdown, etc. a Sopel's plugin (or "module").
+
+    It is through this interface that Sopel will interact with its plugin,
+    being internals (from `sopel.modules`) or externals (from the python files
+    in a directory, to ``sopel_modules.*` subpackages).
+
+    A "Plugin Handler" will be created by Sopel's loader for each plugin it
+    finds, and it'll delegate it to load the plugin, to list its functions
+    (commands, jobs, etc.), to configure it, and to take any required actions
+    on shutdown.
+    """
+    def load(self):
+        """Load the plugin
+
+        This method must be called first, in order to setup, register, shutdown
+        or configure the plugin later.
+        """
+        raise NotImplementedError
+
+    def is_loaded(self):
+        """Tell if the plugin is loaded or not
+
+        :return: ``True`` if the plugin is loaded, ``False`` otherwise
+        :rtype: boolean
+
+        This must return ``True`` if the :meth:`load` method has been called
+        with success.
+        """
+        raise NotImplementedError
+
+    def setup(self, bot):
+        """Setup the plugin with the ``bot``"""
+        raise NotImplementedError
+
+    def has_setup(self):
+        """Tell if the plugin has a setup action
+
+        :return: ``True`` if the plugin has a setup, ``False`` otherwise
+        :rtype: boolean
+        """
+        raise NotImplementedError
+
+    def register(self, bot):
+        """Register the plugin with the ``bot``"""
+        raise NotImplementedError
+
+    def shutdown(self, bot):
+        """Take action on bot's shutdown"""
+        raise NotImplementedError
+
+    def has_shutdown(self):
+        """Tell if the plugin has a shutdown action
+
+        :return: ``True`` if the plugin has a shutdown, ``False`` otherwise
+        :rtype: boolean
+        """
+        raise NotImplementedError
+
+    def configure(self, settings):
+        """Configure Sopel's ``settings`` for this plugin
+
+        :param settings: Sopel's configuration
+        :type settings: :class:`sopel.config.Config`
+
+        This method will be called by the Sopel's configuration wizard.
+        """
+        raise NotImplementedError
+
+    def has_configure(self):
+        """Tell if the plugin has a configure action
+
+        :return: ``True`` if the plugin has a configure, ``False`` otherwise
+        :rtype: boolean
+        """
+        raise NotImplementedError

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from __future__ import unicode_literals, absolute_import, print_function, division
 
+import inspect
 import importlib
 
 from sopel import loader
@@ -26,6 +27,16 @@ class AbstractPluginHandler(object):
 
         This method must be called first, in order to setup, register, shutdown
         or configure the plugin later.
+        """
+        raise NotImplementedError
+
+    def get_label(self):
+        """Retrieve a display label for the plugin
+
+        :return: A human readable label for display purpose
+        :rtype: str
+
+        This method should, at least, return ``module_name + S + "module"``.
         """
         raise NotImplementedError
 
@@ -121,6 +132,16 @@ class PyModulePlugin(AbstractPluginHandler):
             self.module_name = name
 
         self._module = None
+
+    def get_label(self):
+        default_label = '%s module' % self.name
+        module_doc = getattr(self._module, '__doc__', None)
+
+        if not self.is_loaded() or not module_doc:
+            return default_label
+
+        lines = inspect.cleandoc(module_doc).splitlines()
+        return default_label if not lines else lines[0]
 
     def load(self):
         self._module = importlib.import_module(self.module_name)

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -191,12 +191,20 @@ def test_clean_callable_event(tmpconfig, func):
     assert hasattr(func, 'event')
     assert func.event == ['LOW', 'UP', 'MIXED']
 
+    # idempotency
+    loader.clean_callable(func, tmpconfig)
+    assert func.event == ['LOW', 'UP', 'MIXED']
+
 
 def test_clean_callable_event_string(tmpconfig, func):
     setattr(func, 'event', 'some')
     loader.clean_callable(func, tmpconfig)
 
     assert hasattr(func, 'event')
+    assert func.event == ['SOME']
+
+    # idempotency
+    loader.clean_callable(func, tmpconfig)
     assert func.event == ['SOME']
 
 
@@ -213,6 +221,11 @@ def test_clean_callable_rule(tmpconfig, func):
     assert regex.match('abcd')
     assert not regex.match('efg')
 
+    # idempotency
+    loader.clean_callable(func, tmpconfig)
+    assert len(func.rule) == 1
+    assert regex in func.rule
+
 
 def test_clean_callable_rule_string(tmpconfig, func):
     setattr(func, 'rule', r'abc')
@@ -226,6 +239,11 @@ def test_clean_callable_rule_string(tmpconfig, func):
     assert regex.match('abc')
     assert regex.match('abcd')
     assert not regex.match('efg')
+
+    # idempotency
+    loader.clean_callable(func, tmpconfig)
+    assert len(func.rule) == 1
+    assert regex in func.rule
 
 
 def test_clean_callable_rule_nick(tmpconfig, func):
@@ -242,6 +260,11 @@ def test_clean_callable_rule_nick(tmpconfig, func):
     assert regex.match('TestBot, hello')
     assert not regex.match('TestBot not hello')
 
+    # idempotency
+    loader.clean_callable(func, tmpconfig)
+    assert len(func.rule) == 1
+    assert regex in func.rule
+
 
 def test_clean_callable_rule_nickname(tmpconfig, func):
     """Assert ``$nick`` in a rule will match ``TestBot``."""
@@ -255,6 +278,11 @@ def test_clean_callable_rule_nickname(tmpconfig, func):
     regex = func.rule[0]
     assert regex.match('TestBot hello')
     assert not regex.match('TestBot not hello')
+
+    # idempotency
+    loader.clean_callable(func, tmpconfig)
+    assert len(func.rule) == 1
+    assert regex in func.rule
 
 
 def test_clean_callable_nickname_command(tmpconfig, func):
@@ -272,6 +300,11 @@ def test_clean_callable_nickname_command(tmpconfig, func):
     assert regex.match('TestBot, hello!')
     assert regex.match('TestBot: hello!')
     assert not regex.match('TestBot not hello')
+
+    # idempotency
+    loader.clean_callable(func, tmpconfig)
+    assert len(func.rule) == 1
+    assert regex in func.rule
 
 
 def test_clean_callable_events(tmpconfig, func):
@@ -428,6 +461,11 @@ def test_clean_callable_intents(tmpconfig, func):
     assert regex.match('ABC')
     assert regex.match('AbCdE')
     assert not regex.match('efg')
+
+    # idempotency
+    loader.clean_callable(func, tmpconfig)
+    assert len(func.intents) == 1
+    assert regex in func.intents
 
 
 def test_load_module_pymod(tmpdir):


### PR DESCRIPTION
**Based on** #1479 - this PR starts at the `plugin: add AbstractPluginHandler.reload` commit.

Using the new plugin interface defined in `sopel.plugins`, I replaced how plugins are reloaded in `sopel.modules.reload`:

* `sopel.bot.Sopel` now exposes methods to add, remove, and reload plugins
* `sopel.modules.reload` uses the bot's method to reload plugins (all of them, or only one)
* `sopel.plugin.handlers.AbstractPluginHandler` defines a new `reload` method
* `sopel.plugin.handlers.AbstractPluginHandler`'s implementations use the bot's new methods to add or remove the plugin

## It Is Not Perfect And Here Is Why

There are problems unsolved and questions unanswered here:

1. Problem: module tree is not reloaded, only the main file (can and must be fixed),
2. Problem: Python's `imp.reload` and `importlib.reload` do not remove names undefined in a new version of a reloaded module (fix possible only with Py3.4+),
3. Problem: Job's management is still a mess (same as before),
4. Question: should we use (updated) configuration?

### Problem 1: Reload Module Tree

This one is a big problem to solve, because there is more than meets the eye:

* reloading the module tree must not reload built-in or externals modules,
* but because of that a reload may fail if an external module has been changed in a way that it requires a reload...

This leads me to conclude that `.reload` should not be used in production in these cases. And they are hard as hell to fix, or even to warn the user about.

So it's half a problem, half a question. And I don't have the answer either way.

### Problem 2: Python's `reload` Is Weird

**Note**: this behavior is the one currently in place in Sopel. **This is not new**.

Both `imp.reload` and `importlib.reload` have this weird behavior, explained by this line from the documentation ([python2 reload](https://docs.python.org/2/library/functions.html#reload) / [python3 importlib.reload](https://docs.python.org/3.5/library/importlib.html#importlib.reload)):

> If the new version of a module does not define a name that was defined by the old version, the old definition remains.

Meaning that:

1. a module has a function `something`, is loaded at Sopel's startup
2. this module is modified, and `something` does not exist anymore
3. `.reload <this-module>` command is used
4. `something` still exists and is seen by Sopel, no matter what we do, 

However, this can be fixed... with Python 3.4's public internals (namely, `importlib.util` and `importlib.machinery`) (see a [snippet of code](https://www.irccloud.com/pastebin/tE6j0SSM/load_file_py3)). By the way, using Py3.4's public machinery would fix Problem 1 too...

### Problem 3: Job Are Weird Too

**Note**: this behavior is the one currently in place in Sopel. **This is not new**.

I didn't change any of the "unregister a job" behavior, so this is something that requires more work. The good part is: this can be done in a future PR, without any consequences so far, because it's already like that right now.

### Question: Does `.reload` Should Use Updated Configuration?

In Sopel's current version, `.reload` uses the current configuration (potentially modified since startup), to gather a list of plugins:

* if a plugin has been disabled, it might not be unloaded properly,
* if a plugin has been enabled, it will load it, somehow

And that **is a problem for me**, because it means inconsistency and unexpected behavior. I would rather have something stable, that always work, in a predicable way, than the current behavior.

That's why this new version reloads the list of plugins as it exists at the moment in the bot's memory (ie. in `bot._plugins`). We could, if we want, change this behavior to unload a plugin (enabled or not), and to load only the plugin if it's still enabled, and enable all new enabled plugins.

And that's the question: what should we do?