### PR TITLE
cli: move sopel.run_script to sopel.cli.run

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -72,5 +72,5 @@ setup(
     platforms='Linux x86, x86-64',
     install_requires=requires,
     extras_require={'dev': dev_requires},
-    entry_points={'console_scripts': ['sopel = sopel.run_script:main']},
+    entry_points={'console_scripts': ['sopel = sopel.cli.run:main']},
 )

--- a/sopel.py
+++ b/sopel.py
@@ -3,5 +3,5 @@
 from __future__ import unicode_literals, absolute_import, print_function, division
 import sys
 # Different from setuptools script, because we want the one in this dir.
-from sopel import run_script
-sys.exit(run_script.main())
+from sopel.cli import run
+sys.exit(run.main())

--- a/sopel/__init__.py
+++ b/sopel/__init__.py
@@ -24,11 +24,7 @@ if sys.version_info.major > 2:
 
 
 from collections import namedtuple
-import os
 import re
-import time
-import traceback
-import signal
 
 __version__ = '6.6.4'
 
@@ -55,71 +51,3 @@ def _version_info(version=__version__):
 
 
 version_info = _version_info()
-
-
-def run(config, pid_file, daemon=False):
-    import sopel.bot as bot
-    import sopel.logger
-    from sopel.tools import stderr
-    delay = 20
-    # Inject ca_certs from config to web for SSL validation of web requests
-    if not config.core.ca_certs:
-        stderr('Could not open CA certificates file. SSL will not '
-               'work properly.')
-
-    def signal_handler(sig, frame):
-        if sig == signal.SIGUSR1 or sig == signal.SIGTERM or sig == signal.SIGINT:
-            stderr('Got quit signal, shutting down.')
-            p.quit('Closing')
-        elif sig == signal.SIGUSR2 or sig == signal.SIGILL:
-            stderr('Got restart signal.')
-            p.restart('Restarting')
-    while True:
-        try:
-            p = bot.Sopel(config, daemon=daemon)
-            if hasattr(signal, 'SIGUSR1'):
-                signal.signal(signal.SIGUSR1, signal_handler)
-            if hasattr(signal, 'SIGTERM'):
-                signal.signal(signal.SIGTERM, signal_handler)
-            if hasattr(signal, 'SIGINT'):
-                signal.signal(signal.SIGINT, signal_handler)
-            if hasattr(signal, 'SIGUSR2'):
-                signal.signal(signal.SIGUSR2, signal_handler)
-            if hasattr(signal, 'SIGILL'):
-                signal.signal(signal.SIGILL, signal_handler)
-            sopel.logger.setup_logging(p)
-            p.run(config.core.host, int(config.core.port))
-        except KeyboardInterrupt:
-            break
-        except Exception:  # TODO: Be specific
-            trace = traceback.format_exc()
-            try:
-                stderr(trace)
-            except Exception:  # TODO: Be specific
-                pass
-            logfile = open(os.path.join(config.core.logdir, 'exceptions.log'), 'a')
-            logfile.write('Critical exception in core')
-            logfile.write(trace)
-            logfile.write('----------------------------------------\n\n')
-            logfile.close()
-            # TODO: This should be handled in run_script
-            # All we should need here is a return value, but replacing the
-            # os._exit() call below (at the end) broke ^C.
-            # This one is much harder to test, so until that one's sorted it
-            # isn't worth the risk of trying to remove this one.
-            os.unlink(pid_file)
-            os._exit(1)
-
-        if not isinstance(delay, int):
-            break
-        if p.wantsrestart:
-            return -1
-        if p.hasquit:
-            break
-        stderr('Warning: Disconnected. Reconnecting in %s seconds...' % delay)
-        time.sleep(delay)
-    # TODO: This should be handled in run_script
-    # All we should need here is a return value, but making this
-    # a return makes Sopel hang on ^C after it says "Closed!"
-    os.unlink(pid_file)
-    os._exit(0)

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -142,7 +142,9 @@ def add_legacy_options(parser):
                             'module configuration options.'))
     parser.add_argument('-v', action="store_true",
                         dest='version_legacy',
-                        help="Show version number and exit")
+                        help=(
+                            "Show version number and exit (deprecated, and will be "
+                            "removed in Sopel 8; use -V/--version instead)"))
     parser.add_argument('-V', '--version', action='store_true',
                         dest='version',
                         help='Show version number and exit')
@@ -485,21 +487,21 @@ def command_legacy(opts):
         return
     elif opts.version_legacy:
         tools.stderr(
-            'option -v is deprecated, '
+            'WARNING: option -v is deprecated; '
             'use `sopel -V/--version` instead')
         print_version()
         return
 
     if opts.wizard:
         tools.stderr(
-            'option -w/--configure-all is deprecated, '
+            'WARNING: option -w/--configure-all is deprecated; '
             'use `sopel configure` instead')
         _wizard('all', opts.config)
         return
 
     if opts.mod_wizard:
         tools.stderr(
-            'option --configure-modules is deprecated, '
+            'WARNING: option --configure-modules is deprecated; '
             'use `sopel configure --modules` instead')
         _wizard('mod', opts.config)
         return
@@ -536,14 +538,14 @@ def command_legacy(opts):
             return ERR_CODE
         elif opts.kill:
             tools.stderr(
-                'option -k/--kill is deprecated, '
+                'WARNING: option -k/--kill is deprecated; '
                 'use `sopel stop --kill` instead')
             tools.stderr('Killing the Sopel')
             os.kill(old_pid, signal.SIGKILL)
             return
         elif opts.quit:
             tools.stderr(
-                'options -q/--quit is deprecated, '
+                'WARNING: options -q/--quit is deprecated; '
                 'use `sopel stop` instead')
             tools.stderr('Signaling Sopel to stop gracefully')
             if hasattr(signal, 'SIGUSR1'):
@@ -555,7 +557,7 @@ def command_legacy(opts):
             return
         elif opts.restart:
             tools.stderr(
-                'options --restart is deprecated, '
+                'WARNING: options --restart is deprecated; '
                 'use `sopel restart` instead')
             tools.stderr('Asking Sopel to restart')
             if hasattr(signal, 'SIGUSR2'):

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -44,7 +44,7 @@ ERR_CODE_NO_RESTART = 2
 """Error code: program exited with an error and should not be restarted
 
 This error code is used to prevent systemd from restarting the bot when it
-encounter such error case.
+encounters such an error case.
 """
 
 
@@ -255,6 +255,7 @@ def get_running_pid(filename):
 
 
 def command_start(opts):
+    """Start a Sopel instance"""
     # Step One: Get the configuration file and prepare to run
     try:
         config_module = get_configuration(opts)
@@ -302,6 +303,7 @@ def command_start(opts):
 
 
 def command_configure(opts):
+    """Sopel Configuration Wizard"""
     if getattr(opts, 'modules', False):
         _wizard('mod', opts.config)
     else:
@@ -309,6 +311,7 @@ def command_configure(opts):
 
 
 def command_stop(opts):
+    """Stop a running Sopel instance"""
     # Get Configuration
     try:
         settings = utils.load_settings(opts)
@@ -347,6 +350,7 @@ def command_stop(opts):
 
 
 def command_restart(opts):
+    """Restart a running Sopel instance"""
     # Get Configuration
     try:
         settings = utils.load_settings(opts)
@@ -379,7 +383,29 @@ def command_restart(opts):
 
 
 def command_legacy(opts):
-    # Step Three: Handle "No config needed" options
+    """Legacy Sopel run script
+
+    The ``legacy`` command manages the old-style ``sopel`` command line tool.
+    Most of its features are replaced by the following commands:
+
+    * ``sopel start`` replaces the default behavior (run the bot)
+    * ``sopel stop`` replaces the ``--quit/--kill`` options
+    * ``sopel restart`` replaces the ``--restart`` option
+    * ``sopel configure`` replaces the
+      ``-w/--configure-all/--configure-modules`` options
+
+    The ``-v`` option for "version" is deprecated, ``-V/--version`` should be
+    used instead.
+
+    .. seealso::
+
+       The github issue `#1471`__ tracks various changes requested for future
+       versions of Sopel, some of them related to this legacy command.
+
+       .. __: https://github.com/sopel-irc/sopel/issues/1471
+
+    """
+    # Step One: Handle "No config needed" options
     if opts.version:
         print_version()
         return
@@ -408,7 +434,7 @@ def command_legacy(opts):
         print_config()
         return
 
-    # Step Four: Get the configuration file and prepare to run
+    # Step Two: Get the configuration file and prepare to run
     try:
         config_module = get_configuration(opts)
     except ConfigurationError as e:
@@ -419,10 +445,10 @@ def command_legacy(opts):
         stderr('Bot is not configured, can\'t start')
         return ERR_CODE_NO_RESTART
 
-    # Step Five: Manage logfile, stdout and stderr
+    # Step Three: Manage logfile, stdout and stderr
     utils.redirect_outputs(config_module, opts.quiet)
 
-    # Step Six: Handle process-lifecycle options and manage the PID file
+    # Step Four: Handle process-lifecycle options and manage the PID file
     pid_dir = config_module.core.pid_dir
     pid_file_path = get_pid_filename(opts, pid_dir)
     old_pid = get_running_pid(pid_file_path)
@@ -474,7 +500,7 @@ def command_legacy(opts):
     with open(pid_file_path, 'w') as pid_file:
         pid_file.write(str(os.getpid()))
 
-    # Step Seven: Initialize and run Sopel
+    # Step Five: Initialize and run Sopel
     ret = run(config_module, pid_file_path)
     os.unlink(pid_file_path)
     if ret == -1:
@@ -484,6 +510,7 @@ def command_legacy(opts):
 
 
 def main(argv=None):
+    """Sopel run script entry point"""
     try:
         # Step One: Parse The Command Line
         parser = build_parser()

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -121,11 +121,20 @@ def add_legacy_options(parser):
     parser.add_argument("-d", '--fork', action="store_true",
                         dest="daemonize", help="Daemonize Sopel")
     parser.add_argument("-q", '--quit', action="store_true", dest="quit",
-                        help="Gracefully quit Sopel")
+                        help=(
+                            "Gracefully quit Sopel "
+                            "(deprecated, and will be removed in Sopel 8; "
+                            "use `sopel stop` instead)"))
     parser.add_argument("-k", '--kill', action="store_true", dest="kill",
-                        help="Kill Sopel")
+                        help=(
+                            "Kill Sopel "
+                            "(deprecated, and will be removed in Sopel 8; "
+                            "use `sopel stop --kill` instead)"))
     parser.add_argument("-r", '--restart', action="store_true", dest="restart",
-                        help="Restart Sopel")
+                        help=(
+                            "Restart Sopel "
+                            "(deprecated, and will be removed in Sopel 8; "
+                            "use `sopel restart` instead)"))
     parser.add_argument("-l", '--list', action="store_true",
                         dest="list_configs",
                         help="List all config files found")
@@ -135,16 +144,24 @@ def add_legacy_options(parser):
     parser.add_argument('--quiet', action="store_true", dest="quiet",
                         help="Suppress all output")
     parser.add_argument('-w', '--configure-all', action='store_true',
-                        dest='wizard', help='Run the configuration wizard.')
+                        dest='wizard',
+                        help=(
+                            "Run the configuration wizard "
+                            "(deprecated, and will be removed in Sopel 8; "
+                            "use `sopel configure` instead)"))
     parser.add_argument('--configure-modules', action='store_true',
-                        dest='mod_wizard', help=(
-                            'Run the configuration wizard, but only for the '
-                            'module configuration options.'))
+                        dest='mod_wizard',
+                        help=(
+                            "Run the configuration wizard, but only for the "
+                            "module configuration options "
+                            "(deprecated, and will be removed in Sopel 8; "
+                            "use `sopel configure --modules` instead)"))
     parser.add_argument('-v', action="store_true",
                         dest='version_legacy',
                         help=(
-                            "Show version number and exit (deprecated, and will be "
-                            "removed in Sopel 8; use -V/--version instead)"))
+                            "Show version number and exit "
+                            "(deprecated, and will be removed in Sopel 8; "
+                            "use -V/--version instead)"))
     parser.add_argument('-V', '--version', action='store_true',
                         dest='version',
                         help='Show version number and exit')

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -278,10 +278,22 @@ def print_config():
 
 
 def get_configuration(options):
-    """Get an instance of configuration from options.
+    """Get or create a configuration object from ``options``.
 
-    This may raise a ``sopel.config.ConfigurationError`` if the file is an
-    invalid configuration file.
+    :param options: argument parser's options
+    :type options: ``argparse.Namespace``
+    :return: a configuration object
+    :rtype: :class:`sopel.config.Config`
+
+    This may raise a :exc:`sopel.config.ConfigurationError` if the
+    configuration file is invalid.
+
+    .. seealso::
+
+       The configuration file is loaded by
+       :func:`~sopel.cli.run.utils.load_settings` or created using the
+       configuration wizard.
+
     """
     try:
         bot_config = utils.load_settings(options)

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -21,12 +21,14 @@ if sys.version_info.major == 3 and sys.version_info.minor < 3:
     stderr('Error: When running on Python 3, Python 3.3 is required.')
     sys.exit(1)
 
-import os
 import argparse
-import signal
+import os
 import platform
+import signal
+import time
+import traceback
 
-from sopel import run, tools, __version__
+from sopel import bot, logger, tools, __version__
 from sopel.config import (
     Config,
     _create_config,
@@ -46,6 +48,72 @@ ERR_CODE_NO_RESTART = 2
 This error code is used to prevent systemd from restarting the bot when it
 encounters such an error case.
 """
+
+
+def run(config, pid_file, daemon=False):
+    delay = 20
+    # Inject ca_certs from config to web for SSL validation of web requests
+    if not config.core.ca_certs:
+        stderr('Could not open CA certificates file. SSL will not '
+               'work properly!')
+
+    def signal_handler(sig, frame):
+        if sig == signal.SIGUSR1 or sig == signal.SIGTERM or sig == signal.SIGINT:
+            stderr('Got quit signal, shutting down.')
+            p.quit('Closing')
+        elif sig == signal.SIGUSR2 or sig == signal.SIGILL:
+            stderr('Got restart signal.')
+            p.restart('Restarting')
+
+    while True:
+        try:
+            p = bot.Sopel(config, daemon=daemon)
+            if hasattr(signal, 'SIGUSR1'):
+                signal.signal(signal.SIGUSR1, signal_handler)
+            if hasattr(signal, 'SIGTERM'):
+                signal.signal(signal.SIGTERM, signal_handler)
+            if hasattr(signal, 'SIGINT'):
+                signal.signal(signal.SIGINT, signal_handler)
+            if hasattr(signal, 'SIGUSR2'):
+                signal.signal(signal.SIGUSR2, signal_handler)
+            if hasattr(signal, 'SIGILL'):
+                signal.signal(signal.SIGILL, signal_handler)
+            logger.setup_logging(p)
+            p.run(config.core.host, int(config.core.port))
+        except KeyboardInterrupt:
+            break
+        except Exception:  # TODO: Be specific
+            trace = traceback.format_exc()
+            try:
+                stderr(trace)
+            except Exception:  # TODO: Be specific
+                pass
+            logfile = open(os.path.join(config.core.logdir, 'exceptions.log'), 'a')
+            logfile.write('Critical exception in core')
+            logfile.write(trace)
+            logfile.write('----------------------------------------\n\n')
+            logfile.close()
+            # TODO: This should be handled by command_start
+            # All we should need here is a return value, but replacing the
+            # os._exit() call below (at the end) broke ^C.
+            # This one is much harder to test, so until that one's sorted it
+            # isn't worth the risk of trying to remove this one.
+            os.unlink(pid_file)
+            os._exit(1)
+
+        if not isinstance(delay, int):
+            break
+        if p.wantsrestart:
+            return -1
+        if p.hasquit:
+            break
+        stderr('Warning: Disconnected. Reconnecting in %s seconds...' % delay)
+        time.sleep(delay)
+    # TODO: This should be handled by command_start
+    # All we should need here is a return value, but making this
+    # a return makes Sopel hang on ^C after it says "Closed!"
+    os.unlink(pid_file)
+    os._exit(0)
 
 
 def add_legacy_options(parser):

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -12,7 +12,6 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 
 import sys
 
-from sopel.cli import utils
 from sopel.tools import stderr
 
 if sys.version_info < (2, 7):
@@ -36,6 +35,7 @@ from sopel.config import (
     DEFAULT_HOMEDIR,
     _wizard
 )
+from . import utils
 
 
 ERR_CODE = 1

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -243,7 +243,7 @@ def print_version():
     py_ver = '%s.%s.%s' % (sys.version_info.major,
                            sys.version_info.minor,
                            sys.version_info.micro)
-    print('Sopel %s (running on python %s)' % (__version__, py_ver))
+    print('Sopel %s (running on Python %s)' % (__version__, py_ver))
     print('https://sopel.chat/')
 
 

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -12,13 +12,13 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 
 import sys
 
-from sopel.tools import stderr
+from sopel import tools
 
 if sys.version_info < (2, 7):
-    stderr('Error: Requires Python 2.7 or later. Try python2.7 sopel')
+    tools.stderr('Error: Requires Python 2.7 or later. Try python2.7 sopel')
     sys.exit(1)
 if sys.version_info.major == 3 and sys.version_info.minor < 3:
-    stderr('Error: When running on Python 3, Python 3.3 is required.')
+    tools.stderr('Error: When running on Python 3, Python 3.3 is required.')
     sys.exit(1)
 
 import argparse
@@ -28,7 +28,7 @@ import signal
 import time
 import traceback
 
-from sopel import bot, logger, tools, __version__
+from sopel import bot, logger, __version__
 from sopel.config import (
     Config,
     _create_config,

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -90,6 +90,16 @@ def build_parser():
     add_legacy_options(parser_legacy)
     utils.add_common_arguments(parser_legacy)
 
+    # manage `configure` sub-command
+    parser_configure = subparsers.add_parser(
+        'configure', help='Sopel\'s Wizard tool')
+    parser_configure.add_argument(
+        '--modules',
+        action='store_true',
+        default=False,
+        dest='modules')
+    utils.add_common_arguments(parser_configure)
+
     return parser
 
 
@@ -203,6 +213,13 @@ def get_running_pid(filename):
             pass
 
 
+def command_configure(opts):
+    if getattr(opts, 'modules', False):
+        _wizard('mod', opts.config)
+    else:
+        _wizard('all', opts.config)
+
+
 def command_legacy(opts):
     # Step Three: Handle "No config needed" options
     if opts.version:
@@ -210,10 +227,16 @@ def command_legacy(opts):
         return
 
     if opts.wizard:
+        tools.stderr(
+            'option -w/--configure-all is deprecated, '
+            'use `sopel configure` instead')
         _wizard('all', opts.config)
         return
 
     if opts.mod_wizard:
+        tools.stderr(
+            'option --configure-modules is deprecated, '
+            'use `sopel configure --modules` instead')
         _wizard('mod', opts.config)
         return
 
@@ -313,6 +336,7 @@ def main(argv=None):
         action = getattr(opts, 'action', 'legacy')
         command = {
             'legacy': command_legacy,
+            'configure': command_configure,
         }.get(action)
         return command(opts)
     except KeyboardInterrupt:

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -220,6 +220,11 @@ def build_parser():
         action='store_true',
         default=False,
         help='Kill Sopel without a graceful quit')
+    parser_stop.add_argument(
+        '--quiet',
+        action="store_true",
+        dest="quiet",
+        help="Suppress all output")
     utils.add_common_arguments(parser_stop)
 
     # manage `restart` sub-command
@@ -227,6 +232,11 @@ def build_parser():
         'restart',
         description='Restart a running Sopel instance',
         help='Restart a running Sopel instance')
+    parser_restart.add_argument(
+        '--quiet',
+        action="store_true",
+        dest="quiet",
+        help="Suppress all output")
     utils.add_common_arguments(parser_restart)
 
     return parser
@@ -429,7 +439,7 @@ def command_stop(opts):
         return ERR_CODE
 
     # Redirect Outputs
-    utils.redirect_outputs(settings, False)
+    utils.redirect_outputs(settings, opts.quiet)
 
     # Get Sopel's PID
     filename = get_pid_filename(opts, settings.core.pid_dir)
@@ -468,7 +478,7 @@ def command_restart(opts):
         return ERR_CODE
 
     # Redirect Outputs
-    utils.redirect_outputs(settings, False)
+    utils.redirect_outputs(settings, opts.quiet)
 
     # Get Sopel's PID
     filename = get_pid_filename(opts, settings.core.pid_dir)

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -71,8 +71,12 @@ def add_legacy_options(parser):
                         dest='mod_wizard', help=(
                             'Run the configuration wizard, but only for the '
                             'module configuration options.'))
-    parser.add_argument('-v', '--version', action="store_true",
-                        dest="version", help="Show version number and exit")
+    parser.add_argument('-v', action="store_true",
+                        dest='version_legacy',
+                        help="Show version number and exit")
+    parser.add_argument('-V', '--version', action='store_true',
+                        dest='version',
+                        help='Show version number and exit')
 
 
 def build_parser():
@@ -312,6 +316,12 @@ def command_restart(opts):
 def command_legacy(opts):
     # Step Three: Handle "No config needed" options
     if opts.version:
+        print_version()
+        return
+    elif opts.version_legacy:
+        tools.stderr(
+            'option -v is deprecated, '
+            'use `sopel -V/--version` instead')
         print_version()
         return
 

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -168,14 +168,17 @@ def build_parser():
     """Build an ``argparse.ArgumentParser`` for the bot"""
     parser = argparse.ArgumentParser(description='Sopel IRC Bot',
                                      usage='%(prog)s [options]')
+    add_legacy_options(parser)
+    utils.add_common_arguments(parser)
+
     subparsers = parser.add_subparsers(
         title='sub-commands',
         description='List of Sopel\'s sub-commands',
-        dest='action')
+        dest='action',
+        metavar='{start,configure,stop,restart}')
 
     # manage `legacy` sub-command
-    parser_legacy = subparsers.add_parser(
-        'legacy', help='Launch Sopel\'s legacy command line')
+    parser_legacy = subparsers.add_parser('legacy')
     add_legacy_options(parser_legacy)
     utils.add_common_arguments(parser_legacy)
 

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -256,9 +256,7 @@ def command_legacy(opts):
         return ERR_CODE_NO_RESTART
 
     # Step Five: Manage logfile, stdout and stderr
-    logfile = os.path.os.path.join(config_module.core.logdir, 'stdio.log')
-    sys.stderr = tools.OutputRedirect(logfile, True, opts.quiet)
-    sys.stdout = tools.OutputRedirect(logfile, False, opts.quiet)
+    utils.redirect_outputs(config_module, opts.quiet)
 
     # Step Six: Handle process-lifecycle options and manage the PID file
     pid_dir = config_module.core.pid_dir

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -611,6 +611,7 @@ def main(argv=None):
         parser = build_parser()
 
         # make sure to have an action first (`legacy` by default)
+        # TODO: `start` should be the default in Sopel 8
         argv = argv or sys.argv[1:]
         if not argv:
             argv = ['legacy']

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -138,9 +138,6 @@ def add_legacy_options(parser):
     parser.add_argument("-l", '--list', action="store_true",
                         dest="list_configs",
                         help="List all config files found")
-    parser.add_argument("-m", '--migrate', action="store_true",
-                        dest="migrate_configs",
-                        help="Migrate config files to the new format")
     parser.add_argument('--quiet', action="store_true", dest="quiet",
                         help="Suppress all output")
     parser.add_argument('-w', '--configure-all', action='store_true',

--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -2,8 +2,9 @@
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 import os
+import sys
 
-from sopel import config
+from sopel import config, tools
 
 # Allow clean import *
 __all__ = [
@@ -11,6 +12,7 @@ __all__ = [
     'find_config',
     'add_common_arguments',
     'load_settings',
+    'redirect_outputs',
 ]
 
 
@@ -153,3 +155,17 @@ def load_settings(options):
         raise config.ConfigurationNotFound(filename=filename)
 
     return config.Config(filename)
+
+
+def redirect_outputs(settings, is_quiet=False):
+    """Redirect ``sys``'s outputs using Sopel's settings.
+
+    :param settings: Sopel's configuration
+    :type settings: :class:`sopel.config.Config`
+    :param bool is_quiet: Optional, set to True to make Sopel's outputs quiet
+
+    Both ``sys.stderr`` and ``sys.stdout`` are redirected to a logfile.
+    """
+    logfile = os.path.os.path.join(settings.core.logdir, 'stdio.log')
+    sys.stderr = tools.OutputRedirect(logfile, True, is_quiet)
+    sys.stdout = tools.OutputRedirect(logfile, False, is_quiet)

--- a/test/cli/test_cli_run.py
+++ b/test/cli/test_cli_run.py
@@ -47,7 +47,7 @@ def test_get_configuration(tmpdir):
     ]))
 
     parser = build_parser()
-    options = parser.parse_args(['-c', 'default.cfg'])
+    options = parser.parse_args(['legacy', '-c', 'default.cfg'])
 
     with cd(working_dir.strpath):
         result = get_configuration(options)
@@ -59,7 +59,7 @@ def test_get_pid_filename_default():
     """Assert function returns the default filename from given ``pid_dir``"""
     pid_dir = '/pid'
     parser = build_parser()
-    options = parser.parse_args([])
+    options = parser.parse_args(['legacy'])
 
     result = get_pid_filename(options, pid_dir)
     assert result == pid_dir + '/sopel.pid'
@@ -71,13 +71,13 @@ def test_get_pid_filename_named():
     parser = build_parser()
 
     # With extension
-    options = parser.parse_args(['-c', 'test.cfg'])
+    options = parser.parse_args(['legacy', '-c', 'test.cfg'])
 
     result = get_pid_filename(options, pid_dir)
     assert result == pid_dir + '/sopel-test.pid'
 
     # Without extension
-    options = parser.parse_args(['-c', 'test'])
+    options = parser.parse_args(['legacy', '-c', 'test'])
 
     result = get_pid_filename(options, pid_dir)
     assert result == pid_dir + '/sopel-test.pid'
@@ -87,7 +87,7 @@ def test_get_pid_filename_ext_not_cfg():
     """Assert function keeps the config file extension when it is not cfg"""
     pid_dir = '/pid'
     parser = build_parser()
-    options = parser.parse_args(['-c', 'test.ini'])
+    options = parser.parse_args(['legacy', '-c', 'test.ini'])
 
     result = get_pid_filename(options, pid_dir)
     assert result == pid_dir + '/sopel-test.ini.pid'

--- a/test/cli/test_cli_run.py
+++ b/test/cli/test_cli_run.py
@@ -7,7 +7,13 @@ import os
 
 import pytest
 
-from sopel import run_script, config
+from sopel import config
+from sopel.cli.run import (
+    build_parser,
+    get_configuration,
+    get_pid_filename,
+    get_running_pid
+)
 
 
 @contextmanager
@@ -40,11 +46,11 @@ def test_get_configuration(tmpdir):
         'owner = TestName'
     ]))
 
-    parser = run_script.build_parser()
+    parser = build_parser()
     options = parser.parse_args(['-c', 'default.cfg'])
 
     with cd(working_dir.strpath):
-        result = run_script.get_configuration(options)
+        result = get_configuration(options)
         assert isinstance(result, config.Config)
         assert result.core.owner == 'TestName'
 
@@ -52,38 +58,38 @@ def test_get_configuration(tmpdir):
 def test_get_pid_filename_default():
     """Assert function returns the default filename from given ``pid_dir``"""
     pid_dir = '/pid'
-    parser = run_script.build_parser()
+    parser = build_parser()
     options = parser.parse_args([])
 
-    result = run_script.get_pid_filename(options, pid_dir)
+    result = get_pid_filename(options, pid_dir)
     assert result == pid_dir + '/sopel.pid'
 
 
 def test_get_pid_filename_named():
     """Assert function returns a specific filename when config (with extension) is set"""
     pid_dir = '/pid'
-    parser = run_script.build_parser()
+    parser = build_parser()
 
     # With extension
     options = parser.parse_args(['-c', 'test.cfg'])
 
-    result = run_script.get_pid_filename(options, pid_dir)
+    result = get_pid_filename(options, pid_dir)
     assert result == pid_dir + '/sopel-test.pid'
 
     # Without extension
     options = parser.parse_args(['-c', 'test'])
 
-    result = run_script.get_pid_filename(options, pid_dir)
+    result = get_pid_filename(options, pid_dir)
     assert result == pid_dir + '/sopel-test.pid'
 
 
 def test_get_pid_filename_ext_not_cfg():
     """Assert function keeps the config file extension when it is not cfg"""
     pid_dir = '/pid'
-    parser = run_script.build_parser()
+    parser = build_parser()
     options = parser.parse_args(['-c', 'test.ini'])
 
-    result = run_script.get_pid_filename(options, pid_dir)
+    result = get_pid_filename(options, pid_dir)
     assert result == pid_dir + '/sopel-test.ini.pid'
 
 
@@ -92,7 +98,7 @@ def test_get_running_pid(tmpdir):
     pid_file = tmpdir.join('sopel.pid')
     pid_file.write('7814')
 
-    result = run_script.get_running_pid(pid_file.strpath)
+    result = get_running_pid(pid_file.strpath)
     assert result == 7814
 
 
@@ -101,12 +107,12 @@ def test_get_running_pid_not_integer(tmpdir):
     pid_file = tmpdir.join('sopel.pid')
     pid_file.write('')
 
-    result = run_script.get_running_pid(pid_file.strpath)
+    result = get_running_pid(pid_file.strpath)
     assert result is None
 
     pid_file.write('abcdefg')
 
-    result = run_script.get_running_pid(pid_file.strpath)
+    result = get_running_pid(pid_file.strpath)
     assert result is None
 
 
@@ -114,5 +120,5 @@ def test_get_running_pid_no_file(tmpdir):
     """Assert function returns None when there is no such file"""
     pid_file = tmpdir.join('sopel.pid')
 
-    result = run_script.get_running_pid(pid_file.strpath)
+    result = get_running_pid(pid_file.strpath)
     assert result is None


### PR DESCRIPTION
**Related** to #1471

This move the `sopel/run_script.py` file to `sopel/cli/run.py`, and updates the `sopel` command line tool's interface:

* `sopel start` replaces the default behavior (run the bot)
* `sopel stop` replaces the ``--quit/--kill`` options
* `sopel restart` replaces the ``--restart`` option
* `sopel configure` replaces the `-w/--configure-all/--configure-modules` options

The `-v` option for "version" is deprecated, `-V/--version` should be used instead.

By default, `sopel` works as before (100% backward compatible), but adds some warning here and there when needed (when using --restart/--quit/--kill for example).

This is all thanks to #1472 being merged.