### PR TITLE
coretasks: Consistently update privilege tracking

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -205,6 +205,7 @@ def handle_names(bot, trigger):
             # Fortunately, the user should already exist in bot.users by the
             # time this code runs, so this is 99.9% ass-covering.
             user = User(nick, None, None)
+            bot.users[nick] = user
         bot.channels[channel].add_user(user, privs=priv)
 
 

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -178,6 +178,8 @@ def handle_names(bot, trigger):
     channel = Identifier(channels.group(1))
     if channel not in bot.privileges:
         bot.privileges[channel] = dict()
+    if channel not in bot.channels:
+        bot.channels[channel] = Channel(channel)
 
     # This could probably be made flexible in the future, but I don't think
     # it'd be worth it.
@@ -196,6 +198,14 @@ def handle_names(bot, trigger):
                 priv = priv | value
         nick = Identifier(name.lstrip(''.join(mapping.keys())))
         bot.privileges[channel][nick] = priv
+        user = bot.users.get(nick)
+        if user is None:
+            # It's not possible to set the username/hostname from info received
+            # in a NAMES reply, unfortunately.
+            # Fortunately, the user should already exist in bot.users by the
+            # time this code runs, so this is 99.9% ass-covering.
+            user = User(nick, None, None)
+        bot.channels[channel].add_user(user, privs=priv)
 
 
 @sopel.module.rule('(.*)')
@@ -238,12 +248,15 @@ def track_modes(bot, trigger):
             arg = Identifier(arg)
             for mode in modes:
                 priv = bot.channels[channel].privileges.get(arg, 0)
-                # Throw an exception if the two privilege-tracking data
-                # structures get out of sync. That should never happen.
-                # This is a good place to check that bot.channels is doing
+                # Log a warning if the two privilege-tracking data structures
+                # get out of sync. That should never happen.
+                # This is a good place to verify that bot.channels is doing
                 # what it's supposed to do before ultimately removing the old,
                 # deprecated bot.privileges structure completely.
-                assert priv == bot.privileges[channel].get(arg, 0)
+                if priv != bot.privileges[channel].get(arg, 0):
+                    LOGGER.warning("Privilege tracking mismatch in {}! Please "
+                                   "share a raw log with Sopel's developers, if"
+                                   " available".format(channel))
                 value = mapping.get(mode[1])
                 if value is not None:
                     if mode[0] == '+':
@@ -727,6 +740,9 @@ def _record_who(bot, channel, user, host, nick, account=None, away=None, modes=N
     if channel not in bot.channels:
         bot.channels[channel] = Channel(channel)
     bot.channels[channel].add_user(user, privs=priv)
+    if channel not in bot.privileges:
+        bot.privileges[channel] = dict()
+    bot.privileges[channel][nick] = priv
 
 
 @sopel.module.event(events.RPL_WHOREPLY)

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -254,10 +254,12 @@ def track_modes(bot, trigger):
                 # This is a good place to verify that bot.channels is doing
                 # what it's supposed to do before ultimately removing the old,
                 # deprecated bot.privileges structure completely.
-                if priv != bot.privileges[channel].get(arg, 0):
-                    LOGGER.warning("Privilege tracking mismatch in {}! Please "
-                                   "share a raw log with Sopel's developers, if"
-                                   " available".format(channel))
+                ppriv = bot.privileges[channel].get(arg, 0)
+                if priv != ppriv:
+                    LOGGER.warning("Privilege data error! Please share Sopel's"
+                                   "raw log with the developers, if enabled. "
+                                   "(Expected {} == {} for {} in {}.)"
+                                   .format(priv, ppriv, arg, channel))
                 value = mapping.get(mode[1])
                 if value is not None:
                     if mode[0] == '+':

--- a/sopel/test_tools.py
+++ b/sopel/test_tools.py
@@ -47,7 +47,9 @@ class MockSopel(object):
         self.nick = nick
         self.user = "sopel"
 
-        self.channels = ["#channel"]
+        channel = sopel.tools.Identifier("#Sopel")
+        self.channels = sopel.tools.SopelMemory()
+        self.channels[channel] = sopel.tools.target.Channel(channel)
 
         self.memory = sopel.tools.SopelMemory()
 

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -1,0 +1,59 @@
+# coding=utf-8
+"""Regression tests"""
+from __future__ import unicode_literals, absolute_import, print_function, division
+
+import pytest
+
+from sopel import coretasks
+from sopel.tools import Identifier
+from sopel.test_tools import MockSopel, MockSopelWrapper
+from sopel.trigger import PreTrigger, Trigger
+
+
+@pytest.fixture
+def sopel():
+    bot = MockSopel("Sopel")
+    return bot
+
+
+@pytest.fixture
+def sopel_bot(sopel):
+    pretrigger = PreTrigger(Identifier("Foo"), "PING abc")
+    bot = MockSopelWrapper(sopel, pretrigger)
+    bot.privileges = dict()
+    bot.users = dict()
+    return bot
+
+
+def test_bot_legacy_permissions(sopel_bot):
+    """
+    Make sure permissions match after being updated from both RPL_NAMREPLY
+    and RPL_WHOREPLY, #1482
+    """
+
+    nick = Identifier("Admin")
+
+    # RPL_NAMREPLY
+    pretrigger = PreTrigger("Foo", ":test.example.com 353 Foo = #test :Foo ~@Admin")
+    trigger = Trigger(sopel_bot.config, pretrigger, None)
+    coretasks.handle_names(sopel_bot, trigger)
+
+    assert (
+        sopel_bot.channels["#test"].privileges[nick] ==
+        sopel_bot.privileges["#test"][nick]
+    )
+
+    # RPL_WHOREPLY
+    pretrigger = PreTrigger(
+        "Foo",
+        ":test.example.com 352 Foo #test ~Admin adminhost test.example.com Admin Hr~ :0 Admin",
+    )
+    trigger = Trigger(sopel_bot.config, pretrigger, None)
+    coretasks.recv_who(sopel_bot, trigger)
+
+    assert (
+        sopel_bot.channels["#test"].privileges[nick] ==
+        sopel_bot.privileges["#test"][nick]
+    )
+
+    assert sopel_bot.users.get(nick) is not None


### PR DESCRIPTION
Both `handle_names()` and `_record_who()` should update both `bot.privileges` and `bot.channels`. The fact that they don't is a leftover bug from who knows when.

We're also no longer happy with throwing an `assert` in released code, so the consistency check in `track_modes()` is now a logger warning.