### PR TITLE
test_tools: fix invalid raw line in example tests

### DIFF
--- a/sopel/test_tools.py
+++ b/sopel/test_tools.py
@@ -122,7 +122,7 @@ def get_example_test(tested_func, msg, results, privmsg, admin,
         assert match, "Example did not match any command."
 
         sender = bot.nick if privmsg else "#channel"
-        hostmask = "%s!%s@%s " % (bot.nick, "UserName", "example.com")
+        hostmask = "%s!%s@%s" % (bot.nick, "UserName", "example.com")
         # TODO enable message tags
         full_message = ':{} PRIVMSG {} :{}'.format(hostmask, sender, msg)
 


### PR DESCRIPTION
Before:
```
:NickName!UserName@example.com  PRIVMSG NickName :msg param to @example
```

After:
```
:NickName!UserName@example.com PRIVMSG NickName :msg param to @example
```

Yes, it's that subtle. :smirk_cat:

----

For quite some time, the example-test hostmask has been causing an invalid raw line per IRC specs (the prefix and command MUST be separated by a single space, no more—this code was generating two).

This manifested as `KeyError: Identifier('PRIVMSG')` when a tested callable tried to find `trigger.sender` in `bot.channels` (or, though I didn't check it, presumably also `bot.privileges`). While the error was expected, the value should not have been `PRIVMSG` but a channel/nick.

Alone, this fix doesn't do anything for the tests I'm trying to write… but it's still a silly bug worth fixing.