### PR TITLE
module: optional `reply` arg for all `require_*` decorators

### DIFF
--- a/sopel/module.py
+++ b/sopel/module.py
@@ -371,19 +371,29 @@ def require_admin(message=None, reply=False):
     return actual_decorator
 
 
-def require_owner(message=None):
+def require_owner(message=None, reply=False):
     """Decorate a function to require the triggering user to be the bot owner.
 
-    If they are not, `message` will be said if given."""
+    :param str message: optional message said to non-owner user
+    :param bool reply: use `reply` instead of `say` when true, default to false
+
+    When the triggering user is not the bot's owner, the command is not run,
+    and the bot will say ``message`` if given. By default, it uses ``bot.say``,
+    but when ``reply`` is true, then it uses ``bot.reply`` instead.
+    """
     def actual_decorator(function):
         @functools.wraps(function)
         def guarded(bot, trigger, *args, **kwargs):
             if not trigger.owner:
                 if message and not callable(message):
-                    bot.say(message)
+                    if reply:
+                        bot.reply(message)
+                    else:
+                        bot.say(message)
             else:
                 return function(bot, trigger, *args, **kwargs)
         return guarded
+
     # Hack to allow decorator without parens
     if callable(message):
         return actual_decorator(message)

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -278,11 +278,14 @@ def require_privmsg(message=None, reply=False):
     """Decorate a function to only be triggerable from a private message.
 
     :param str message: optional message said if triggered in a channel
-    :param bool reply: use `reply` instead of `say` when true, default to false
+    :param bool reply: use :meth:`~sopel.bot.Sopel.reply` instead of
+                       :meth:`~sopel.bot.Sopel.say` when ``True``; defaults to
+                       ``False``
 
-    If it is triggered in a channel message, ``message`` will be said if given.
-    By default, it uses ``bot.say``, but when ``reply`` is true, then it uses
-    ``bot.reply`` instead.
+    If it is triggered in a channel message, ``message`` will be said if
+    given. By default, it uses :meth:`bot.say() <.bot.Sopel.say>`, but when
+    ``reply`` is true, then it     uses :meth:`bot.reply() <.bot.Sopel.reply>`
+    instead.
 
     .. versionchanged:: 7.0.0
         Added the ``reply`` parameter.
@@ -312,11 +315,14 @@ def require_chanmsg(message=None, reply=False):
     """Decorate a function to only be triggerable from a channel message.
 
     :param str message: optional message said if triggered in private message
-    :param bool reply: use `reply` instead of `say` when true, default to false
+    :param bool reply: use :meth:`~.bot.Sopel.reply` instead of
+                       :meth:`~.bot.Sopel.say` when ``True``; defaults to
+                       ``False``
 
-    If it is triggered in a private message, ``message`` will be said if given.
-    By default, it uses ``bot.say``, but when ``reply`` is true, then it uses
-    ``bot.reply`` instead.
+    If it is triggered in a private message, ``message`` will be said if
+    given. By default, it uses :meth:`bot.say() <.bot.Sopel.say>`, but when
+    ``reply`` is true, then it uses :meth:`bot.reply() <.bot.Sopel.reply>`
+    instead.
 
     .. versionchanged:: 7.0.0
         Added the ``reply`` parameter.
@@ -347,12 +353,15 @@ def require_privilege(level, message=None, reply=False):
 
     :param int level: required privilege level to use this command
     :param str message: optional message said to insufficiently privileged user
-    :param bool reply: use `reply` instead of `say` when true, default to false
+    :param bool reply: use :meth:`~.bot.Sopel.reply` instead of
+                       :meth:`~.bot.Sopel.say` when ``True``; defaults to
+                       ``False``
 
     ``level`` can be one of the privilege level constants defined in this
     module. If the user does not have the privilege, the bot will say
-    ``message`` if given. By default, it uses ``bot.say``, but when ``reply``
-    is true, then it uses ``bot.reply`` instead.
+    ``message`` if given. By default, it uses :meth:`bot.say()
+    <.bot.Sopel.say>`, but when ``reply`` is true, then it uses
+    :meth:`bot.reply() <.bot.Sopel.reply>` instead.
 
     Privilege requirements are ignored in private messages.
 
@@ -383,11 +392,14 @@ def require_admin(message=None, reply=False):
     """Decorate a function to require the triggering user to be a bot admin.
 
     :param str message: optional message said to non-admin user
-    :param bool reply: use `reply` instead of `say` when true, default to false
+    :param bool reply: use :meth:`~.bot.Sopel.reply` instead of
+                       :meth:`~.bot.Sopel.say` when ``True``; defaults to
+                       ``False``
 
     When the triggering user is not an admin, the command is not run, and the
-    bot will say the ``message`` if given. By default, it uses ``bot.say``,
-    but when ``reply`` is true, then it uses ``bot.reply`` instead.
+    bot will say the ``message`` if given. By default, it uses
+    :meth:`bot.say() <.bot.Sopel.say>`, but when ``reply`` is true, then it
+    uses :meth:`bot.reply() <.bot.Sopel.reply>` instead.
 
     .. versionchanged:: 7.0.0
         Added the ``reply`` parameter.
@@ -416,11 +428,14 @@ def require_owner(message=None, reply=False):
     """Decorate a function to require the triggering user to be the bot owner.
 
     :param str message: optional message said to non-owner user
-    :param bool reply: use `reply` instead of `say` when true, default to false
+    :param bool reply: use :meth:`~.bot.Sopel.reply` instead of
+                       :meth:`~.bot.Sopel.say` when ``True``; defaults to
+                       ``False``
 
     When the triggering user is not the bot's owner, the command is not run,
-    and the bot will say ``message`` if given. By default, it uses ``bot.say``,
-    but when ``reply`` is true, then it uses ``bot.reply`` instead.
+    and the bot will say ``message`` if given. By default, it uses
+    :meth:`bot.say() <.bot.Sopel.say>`, but when ``reply`` is true, then it
+    uses :meth:`bot.reply() <.bot.Sopel.reply>` instead.
 
     .. versionchanged:: 7.0.0
         Added the ``reply`` parameter.

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -318,12 +318,20 @@ def require_chanmsg(message=None):
     return actual_decorator
 
 
-def require_privilege(level, message=None):
+def require_privilege(level, message=None, reply=False):
     """Decorate a function to require at least the given channel permission.
 
-    `level` can be one of the privilege levels defined in this module. If the
-    user does not have the privilege, `message` will be said if given. If it is
-    a private message, no checking will be done."""
+    :param int level: required privilege level to use this command
+    :param str message: optional message said to insufficiently privileged user
+    :param bool reply: use `reply` instead of `say` when true, default to false
+
+    ``level`` can be one of the privilege level constants defined in this
+    module. If the user does not have the privilege, the bot will say
+    ``message`` if given. By default, it uses ``bot.say``, but when ``reply``
+    is true, then it uses ``bot.reply`` instead.
+
+    Privilege requirements are ignored in private messages.
+    """
     def actual_decorator(function):
         @functools.wraps(function)
         def guarded(bot, trigger, *args, **kwargs):
@@ -334,7 +342,10 @@ def require_privilege(level, message=None):
             allowed = channel_privs.get(trigger.nick, 0) >= level
             if not trigger.is_privmsg and not allowed:
                 if message and not callable(message):
-                    bot.say(message)
+                    if reply:
+                        bot.reply(message)
+                    else:
+                        bot.say(message)
             else:
                 return function(bot, trigger, *args, **kwargs)
         return guarded

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -283,6 +283,9 @@ def require_privmsg(message=None, reply=False):
     If it is triggered in a channel message, ``message`` will be said if given.
     By default, it uses ``bot.say``, but when ``reply`` is true, then it uses
     ``bot.reply`` instead.
+
+    .. versionchanged:: 7.0.0
+        Added the ``reply`` parameter.
     """
     def actual_decorator(function):
         @functools.wraps(function)
@@ -314,6 +317,9 @@ def require_chanmsg(message=None, reply=False):
     If it is triggered in a private message, ``message`` will be said if given.
     By default, it uses ``bot.say``, but when ``reply`` is true, then it uses
     ``bot.reply`` instead.
+
+    .. versionchanged:: 7.0.0
+        Added the ``reply`` parameter.
     """
     def actual_decorator(function):
         @functools.wraps(function)
@@ -349,6 +355,9 @@ def require_privilege(level, message=None, reply=False):
     is true, then it uses ``bot.reply`` instead.
 
     Privilege requirements are ignored in private messages.
+
+    .. versionchanged:: 7.0.0
+        Added the ``reply`` parameter.
     """
     def actual_decorator(function):
         @functools.wraps(function)
@@ -379,6 +388,9 @@ def require_admin(message=None, reply=False):
     When the triggering user is not an admin, the command is not run, and the
     bot will say the ``message`` if given. By default, it uses ``bot.say``,
     but when ``reply`` is true, then it uses ``bot.reply`` instead.
+
+    .. versionchanged:: 7.0.0
+        Added the ``reply`` parameter.
     """
     def actual_decorator(function):
         @functools.wraps(function)
@@ -409,6 +421,9 @@ def require_owner(message=None, reply=False):
     When the triggering user is not the bot's owner, the command is not run,
     and the bot will say ``message`` if given. By default, it uses ``bot.say``,
     but when ``reply`` is true, then it uses ``bot.reply`` instead.
+
+    .. versionchanged:: 7.0.0
+        Added the ``reply`` parameter.
     """
     def actual_decorator(function):
         @functools.wraps(function)

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -274,10 +274,15 @@ def rate(user=0, channel=0, server=0):
     return add_attribute
 
 
-def require_privmsg(message=None):
+def require_privmsg(message=None, reply=False):
     """Decorate a function to only be triggerable from a private message.
 
-    If it is triggered in a channel message, `message` will be said if given.
+    :param str message: optional message said if triggered in a channel
+    :param bool reply: use `reply` instead of `say` when true, default to false
+
+    If it is triggered in a channel message, ``message`` will be said if given.
+    By default, it uses ``bot.say``, but when ``reply`` is true, then it uses
+    ``bot.reply`` instead.
     """
     def actual_decorator(function):
         @functools.wraps(function)
@@ -288,8 +293,12 @@ def require_privmsg(message=None):
                 return function(*args, **kwargs)
             else:
                 if message and not callable(message):
-                    bot.say(message)
+                    if reply:
+                        bot.reply(message)
+                    else:
+                        bot.say(message)
         return _nop
+
     # Hack to allow decorator without parens
     if callable(message):
         return actual_decorator(message)

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -296,10 +296,15 @@ def require_privmsg(message=None):
     return actual_decorator
 
 
-def require_chanmsg(message=None):
+def require_chanmsg(message=None, reply=False):
     """Decorate a function to only be triggerable from a channel message.
 
-    If it is triggered in a private message, `message` will be said if given.
+    :param str message: optional message said if triggered in private message
+    :param bool reply: use `reply` instead of `say` when true, default to false
+
+    If it is triggered in a private message, ``message`` will be said if given.
+    By default, it uses ``bot.say``, but when ``reply`` is true, then it uses
+    ``bot.reply`` instead.
     """
     def actual_decorator(function):
         @functools.wraps(function)
@@ -310,8 +315,12 @@ def require_chanmsg(message=None):
                 return function(*args, **kwargs)
             else:
                 if message and not callable(message):
-                    bot.say(message)
+                    if reply:
+                        bot.reply(message)
+                    else:
+                        bot.say(message)
         return _nop
+
     # Hack to allow decorator without parens
     if callable(message):
         return actual_decorator(message)


### PR DESCRIPTION
Since @Exirel added `reply` as an optional argument to `module.require_admin` (in #1456), it seemed prudent to implement the same argument on all of its relatives for consistency's sake.

Also added the parameters to docstrings for the functions I touched, since I was in there anyway.

Now this is a full-blown API addition instead of a one-off oddity! :grin: