### PR TITLE
core: URL Callbacks new interface

### DIFF
--- a/sopel/modules/bugzilla.py
+++ b/sopel/modules/bugzilla.py
@@ -11,7 +11,6 @@ import requests
 
 import xmltodict
 
-from sopel import tools
 from sopel.config.types import StaticSection, ListAttribute
 from sopel.logger import get_logger
 from sopel.module import rule
@@ -46,24 +45,17 @@ def setup(bot):
 
     if not bot.config.bugzilla.domains:
         return
-    if not bot.memory.contains('url_callbacks'):
-        bot.memory['url_callbacks'] = tools.SopelMemory()
 
     domains = '|'.join(bot.config.bugzilla.domains)
     regex = re.compile((r'https?://(%s)'
                         r'(/show_bug.cgi\?\S*?)'
                         r'(id=\d+)')
                        % domains)
-    bot.memory['url_callbacks'][regex] = show_bug
+    bot.register_url_callback(regex, show_bug)
 
 
 def shutdown(bot):
-    try:
-        del bot.memory['url_callbacks'][regex]
-    except KeyError:
-        # bot.config.bugzilla.domains was probably just empty on startup
-        # everything's daijoubu
-        pass
+    bot.unregister_url_callback(regex)
 
 
 @rule(r'.*https?://(\S+?)'

--- a/sopel/modules/instagram.py
+++ b/sopel/modules/instagram.py
@@ -13,7 +13,7 @@ from datetime import datetime
 
 from requests import get
 
-from sopel import module, tools
+from sopel import module
 
 try:
     from ujson import loads
@@ -26,13 +26,11 @@ instagram_pattern = re.compile(instagram_regex)
 
 
 def setup(bot):
-    if not bot.memory.contains('url_callbacks'):
-        bot.memory['url_callbacks'] = tools.SopelMemory()
-    bot.memory['url_callbacks'][instagram_pattern] = instaparse
+    bot.register_url_callback(instagram_pattern, instaparse)
 
 
 def shutdown(bot):
-    del bot.memory['url_callbacks'][instagram_pattern]
+    bot.unregister_url_callback(instagram_pattern)
 
 # TODO: Parse Instagram profile page
 

--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -5,7 +5,7 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 from sopel.module import commands, rule, example, require_chanmsg, NOLIMIT, OP
 from sopel.formatting import bold, color, colors
 from sopel.web import USER_AGENT
-from sopel.tools import SopelMemory, time
+from sopel.tools import time
 import datetime as dt
 import praw
 import re
@@ -34,15 +34,13 @@ spoiler_subs = [
 
 
 def setup(bot):
-    if not bot.memory.contains('url_callbacks'):
-        bot.memory['url_callbacks'] = SopelMemory()
-    bot.memory['url_callbacks'][post_regex] = rpost_info
-    bot.memory['url_callbacks'][user_regex] = redditor_info
+    bot.register_url_callback(post_regex, rpost_info)
+    bot.register_url_callback(user_regex, redditor_info)
 
 
 def shutdown(bot):
-    del bot.memory['url_callbacks'][post_regex]
-    del bot.memory['url_callbacks'][user_regex]
+    bot.unregister_url_callback(post_regex)
+    bot.unregister_url_callback(user_regex)
 
 
 @rule('.*%s.*' % post_url)

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -88,9 +88,7 @@ def setup(bot):
             exclude.extend(regexes)
         bot.memory['url_exclude'] = exclude
 
-    # Ensure that url_callbacks and last_seen_url are in memory
-    if not bot.memory.contains('url_callbacks'):
-        bot.memory['url_callbacks'] = tools.SopelMemory()
+    # Ensure last_seen_url is in memory
     if not bot.memory.contains('last_seen_url'):
         bot.memory['last_seen_url'] = tools.SopelMemory()
 
@@ -237,13 +235,11 @@ def check_callbacks(bot, trigger, url, run=True):
     # Check if it matches the exclusion list first
     matched = any(regex.search(url) for regex in bot.memory['url_exclude'])
     # Then, check if there's anything in the callback list
-    for regex, function in tools.iteritems(bot.memory['url_callbacks']):
-        match = regex.search(url)
-        if match:
-            # Always run ones from @url; they don't run on their own.
-            if run or hasattr(function, 'url_regex'):
-                function(bot, trigger, match)
-            matched = True
+    for function, match in bot.search_url_callbacks(url):
+        # Always run ones from @url; they don't run on their own.
+        if run or hasattr(function, 'url_regex'):
+            function(bot, trigger, match)
+        matched = True
     return matched
 
 

--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -3,7 +3,6 @@
 # Licensed under the Eiffel Forum License 2.
 from __future__ import unicode_literals, absolute_import, print_function, division
 
-from sopel import tools
 from sopel.config.types import StaticSection, ValidatedAttribute
 from sopel.module import NOLIMIT, commands, example, rule
 from requests import get
@@ -19,6 +18,7 @@ else:
     from urllib.parse import quote, unquote
 
 REDIRECT = re.compile(r'^REDIRECT (.*)')
+WIKIPEDIA_REGEX = re.compile('([a-z]+).(wikipedia.org/wiki/)([^ ]+)')
 
 
 class WikipediaSection(StaticSection):
@@ -30,11 +30,11 @@ class WikipediaSection(StaticSection):
 
 def setup(bot):
     bot.config.define_section('wikipedia', WikipediaSection)
+    bot.register_url_callback(WIKIPEDIA_REGEX, mw_info)
 
-    regex = re.compile('([a-z]+).(wikipedia.org/wiki/)([^ ]+)')
-    if not bot.memory.contains('url_callbacks'):
-        bot.memory['url_callbacks'] = tools.SopelMemory()
-    bot.memory['url_callbacks'][regex] = mw_info
+
+def shutdown(bot):
+    bot.unregister_url_callback(WIKIPEDIA_REGEX)
 
 
 def configure(config):


### PR DESCRIPTION
This new interface adds:

* `bot.register_url_callback(regex, callback)`, to register a `callback` to call when a URL matches `regex`
* `bot.unregister_url_callback(regex)` to remove this regex from triggering callbacks
* `bot.search_url_callbacks(url)` to get a list of (callback, match) for each pattern matched by the URL

This provides a unified interface to work with URL Callbacks, but does not change how the built-in url plugin works (yet).

So this:

    if not bot.memory.contains('url_callbacks'):
        bot.memory['url_callbacks'] = tools.SopelMemory()
    bot.memory['url_callbacks'][instagram_pattern] = instaparse

Become this:

    bot.register_url_callback(instagram_pattern, instaparse)

It does not change the fact that the `url` built-in plugin is required at the moment in order to work with URL Callback (see #1489 for that).

@dgw now my question is, should I keep moving forward, and replace the `url` built-in plugin? Or should we merge this PR as-is, and work from there in another PR?