### PR TITLE
core: handle URL callbacks in coretasks

### DIFF
--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -91,7 +91,13 @@ class CoreSection(StaticSection):
         'auto_url_schemes',
         strip=True,
         default=['http', 'https', 'ftp'])
-    """List of URL schemes that will trigger URL callbacks."""
+    """List of URL schemes that will trigger URL callbacks.
+
+    Used by the URL callbacks feature; see :func:`sopel.module.url` decorator
+    for plugins.
+
+    The default value allows ``http``, ``https``, and ``ftp``.
+    """
 
     bind_host = ValidatedAttribute('bind_host')
     """Bind the connection to a specific IP"""

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -87,6 +87,12 @@ class CoreSection(StaticSection):
 
     May not apply, depending on ``auth_method``."""
 
+    auto_url_schemes = ListAttribute(
+        'auto_url_schemes',
+        strip=True,
+        default=['http', 'https', 'ftp'])
+    """List of URL schemes that will trigger URL callbacks."""
+
     bind_host = ValidatedAttribute('bind_host')
     """Bind the connection to a specific IP"""
 

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -18,6 +18,7 @@ import sys
 import time
 import sopel
 import sopel.module
+import sopel.web
 from sopel.bot import _CapReq
 from sopel.tools import Identifier, iteritems, events
 from sopel.tools.target import User, Channel
@@ -797,3 +798,20 @@ def track_topic(bot, trigger):
     if channel not in bot.channels:
         return
     bot.channels[channel].topic = trigger.args[-1]
+
+
+@sopel.module.rule(r'(?u).*(https?://\S+).*')
+@sopel.module.unblockable
+def handle_url_callbacks(bot, trigger):
+    """Dispatch callbacks on URLs
+
+    For each URL found in the trigger, trigger the URL callback registered by
+    the ``@url`` decorator.
+    """
+    # find URLs in the trigger
+    for url in sopel.web.search_urls(trigger):
+        # find callbacks for said URL
+        for function, match in bot.search_url_callbacks(url):
+            # trigger callback defined by the `@url` decorator
+            if hasattr(function, 'url_regex'):
+                function(bot, trigger, match=match)

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -800,7 +800,7 @@ def track_topic(bot, trigger):
     bot.channels[channel].topic = trigger.args[-1]
 
 
-@sopel.module.rule(r'(?u).*(https?://\S+).*')
+@sopel.module.rule(r'(?u).*(.+://\S+).*')
 @sopel.module.unblockable
 def handle_url_callbacks(bot, trigger):
     """Dispatch callbacks on URLs
@@ -808,8 +808,9 @@ def handle_url_callbacks(bot, trigger):
     For each URL found in the trigger, trigger the URL callback registered by
     the ``@url`` decorator.
     """
+    schemes = bot.config.core.auto_url_schemes
     # find URLs in the trigger
-    for url in sopel.web.search_urls(trigger):
+    for url in sopel.web.search_urls(trigger, schemes=schemes):
         # find callbacks for said URL
         for function, match in bot.search_url_callbacks(url):
             # trigger callback defined by the `@url` decorator

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -408,11 +408,31 @@ def require_owner(message=None):
 def url(url_rule):
     """Decorate a function to handle URLs.
 
+    :param str url_rule: regex pattern to match URLs
+
     This decorator takes a regex string that will be matched against URLs in a
     message. The function it decorates, in addition to the bot and trigger,
     must take a third argument ``match``, which is the regular expression match
-    of the URL. This should be used rather than the matching in trigger, in
-    order to support e.g. the ``.title`` command.
+    of the URL::
+
+        from sopel import module
+
+        @module.url(r'https://example.com/bugs/([a-z0-9]+)')
+        def handle_example_bugs(bot, trigger, match):
+            bot.reply('Found bug ID #%s' % match.group(1))
+
+    This should be used rather than the matching in trigger, in order to
+    support e.g. the ``.title`` command.
+
+    Under the hood, when Sopel collects the decorated handler it uses
+    :meth:`sopel.bot.Sopel.register_url_callback` to register the handler.
+
+    .. seealso::
+
+        To detect URLs, Sopel uses a matching pattern built from a list of URL
+        schemes, configured by
+        :attr:`~sopel.config.core_section.CoreSection.auto_url_schemes`.
+
     """
     def actual_decorator(function):
         @functools.wraps(function)

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -95,6 +95,10 @@ def setup(bot):
     if not bot.memory.contains('last_seen_url'):
         bot.memory['last_seen_url'] = tools.SopelMemory()
 
+    # Initialize shortened_urls as a dict if it doesn't exist.
+    if not bot.memory.contains('shortened_urls'):
+        bot.memory['shortened_urls'] = tools.SopelMemory()
+
 
 @commands('title')
 @example('.title http://google.com', '[ Google ] - google.com')
@@ -192,9 +196,6 @@ def process_urls(bot, trigger, urls):
             if (shorten_url_length > 0) and (len(url) > shorten_url_length):
                 # Check bot memory to see if the shortened URL is already in
                 # memory
-                if not bot.memory.contains('shortened_urls'):
-                    # Initialize shortened_urls as a dict if it doesn't exist.
-                    bot.memory['shortened_urls'] = tools.SopelMemory()
                 if bot.memory['shortened_urls'].contains(url):
                     tinyurl = bot.memory['shortened_urls'][url]
                 else:

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -115,26 +115,15 @@ def title_command(bot, trigger):
         else:
             urls = [bot.memory['last_seen_url'][trigger.sender]]
     else:
-        urls = list(
-            web.search_urls(
-                trigger,
-                exclusion_char=bot.config.url.exclusion_char
-            )
-        )
+        urls = web.search_urls(
+            trigger,
+            exclusion_char=bot.config.url.exclusion_char)
 
-    results = list(process_urls(bot, trigger, urls))
-    for _url, title, domain, tinyurl in results[:4]:
+    for _url, title, domain, tinyurl in process_urls(bot, trigger, urls):
         message = '[ %s ] - %s' % (title, domain)
         if tinyurl:
             message += ' ( %s )' % tinyurl
         bot.reply(message)
-
-    # Nice to have different failure messages for one-and-only requested URL
-    # failed vs. one-of-many failed.
-    if len(urls) == 1 and not results:
-        bot.reply('Sorry, fetching that title failed. Make sure the site is working.')
-    elif len(urls) > len(results):
-        bot.reply('I couldn\'t get all of the titles, but I fetched what I could!')
 
 
 @module.rule(r'(?u).*(https?://\S+).*')
@@ -155,8 +144,7 @@ def title_auto(bot, trigger):
     urls = web.search_urls(
         trigger, exclusion_char=bot.config.url.exclusion_char, clean=True)
 
-    for i, info in enumerate(process_urls(bot, trigger, urls)):
-        url, title, domain, tinyurl = info
+    for url, title, domain, tinyurl in process_urls(bot, trigger, urls):
         message = '[ %s ] - %s' % (title, domain)
         if tinyurl:
             message += ' ( %s )' % tinyurl
@@ -164,10 +152,6 @@ def title_auto(bot, trigger):
         if message != trigger:
             bot.say(message)
             bot.memory['last_seen_url'][trigger.sender] = url
-
-        # stop at 4th iteration
-        if i == 3:
-            break
 
 
 def process_urls(bot, trigger, urls):

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -15,10 +15,8 @@ import re
 
 import requests
 
-from sopel import web, tools, __version__
-from sopel.config.types import ValidatedAttribute, ListAttribute, StaticSection
-from sopel.module import commands, rule, example
-
+from sopel import __version__, module, tools, web
+from sopel.config.types import ListAttribute, StaticSection, ValidatedAttribute
 
 USER_AGENT = 'Sopel/{} (https://sopel.chat)'.format(__version__)
 default_headers = {'User-Agent': USER_AGENT}
@@ -100,8 +98,8 @@ def setup(bot):
         bot.memory['shortened_urls'] = tools.SopelMemory()
 
 
-@commands('title')
-@example('.title http://google.com', '[ Google ] - google.com')
+@module.commands('title')
+@module.example('.title https://www.google.com', '[ Google ] - www.google.com')
 def title_command(bot, trigger):
     """
     Show the title or URL information for the given URL, or the last URL seen
@@ -139,7 +137,7 @@ def title_command(bot, trigger):
         bot.reply('I couldn\'t get all of the titles, but I fetched what I could!')
 
 
-@rule(r'(?u).*(https?://\S+).*')
+@module.rule(r'(?u).*(https?://\S+).*')
 def title_auto(bot, trigger):
     """
     Automatically show titles for URLs. For shortened URLs/redirects, find

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -109,7 +109,7 @@ def title_command(bot, trigger):
         if trigger.sender not in bot.memory['last_seen_url']:
             return
         matched = check_callbacks(
-            bot, trigger, bot.memory['last_seen_url'][trigger.sender])
+            bot, bot.memory['last_seen_url'][trigger.sender])
         if matched:
             return
         else:
@@ -185,7 +185,7 @@ def process_urls(bot, trigger, urls):
             continue
 
         # Check the URL does not match an existing URL callback
-        if check_callbacks(bot, trigger, url):
+        if check_callbacks(bot, url):
             continue
 
         # Call the URL to get a title, if possible
@@ -202,11 +202,10 @@ def process_urls(bot, trigger, urls):
         yield (url, title, get_hostname(url), tinyurl)
 
 
-def check_callbacks(bot, trigger, url):
+def check_callbacks(bot, url):
     """Check if ``url`` is excluded or matches any URL callback patterns.
 
     :param bot: Sopel instance
-    :param trigger: IRC line
     :param str url: URL to check
     :return: True if ``url`` is excluded or matches any URL Callback pattern
 

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -151,7 +151,10 @@ def title_auto(bot, trigger):
             return
 
     urls = list(
-        web.search_urls(trigger, exclusion_char=bot.config.url.exclusion_char))
+        web.search_urls(
+            trigger,
+            exclusion_char=bot.config.url.exclusion_char,
+            clean=True))
 
     if not urls:
         return

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -119,11 +119,12 @@ def title_command(bot, trigger):
             trigger,
             exclusion_char=bot.config.url.exclusion_char)
 
-    for _url, title, domain, tinyurl in process_urls(bot, trigger, urls):
+    for url, title, domain, tinyurl in process_urls(bot, trigger, urls):
         message = '[ %s ] - %s' % (title, domain)
         if tinyurl:
             message += ' ( %s )' % tinyurl
         bot.reply(message)
+        bot.memory['last_seen_url'][trigger.sender] = url
 
 
 @module.rule(r'(?u).*(https?://\S+).*')

--- a/sopel/web.py
+++ b/sopel/web.py
@@ -239,19 +239,20 @@ else:
     urlencode = urllib.parse.urlencode
 
 
-def search_urls(text, exclusion_char=None, clean=False):
-    def trim_url(url):
-        # clean trailing sentence- or clause-ending punctuation
-        while url[-1] in '.,?!\'":;':
+def trim_url(url):
+    # clean trailing sentence- or clause-ending punctuation
+    while url[-1] in '.,?!\'":;':
+        url = url[:-1]
+
+    # clean unmatched parentheses/braces/brackets
+    for (opener, closer) in [('(', ')'), ('[', ']'), ('{', '}'), ('<', '>')]:
+        if url[-1] is closer and url.count(opener) < url.count(closer):
             url = url[:-1]
 
-        # clean unmatched parentheses/braces/brackets
-        for (opener, closer) in [('(', ')'), ('[', ']'), ('{', '}'), ('<', '>')]:
-            if url[-1] is closer and url.count(opener) < url.count(closer):
-                url = url[:-1]
+    return url
 
-        return url
 
+def search_urls(text, exclusion_char=None, clean=False):
     re_url = r'((?:http|https|ftp)(?::\/\/\S+))'
     if exclusion_char is not None:
         re_url = r'((?<!%s)(?:http|https|ftp)(?::\/\/\S+))' % (exclusion_char)

--- a/sopel/web.py
+++ b/sopel/web.py
@@ -246,7 +246,7 @@ def trim_url(url):
 
     # clean unmatched parentheses/braces/brackets
     for (opener, closer) in [('(', ')'), ('[', ']'), ('{', '}'), ('<', '>')]:
-        if url[-1] is closer and url.count(opener) < url.count(closer):
+        if url[-1] == closer and url.count(opener) < url.count(closer):
             url = url[:-1]
 
     return url

--- a/sopel/web.py
+++ b/sopel/web.py
@@ -252,10 +252,13 @@ def trim_url(url):
     return url
 
 
-def search_urls(text, exclusion_char=None, clean=False):
-    re_url = r'((?:http|https|ftp)(?::\/\/\S+))'
+def search_urls(text, exclusion_char=None, clean=False, schemes=None):
+    schemes = schemes or ['http', 'https', 'ftp']
+    schemes_patterns = '|'.join(re.escape(scheme) for scheme in schemes)
+    re_url = r'((?:%s)(?::\/\/\S+))' % schemes_patterns
     if exclusion_char is not None:
-        re_url = r'((?<!%s)(?:http|https|ftp)(?::\/\/\S+))' % (exclusion_char)
+        re_url = r'((?<!%s)(?:%s)(?::\/\/\S+))' % (
+            exclusion_char, schemes_patterns)
 
     r = re.compile(re_url, re.IGNORECASE | re.UNICODE)
 

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -2,8 +2,9 @@
 """Tests Sopel's web tools"""
 from __future__ import unicode_literals, absolute_import, print_function, division
 
+import pytest
 
-from sopel.web import search_urls
+from sopel.web import search_urls, trim_url
 
 
 def test_search_urls():
@@ -93,3 +94,50 @@ def test_search_urls_exclusion_char_only_once():
     assert len(urls) == 2, 'Must find 1 URL, found %d' % len(urls)
     assert 'http://a.com' in urls
     assert 'http://b.com' in urls
+
+
+TRAILING_CHARS = list('.,?!\'":;')
+ENCLOSING_PAIRS = [('(', ')'), ('[', ']'), ('{', '}'), ('<', '>')]
+
+
+@pytest.mark.parametrize('trailing_char', TRAILING_CHARS)
+def test_trim_url_remove_trailing_char(trailing_char):
+    test_url = 'http://example.com/'
+    assert trim_url(test_url + trailing_char) == test_url
+
+    # assert trailing_char removed only if it is trailing
+    test_url = 'http://example.com/' + trailing_char + 'content'
+    assert trim_url(test_url) == test_url
+
+
+@pytest.mark.parametrize('left, right', ENCLOSING_PAIRS)
+def test_trim_url_remove_trailing_enclosing(left, right):
+    # right without left => right is removed
+    test_url = 'http://example.com/'
+    assert test_url == trim_url(test_url + right)
+
+    # right after path without left => right is removed
+    test_url = 'http://example.com/a'
+    assert test_url == trim_url(test_url + right)
+
+    # trailing left without right => left is kept
+    test_url = 'http://example.com/a' + left
+    assert test_url == trim_url(test_url)
+
+    # left before content without right => left is kept
+    test_url = 'http://example.com/a' + left + 'something'
+    assert test_url == trim_url(test_url)
+
+    # left + content + right => right is kept
+    assert test_url + right == trim_url(test_url + right)
+
+
+@pytest.mark.parametrize('trailing_char', TRAILING_CHARS)
+@pytest.mark.parametrize('left, right', ENCLOSING_PAIRS)
+def test_trim_url_trailing_char_and_enclosing(trailing_char, left, right):
+    test_url = 'http://example.com/'
+    assert test_url == trim_url(test_url + right + trailing_char)
+
+    # assert the trailing char is kept if there is something else
+    test_url = 'http://example.com/' + trailing_char
+    assert test_url == trim_url(test_url + right)

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -1,0 +1,95 @@
+# coding=utf-8
+"""Tests Sopel's web tools"""
+from __future__ import unicode_literals, absolute_import, print_function, division
+
+
+from sopel.web import search_urls
+
+
+def test_search_urls():
+    urls = list(search_urls('http://example.com'))
+    assert len(urls) == 1, 'Must find 1 URL, found %d' % len(urls)
+    assert 'http://example.com' in urls
+
+
+def test_search_urls_with_text():
+    urls = list(search_urls('before http://example.com after'))
+    assert len(urls) == 1, 'Must find 1 URL, found %d' % len(urls)
+    assert 'http://example.com' in urls
+
+
+def test_search_urls_multiple_urls():
+    urls = list(search_urls('http://a.com/ http://b.com/'))
+    assert len(urls) == 2, 'Must find 2 URLs, found %d' % len(urls)
+    assert 'http://a.com/' in urls
+    assert 'http://b.com/' in urls
+
+
+def test_search_urls_multiple_urls_with_text():
+    urls = list(
+        search_urls('before http://a.com/ between http://b.com/ after'))
+    assert len(urls) == 2, 'Must find 2 URLs, found %d' % len(urls)
+    assert 'http://a.com/' in urls
+    assert 'http://b.com/' in urls
+
+
+def test_search_urls_multiple_urls_unique():
+    urls = list(search_urls('http://a.com/ http://b.com/ http://a.com/'))
+    assert len(urls) == 2, 'Must find 2 URLs, found %d' % len(urls)
+    assert 'http://a.com/' in urls
+    assert 'http://b.com/' in urls
+
+
+def test_search_urls_multiple_urls_unique_keep_ordering():
+    urls = list(
+        search_urls('http://a.com/ http://c.com/ http://b.com/ http://a.com/'))
+    assert len(urls) == 3, 'Must find 3 URLs, found %d' % len(urls)
+    assert 'http://a.com/' in urls
+    assert 'http://b.com/' in urls
+    assert 'http://c.com/' in urls
+    assert urls == [
+        'http://a.com/',
+        'http://c.com/',
+        'http://b.com/',
+    ]
+
+
+def test_search_urls_exclusion_char():
+    # assert url is excluded
+    urls = list(search_urls('!http://example.com', exclusion_char='!'))
+    assert not urls, 'Must not find URL, found %d' % len(urls)
+
+    # assert the other url is not excluded
+    urls = list(
+        search_urls('http://b.com !http://a.com', exclusion_char='!'))
+    assert len(urls) == 1, 'Must find 1 URL, found %d' % len(urls)
+    assert 'http://b.com' in urls
+
+    # assert the order of appearance does not matter
+    urls = list(
+        search_urls('!http://a.com http://b.com', exclusion_char='!'))
+    assert len(urls) == 1, 'Must find 1 URL, found %d' % len(urls)
+    assert 'http://b.com' in urls
+
+
+def test_search_urls_exclusion_char_with_text():
+    urls = list(
+        search_urls(
+            'before !http://a.com between http://b.com after',
+            exclusion_char='!')
+    )
+    assert len(urls) == 1, 'Must find 1 URL, found %d' % len(urls)
+    assert 'http://b.com' in urls
+
+
+def test_search_urls_exclusion_char_only_once():
+    # assert only the instance excluded is excluded
+    # ie. that it is not a global exclude, otherwise that would return 1 url
+    urls = list(
+        search_urls(
+            '!http://a.com http://a.com http://b.com',
+            exclusion_char='!')
+    )
+    assert len(urls) == 2, 'Must find 1 URL, found %d' % len(urls)
+    assert 'http://a.com' in urls
+    assert 'http://b.com' in urls

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -96,6 +96,30 @@ def test_search_urls_exclusion_char_only_once():
     assert 'http://b.com' in urls
 
 
+def test_search_urls_default_schemes():
+    urls = list(search_urls('http://a.com ftp://b.com https://c.com'))
+    assert len(urls) == 3, 'Must find all three URLs'
+    assert 'http://a.com' in urls
+    assert 'ftp://b.com' in urls
+    assert 'https://c.com' in urls
+
+
+@pytest.mark.parametrize('scheme', ['http', 'https', 'ftp', 'steam'])
+def test_search_urls_defined_schemes(scheme):
+    expected = {
+        'http': 'http://a.com',
+        'https': 'https://c.com',
+        'ftp': 'ftp://b.com',
+        'steam': 'steam://portal2',
+    }.get(scheme)
+
+    urls = list(
+        search_urls('http://a.com ftp://b.com https://c.com steam://portal2',
+        schemes=[scheme]))
+    assert len(urls) == 1, 'Only %s URLs must be found' % scheme
+    assert expected in urls
+
+
 TRAILING_CHARS = list('.,?!\'":;')
 ENCLOSING_PAIRS = [('(', ')'), ('[', ']'), ('{', '}'), ('<', '>')]
 


### PR DESCRIPTION
This fix #1489 - at last!

PR #1508 added a new interface for plugin maintainers, that would help us work with URL callbacks. In this PR, I:

* never trigger URL Callbacks from the `url` built-in plugin
* share the "find URL" feature into `sopel.web` (with unit tests for good measure)
* trigger URL callbacks from a `@url` defined in `coretasks`

This way, one may disable the `url` plugin, and the bot won't auto-title URLs. However, other plugins will still be able to define and use URL Callbacks.

Plugins that use `@rule` and define their own callback will still work, and that won't trigger callbacks.

By the way, this should fix https://github.com/sopel-irc/sopel-github/issues/13 too as soon as the github plugin uses `@url` instead of `@rule`.