### PR TITLE
systemd service files: use network-online.target

### DIFF
--- a/contrib/sopel.service
+++ b/contrib/sopel.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Sopel IRC bot
 Documentation=https://sopel.chat/
-After=network.target
+After=network-online.target
 
 [Service]
 Type=simple

--- a/contrib/sopel@.service
+++ b/contrib/sopel@.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Sopel IRC bot
 Documentation=https://sopel.chat/
-After=network.target
+After=network-online.target
 DefaultInstance=sopel
 
 [Service]


### PR DESCRIPTION
The service files also specify their unit to start After=network.target
but that target only defines the start of networking, and network
configuration may not be complete yet; instead it should use
network-online.target to ensure it starts after the network is
ready to use.

[EDIT: I removed the PIDFile= removal that was originally in this pull request]