### PR TITLE
auth: split 'auth_method' into 'server_auth_method' and 'nick_auth_method'

### DIFF
--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -69,9 +69,17 @@ class CoreSection(StaticSection):
 
     auth_method = ChoiceAttribute('auth_method', choices=[
         'nickserv', 'authserv', 'Q', 'sasl', 'server', 'userserv'])
-    """The method to use to authenticate with the server.
+    """Simple method to authenticate with the server.
 
-    Can be ``nickserv``, ``authserv``, ``Q``, ``sasl``, or ``server`` or ``userserv``."""
+    Can be ``nickserv``, ``authserv``, ``Q``, ``sasl``, or ``server`` or ``userserv``.
+
+    This allows only a single authentication method; to use both a server-based
+    authentication method as well as a nick-based authentication method, see
+    ``server_auth_method`` and ``nick_auth_method``.
+
+    If this is specified, both ``server_auth_method`` and ``nick_auth_method``
+    will be ignored.
+    """
 
     auth_password = ValidatedAttribute('auth_password')
     """The password to use to authenticate with the server."""
@@ -239,6 +247,32 @@ class CoreSection(StaticSection):
     nick = ValidatedAttribute('nick', Identifier, default=Identifier('Sopel'))
     """The nickname for the bot"""
 
+    nick_auth_method = ChoiceAttribute('nick_auth_method', choices=[
+        'nickserv', 'authserv', 'Q', 'userserv'])
+    """The nick authentication method.
+
+    Can be ``nickserv``, ``authserv``, ``Q``, or ``userserv``.
+    """
+
+    nick_auth_password = ValidatedAttribute('nick_auth_password')
+    """The password to use to authenticate your nick."""
+
+    nick_auth_target = ValidatedAttribute('nick_auth_target')
+    """The target user for nick authentication.
+
+    May not apply, depending on ``nick_auth_method``.
+
+    Defaults to NickServ for nickserv, and UserServ for userserv.
+    """
+
+    nick_auth_username = ValidatedAttribute('nick_auth_username')
+    """The username/account to use for nick authentication.
+
+    May not apply, depending on ``nick_auth_method``.
+
+    Defaults to the value of ``nick``.
+    """
+
     nick_blocks = ListAttribute('nick_blocks')
     """A list of nicks which Sopel should ignore.
 
@@ -278,6 +312,24 @@ class CoreSection(StaticSection):
 
     reply_errors = ValidatedAttribute('reply_errors', bool, default=True)
     """Whether to message the sender of a message that triggered an error with the exception."""
+
+    server_auth_method = ChoiceAttribute('server_auth_method', choices=['sasl', 'server'])
+    """The server authentication method.
+
+    Can be ``sasl`` or ``server``.
+    """
+
+    server_auth_password = ValidatedAttribute('server_auth_password')
+    """The password to use to authenticate with the server."""
+
+    server_auth_sasl_mech = ValidatedAttribute('server_auth_sasl_mech')
+    """The SASL mechanism.
+
+    Defaults to PLAIN.
+    """
+
+    server_auth_username = ValidatedAttribute('server_auth_username')
+    """The username/account to use to authenticate with the server."""
 
     throttle_join = ValidatedAttribute('throttle_join', int)
     """Slow down the initial join of channels to prevent getting kicked.

--- a/sopel/irc.py
+++ b/sopel/irc.py
@@ -288,8 +288,9 @@ class Bot(asynchat.async_chat):
 
         # authenticate account if needed
         if self.config.core.auth_method == 'server':
-            password = self.config.core.auth_password
-            self.write(('PASS', password))
+            self.write(('PASS', self.config.core.auth_password))
+        elif self.config.core.server_auth_method == 'server':
+            self.write(('PASS', self.config.core.server_auth_password))
         self.write(('NICK', self.nick))
         self.write(('USER', self.user, '+iw', self.nick), self.name)
 


### PR DESCRIPTION
currently only a single authentication method may be specified, so it is
not possible to do both server-based and nick-based authentication.  This
splits that into 'server_auth_method' which can be either 'server' and 'sasl'
and 'nick_auth_method' which can be 'nickserv', 'userserv', 'authserv',
or 'Q'.  This allows, for example, authenticating with username/password
to a server as well as performing nickserv authentication after login.

The existing 'auth_method' param remains, and if specified will override
both 'server_auth_method' and 'nick_auth_method'.