### PR TITLE
config: add [core] 'interpolation' and 'interpolation_extended' params

### DIFF
--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -135,6 +135,20 @@ class CoreSection(StaticSection):
 
     Regular expression syntax is used"""
 
+    interpolation = ValidatedAttribute('interpolation', bool, default=False)
+    """Whether to parse the config file with basic interpolation enabled."""
+
+    interpolation_extended = ValidatedAttribute('interpolation_extended', bool, default=False)
+    """Whether to parse the config file with extended interpolation enabled.
+
+    As basic and extended interpolation are not compatible, and extended
+    interpolation is only available with Python3, if this is enabled
+    when running under Python2, a RuntimeError is generated.
+
+    For details on config file interpolation see:
+    https://docs.python.org/3/library/configparser.html#interpolation-of-values
+    """
+
     log_raw = ValidatedAttribute('log_raw', bool, default=False)
     """Whether a log of raw lines as sent and received should be kept."""
 


### PR DESCRIPTION
RawConfigParser is the legacy python2 parser and does not allow/perform
interpolation.  More complex config files can benefit greatly from
interpolation and so we should use ConfigParser and allow interpolation.

The new params allow backwards compatibility if neither param is set
(or they are set to False).  If either basic or extended interpolation
is desired, either param can be added to the [core] section and set to
True to cause sopel to change its parser to the newer ConfigParser
and re-read the file, with either basic (the default) or extended
interpolation enabled.

Note that as extended interpolation is not available in Python2, if
the config file has 'interpolation_extended' enabled when running
Sopel under Python2, a RuntimeError is raised.