### PR TITLE
url: Actually clean URLs when auto-fetching titles

### DIFF
--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -166,7 +166,7 @@ def title_auto(bot, trigger):
         if bot.memory['safety_cache'][trigger]['positives'] > 1:
             return
 
-    urls = find_urls(trigger)
+    urls = find_urls(trigger, clean=True)
     if len(urls) == 0:
         return
 


### PR DESCRIPTION
A change that should have been made in #1413, but was overlooked. This proves why having more than one developer review changes is useful.

@Exirel indirectly found this omission during an overhaul of Sopel's URL-handling for version 7.

See https://github.com/sopel-irc/sopel/pull/1510#discussion_r268139814