### PR TITLE
url: Fix py2 compatibility in trim_url()

### DIFF
--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -99,7 +99,7 @@ def setup(bot):
 
             # clean unmatched parentheses/braces/brackets
             for (opener, closer) in [('(', ')'), ('[', ']'), ('{', '}'), ('<', '>')]:
-                if url[-1] is closer and url.count(opener) < url.count(closer):
+                if (url[-1] == closer) and (url.count(opener) < url.count(closer)):
                     url = url[:-1]
 
             return url


### PR DESCRIPTION
Python 2 doesn't like `thing is unicode`; it wants `thing == unicode`. Of course, it just works with regular str in both py2 and py3… Oh well.

This is another find from @Exirel's overhaul of URL handling for 7.x.

As long as I was touching the line anyway, I added parentheses to make the operator precedence explicit. Likely unnecessary, but probably easier to read by some small measure. (@Exirel, if you don't think the added parens are useful, I can drop it from this PR so you don't have to mirror it in #1510. :smile_cat:)