### PR TITLE
dev: add a Makefile to the project and use setup.cfg to configure flake8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,21 @@
+.PHONY: quality test coverage clean_doc build_doc
+
+quality:
+	./checkstyle.sh
+
+test:
+	coverage run -m py.test -v .
+
+coverage:
+	coverage report
+	coverage html
+
+qa: quality test coverage
+
+clean_doc:
+	$(MAKE) -C docs clean
+
+build_doc:
+	$(MAKE) -C docs html
+
+doc: clean_doc build_doc

--- a/checkstyle.sh
+++ b/checkstyle.sh
@@ -12,22 +12,6 @@ if ! flake8; then
     exit_code=1
 fi
 
-fail_coding=false
-for file in $(find_source_files); do
-    line=$(head -n 1 $file)
-    if echo $line | grep -q '#!/usr/bin/env python'; then
-        line=$(head -n 2 $file | tail -n 1)
-    fi
-    if ! echo $line | grep -q '# coding=utf-8'; then
-        echo $file
-        fail_coding=true
-    fi
-done
-if $fail_coding; then
-    echo "ERROR: Above files do not have utf-8 coding declared."
-    exit_code=1
-fi
-
 # Find files which use the unicode type but (heuristically) don't make it py3
 # safe
 fail_py3_unicode=false

--- a/checkstyle.sh
+++ b/checkstyle.sh
@@ -4,25 +4,10 @@ find_source_files() {
     find . -name '*.py' -size +0 -print | grep -ve './docs' -e 'env' -e './contrib' -e './conftest.py'
 }
 files=$(find_source_files)
-# These are acceptable (for now). 128 and 127 should be removed eventually.
-ignore='--ignore=E501,E128,E127'
-# These are ignored by default (and we want to keep them ignored)
-ignore=$ignore',W504'
-# These are forbidding certain __future__ imports. The plugin has errors both
-# for having and not having them; we want to always have them, so we ignore
-# the having them errors and keep the not having them errors.
-ignore=$ignore',FI50,FI51,FI52,FI53,FI54,FI55'
-# F12 is with_statement, which is already in 2.7. F15 requires and F55 forbids
-# generator_stop, which should probably be made mandatory at some point.
-ignore=$ignore',F12,F15,F55'
-# These are rules that are relatively new or have had their definitions tweaked
-# recently, so we'll forgive them until versions of PEP8 in various developers'
-# distros are updated
-ignore=$ignore',E265,E713,E111,E113,E402,E731'
 # For now, go through all the checking stages and only die at the end
 exit_code=0
 
-if ! flake8 $ignore --filename=*.py $(find_source_files); then
+if ! flake8; then
     echo "ERROR: flake8 does not pass."
     exit_code=1
 fi

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,4 +2,5 @@ pytest
 coveralls
 flake8<3.6.0; python_version == '3.3'
 flake8>=3.6.0,<3.7.0; python_version != '3.3'
+flake8-coding
 setuptools<40.0; python_version == '3.3'

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,3 +21,4 @@ exclude =
     env/*,
     contrib/*,
     conftest.py
+accept-encodings = utf-8

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,23 @@
+[flake8]
+max-line-length = 79
+ignore =
+    # These are acceptable (for now). 128 and 127 should be removed eventually.
+    E501,E128,E127,
+    # These are ignored by default (and we want to keep them ignored)
+    W504,
+    # These are forbidding certain __future__ imports. The plugin has errors both
+    # for having and not having them; we want to always have them, so we ignore
+    # the having them errors and keep the not having them errors.
+    FI50,FI51,FI52,FI53,FI54,FI55,
+    # F12 is with_statement, which is already in 2.7. F15 requires and F55 forbids
+    # generator_stop, which should probably be made mandatory at some point.
+    F12,F15,F55,
+    # These are rules that are relatively new or have had their definitions tweaked
+    # recently, so we'll forgive them until versions of PEP8 in various developers'
+    # distros are updated
+    E265,E713,E111,E113,E402,E731
+exclude =
+    docs/*,
+    env/*,
+    contrib/*,
+    conftest.py


### PR DESCRIPTION
**TL;DR**: I'm super lazy and it shows.

There are 2 things I can't remember:

* the full line to checkstyle + coverage + tests
* the exact parameters for flake8

And I really like `make`, it's a great tool for any projects, not just for C/C++ stuff. So here is a short one, with few commands that I find useful. This is the kind of commands I use in my own project, be they personal or professional.

For `flake8`, I wish I could just run it without having to resort to `checkstyle.sh`, and the `setup.cfg` file is perfect for that. I tested it worked, by adding/removing ignored errors/warnings. Isn't it great?

Bonus point: I hate having to cd into docs to build the doc, then to cd back in the project.  So I added that, too.