### PR TITLE
install: use setup.cfg to configure Sopel's package metadata

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,9 @@ addons:
       - aspell-en
       - libaspell-dev
 install:
+  - pip install --upgrade "setuptools<=39.2.0"  # last version to support Python 3.3
   - pip install --upgrade -r requirements.txt -r dev-requirements.txt
+  - python setup.py develop
 script:
   - make travis
 env:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,4 @@
 include *requirements.txt
+include setup.cfg
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,31 @@
+[metadata]
+name = sopel
+version = 6.6.9
+description = Simple and extendible IRC bot
+author = Elsie Powell
+author_email = powell.518@gmail.com
+url = https://sopel.chat/
+license = Eiffel Forum License, version 2
+platforms = Linux x86, x86-64
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Intended Audience :: Developers
+    Intended Audience :: System Administrators
+    License :: Eiffel Forum License (EFL)
+    License :: OSI Approved :: Eiffel Forum License
+    Operating System :: POSIX :: Linux
+    Programming Language :: Python :: 2.7
+    Programming Language :: Python :: 3.3
+    Programming Language :: Python :: 3.4
+    Programming Language :: Python :: 3.5
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Topic :: Communications :: Chat :: Internet Relay Chat
+
+[options]
+packages = find:
+zip_safe = false
+
 [flake8]
 max-line-length = 79
 ignore =

--- a/setup.py
+++ b/setup.py
@@ -65,4 +65,5 @@ setup(
             'sopel-config = sopel.cli.config:main',
         ],
     },
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, <4',
 )

--- a/setup.py
+++ b/setup.py
@@ -2,21 +2,35 @@
 # coding=utf-8
 from __future__ import unicode_literals, absolute_import, print_function, division
 
-from sopel import __version__
 import sys
 
 try:
-    from setuptools import setup
+    from setuptools import setup, __version__ as setuptools_version
 except ImportError:
     print(
         'You do not have setuptools, and can not install Sopel. The easiest '
         'way to fix this is to install pip by following the instructions at '
-        'http://pip.readthedocs.org/en/latest/installing.html\n'
-        'Alternately, you can run sopel without installing it by running '
+        'https://pip.readthedocs.io/en/latest/installing/\n'
+        'Alternately, you can run Sopel without installing it by running '
         '"python sopel.py"',
         file=sys.stderr,
     )
     sys.exit(1)
+else:
+    version_info = setuptools_version.split('.')
+    major = int(version_info[0])
+    minor = int(version_info[1])
+
+    if major < 30 or (major == 30 and minor < 3):
+        print(
+            'Your version of setuptools is outdated: version 30.3 or above '
+            'is required to install Sopel. You can do that with '
+            '"pip install -U setuptools"\n'
+            'Alternately, you can run Sopel without installing it by running '
+            '"python sopel.py"',
+            file=sys.stderr,
+        )
+        sys.exit(1)
 
 if sys.version_info < (2, 7) or (
         sys.version_info[0] > 3 and sys.version_info < (3, 3)):
@@ -37,47 +51,18 @@ if sys.version_info[0] < 3:
     requires.append('backports.ssl_match_hostname')
 dev_requires = requires + read_reqs('dev-requirements.txt')
 
-classifiers = [
-    'Development Status :: 5 - Production/Stable',
-    'Intended Audience :: Developers',
-    'Intended Audience :: System Administrators',
-    'License :: Eiffel Forum License (EFL)',
-    'License :: OSI Approved :: Eiffel Forum License',
-    'Operating System :: POSIX :: Linux',
-    'Programming Language :: Python :: 2.7',
-    'Programming Language :: Python :: 3.3',
-    'Programming Language :: Python :: 3.4',
-    'Programming Language :: Python :: 3.5',
-    'Programming Language :: Python :: 3.6',
-    'Programming Language :: Python :: 3.7',
-    'Topic :: Communications :: Chat :: Internet Relay Chat',
-]
-
 setup(
-    name='sopel',
-    version=__version__,
-    description='Simple and extendible IRC bot',
-    author='Elsie Powell',
-    author_email='powell.518@gmail.com',
-    url='https://sopel.chat/',
     long_description=(
         "Sopel is a simple, extendible, easy-to-use IRC Utility bot, written "
         "in Python. It's designed to be easy to use, easy to run, and easy to "
         "make new features for."
     ),
-    # Distutils is shit, and doesn't check if it's a list of basestring
-    # but instead requires str.
-    packages=[str('sopel'), str('sopel.modules'), str('sopel.plugins'),
-              str('sopel.cli'), str('sopel.config'), str('sopel.tools')],
-    classifiers=classifiers,
-    license='Eiffel Forum License, version 2',
-    platforms='Linux x86, x86-64',
     install_requires=requires,
     extras_require={'dev': dev_requires},
     entry_points={
         'console_scripts': [
             'sopel = sopel.cli.run:main',
             'sopel-config = sopel.cli.config:main',
-        ]
+        ],
     },
 )

--- a/sopel/__init__.py
+++ b/sopel/__init__.py
@@ -14,6 +14,7 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 
 from collections import namedtuple
 import locale
+import pkg_resources
 import re
 import sys
 
@@ -25,7 +26,8 @@ if sys.version_info.major > 2:
               'stupid things. If you get strange errors, please set it to '
               'something like "en_US.UTF-8".', file=sys.stderr)
 
-__version__ = '6.6.9'
+
+__version__ = pkg_resources.get_distribution('sopel').version
 
 
 def _version_info(version=__version__):


### PR DESCRIPTION
Did you know it's not safe to `import sopel` in `setup.py`? It's because when you do  `pip install sopel`, what it does is:

* fetch `sopel-{version}.tgz` from PyPI
* un-tar and uncompress it
* run `python setup.py install` (more or less)

It means that, anything that is imported in `setup.py` must be available *before* the project is installed, meaning none of Sopel's requirements are available at this very moment. Which is not ideal!

On the other side, how do you get Sopel's version once it's installed? Or even before? This is what we want (Python 3.5.2):

```console
$ python setup.py --version
6.6.5
$ python sopel.py --version
Sopel 6.6.5 (running on Python 3.5.2)
https://sopel.chat/
```

and with Python 2.7:

```console
$ python setup.py --version
Warning: Python 2.x is near end of life. Sopel support at that point is TBD.
6.6.5
$ python sopel.py --version
Warning: Python 2.x is near end of life. Sopel support at that point is TBD.
Sopel 6.6.5 (running on Python 2.7.12)
https://sopel.chat/
```

For that to work, we need:

* setuptools 30.3 or above
* an updated `setup.cfg` file

The trick is here, in `sopel/__init__.py`:

```
import pkg_resources

__version__ = pkg_resources.get_distribution('sopel').version
```

```