### PR TITLE
ip: fix tests (again)

### DIFF
--- a/sopel/modules/ip.py
+++ b/sopel/modules/ip.py
@@ -99,7 +99,7 @@ def _find_geoip_db(bot):
 
 @commands('iplookup', 'ip')
 @example('.ip 8.8.8.8',
-         r'[IP/Host Lookup] Hostname: google-public-dns-a.google.com | Location: United States | ISP: AS15169 Google LLC',
+         r'\[IP\/Host Lookup\] Hostname: \S*dns\S*\.google\S* \| Location: United States \| ISP: AS15169 Google LLC',
          re=True,
          ignore='Downloading GeoIP database, please wait...')
 def ip(bot, trigger):


### PR DESCRIPTION
`dns.google` is quite a catchy name, but our tests were failing because of this sudden (not that I know where they would announce it) change.

On the plus side, we now have robust tests that should correctly handle both the old and new hostnames, and probably most potential future changes as well. And they're *actually* using regex syntax, unlike before with the unescaped brackets and pipes.