### PR TITLE
db: add methods to delete a channel or nick's key from database

### DIFF
--- a/sopel/db.py
+++ b/sopel/db.py
@@ -247,6 +247,26 @@ class SopelDB(object):
         finally:
             session.close()
 
+    def delete_nick_value(self, nick, key):
+        """Deletes the value for a given key associated with a nick."""
+        nick = Identifier(nick)
+        nick_id = self.get_nick_id(nick)
+        session = self.ssession()
+        try:
+            result = session.query(NickValues) \
+                .filter(NickValues.nick_id == nick_id) \
+                .filter(NickValues.key == key) \
+                .one_or_none()
+            # NickValue exists, delete
+            if result:
+                session.delete(result)
+                session.commit()
+        except SQLAlchemyError:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
     def get_nick_value(self, nick, key):
         """Retrieves the value for a given key associated with a nick."""
         nick = Identifier(nick)
@@ -360,6 +380,25 @@ class SopelDB(object):
             else:
                 new_channelvalue = ChannelValues(channel=channel, key=key, value=value)
                 session.add(new_channelvalue)
+                session.commit()
+        except SQLAlchemyError:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    def delete_channel_value(self, channel, key):
+        """Deletes the value for a given key associated with a channel."""
+        channel = Identifier(channel).lower()
+        session = self.ssession()
+        try:
+            result = session.query(ChannelValues) \
+                .filter(ChannelValues.channel == channel)\
+                .filter(ChannelValues.key == key) \
+                .one_or_none()
+            # ChannelValue exists, delete
+            if result:
+                session.delete(result)
                 session.commit()
         except SQLAlchemyError:
             session.rollback()

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -151,6 +151,14 @@ def test_get_nick_value(db):
         assert found_value == value
 
 
+def test_delete_nick_value(db):
+    nick = 'Embolalia'
+    db.set_nick_value(nick, 'wasd', 'uldr')
+    assert db.get_nick_value(nick, 'wasd') == 'uldr'
+    db.delete_nick_value(nick, 'wasd')
+    assert db.get_nick_value(nick, 'wasd') is None
+
+
 def test_unalias_nick(db):
     conn = sqlite3.connect(db_filename)
     nick = 'Embolalia'
@@ -230,6 +238,13 @@ def test_set_channel_value(db):
         'SELECT value FROM channel_values WHERE channel = ? and key = ?',
         ['#asdf', 'qwer']).fetchone()[0]
     assert result == '"zxcv"'
+
+
+def test_delete_channel_value(db):
+    db.set_channel_value('#asdf', 'wasd', 'uldr')
+    assert db.get_channel_value('#asdf', 'wasd') == 'uldr'
+    db.delete_channel_value('#asdf', 'wasd')
+    assert db.get_channel_value('#asdf', 'wasd') is None
 
 
 def test_get_channel_value(db):


### PR DESCRIPTION
These are functions I've had for my bot for a long time,

* reset - sets a value to None
* adjust - allows math adjustments to existing values

Reset can likely use a better method like `DELETE FROM` instead of replacing values with None.

Adjust is something I've been using for a long time now to retrieve a current value and add a positive or negative number to it. Handy for modules that need to update stat counters.