### PR TITLE
core: fix broken interrupt handling

### DIFF
--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -67,7 +67,11 @@ def run(config, pid_file, daemon=False):
             tools.stderr('Got restart signal.')
             p.restart('Restarting')
 
+    # Define empty variable `p` for bot
+    p = None
     while True:
+        if p and p.hasquit:  # Check if `hasquit` was set for bot during disconnected phase
+            break
         try:
             p = bot.Sopel(config, daemon=daemon)
             if hasattr(signal, 'SIGUSR1'):


### PR DESCRIPTION
@dgw did a good job describing the issue in #1478, so I refer the reviewer there for the details.

The fixes provided here use simple checks to ensure 1) that a socket is present before attempting to send a `QUIT` message, and 2) a `hasquit` flag was not set on a bot instance during a disconnected phase.

Generally, in both cases, the issue was the signal setting the `hasquit` flag too late, and allowing a new `while` loop to begin. The bot would still have the `hasquit` flag set, but this would not be caught until a new `Exception`/`signal`. 