### PR TITLE
core: perform commands on connect

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -223,7 +223,47 @@ policy.
    options have been added: ``flood_burst_lines``, ``flood_empty_wait``, and
    ``flood_refill_rate``.
 
+Perform commands on connect
+---------------------------
 
+The bot can be configured to send custom commands upon successful connection to
+the IRC server. This can be used in situations where the bot's built-in
+capabilities are not sufficient, or further automation is desired. The list of
+commands to send is set with :attr:`~CoreSection.commands_on_connect`.
+
+For example, the following configuration:
+
+.. code-block:: ini
+
+    [core]
+    commands_on_connect = PRIVMSG X@Channels.undernet.org :LOGIN MyUserName A$_Strong\,*pasSWord,PRIVMSG IDLEBOT :login IdleUsername idLEPasswoRD
+
+
+will, upon connection:
+    
+    1) identify to Undernet services
+    2) login with ``IDLEBOT``
+
+.. important::
+
+    Commas are used to delimit separate commands, so any comma found within a
+    command must be escaped with ``\``. In the example above, the password
+    ``A$_Strong,*pasSWord`` is escaped as ``A$_Strong\,pasSWord`` (note the
+    escaped comma in the middle of the password, but not immediately following,
+    which is delimiting the next command).
+
+    No other text needs to be escaped.
+
+.. 
+    TODO: update this note (and the example config) once #1628 is merged in,
+    changing the delimiter to newlines (from commas).
+
+.. seealso::
+    
+    This functionality is analogous to ZNC's ``perform`` module:
+    https://wiki.znc.in/Perform
+    
+    
 Authentication
 ==============
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -228,21 +228,25 @@ Perform commands on connect
 
 The bot can be configured to send custom commands upon successful connection to
 the IRC server. This can be used in situations where the bot's built-in
-capabilities are not sufficient, or further automation is desired. The list of
-commands to send is set with :attr:`~CoreSection.commands_on_connect`.
+capabilities are not sufficient, or further automation is desired.
+``$nickname`` can be used in a command as a placeholder, and it will be
+replaced with the bot's nickname, as specified in the configuration
+(:attr:`~CoreSection.nick`). 
 
-For example, the following configuration:
+The list of commands to send is set with
+:attr:`~CoreSection.commands_on_connect`. For example, the following
+configuration:
 
 .. code-block:: ini
 
     [core]
-    commands_on_connect = PRIVMSG X@Channels.undernet.org :LOGIN MyUserName A$_Strong\,*pasSWord,PRIVMSG IDLEBOT :login IdleUsername idLEPasswoRD
+    commands_on_connect = PRIVMSG X@Channels.undernet.org :LOGIN MyUserName A$_Strong\,*pasSWord,PRIVMSG IDLEBOT :login $nickname idLEPasswoRD
 
 
 will, upon connection:
     
-    1) identify to Undernet services
-    2) login with ``IDLEBOT``
+    1) identify to Undernet services (``PRIVMSG X@Channels...``)
+    2) login with ``IDLEBOT`` using the bot's nickname (``PRIVMSG IDLEBOT ...``)
 
 .. important::
 

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -231,43 +231,28 @@ the IRC server. This can be used in situations where the bot's built-in
 capabilities are not sufficient, or further automation is desired.
 ``$nickname`` can be used in a command as a placeholder, and it will be
 replaced with the bot's nickname, as specified in the configuration
-(:attr:`~CoreSection.nick`). 
+(:attr:`~CoreSection.nick`).
 
 The list of commands to send is set with
 :attr:`~CoreSection.commands_on_connect`. For example, the following
-configuration:
-
-.. code-block:: ini
+configuration::
 
     [core]
-    commands_on_connect = PRIVMSG X@Channels.undernet.org :LOGIN MyUserName A$_Strong\,*pasSWord,PRIVMSG IDLEBOT :login $nickname idLEPasswoRD
-
+    commands_on_connect =
+        PRIVMSG X@Channels.undernet.org :LOGIN MyUserName A$_Strong,*pasSWord
+        PRIVMSG IDLEBOT :login $nickname idLEPasswoRD
 
 will, upon connection:
-    
-    1) identify to Undernet services (``PRIVMSG X@Channels...``)
-    2) login with ``IDLEBOT`` using the bot's nickname (``PRIVMSG IDLEBOT ...``)
 
-.. important::
-
-    Commas are used to delimit separate commands, so any comma found within a
-    command must be escaped with ``\``. In the example above, the password
-    ``A$_Strong,*pasSWord`` is escaped as ``A$_Strong\,pasSWord`` (note the
-    escaped comma in the middle of the password, but not immediately following,
-    which is delimiting the next command).
-
-    No other text needs to be escaped.
-
-.. 
-    TODO: update this note (and the example config) once #1628 is merged in,
-    changing the delimiter to newlines (from commas).
+1) identify to Undernet services (``PRIVMSG X@Channels...``)
+2) login with ``IDLEBOT`` using the bot's nickname (``PRIVMSG IDLEBOT ...``)
 
 .. seealso::
-    
-    This functionality is analogous to ZNC's ``perform`` module:
-    https://wiki.znc.in/Perform
-    
-    
+
+   This functionality is analogous to ZNC's ``perform`` module:
+   https://wiki.znc.in/Perform
+
+
 Authentication
 ==============
 

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -49,6 +49,10 @@ def configure(config):
         'channels',
         'Enter the channels to connect to at startup, separated by commas.'
     )
+    config.core.configure_setting(
+        'commands_on_connect',
+        'Enter commands to perform on successful connection to server (one per \'?\' prompt).'
+    )
 
 
 class CoreSection(StaticSection):
@@ -346,6 +350,19 @@ class CoreSection(StaticSection):
     This should only be set on networks which support IRCv3 account
     capabilities.
     """
+
+    commands_on_connect = ListAttribute('commands_on_connect')
+    r"""A list of commands to perform upon successful connection to IRC server.
+
+    When entered using the config wizard, commas will be escaped automatically.
+    Otherwise, commas must be escaped, e.g.: ``PRIVMSG Q@CServe.quakenet.org
+    :AUTH my_username MyPassword\,HasAComma@#$%!`` Nothing else needs to be
+    escaped.
+
+    .. versionadded:: 7.0
+    """
+    # TODO: update the docstring above in/after #1628 removes commas as
+    # delimiters for `ListAttribute`s.
 
     pid_dir = FilenameAttribute('pid_dir', directory=True, default='.')
     """The directory in which to put the file Sopel uses to track its process ID.

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -359,6 +359,9 @@ class CoreSection(StaticSection):
     :AUTH my_username MyPassword\,HasAComma@#$%!`` Nothing else needs to be
     escaped.
 
+    ``$nickname`` can be used in a command as a placeholder, and it will be
+    replaced with the bot's :attr:`~CoreSection.nick`; e.g., ``MODE $nickname +Xxw``.
+
     .. versionadded:: 7.0
     """
     # TODO: update the docstring above in/after #1628 removes commas as

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -352,20 +352,21 @@ class CoreSection(StaticSection):
     """
 
     commands_on_connect = ListAttribute('commands_on_connect')
-    r"""A list of commands to perform upon successful connection to IRC server.
+    """A list of commands to perform upon successful connection to IRC server.
 
-    When entered using the config wizard, commas will be escaped automatically.
-    Otherwise, commas must be escaped, e.g.: ``PRIVMSG Q@CServe.quakenet.org
-    :AUTH my_username MyPassword\,HasAComma@#$%!`` Nothing else needs to be
-    escaped.
+    Each line is a message that will be sent to the server once connected.
+    Example::
+
+        PRIVMSG Q@CServe.quakenet.org :AUTH my_username MyPassword,@#$%!
+        PRIVMSG MyOwner :I'm here!
 
     ``$nickname`` can be used in a command as a placeholder, and it will be
-    replaced with the bot's :attr:`~CoreSection.nick`; e.g., ``MODE $nickname +Xxw``.
+    replaced with the bot's :attr:`~CoreSection.nick`. For example when the
+    nick is ``Sopel``, then this ``MODE $nickname +Xxw`` will become
+    ``MODE Sopel +Xxw``.
 
     .. versionadded:: 7.0
     """
-    # TODO: update the docstring above in/after #1628 removes commas as
-    # delimiters for `ListAttribute`s.
 
     pid_dir = FilenameAttribute('pid_dir', directory=True, default='.')
     """The directory in which to put the file Sopel uses to track its process ID.

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -62,7 +62,7 @@ def auth_after_register(bot):
                 auth_target or 'UserServ')
 
 
-def execute_perform(bot):
+def _execute_perform(bot):
     """Execute commands specified to perform on IRC server connect."""
     if not bot.connection_registered:
         # How did you even get this command, bot?
@@ -78,9 +78,9 @@ def execute_perform(bot):
 @sopel.module.require_privmsg("This command only works as a private message.")
 @sopel.module.require_admin("This command requires admin privileges.")
 @sopel.module.commands('execute')
-def _execute_perform(bot, trigger):
+def execute_perform(bot, trigger):
     """Execute commands specified to perform on IRC server connect."""
-    execute_perform(bot)
+    _execute_perform(bot)
 
 
 @sopel.module.event(events.RPL_WELCOME, events.RPL_LUSERCLIENT)
@@ -132,7 +132,7 @@ def startup(bot, trigger):
         ).format(bot.config.core.help_prefix)
         bot.say(msg, bot.config.core.owner)
 
-    execute_perform(bot)
+    _execute_perform(bot)
 
 
 @sopel.module.require_privmsg()

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -70,6 +70,7 @@ def execute_perform(bot):
 
     LOGGER.debug('{} commands to execute:'.format(len(bot.config.core.commands_on_connect)))
     for i, command in enumerate(bot.config.core.commands_on_connect):
+        command = command.replace('$nickname', bot.config.core.nick)
         LOGGER.debug(command)
         bot.write((command,))
 

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -62,6 +62,26 @@ def auth_after_register(bot):
                 auth_target or 'UserServ')
 
 
+def execute_perform(bot):
+    """Execute commands specified to perform on IRC server connect."""
+    if not bot.connection_registered:
+        # How did you even get this command, bot?
+        raise Exception('Bot must be connected to server to perform commands.')
+
+    LOGGER.debug('{} commands to execute:'.format(len(bot.config.core.commands_on_connect)))
+    for i, command in enumerate(bot.config.core.commands_on_connect):
+        LOGGER.debug(command)
+        bot.write((command,))
+
+
+@sopel.module.require_privmsg("This command only works as a private message.")
+@sopel.module.require_admin("This command requires admin privileges.")
+@sopel.module.commands('execute')
+def _execute_perform(bot, trigger):
+    """Execute commands specified to perform on IRC server connect."""
+    execute_perform(bot)
+
+
 @sopel.module.event(events.RPL_WELCOME, events.RPL_LUSERCLIENT)
 @sopel.module.thread(False)
 @sopel.module.unblockable
@@ -110,6 +130,8 @@ def startup(bot, trigger):
             "and reply with \"{}useserviceauth\""
         ).format(bot.config.core.help_prefix)
         bot.say(msg, bot.config.core.owner)
+
+    execute_perform(bot)
 
 
 @sopel.module.require_privmsg()

--- a/test/test_coretasks.py
+++ b/test/test_coretasks.py
@@ -136,3 +136,15 @@ def test_execute_perform_send_commands(mockbot):
 
     coretasks.execute_perform(mockbot)
     assert mockbot.backend.message_sent == rawlist(*commands)
+
+
+def test_execute_perform_replaces_nickname(mockbot):
+    """Confirm that bot replaces ``$nickname`` placeholder in commands."""
+    command = 'MODE $nickname +Xxw'
+    sent_command = 'MODE {} +Xxw'.format(mockbot.config.core.nick)
+
+    mockbot.config.core.commands_on_connect = [command, ]
+    mockbot.connection_registered = True  # For testing, simulate connected
+
+    coretasks.execute_perform(mockbot)
+    assert mockbot.backend.message_sent == rawlist(sent_command)

--- a/test/test_coretasks.py
+++ b/test/test_coretasks.py
@@ -117,7 +117,7 @@ def test_mode_colon(mockbot, ircfactory):
 def test_execute_perform_raise_not_connected(mockbot):
     """Ensure bot will not execute ``commands_on_connect`` unless connected."""
     with pytest.raises(Exception):
-        coretasks.execute_perform(mockbot)
+        coretasks._execute_perform(mockbot)
 
 
 def test_execute_perform_send_commands(mockbot):
@@ -134,7 +134,7 @@ def test_execute_perform_send_commands(mockbot):
     mockbot.config.core.commands_on_connect = commands
     mockbot.connection_registered = True
 
-    coretasks.execute_perform(mockbot)
+    coretasks._execute_perform(mockbot)
     assert mockbot.backend.message_sent == rawlist(*commands)
 
 
@@ -146,5 +146,5 @@ def test_execute_perform_replaces_nickname(mockbot):
     mockbot.config.core.commands_on_connect = [command, ]
     mockbot.connection_registered = True  # For testing, simulate connected
 
-    coretasks.execute_perform(mockbot)
+    coretasks._execute_perform(mockbot)
     assert mockbot.backend.message_sent == rawlist(sent_command)

--- a/test/test_coretasks.py
+++ b/test/test_coretasks.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 
 import pytest
 
+from sopel import coretasks
 from sopel.module import VOICE, HALFOP, OP, ADMIN, OWNER
 from sopel.tools import Identifier
 from sopel.tests import rawlist
@@ -111,3 +112,27 @@ def test_mode_colon(mockbot, ircfactory):
 
     assert mockbot.channels["#test"].privileges[Identifier("Uvoice")] == VOICE
     assert mockbot.channels["#test"].privileges[Identifier("Uadmin")] == ADMIN
+
+
+def test_execute_perform_raise_not_connected(mockbot):
+    """Ensure bot will not execute ``commands_on_connect`` unless connected."""
+    with pytest.raises(Exception):
+        coretasks.execute_perform(mockbot)
+
+
+def test_execute_perform_send_commands(mockbot):
+    """Ensure bot sends ``commands_on_connect`` as specified in config."""
+    commands = [
+        # Example command for identifying to services on Undernet
+        'PRIVMSG X@Channels.undernet.org :LOGIN my_username my_password',
+        # Set modes on connect
+        'MODE some_nick +Xx',
+        # Oper on connect
+        'OPER oper_username oper_password',
+    ]
+
+    mockbot.config.core.commands_on_connect = commands
+    mockbot.connection_registered = True
+
+    coretasks.execute_perform(mockbot)
+    assert mockbot.backend.message_sent == rawlist(*commands)


### PR DESCRIPTION
This PR is meant to address #1455. It adds a `core` setting that is a `ListAttribute` of commands to perform upon successful connection with the IRC server. These commands are executed at the end of the `startup` sequence (set `MODE`s, `JOIN` channels, and now, _perform_ commands).

It depends on #1460.

**Example setting**
```
perform_commands = NICKSERV identify testbot ThisIsMy\,complexP@$sW0RD!!,JOIN #testing,PRIVMSG #testing :I am here!!
```
`raw.log`, as expected:
```
...
>>1553928396.52 NICKSERV identify testbot ThisIsMy,complexP@$sW0RD!!
>>1553928396.53 JOIN #testing
>>1553928396.53 PRIVMSG #testing :I am here!!
<<1553928396.57 :testbot!sopel@pumba.local JOIN #testing * :Sopel: https://sopel.chat
>>1553928396.57 TOPIC #testing
>>1553928396.57 WHO #testing a%nuachtf,387
<<1553928396.57 :e9b9f479e8eb.example.net 353 testbot = #testing :@testbot
<<1553928396.57 :e9b9f479e8eb.example.net 366 testbot #testing :End of /NAMES list.
<<1553928396.57 :e9b9f479e8eb.example.net 331 testbot #testing :No topic is set.
<<1553928396.57 :e9b9f479e8eb.example.net 352 testbot #testing sopel pumba.local e9b9f479e8eb.example.net testbot H@ :0 Sopel:
https://sopel.chat
<<1553928396.57 :e9b9f479e8eb.example.org 315 testbot #testing :End of /WHO list.
<<1553928396.61 :NickServ!NickServ@services.int NOTICE testbot :You are now identified for testbot.
...
```
_Note_: 
- There is no space around commas delimiting commands 
- Only the comma of the password is escaped; all other characters do not need to be escaped.

**Why `[core]`?**
I had considered two alternatives to adding `perform_commands` directly into core:
1) Make `perform` its own module
  - _Pros_
    - Get its own config section
    - Easily add the `list`, `swap`, `add`, `del` commands from ZNC's perform as commands that the bot's admin can use
    - No need to modify the core bot
  - _Cons_
    - Would have to do something like: set `@interval` on a function that checks if `bot.connection_registered`; once connected, execute the commands; remove the `@interval` function from the job scheduler (from within the same function itself)
    - The above approach would go crazy on `.reload` without additional measures to track the execution status of commands
2) Introduce a signal/slot system to connect the _successful startup_ event (basically represented by the `startup` function to perform actions)
  - _Pros_
    - Same as (1), except modifying the core bot part
 - _Cons_
    - Need to modify the core bot to add signals
    - Don't even get me started on `.reload` :boom:... it's bad enough register/unregistering commands
    - I imagine something like this will be in the works soon anyway :smile: :crossed_fingers:, so have a dedicated PR for that, instead of this being introduced as a by-product of this PR.


**Plans**
I hope a solution like (2) can be achieved at some point. With all the changes to the module loading interface coming along, I think it would be reasonable (and relatively simple) to migrate this to its own module.