### PR TITLE
fix: regression in testing individual modules

### DIFF
--- a/sopel/modules/ipython.py
+++ b/sopel/modules/ipython.py
@@ -9,6 +9,7 @@ Sopel: https://sopel.chat/
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 import sopel
+import sopel.module
 import sys
 if sys.version_info.major >= 3:
     # Backup stderr/stdout wrappers

--- a/sopel/test_tools.py
+++ b/sopel/test_tools.py
@@ -22,6 +22,7 @@ except ImportError:
 import sopel.config
 import sopel.config.core_section
 import sopel.tools
+import sopel.tools.target
 import sopel.trigger
 
 


### PR DESCRIPTION
Any individual test of a Sopel module (either as `python a_module.py` or `pytest a_module.py`; even with full path), leads to this exception:
```
___________________________________________ test_example_rand_1 ___________________________________________
Traceback (most recent call last):                                                                         
  File "/home/sopel/pkgs/sopel/sopel/test_tools.py", line 113, in test                                     
    bot = MockSopel("NickName", admin=admin, owner=owner)                                                  
  File "/home/sopel/pkgs/sopel/sopel/test_tools.py", line 52, in __init__                                  
    self.channels[channel] = sopel.tools.target.Channel(channel)                                           
AttributeError: 'module' object has no attribute 'target'                                                  
```

Using `sopel.tools.target...` in `Sopel/test_tools.py` throws an error because
`sopel.tools` does not seem to be aware of `target`. I expect this is
because `target.py` requires a class from `sopel.tools` and this would
lead to circular imports. Need to `import sopel.tools.target`
separately to avoid this.

`pytest` tests work fine because it knows of `sopel.tools.target` by
that name already from traversing the `rootdir`.