### PR TITLE
Running instance check

### DIFF
--- a/sopel/run_script.py
+++ b/sopel/run_script.py
@@ -168,21 +168,22 @@ def main(argv=None):
                 except ValueError:
                     old_pid = None
             if old_pid is not None and tools.check_pid(old_pid):
-                if not opts.quit and not opts.kill:
-                    stderr('There\'s already a Sopel instance running with this config file')
-                    stderr('Try using the --quit or the --kill options')
-                    sys.exit(1)
-                elif opts.kill:
-                    stderr('Killing the sopel')
-                    os.kill(old_pid, signal.SIGKILL)
-                    sys.exit(0)
-                elif opts.quit:
-                    stderr('Signaling Sopel to stop gracefully')
-                    if hasattr(signal, 'SIGUSR1'):
-                        os.kill(old_pid, signal.SIGUSR1)
-                    else:
-                        os.kill(old_pid, signal.SIGTERM)
-                    sys.exit(0)
+                if os.getpid() != old_pid:
+                    if not opts.quit and not opts.kill:
+                        stderr('There\'s already a Sopel instance running with this config file')
+                        stderr('Try using the --quit or the --kill options')
+                        sys.exit(1)
+                    elif opts.kill:
+                        stderr('Killing the sopel')
+                        os.kill(old_pid, signal.SIGKILL)
+                        sys.exit(0)
+                    elif opts.quit:
+                        stderr('Signaling Sopel to stop gracefully')
+                        if hasattr(signal, 'SIGUSR1'):
+                            os.kill(old_pid, signal.SIGUSR1)
+                        else:
+                            os.kill(old_pid, signal.SIGTERM)
+                        sys.exit(0)
             elif opts.kill or opts.quit:
                 stderr('Sopel is not running!')
                 sys.exit(1)


### PR DESCRIPTION
Sopel keeps track of the current process ID in a file to be used to check if Sopel is already running an instance with the same configuration file. 

When running Sopel in Docker and when the container restarts it retains the filesystem and thus has still the file with the process ID. Due to Dockers nature it's likely that Sopel is going to be running with the same process ID as before and thus will fail the running instance check on itself. 

To mitigate this I've added a check to this system which checks first if the current process ID does not equal with the one in the file and then proceeds with the check. If it does equal it should just go ahead with running.