### PR TITLE
fix _store() so it accepts any named arguments

### DIFF
--- a/sopel/modules/ipython.py
+++ b/sopel/modules/ipython.py
@@ -9,6 +9,7 @@ Sopel: https://sopel.chat/
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 import sopel
+import sopel.module
 import sys
 if sys.version_info.major >= 3:
     # Backup stderr/stdout wrappers

--- a/sopel/test_tools.py
+++ b/sopel/test_tools.py
@@ -22,6 +22,7 @@ except ImportError:
 import sopel.config
 import sopel.config.core_section
 import sopel.tools
+import sopel.tools.target
 import sopel.trigger
 
 


### PR DESCRIPTION
When running a testsuite where the bot.say, reply or action function has any other than the defined arguments set, for example max_arguments, it will fail. With this change it should accept any named arguments. 

Would be nice if this could also be done for the 6.6.x branch.

```
TypeError: _store() got an unexpected keyword argument 'max_messages'    
```