### PR TITLE
fix _store() so it accepts any named arguments

### DIFF
--- a/sopel/test_tools.py
+++ b/sopel/test_tools.py
@@ -82,7 +82,7 @@ class MockSopelWrapper(object):
         self.pretrigger = pretrigger
         self.output = []
 
-    def _store(self, string, recipent=None):
+    def _store(self, string, recipent=None, **kwargs):
         self.output.append(string.strip())
 
     say = reply = action = _store


### PR DESCRIPTION
New PR as I absolutely messed up the original one..

When running a testsuite where the bot.say, reply or action function has any other than the defined arguments set, for example max_arguments, it will fail. With this change it should accept any named arguments.

Would be nice if this could also be done for the 6.6.x branch.

```
TypeError: _store() got an unexpected keyword argument 'max_messages'    
```