### PR TITLE
Provide a simpler way to kick users from channels.

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -485,6 +485,16 @@ class Sopel(irc.Bot):
         else:
             self.say(text, dest)
 
+    def kick(self, nick, channel, text=None):
+        """Send an IRC KICK command.
+        Within the context of a triggered callable, ``channel`` will default to the
+        channel in which the call was triggered. If triggered from a private message,
+        ``channel`` is required (or the call to ``kick()`` will be ignored).
+        The bot must be a channel operator in specified channel for this to work.
+        .. versionadded:: 7.0
+        """
+        self.write(['KICK', channel, nick], text)
+
     def call(self, func, sopel, trigger):
         nick = trigger.nick
         current_time = time.time()
@@ -887,3 +897,13 @@ class SopelWrapper(object):
         if reply_to is None:
             reply_to = self._trigger.nick
         self._bot.reply(message, destination, reply_to, notice)
+
+    def kick(self, nick, channel=None, message=None):
+        if channel is None:
+            if self._trigger.is_privmsg:
+                raise RuntimeError('Error: KICK requires a channel.')
+            else:
+                channel = self._trigger.sender
+        if nick is None:
+            raise RuntimeError('Error: KICK requires a nick.')
+        self._bot.kick(nick, channel, message)

--- a/sopel/modules/adminchannel.py
+++ b/sopel/modules/adminchannel.py
@@ -119,7 +119,7 @@ def kick(bot, trigger):
         reasonidx = 3
     reason = ' '.join(text[reasonidx:])
     if nick != bot.config.core.nick:
-        bot.write(['KICK', channel, nick], reason)
+        bot.kick(nick, channel, reason)
 
 
 def configureHostMask(mask):
@@ -290,7 +290,7 @@ def kickban(bot, trigger):
     if mask == '':
         return
     bot.write(['MODE', channel, '+b', mask])
-    bot.write(['KICK', channel, nick], reason)
+    bot.kick(nick, channel, reason)
 
 
 @require_chanmsg

--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -74,8 +74,8 @@ def rpost_info(bot, trigger, match):
             sfw = bot.db.get_channel_value(trigger.sender, 'sfw')
             if sfw:
                 link = '(link hidden)'
-                bot.write(['KICK', trigger.sender, trigger.nick,
-                           'Linking to NSFW content in a SFW channel.'])
+                bot.kick(trigger.nick, trigger.sender,
+                     'Linking to NSFW content in a SFW channel.')
         else:
             nsfw = ''
 

--- a/sopel/modules/safety.py
+++ b/sopel/modules/safety.py
@@ -183,8 +183,7 @@ def url_handler(bot, trigger):
         msg += '(confidence %s - %s/%s)' % (confidence, positives, total)
         bot.say('[' + bold(color('WARNING', 'red')) + '] ' + msg)
         if strict:
-            bot.write(['KICK', trigger.sender, trigger.nick,
-                       'Posted a malicious link'])
+            bot.kick(trigger.nick, trigger.sender, 'Posted a malicious link')
 
 
 @sopel.module.commands('safety')


### PR DESCRIPTION
this adds a `bot.kick(text, channel, nick)` ability to the bot, instead of using `bot.write(['KICK', channel, nick], text)`.

If the bot isn't OP, nothing happens (expected).