### PR TITLE
tests: make MockSopelWrapper subclass actual SopelWrapper class

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -376,47 +376,6 @@ class Sopel(irc.Bot):
         else:
             self.say(text, dest)
 
-    class SopelWrapper(object):
-        def __init__(self, sopel, trigger):
-            # The custom __setattr__ for this class sets the attribute on the
-            # original bot object. We don't want that for these, so we set them
-            # with the normal __setattr__.
-            object.__setattr__(self, '_bot', sopel)
-            object.__setattr__(self, '_trigger', trigger)
-
-        def __dir__(self):
-            classattrs = [attr for attr in self.__class__.__dict__
-                          if not attr.startswith('__')]
-            return list(self.__dict__) + classattrs + dir(self._bot)
-
-        def __getattr__(self, attr):
-            return getattr(self._bot, attr)
-
-        def __setattr__(self, attr, value):
-            return setattr(self._bot, attr, value)
-
-        def say(self, message, destination=None, max_messages=1):
-            if destination is None:
-                destination = self._trigger.sender
-            self._bot.say(message, destination, max_messages)
-
-        def action(self, message, destination=None):
-            if destination is None:
-                destination = self._trigger.sender
-            self._bot.action(message, destination)
-
-        def notice(self, message, destination=None):
-            if destination is None:
-                destination = self._trigger.sender
-            self._bot.notice(message, destination)
-
-        def reply(self, message, destination=None, reply_to=None, notice=False):
-            if destination is None:
-                destination = self._trigger.sender
-            if reply_to is None:
-                reply_to = self._trigger.nick
-            self._bot.reply(message, destination, reply_to, notice)
-
     def call(self, func, sopel, trigger):
         nick = trigger.nick
         current_time = time.time()
@@ -493,7 +452,7 @@ class Sopel(irc.Bot):
                 user_obj = self.users.get(pretrigger.nick)
                 account = user_obj.account if user_obj else None
                 trigger = Trigger(self.config, pretrigger, match, account)
-                wrapper = self.SopelWrapper(self, trigger)
+                wrapper = SopelWrapper(self, trigger)
 
                 for func in funcs:
                     if (not trigger.admin and
@@ -742,3 +701,45 @@ class Sopel(irc.Bot):
             match = regex.search(url)
             if match:
                 yield function, match
+
+
+class SopelWrapper(object):
+        def __init__(self, sopel, trigger):
+            # The custom __setattr__ for this class sets the attribute on the
+            # original bot object. We don't want that for these, so we set them
+            # with the normal __setattr__.
+            object.__setattr__(self, '_bot', sopel)
+            object.__setattr__(self, '_trigger', trigger)
+
+        def __dir__(self):
+            classattrs = [attr for attr in self.__class__.__dict__
+                          if not attr.startswith('__')]
+            return list(self.__dict__) + classattrs + dir(self._bot)
+
+        def __getattr__(self, attr):
+            return getattr(self._bot, attr)
+
+        def __setattr__(self, attr, value):
+            return setattr(self._bot, attr, value)
+
+        def say(self, message, destination=None, max_messages=1):
+            if destination is None:
+                destination = self._trigger.sender
+            self._bot.say(message, destination, max_messages)
+
+        def action(self, message, destination=None):
+            if destination is None:
+                destination = self._trigger.sender
+            self._bot.action(message, destination)
+
+        def notice(self, message, destination=None):
+            if destination is None:
+                destination = self._trigger.sender
+            self._bot.notice(message, destination)
+
+        def reply(self, message, destination=None, reply_to=None, notice=False):
+            if destination is None:
+                destination = self._trigger.sender
+            if reply_to is None:
+                reply_to = self._trigger.nick
+            self._bot.reply(message, destination, reply_to, notice)

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -9,7 +9,6 @@
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 import re
-import sopel.test_tools
 import functools
 
 NOLIMIT = 1
@@ -471,6 +470,8 @@ class example(object):
             func.example = []
 
         import sys
+
+        import sopel.test_tools  # TODO: fix circular import with sopel.bot and sopel.test_tools
 
         # only inject test-related stuff if we're running tests
         # see https://stackoverflow.com/a/44595269/5991

--- a/sopel/test_tools.py
+++ b/sopel/test_tools.py
@@ -66,10 +66,17 @@ class MockSopel(object):
         self.config = MockConfig()
         self._init_config()
 
+        self.output = []
+
         if admin:
             self.config.core.admins = [self.nick]
         if owner:
             self.config.core.owner = self.nick
+
+    def _store(self, string, *args, **kwargs):
+        self.output.append(string.strip())
+
+    write = msg = say = notice = action = reply = _store
 
     def _init_config(self):
         cfg = self.config

--- a/sopel/test_tools.py
+++ b/sopel/test_tools.py
@@ -19,6 +19,7 @@ try:
 except ImportError:
     import configparser as ConfigParser
 
+from sopel.bot import SopelWrapper
 import sopel.config
 import sopel.config.core_section
 import sopel.tools
@@ -101,19 +102,8 @@ class MockSopel(object):
                 yield function, match
 
 
-class MockSopelWrapper(object):
-    def __init__(self, bot, pretrigger):
-        self.bot = bot
-        self.pretrigger = pretrigger
-        self.output = []
-
-    def _store(self, string, recipent=None):
-        self.output.append(string.strip())
-
-    say = reply = action = _store
-
-    def __getattr__(self, attr):
-        return getattr(self.bot, attr)
+class MockSopelWrapper(SopelWrapper):
+    pass
 
 
 def get_example_test(tested_func, msg, results, privmsg, admin,

--- a/sopel/test_tools.py
+++ b/sopel/test_tools.py
@@ -163,11 +163,13 @@ def get_example_test(tested_func, msg, results, privmsg, admin,
                     return False
             return True
 
+        expected_output_count = 0
         for _i in range(repeat):
+            expected_output_count += len(results)
             wrapper = MockSopelWrapper(bot, trigger)
             tested_func(wrapper, trigger)
             wrapper.output = list(filter(isnt_ignored, wrapper.output))
-            assert len(wrapper.output) == len(results)
+            assert len(wrapper.output) == expected_output_count
             for result, output in zip(results, wrapper.output):
                 if type(output) is bytes:
                     output = output.decode('utf-8')


### PR DESCRIPTION
Despite notes like this: https://github.com/sopel-irc/sopel/blob/229f3bfacaf393f331bf79569783f23d88d05a03/sopel/bot.py#L270-L272
each outgoing method (`bot.msg`, `bot.say`, `bot.notice`, `bot.action`,
`bot.reply`) should be present in the mock as long as they are present
in the codebase such that they can be used in testing.


These "mocks" need to exist so that more tests can be written (e.g., #1540) that use _actual_ mockers (`e.g., pytest-mock`).


