### PR TITLE
coretasks: fix malformed MODE command in startup()

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -89,7 +89,7 @@ def startup(bot, trigger):
     auth_after_register(bot)
 
     modes = bot.config.core.modes
-    bot.write(('MODE ', '%s +%s' % (bot.nick, modes)))
+    bot.write(('MODE', '%s +%s' % (bot.nick, modes)))
 
     bot.memory['retry_join'] = dict()
 


### PR DESCRIPTION
`bot.write()` joins the elements of a sequence type (tuple, here) with a space already, so including a space in `'MODE '` caused Sopel to send <code>MODE &nbsp;SopelsNick +modes</code>. Technically, that's invalid.

Discovered while trying to test #1470 on a network with actual support for `echo-message`, when darwin.network disconnected the bot during registration with the message "ERROR :Received malformed line". Annoying because I was trying to test something else, but useful in the end.