### PR TITLE
logging: use config's basename in log filenames

### DIFF
--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -82,7 +82,7 @@ def run(settings, pid_file, daemon=False):
                 tools.stderr(trace)
             except Exception:  # TODO: Be specific
                 pass
-            logfile = open(os.path.join(settings.core.logdir, 'exceptions.log'), 'a')
+            logfile = open(os.path.join(settings.core.logdir, settings.basename + '.exceptions.log'), 'a')
             logfile.write('Critical exception in core')
             logfile.write(trace)
             logfile.write('----------------------------------------\n\n')

--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -279,6 +279,6 @@ def redirect_outputs(settings, is_quiet=False):
 
     Both ``sys.stderr`` and ``sys.stdout`` are redirected to a logfile.
     """
-    logfile = os.path.os.path.join(settings.core.logdir, 'stdio.log')
+    logfile = os.path.os.path.join(settings.core.logdir, settings.basename + '.stdio.log')
     sys.stderr = tools.OutputRedirect(logfile, True, is_quiet)
     sys.stdout = tools.OutputRedirect(logfile, False, is_quiet)

--- a/sopel/config/__init__.py
+++ b/sopel/config/__init__.py
@@ -67,6 +67,7 @@ class Config(object):
         config file, or a config file is not loaded. They are documented below.
         """
         self.filename = filename
+        self.basename = os.path.basename(filename).rsplit('.', 1)[0]
         """The config object's associated file, as noted above."""
         self.parser = ConfigParser.RawConfigParser(allow_no_value=True)
         self.parser.read(self.filename)

--- a/sopel/irc.py
+++ b/sopel/irc.py
@@ -102,7 +102,7 @@ class Bot(asynchat.async_chat):
                 stderr('%s %s' % (str(e.__class__), str(e)))
                 stderr('Please fix this and then run Sopel again.')
                 os._exit(1)
-        f = codecs.open(os.path.join(self.config.core.logdir, 'raw.log'),
+        f = codecs.open(os.path.join(self.config.core.logdir, self.config.basename + '.raw.log'),
                         'a', encoding='utf-8')
         f.write(prefix + unicode(time.time()) + "\t")
         temp = line.replace('\n', '')
@@ -441,7 +441,7 @@ class Bot(asynchat.async_chat):
 
                 signature = '%s (%s)' % (report[0], report[1])
                 # TODO: make not hardcoded
-                log_filename = os.path.join(self.config.core.logdir, 'exceptions.log')
+                log_filename = os.path.join(self.config.core.logdir, self.config.basename + '.exceptions.log')
                 with codecs.open(log_filename, 'a', encoding='utf-8') as logfile:
                     logfile.write('Signature: %s\n' % signature)
                     if trigger:
@@ -476,7 +476,7 @@ class Bot(asynchat.async_chat):
         LOGGER.error('Fatal error in core, please review exception log')
         # TODO: make not hardcoded
         logfile = codecs.open(
-            os.path.join(self.config.core.logdir, 'exceptions.log'),
+            os.path.join(self.config.core.logdir, self.config.basename + '.exceptions.log'),
             'a',
             encoding='utf-8'
         )


### PR DESCRIPTION
This is a fairly simple tweak to the way log files are named.

The use case is for people that run more than one Sopel bot, distinguishing exceptions and stdio log files would be a bit easier this way.