### PR TITLE
admin: .mode compliance with IRC specs

### DIFF
--- a/sopel/modules/admin.py
+++ b/sopel/modules/admin.py
@@ -164,7 +164,7 @@ def hold_ground(bot, trigger):
 def mode(bot, trigger):
     """Set a user mode on Sopel. Can only be done in privmsg by an admin."""
     mode = trigger.group(3)
-    bot.write(('MODE ', bot.nick + ' ' + mode))
+    bot.write(('MODE', bot.nick + ' ' + mode))
 
 
 @sopel.module.require_privmsg("This command only works as a private message.")


### PR DESCRIPTION
Just like #1544, but in the `admin.py` module instead of coretasks.

This was the only relevant occurrence I could find with a search for strings with trailing spaces. Hopefully after this, we're golden.