### PR TITLE
core: limit maximum flood penalty

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -313,7 +313,7 @@ class Sopel(irc.Bot):
                 elapsed = time.time() - self.stack[recipient_id][-1][0]
                 if elapsed < 3:
                     penalty = float(max(0, len(text) - 40)) / 70
-                    wait = 0.8 + penalty
+                    wait = min(0.8 + penalty, 2)  # Never wait more than 2 seconds
                     if elapsed < wait:
                         time.sleep(wait - elapsed)
 


### PR DESCRIPTION
The penalty for a message that trips flood protection scales directly with the message length and has no upper bound. As seen in #1550 and #1551, a 64bk message (which can apparently be returned during normal bot function) would incur a penalty of ~37 minutes between message sends.

I think the best option is to just cap the maximum wait time between messages. I followed the example of ZNC, which has a default of `1.00` seconds between messages that trip its flood protection.

This option is configurable under `[core]` with the `flood_trickle_rate` setting.

Fixes #1550 and fixes #1551