### PR TITLE
test: add an --offline option to pytest

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,2 +1,19 @@
+import pytest
+
 # This file lists files which should be ignored by pytest
 collect_ignore = ["setup.py", "sopel.py", "sopel/modules/ipython.py"]
+
+
+def pytest_addoption(parser):
+    parser.addoption('--offline', action='store_true', default=False)
+
+
+def pytest_collection_modifyitems(config, items):
+    if not config.getoption('--offline'):
+        # nothing to skip
+        return
+
+    skip_online = pytest.mark.skip(reason='deactivated when --offline is used')
+    for item in items:
+        if 'online' in item.keywords:
+            item.add_marker(skip_online)

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -549,9 +549,12 @@ class example(object):
         user_help:
             Whether this example should be displayed in user-facing help output
             such as `.help command`.
+        online:
+            If true, pytest will mark it as "online".
     """
     def __init__(self, msg, result=None, privmsg=False, admin=False,
-                 owner=False, repeat=1, re=False, ignore=None, user_help=False):
+                 owner=False, repeat=1, re=False, ignore=None,
+                 user_help=False, online=True):
         # Wrap result into a list for get_example_test
         if isinstance(result, list):
             self.result = result
@@ -565,6 +568,7 @@ class example(object):
         self.admin = admin
         self.owner = owner
         self.repeat = repeat
+        self.online = online
 
         if isinstance(ignore, list):
             self.ignore = ignore
@@ -580,6 +584,7 @@ class example(object):
             func.example = []
 
         import sys
+        import pytest
 
         import sopel.test_tools  # TODO: fix circular import with sopel.bot and sopel.test_tools
 
@@ -590,6 +595,10 @@ class example(object):
                 func, self.msg, self.result, self.privmsg, self.admin,
                 self.owner, self.repeat, self.use_re, self.ignore
             )
+
+            if self.online:
+                test = pytest.mark.online(test)
+
             sopel.test_tools.insert_into_module(
                 test, func.__module__, func.__name__, 'test_example'
             )

--- a/sopel/modules/calc.py
+++ b/sopel/modules/calc.py
@@ -55,7 +55,7 @@ def c(bot, trigger):
 
 
 @commands('py')
-@example('.py len([1,2,3])', '3')
+@example('.py len([1,2,3])', '3', online=True)
 def py(bot, trigger):
     """Evaluate a Python expression."""
     if not trigger.group(2):

--- a/sopel/modules/ip.py
+++ b/sopel/modules/ip.py
@@ -106,7 +106,8 @@ def _find_geoip_db(bot):
 @example('.ip 8.8.8.8',
          r'\[IP\/Host Lookup\] Hostname: \S*dns\S*\.google\S* \| Location: United States \| ISP: AS15169 Google LLC',
          re=True,
-         ignore='Downloading GeoIP database, please wait...')
+         ignore='Downloading GeoIP database, please wait...',
+         online=True)
 def ip(bot, trigger):
     """IP Lookup tool"""
     # Check if there is input at all

--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -99,9 +99,16 @@ def duck_api(query):
 
 @commands('duck', 'ddg', 'g')
 # test for bad Unicode handling in py2
-@example('.duck grandorder.wiki chulainn alter', 'https://grandorder.wiki/Cú_Chulainn_(Alter)')
+@example(
+    '.duck grandorder.wiki chulainn alter',
+    'https://grandorder.wiki/Cú_Chulainn_(Alter)',
+    online=True)
 # the last example (in source line order) is what .help displays
-@example('.duck sopel irc bot', r'https?:\/\/sopel\.chat\/?', re=True)
+@example(
+    '.duck sopel irc bot',
+    r'https?:\/\/sopel\.chat\/?',
+    re=True,
+    online=True)
 def duck(bot, trigger):
     """Queries DuckDuckGo for the specified input."""
     query = trigger.group(2)
@@ -167,9 +174,9 @@ def search(bot, trigger):
 
 
 @commands('suggest')
-@example('.suggest wikip', 'wikipedia')
-@example('.suggest ', 'No query term.')
-@example('.suggest lkashdfiauwgeaef', 'Sorry, no result.')
+@example('.suggest wikip', 'wikipedia', online=True)
+@example('.suggest ', 'No query term.', online=True)
+@example('.suggest lkashdfiauwgeaef', 'Sorry, no result.', online=True)
 def suggest(bot, trigger):
     """Suggests terms starting with given input"""
     if not trigger.group(2):

--- a/sopel/modules/translate.py
+++ b/sopel/modules/translate.py
@@ -106,9 +106,13 @@ def tr(bot, trigger):
 
 
 @commands('translate', 'tr')
-@example('.tr :en :fr my dog', '"mon chien" (en to fr, translate.google.com)')
-@example('.tr היי', '"Hey" (iw to en, translate.google.com)')
-@example('.tr mon chien', '"my dog" (fr to en, translate.google.com)')
+@example('.tr :en :fr my dog',
+         '"mon chien" (en to fr, translate.google.com)',
+         online=True)
+@example('.tr היי', '"Hey" (iw to en, translate.google.com)', online=True)
+@example('.tr mon chien',
+         '"my dog" (fr to en, translate.google.com)',
+         online=True)
 def tr2(bot, trigger):
     """Translates a phrase, with an optional language hint."""
     command = trigger.group(2)

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -99,7 +99,10 @@ def setup(bot):
 
 
 @module.commands('title')
-@module.example('.title https://www.google.com', '[ Google ] - www.google.com')
+@module.example(
+    '.title https://www.google.com',
+    '[ Google ] - www.google.com',
+    online=True)
 def title_command(bot, trigger):
     """
     Show the title or URL information for the given URL, or the last URL seen


### PR DESCRIPTION
Usage:

    $ py.test --offline

This option skip all tests that can not be run offline, as they are marked as "online". Either from manual tag:

    @pytest.mark.online
    def test_call_google():
        request.get('https://google.com')

Or from a command example:

    @example('.title http://google.com', '[ Google ] - google.com', online=True)
    def title_command(bot, trigger):
        # ...

This is especially useful for people like me who are always traveling and can't have access to a reliable Internet connection.

Existing online examples have been marked as such.