### PR TITLE
jobs: make JobScheduler easier to stop

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -553,10 +553,23 @@ class Sopel(irc.Bot):
         return False
 
     def _shutdown(self):
+        # Stop Job Scheduler
+        stderr('Stopping the Job Scheduler.')
+        self.scheduler.stop()
+
+        try:
+            self.scheduler.join(timeout=15)
+        except RuntimeError:
+            stderr('Unable to stop the Job Scheduler.')
+        else:
+            stderr('Job Scheduler stopped.')
+
+        self.scheduler.clear_jobs()
+
+        # Shutdown plugins
         stderr(
             'Calling shutdown for %d modules.' % (len(self.shutdown_methods),)
         )
-
         for shutdown_method in self.shutdown_methods:
             try:
                 stderr(

--- a/test/tools/test_tools_jobs.py
+++ b/test/tools/test_tools_jobs.py
@@ -1,0 +1,23 @@
+# coding=utf-8
+"""Tests for Job Scheduler"""
+from __future__ import unicode_literals, absolute_import, print_function, division
+
+import pytest
+
+from sopel import test_tools
+from sopel.tools import jobs
+
+
+@pytest.fixture
+def sopel():
+    bot = test_tools.MockSopel('Sopel')
+    bot.config.core.owner = 'Bar'
+    return bot
+
+
+def test_jobscheduler_stop(sopel):
+    scheduler = jobs.JobScheduler(sopel)
+    assert not scheduler.stopping.is_set(), 'Stopping must not be set at init'
+
+    scheduler.stop()
+    assert scheduler.stopping.is_set(), 'Stopping must have been set'

--- a/test/tools/test_tools_jobs.py
+++ b/test/tools/test_tools_jobs.py
@@ -2,6 +2,7 @@
 """Tests for Job Scheduler"""
 from __future__ import unicode_literals, absolute_import, print_function, division
 
+import datetime
 import time
 
 import pytest
@@ -31,3 +32,13 @@ def test_job_is_ready_to_run():
 
     assert job.is_ready_to_run(now + 20)
     assert not job.is_ready_to_run(now - 20)
+
+
+def test_job_string_representation():
+    timestamp = 523549800
+    job = jobs.Job(5, None)
+    job.next_time = timestamp
+    test_date = str(datetime.datetime.fromtimestamp(timestamp))
+    expected = '<Job(%s, 5s, None)>' % test_date
+
+    assert str(job) == expected

--- a/test/tools/test_tools_jobs.py
+++ b/test/tools/test_tools_jobs.py
@@ -2,6 +2,8 @@
 """Tests for Job Scheduler"""
 from __future__ import unicode_literals, absolute_import, print_function, division
 
+import time
+
 import pytest
 
 from sopel import test_tools
@@ -21,3 +23,11 @@ def test_jobscheduler_stop(sopel):
 
     scheduler.stop()
     assert scheduler.stopping.is_set(), 'Stopping must have been set'
+
+
+def test_job_is_ready_to_run():
+    now = time.time()
+    job = jobs.Job(5, None)
+
+    assert job.is_ready_to_run(now + 20)
+    assert not job.is_ready_to_run(now - 20)


### PR DESCRIPTION
Two main ideas:

* instead of a `while True` loop to run the scheduler, a `threading.Event` object is used: the scheduler run until this event is set
* instead of a custom `PriorityQueue`, a built-in list object is used to store job: every now and then, the scheduler will look for jobs that are ready to run, run them, and never modify its list, keeping everything thread-safe and simpler

It is kept thread-safe by using properly a `lock`, and it has the advantage of not having to release it or rely to heavily on `time.sleep()` - or at least, only for a second each loop.