### PR TITLE
core: fix interrupt during connection phase (before connection accepted)

### DIFF
--- a/sopel/irc.py
+++ b/sopel/irc.py
@@ -210,7 +210,8 @@ class Bot(asynchat.async_chat):
         # This will eventually call asyncore dispatchers close method, which
         # will release the main thread. This should be called last to avoid
         # race conditions.
-        self.close()
+        if self.socket:
+            self.close()
 
     def handle_connect(self):
         """


### PR DESCRIPTION
Before the connection is accepted (and the socket exists), <kbd>CTRL</kbd>+<kbd>C</kbd> will
start closing nicely, until `irc.Bot.handle_close`. `handle_close()`
tries to close the socket, even if it may not exist, which leads to a
messy exit.

All that is needed is a quick check to ensure a socket exists before
trying to close it.