### PR TITLE
style: replace deprecated `SopelMemory.contains()` with `in`

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -148,7 +148,7 @@ class Sopel(irc.Bot):
 
         Bot must be connected and in at least one channel.
         """
-        if not self.users or not self.users.contains(self.nick):
+        if not self.users or self.nick not in self.users:
             raise KeyError("'hostmask' not available: bot must be connected and in at least one channel.")
 
         return self.users.get(self.nick).hostmask
@@ -653,7 +653,7 @@ class Sopel(irc.Bot):
             This method replaces manual management of ``url_callbacks`` in
             Sopel's plugins, so instead of doing this in ``setup()``::
 
-                if not bot.memory.contains('url_callbacks'):
+                if 'url_callbacks' not in bot.memory:
                     bot.memory['url_callbacks'] = tools.SopelMemory()
 
                 regex = re.compile(r'http://example.com/path/.*')
@@ -665,7 +665,7 @@ class Sopel(irc.Bot):
                 bot.register_url_callback(regex, callback)
 
         """
-        if not self.memory.contains('url_callbacks'):
+        if 'url_callbacks' not in self.memory:
             self.memory['url_callbacks'] = tools.SopelMemory()
 
         if isinstance(pattern, basestring):
@@ -695,7 +695,7 @@ class Sopel(irc.Bot):
                 bot.unregister_url_callback(regex)
 
         """
-        if not self.memory.contains('url_callbacks'):
+        if 'url_callbacks' not in self.memory:
             # nothing to unregister
             return
 

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -81,7 +81,7 @@ def setup(bot):
     # callbacks list because 1, it's easier to deal with modules that are still
     # using this list, and not the newer callbacks list and 2, having a lambda
     # just to pass is kinda ugly.
-    if not bot.memory.contains('url_exclude'):
+    if 'url_exclude' not in bot.memory:
         bot.memory['url_exclude'] = regexes
     else:
         exclude = bot.memory['url_exclude']
@@ -90,11 +90,11 @@ def setup(bot):
         bot.memory['url_exclude'] = exclude
 
     # Ensure last_seen_url is in memory
-    if not bot.memory.contains('last_seen_url'):
+    if 'last_seen_url' not in bot.memory:
         bot.memory['last_seen_url'] = tools.SopelMemory()
 
     # Initialize shortened_urls as a dict if it doesn't exist.
-    if not bot.memory.contains('shortened_urls'):
+    if 'shortened_urls' not in bot.memory:
         bot.memory['shortened_urls'] = tools.SopelMemory()
 
 
@@ -279,7 +279,7 @@ def get_or_create_shorturl(bot, url):
     """
     # Check bot memory to see if the shortened URL is already in
     # memory
-    if bot.memory['shortened_urls'].contains(url):
+    if url in bot.memory['shortened_urls']:
         return bot.memory['shortened_urls'][url]
 
     tinyurl = get_tinyurl(url)


### PR DESCRIPTION
The title says it all!

The flood of deprecation warnings from `.contains()` was quite unpleasant.