### PR TITLE
tools: decrease deprecation warning output

### DIFF
--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -237,8 +237,7 @@ def deprecated(old):
     def new(*args, **kwargs):
         print('Function "%s" is deprecated.' % old.__name__, file=sys.stderr)
         trace = traceback.extract_stack()
-        for line in traceback.format_list(trace[:-1]):
-            stderr(line[:-1])
+        stderr(traceback.format_list(trace[:-1])[-1][:-1])  # Only display the last frame
         return old(*args, **kwargs)
     return new
 

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -235,7 +235,7 @@ def deprecated(old):
     """
     @functools.wraps(old)
     def new(*args, **kwargs):
-        print('Function %s is deprecated.' % old.__name__, file=sys.stderr)
+        print('Function "%s" is deprecated.' % old.__name__, file=sys.stderr)
         trace = traceback.extract_stack()
         for line in traceback.format_list(trace[:-1]):
             stderr(line[:-1])


### PR DESCRIPTION
Previously the deprecation warning message was too long!
```
Function contains is deprecated.                                             
  File "/usr/local/bin/debug-sopel.py", line 22, in <module>                 
    sys.exit(run_script.main())                                              
  File "/home/sopel/pkgs/sopel/sopel/cli/run.py", line 663, in main          
    return command(opts)                                                     
  File "/home/sopel/pkgs/sopel/sopel/cli/run.py", line 623, in command_legacy
    ret = run(config_module, pid_file_path)                                  
  File "/home/sopel/pkgs/sopel/sopel/cli/run.py", line 72, in run            
    p = bot.Sopel(config, daemon=daemon)                                     
  File "/home/sopel/pkgs/sopel/sopel/bot.py", line 143, in __init__          
    self.setup()                                                             
  File "/home/sopel/pkgs/sopel/sopel/bot.py", line 201, in setup             
    module.setup(self)                                                       
  File "/home/sopel/pkgs/sopel/sopel/modules/url.py", line 97, in setup      
    if not bot.memory.contains('shortened_urls'):                            
```

Only the last frame was really needed...
```
Function "contains" is deprecated.                                        
  File "/home/sopel/pkgs/sopel/sopel/modules/url.py", line 97, in setup 
    if not bot.memory.contains('shortened_urls'):                       
```

Also, I added the `"`s around the function in the message for clarity.