### PR TITLE
modules: always safely set up/clear memory

### DIFF
--- a/sopel/modules/find.py
+++ b/sopel/modules/find.py
@@ -20,7 +20,15 @@ from sopel.formatting import bold
 
 
 def setup(bot):
-    bot.memory['find_lines'] = SopelMemory()
+    if 'find_lines' not in bot.memory:
+        bot.memory['find_lines'] = SopelMemory()
+
+
+def shutdown(bot):
+    try:
+        del bot.memory['find_lines']
+    except KeyError:
+        pass
 
 
 @echo

--- a/sopel/modules/safety.py
+++ b/sopel/modules/safety.py
@@ -81,7 +81,8 @@ def configure(config):
 def setup(bot):
     bot.config.define_section('safety', SafetySection)
 
-    bot.memory['safety_cache'] = sopel.tools.SopelMemory()
+    if 'safety_cache' not in bot.memory:
+        bot.memory['safety_cache'] = sopel.tools.SopelMemory()
     for item in bot.config.safety.known_good:
         known_good.append(re.compile(item, re.I))
 
@@ -97,6 +98,13 @@ def setup(bot):
             clean_line = unicode(line).strip().lower()
             if clean_line != '':
                 malware_domains.add(clean_line)
+
+
+def shutdown(bot):
+    try:
+        del bot.memory['safety_cache']
+    except KeyError:
+        pass
 
 
 def _download_malwaredomains_db(path):

--- a/sopel/modules/tell.py
+++ b/sopel/modules/tell.py
@@ -76,8 +76,18 @@ def setup(bot):
         else:
             f.write('')
             f.close()
-    bot.memory['tell_lock'] = threading.Lock()
-    bot.memory['reminders'] = loadReminders(bot.tell_filename, bot.memory['tell_lock'])
+    if 'tell_lock' not in bot.memory:
+        bot.memory['tell_lock'] = threading.Lock()
+    if 'reminders' not in bot.memory:
+        bot.memory['reminders'] = loadReminders(bot.tell_filename, bot.memory['tell_lock'])
+
+
+def shutdown(bot):
+    for key in ['tell_lock', 'reminders']:
+        try:
+            del bot.memory[key]
+        except KeyError:
+            pass
 
 
 @commands('tell', 'ask')

--- a/sopel/modules/tell.py
+++ b/sopel/modules/tell.py
@@ -65,19 +65,19 @@ def dumpReminders(fn, data, lock):
     return True
 
 
-def setup(self):
-    fn = self.nick + '-' + self.config.core.host + '.tell.db'
-    self.tell_filename = os.path.join(self.config.core.homedir, fn)
-    if not os.path.exists(self.tell_filename):
+def setup(bot):
+    fn = bot.nick + '-' + bot.config.core.host + '.tell.db'
+    bot.tell_filename = os.path.join(bot.config.core.homedir, fn)
+    if not os.path.exists(bot.tell_filename):
         try:
-            f = open(self.tell_filename, 'w')
-        except (OSError, IOError):  # Remove IOError when dropping py2 support
+            f = open(bot.tell_filename, 'w')
+        except (OSError, IOError):  # TODO: Remove IOError when dropping py2 support
             pass
         else:
             f.write('')
             f.close()
-    self.memory['tell_lock'] = threading.Lock()
-    self.memory['reminders'] = loadReminders(self.tell_filename, self.memory['tell_lock'])
+    bot.memory['tell_lock'] = threading.Lock()
+    bot.memory['reminders'] = loadReminders(bot.tell_filename, bot.memory['tell_lock'])
 
 
 @commands('tell', 'ask')

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -98,6 +98,17 @@ def setup(bot):
         bot.memory['shortened_urls'] = tools.SopelMemory()
 
 
+def shutdown(bot):
+    # Unset `url_exclude` and `last_seen_url`, but not `shortened_urls`;
+    # clearing `shortened_urls` will increase API calls. Leaving it in memory
+    # should not lead to unexpected behavior.
+    for key in ['url_exclude', 'last_seen_url']:
+        try:
+            del bot.memory[key]
+        except KeyError:
+            pass
+
+
 @module.commands('title')
 @module.example('.title https://www.google.com', '[ Google ] - www.google.com')
 def title_command(bot, trigger):


### PR DESCRIPTION
Modules will safely initialize (ensure key does not exist in memory already) in `setup()` and clean up (remove module-specific keys from memory) in `shutdown()`, where necessary.