### PR TITLE
bot: prevent KeyError from search_url_callbacks

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -824,6 +824,10 @@ class Sopel(irc.Bot):
         .. __: https://docs.python.org/3.6/library/re.html#match-objects
 
         """
+        if 'url_callbacks' not in self.memory:
+            # nothing to search
+            return
+
         for regex, function in tools.iteritems(self.memory['url_callbacks']):
             match = regex.search(url)
             if match:


### PR DESCRIPTION
Discovered after removing stock modules. If not in memory, the search fails with a KeyError.