### PR TITLE
Unignore even more style checks

### DIFF
--- a/checkstyle.sh
+++ b/checkstyle.sh
@@ -17,7 +17,8 @@ fi
 fail_py3_unicode=false
 for file in $(find_source_files); do
     if grep -qle 'unicode(' -e 'class .*(unicode)' $file; then
-        if ! grep -L 'unicode = str' $file; then
+        if ! grep -ql 'unicode = str' $file; then
+            echo "Suspicious 'unicode' use: $file"
             fail_py3_unicode=true
         fi
     fi

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,7 +2,7 @@ pytest<3.3; python_version == '3.3'
 pytest>=4.6,<4.7; python_version != '3.3'
 coveralls
 flake8<3.6.0; python_version == '3.3'
-flake8>=3.6.0,<3.7.0; python_version != '3.3'
+flake8>=3.7.0,<3.8.0; python_version != '3.3'
 flake8-coding
 flake8-future-import
 setuptools<40.0; python_version == '3.3'

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,9 +29,9 @@ zip_safe = false
 [flake8]
 max-line-length = 79
 ignore =
-    # These are acceptable (for now). 128 and 127 should be removed eventually.
-    E501,E128,E127,
-    # These are ignored by default (and we want to keep them ignored)
+    # Line length limit. Acceptable (for now).
+    E501,
+    # Newline after binary operator. Ignored by default (which we want to keep)
     W504,
     # These are forbidding certain __future__ imports. The future-import plugin
     # has errors both for having and not having them; we want to have these until

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -312,8 +312,10 @@ class Sopel(irc.Bot):
                     callb_list.remove(obj)
         if hasattr(obj, 'interval'):
             self.scheduler.remove_callable_job(obj)
-        if (getattr(obj, '__name__', None) == 'shutdown' and
-                    obj in self.shutdown_methods):
+        if (
+                getattr(obj, "__name__", None) == "shutdown" and
+                obj in self.shutdown_methods
+        ):
             self.shutdown_methods.remove(obj)
 
     def register(self, callables, jobs, shutdowns, urls):

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -384,7 +384,7 @@ def command_start(opts):
 
     if opts.daemonize:
         child_pid = os.fork()
-        if child_pid is not 0:
+        if child_pid != 0:
             return
 
     with open(pid_file_path, 'w') as pid_file:
@@ -605,7 +605,7 @@ def command_legacy(opts):
 
     if opts.daemonize:
         child_pid = os.fork()
-        if child_pid is not 0:
+        if child_pid != 0:
             return
     with open(pid_file_path, 'w') as pid_file:
         pid_file.write(str(os.getpid()))

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -180,11 +180,13 @@ def handle_names(bot, trigger):
     # it'd be worth it.
     # If this ever needs to be updated, remember to change the mode handling in
     # the WHO-handler functions below, too.
-    mapping = {'+': sopel.module.VOICE,
-               '%': sopel.module.HALFOP,
-               '@': sopel.module.OP,
-               '&': sopel.module.ADMIN,
-               '~': sopel.module.OWNER}
+    mapping = {
+        "+": sopel.module.VOICE,
+        "%": sopel.module.HALFOP,
+        "@": sopel.module.OP,
+        "&": sopel.module.ADMIN,
+        "~": sopel.module.OWNER,
+    }
 
     for name in names:
         priv = 0
@@ -240,11 +242,13 @@ def track_modes(bot, trigger):
     modestring = trigger.args[1]
     nicks = [Identifier(nick) for nick in trigger.args[2:]]
 
-    mapping = {'v': sopel.module.VOICE,
-               'h': sopel.module.HALFOP,
-               'o': sopel.module.OP,
-               'a': sopel.module.ADMIN,
-               'q': sopel.module.OWNER}
+    mapping = {
+        "v": sopel.module.VOICE,
+        "h": sopel.module.HALFOP,
+        "o": sopel.module.OP,
+        "a": sopel.module.ADMIN,
+        "q": sopel.module.OWNER,
+    }
 
     # Parse modes before doing anything else
     modes = []
@@ -303,17 +307,17 @@ def track_nicks(bot, trigger):
 
     # Give debug mssage, and PM the owner, if the bot's own nick changes.
     if old == bot.nick and new != bot.nick:
-        privmsg = ("Hi, I'm your bot, %s."
-                   "Something has made my nick change. "
-                   "This can cause some problems for me, "
-                   "and make me do weird things. "
-                   "You'll probably want to restart me, "
-                   "and figure out what made that happen "
-                   "so you can stop it happening again. "
-                   "(Usually, it means you tried to give me a nick "
-                   "that's protected by NickServ.)") % bot.nick
-        debug_msg = ("Nick changed by server. "
-            "This can cause unexpected behavior. Please restart the bot.")
+        privmsg = (
+            "Hi, I'm your bot, %s. Something has made my nick change. This "
+            "can cause some problems for me, and make me do weird things. "
+            "You'll probably want to restart me, and figure out what made "
+            "that happen so you can stop it happening again. (Usually, it "
+            "means you tried to give me a nick that's protected by NickServ.)"
+        ) % bot.nick
+        debug_msg = (
+            "Nick changed by server. This can cause unexpected behavior. "
+            "Please restart the bot."
+        )
         LOGGER.critical(debug_msg)
         bot.say(privmsg, bot.config.core.owner)
         return
@@ -779,11 +783,13 @@ def _record_who(bot, channel, user, host, nick, account=None, away=None, modes=N
     usr.away = away
     priv = 0
     if modes:
-        mapping = {'+': sopel.module.VOICE,
-           '%': sopel.module.HALFOP,
-           '@': sopel.module.OP,
-           '&': sopel.module.ADMIN,
-           '~': sopel.module.OWNER}
+        mapping = {
+            "+": sopel.module.VOICE,
+            "%": sopel.module.HALFOP,
+            "@": sopel.module.OP,
+            "&": sopel.module.ADMIN,
+            "~": sopel.module.OWNER,
+        }
         for c in modes:
             priv = priv | mapping[c]
     if channel not in bot.channels:

--- a/sopel/irc.py
+++ b/sopel/irc.py
@@ -114,7 +114,7 @@ class Bot(asynchat.async_chat):
     def safe(self, string):
         """Remove newlines from a string."""
         if sys.version_info.major >= 3 and isinstance(string, bytes):
-            string = string.decode('utf8')
+            string = string.decode("utf8")
         elif sys.version_info.major < 3:
             if not isinstance(string, unicode):
                 string = unicode(string, encoding='utf8')
@@ -176,8 +176,10 @@ class Bot(asynchat.async_chat):
                 except KeyError:
                     pass  # we tried, and that's good enough
 
-            pretrigger = PreTrigger(self.nick, ':{0}!{1}@{2} {3}'
-                .format(self.nick, self.user, host, temp))
+            pretrigger = PreTrigger(
+                self.nick,
+                ":{0}!{1}@{2} {3}".format(self.nick, self.user, host, temp)
+            )
             self.dispatch(pretrigger)
 
     def run(self, host, port=6667):

--- a/sopel/irc.py
+++ b/sopel/irc.py
@@ -114,7 +114,7 @@ class Bot(asynchat.async_chat):
     def safe(self, string):
         """Remove newlines from a string."""
         if sys.version_info.major >= 3 and isinstance(string, bytes):
-                string = string.decode('utf8')
+            string = string.decode('utf8')
         elif sys.version_info.major < 3:
             if not isinstance(string, unicode):
                 string = unicode(string, encoding='utf8')

--- a/sopel/modules/dice.py
+++ b/sopel/modules/dice.py
@@ -223,8 +223,10 @@ def roll(bot, trigger):
     try:
         result = eval_equation(eval_str)
     except TypeError:
-        bot.reply("The type of this equation is, apparently, not a string. " +
-            "How did you do that, anyway?")
+        bot.reply(
+            "The type of this equation is, apparently, not a string. " +
+            "How did you do that, anyway?"
+        )
     except ValueError:
         # As it seems that ValueError is raised if the resulting equation would
         # be too big, give a semi-serious answer to reflect on this.
@@ -232,8 +234,10 @@ def roll(bot, trigger):
             trigger.group(2), pretty_str))
         return
     except (SyntaxError, eval_equation.Error):
-        bot.reply("I don't know how to process that. " +
-            "Are the dice as well as the algorithms correct?")
+        bot.reply(
+            "I don't know how to process that. " +
+            "Are the dice as well as the algorithms correct?"
+        )
         return
 
     bot.reply("You roll %s: %s = %d" % (

--- a/sopel/modules/dice.py
+++ b/sopel/modules/dice.py
@@ -224,7 +224,7 @@ def roll(bot, trigger):
         result = eval_equation(eval_str)
     except TypeError:
         bot.reply(
-            "The type of this equation is, apparently, not a string. " +
+            "The type of this equation is, apparently, not a string. "
             "How did you do that, anyway?"
         )
     except ValueError:
@@ -235,7 +235,7 @@ def roll(bot, trigger):
         return
     except (SyntaxError, eval_equation.Error):
         bot.reply(
-            "I don't know how to process that. " +
+            "I don't know how to process that. "
             "Are the dice as well as the algorithms correct?"
         )
         return

--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -74,8 +74,10 @@ def rpost_info(bot, trigger, match):
             sfw = bot.db.get_channel_value(trigger.sender, 'sfw')
             if sfw:
                 link = '(link hidden)'
-                bot.kick(trigger.nick, trigger.sender,
-                     'Linking to NSFW content in a SFW channel.')
+                bot.kick(
+                    trigger.nick, trigger.sender,
+                    'Linking to NSFW content in a SFW channel.'
+                )
         else:
             nsfw = ''
 

--- a/sopel/modules/tld.py
+++ b/sopel/modules/tld.py
@@ -53,8 +53,9 @@ def gettld(bot, trigger):
         desc = matches[2]
         if len(desc) > 400:
             desc = desc[:400] + "..."
-        reply = "%s -- %s. IDN: %s, DNSSEC: %s" % (matches[1], desc,
-                matches[3], matches[4])
+        reply = "%s -- %s. IDN: %s, DNSSEC: %s" % (
+            matches[1], desc, matches[3], matches[4]
+        )
     else:
         search = r'<td><a href="\S+" title="\S+">.{0}</a></td>\n<td><span class="flagicon"><img.*?\">(.*?)</a></td>\n<td[^>]*>(.*?)</td>\n<td[^>]*>(.*?)</td>\n<td[^>]*>(.*?)</td>\n<td[^>]*>(.*?)</td>\n<td[^>]*>(.*?)</td>\n'
         search = search.format(unicode(tld))

--- a/sopel/modules/xkcd.py
+++ b/sopel/modules/xkcd.py
@@ -102,11 +102,11 @@ def numbered_result(bot, query, latest, verify_ssl=True):
     max_int = latest['num']
     if query > max_int:
         bot.say(("Sorry, comic #{} hasn't been posted yet. "
-                    "The last comic was #{}").format(query, max_int))
+                 "The last comic was #{}").format(query, max_int))
         return
     elif query <= -max_int:
         bot.say(("Sorry, but there were only {} comics "
-                    "released yet so far").format(max_int))
+                 "released yet so far").format(max_int))
         return
     elif abs(query) == 0:
         requested = latest

--- a/test/modules/test_modules_remind.py
+++ b/test/modules/test_modules_remind.py
@@ -28,23 +28,35 @@ VALID_MATCH_LINES = (
     ('13:37 message', TimeReminder('13', '37', None, None, 'message')),
     ('13:37:00 message', TimeReminder('13', '37', '00', None, 'message')),
     # Make sure numbers are not confused with anything else
-    ('13:37:00 10 message',
-     TimeReminder('13', '37', '00', None, '10 message')),
+    (
+        '13:37:00 10 message',
+        TimeReminder('13', '37', '00', None, '10 message')
+    ),
     # Weird stuff
-    ('13:37:00 message\tanother one',
-     TimeReminder('13', '37', '00', None, 'message\tanother one')),
-    ('13:37:00 ( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ'
-     '( •ᴗ ^B^]^_ITS CARDBACK TIME!!!!!!!!!!!!!!!!!!!!!!!^B^]^_'
-     '( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ',
-     TimeReminder('13', '37', '00', None,
-        '( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ'
+    (
+        '13:37:00 message\tanother one',
+        TimeReminder('13', '37', '00', None, 'message\tanother one')
+    ),
+    (
+        '13:37:00 ( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ'
         '( •ᴗ ^B^]^_ITS CARDBACK TIME!!!!!!!!!!!!!!!!!!!!!!!^B^]^_'
-        '( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ')),
+        '( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ',
+        TimeReminder(
+            '13', '37', '00', None,
+            '( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ'
+            '( •ᴗ ^B^]^_ITS CARDBACK TIME!!!!!!!!!!!!!!!!!!!!!!!^B^]^_'
+            '( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ( •ᴗ•)ψ'
+        )
+    ),
     # Timezone
-    ('13:37Europe/Paris message',
-     TimeReminder('13', '37', None, 'Europe/Paris', 'message')),
-    ('13:37:00Europe/Paris message',
-     TimeReminder('13', '37', '00', 'Europe/Paris', 'message')),
+    (
+        '13:37Europe/Paris message',
+        TimeReminder('13', '37', None, 'Europe/Paris', 'message')
+    ),
+    (
+        '13:37:00Europe/Paris message',
+        TimeReminder('13', '37', '00', 'Europe/Paris', 'message')
+    ),
     # these should not pass, but they do at the moment
     ('13:7 message', TimeReminder('13', '7', None, None, 'message')),
     ('0000:20 message', TimeReminder('0000', '20', None, None, 'message')),

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -114,8 +114,11 @@ def test_search_urls_defined_schemes(scheme):
     }.get(scheme)
 
     urls = list(
-        search_urls('http://a.com ftp://b.com https://c.com steam://portal2',
-        schemes=[scheme]))
+        search_urls(
+            'http://a.com ftp://b.com https://c.com steam://portal2',
+            schemes=[scheme]
+        )
+    )
     assert len(urls) == 1, 'Only %s URLs must be found' % scheme
     assert expected in urls
 


### PR DESCRIPTION
Unignores (or updates to add) and fixes the following:
E117 over-indented
E127 continuation line over-indented for visual indent
E128 continuation line under-indented for visual indent
F632 use ==/!= to compare str, bytes, and int literals

With the above fixed, flake8 3.7.7 finds no errors, so the 3.6 pin is replaced with 3.7

`checkstyle.sh`'s py3-unsafe `unicode()` detection seemed to have some inverted logic and was reporting files _containing_ `unicode = str` as potentially unsafe, instead of only files _not_ containing that.