### PR TITLE
core: add `__all__` statements in sopel fix #765

### DIFF
--- a/docs/source/bot.rst
+++ b/docs/source/bot.rst
@@ -16,3 +16,7 @@ The bot and its state
     .. py:attribute:: name
 
         Sopel's "real name", as used for whois.
+
+
+.. autoclass:: sopel.bot.SopelWrapper
+    :members:

--- a/sopel/__init__.py
+++ b/sopel/__init__.py
@@ -18,6 +18,20 @@ import pkg_resources
 import re
 import sys
 
+__all__ = [
+    'bot',
+    'config',
+    'db',
+    'formatting',
+    'irc',
+    'loader',
+    'logger',
+    'module',
+    'tools',
+    'trigger',
+    'version_info',
+]
+
 loc = locale.getlocale()
 if sys.version_info.major > 2:
     if not loc[1] or 'UTF-8' not in loc[1]:

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -869,7 +869,7 @@ class SopelWrapper(object):
     """Wrapper around a Sopel instance and a Trigger
 
     :param sopel: Sopel instance
-    :type sopel: :class:`sopel.bot.Sopel`
+    :type sopel: :class:`~sopel.bot.Sopel`
     :param trigger: IRC Trigger line
     :type trigger: :class:`sopel.trigger.Trigger`
 
@@ -897,43 +897,59 @@ class SopelWrapper(object):
         return setattr(self._bot, attr, value)
 
     def say(self, message, destination=None, max_messages=1):
-        """Override :meth:`sopel.bot.Sopel.say` to send message to sender
+        """Override ``Sopel.say`` to send message to sender
 
         :param str message: message to say
         :param str destination: channel or person; defaults to trigger's sender
         :param int max_messages: max number of message splits
+
+        .. seealso::
+
+            :meth:`sopel.bot.Sopel.say`
         """
         if destination is None:
             destination = self._trigger.sender
         self._bot.say(message, destination, max_messages)
 
     def action(self, message, destination=None):
-        """Override :meth:`sopel.bot.Sopel.action` to send action to sender
+        """Override ``Sopel.action`` to send action to sender
 
         :param str message: action message
         :param str destination: channel or person; defaults to trigger's sender
+
+        .. seealso::
+
+            :meth:`sopel.bot.Sopel.action`
         """
         if destination is None:
             destination = self._trigger.sender
         self._bot.action(message, destination)
 
     def notice(self, message, destination=None):
-        """Override :meth:`sopel.bot.Sopel.notice` to send a notice to sender
+        """Override ``Sopel.notice`` to send a notice to sender
 
         :param str message: notice message
         :param str destination: channel or person; defaults to trigger's sender
+
+        .. seealso::
+
+            :meth:`sopel.bot.Sopel.notice`
         """
         if destination is None:
             destination = self._trigger.sender
         self._bot.notice(message, destination)
 
     def reply(self, message, destination=None, reply_to=None, notice=False):
-        """Override :meth:`sopel.bot.Sopel.reply` to reply to someone
+        """Override ``Sopel.reply`` to reply to someone
 
         :param str message: reply message
         :param str destination: channel or person; defaults to trigger's sender
         :param str reply_to: person to reply to; defaults to trigger's nick
         :param bool notice: reply as an IRC notice or with a simple message
+
+        .. seealso::
+
+            :meth:`sopel.bot.Sopel.reply`
         """
         if destination is None:
             destination = self._trigger.sender

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -26,6 +26,8 @@ from sopel.logger import get_logger
 import sopel.loader
 
 
+__all__ = ['Sopel', 'SopelWrapper']
+
 LOGGER = get_logger(__name__)
 
 if sys.version_info.major >= 3:
@@ -864,6 +866,18 @@ class Sopel(irc.Bot):
 
 
 class SopelWrapper(object):
+    """Wrapper around a Sopel instance and a Trigger
+
+    :param sopel: Sopel instance
+    :type sopel: :class:`sopel.bot.Sopel`
+    :param trigger: IRC Trigger line
+    :type trigger: :class:`sopel.trigger.Trigger`
+
+    This wrapper will be used to call Sopel's triggered commands and rules as
+    their ``bot`` argument. It acts as a proxy to :meth:`send messages<say>` to
+    the sender (either a channel or in a private message) and even to
+    :meth:`reply to someone<reply>` in a channel.
+    """
     def __init__(self, sopel, trigger):
         # The custom __setattr__ for this class sets the attribute on the
         # original bot object. We don't want that for these, so we set them
@@ -883,21 +897,44 @@ class SopelWrapper(object):
         return setattr(self._bot, attr, value)
 
     def say(self, message, destination=None, max_messages=1):
+        """Override :meth:`sopel.bot.Sopel.say` to send message to sender
+
+        :param str message: message to say
+        :param str destination: channel or person; defaults to trigger's sender
+        :param int max_messages: max number of message splits
+        """
         if destination is None:
             destination = self._trigger.sender
         self._bot.say(message, destination, max_messages)
 
     def action(self, message, destination=None):
+        """Override :meth:`sopel.bot.Sopel.action` to send action to sender
+
+        :param str message: action message
+        :param str destination: channel or person; defaults to trigger's sender
+        """
         if destination is None:
             destination = self._trigger.sender
         self._bot.action(message, destination)
 
     def notice(self, message, destination=None):
+        """Override :meth:`sopel.bot.Sopel.notice` to send a notice to sender
+
+        :param str message: notice message
+        :param str destination: channel or person; defaults to trigger's sender
+        """
         if destination is None:
             destination = self._trigger.sender
         self._bot.notice(message, destination)
 
     def reply(self, message, destination=None, reply_to=None, notice=False):
+        """Override :meth:`sopel.bot.Sopel.reply` to reply to someone
+
+        :param str message: reply message
+        :param str destination: channel or person; defaults to trigger's sender
+        :param str reply_to: person to reply to; defaults to trigger's nick
+        :param bool notice: reply as an IRC notice or with a simple message
+        """
         if destination is None:
             destination = self._trigger.sender
         if reply_to is None:

--- a/sopel/config/__init__.py
+++ b/sopel/config/__init__.py
@@ -32,6 +32,15 @@ else:
     import configparser as ConfigParser
 
 
+__all__ = [
+    'core_section',
+    'types',
+    'DEFAULT_HOMEDIR',
+    'ConfigurationError',
+    'ConfigurationNotFound',
+    'Config',
+]
+
 DEFAULT_HOMEDIR = os.path.join(os.path.expanduser('~'), '.sopel')
 
 

--- a/sopel/formatting.py
+++ b/sopel/formatting.py
@@ -31,6 +31,8 @@ __all__ = [
     'strikethrough',
     'monospace',
     'reverse',
+    # utility class
+    'colors',
 ]
 
 if sys.version_info.major >= 3:

--- a/sopel/formatting.py
+++ b/sopel/formatting.py
@@ -9,6 +9,30 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 
 import string
 import sys
+
+
+__all__ = [
+    # control chars
+    'CONTROL_NORMAL',
+    'CONTROL_COLOR',
+    'CONTROL_HEX_COLOR',
+    'CONTROL_BOLD',
+    'CONTROL_ITALIC',
+    'CONTROL_UNDERLINE',
+    'CONTROL_STRIKETHROUGH',
+    'CONTROL_MONOSPACE',
+    'CONTROL_REVERSE',
+    # utility functions
+    'color',
+    'hex_color',
+    'bold',
+    'italic',
+    'underline',
+    'strikethrough',
+    'monospace',
+    'reverse',
+]
+
 if sys.version_info.major >= 3:
     unicode = str
 

--- a/sopel/irc.py
+++ b/sopel/irc.py
@@ -39,6 +39,9 @@ from datetime import datetime
 if sys.version_info.major >= 3:
     unicode = str
 
+
+__all__ = ['Bot']
+
 LOGGER = get_logger(__name__)
 
 

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -11,6 +11,30 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 import re
 import functools
 
+__all__ = [
+    # constants
+    'NOLIMIT', 'VOICE', 'HALFOP', 'OP', 'ADMIN', 'OWNER',
+    # decorators
+    'commands',
+    'echo',
+    'example',
+    'intent',
+    'interval',
+    'nickname_commands',
+    'priority',
+    'rate',
+    'require_admin',
+    'require_chanmsg',
+    'require_owner',
+    'require_privilege',
+    'require_privmsg',
+    'rule',
+    'thread',
+    'unblockable',
+    'url',
+]
+
+
 NOLIMIT = 1
 """Return value for ``callable``\\s, which suppresses rate limiting for the call.
 

--- a/sopel/test_tools.py
+++ b/sopel/test_tools.py
@@ -27,6 +27,16 @@ import sopel.tools.target
 import sopel.trigger
 
 
+__all__ = [
+    'MockConfig',
+    'MockSopel',
+    'MockSopelWrapper',
+    'get_example_test',
+    'get_disable_setup',
+    'insert_into_module',
+    'run_example_tests',
+]
+
 if sys.version_info.major >= 3:
     basestring = str
 

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -1,11 +1,18 @@
 # coding=utf-8
+"""Sopel IRC Trigger Lines"""
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 import re
 import sys
 import datetime
 
-import sopel.tools
+from sopel import tools
+
+
+__all__ = [
+    'PreTrigger',
+    'Trigger',
+]
 
 if sys.version_info.major >= 3:
     unicode = str
@@ -72,12 +79,12 @@ class PreTrigger(object):
         self.args = self.args[1:]
         components = PreTrigger.component_regex.match(self.hostmask or '').groups()
         self.nick, self.user, self.host = components
-        self.nick = sopel.tools.Identifier(self.nick)
+        self.nick = tools.Identifier(self.nick)
 
         # If we have arguments, the first one is the sender
         # Unless it's a QUIT event
         if self.args and self.event != 'QUIT':
-            target = sopel.tools.Identifier(self.args[0])
+            target = tools.Identifier(self.args[0])
         else:
             target = None
 
@@ -179,7 +186,7 @@ class Trigger(unicode):
         self._is_privmsg = message.sender and message.sender.is_nick()
 
         def match_host_or_nick(pattern):
-            pattern = sopel.tools.get_hostmask_regex(pattern)
+            pattern = tools.get_hostmask_regex(pattern)
             return bool(
                 pattern.match(self.nick) or
                 pattern.match('@'.join((self.nick, self.host)))

--- a/sopel/web.py
+++ b/sopel/web.py
@@ -1,9 +1,9 @@
 # coding=utf-8
 """
-*Availability: 3+, depreacted in 6.2.0*
+*Availability: 3+, deprecated in 6.2.0*
 
 The web class contains essential web-related functions for interaction with web
-applications or websites in your modules.  It supports HTTP GET, HTTP POST and
+applications or websites in your modules. It supports HTTP GET, HTTP POST and
 HTTP HEAD.
 """
 # Copyright © 2008, Sean B. Palmer, inamidst.com
@@ -45,6 +45,18 @@ try:
     has_ssl = True
 except ImportError:
     has_ssl = False
+
+__all__ = [
+    'decode',
+    'entity',
+    'iri_to_uri',
+    'quote',
+    'quote_query',
+    'search_urls',
+    'trim_url',
+    'urlencode',
+    'urlencode_non_ascii',
+]
 
 USER_AGENT = 'Sopel/{} (https://sopel.chat)'.format(__version__)
 default_headers = {'User-Agent': USER_AGENT}


### PR DESCRIPTION
The `__all__` statement in a Python module is used at import time when `from module import *` is used to expose only a defined list of object to be imported in the `locals()` environment of the importer.

Even though the [Python documentation](https://docs.python.org/3/tutorial/modules.html#importing-from-a-package) talks about "sub-modules" to import, it is widely used to define a set of names to import instead (being objects, functions, or sub-modules).