### PR TITLE
cli: `cli.utils.find_config` returns absolute path, as expected

### DIFF
--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -183,7 +183,7 @@ def find_config(config_dir, name, extension='.cfg'):
 
     """
     if os.path.isfile(name):
-        return name
+        return os.path.abspath(name)
     name_ext = name + extension
     for filename in enumerate_configs(config_dir, extension):
         if name_ext == filename:

--- a/test/cli/test_cli_utils.py
+++ b/test/cli/test_cli_utils.py
@@ -62,7 +62,7 @@ def test_find_config_local(tmpdir, config_dir):
 
     with cd(working_dir.strpath):
         found_config = find_config(config_dir.strpath, 'local.cfg')
-        assert found_config == 'local.cfg'
+        assert found_config == working_dir.join('local.cfg').strpath
 
         found_config = find_config(config_dir.strpath, 'local')
         assert found_config == config_dir.join('local').strpath


### PR DESCRIPTION
According to this:
https://github.com/sopel-irc/sopel/blob/0952f4443f831ef7eeba0c04ab34ff3f6dc76197/sopel/cli/utils.py#L153-L154
`find_config` is expected to always return an absolute file path.

However, here:
https://github.com/sopel-irc/sopel/blob/0952f4443f831ef7eeba0c04ab34ff3f6dc76197/sopel/cli/utils.py#L185-L186
it is possible for a simple filename (or relative path, which is not as bad, but still not the expected result) to be returned.

This is usually not an issue, but in the wizard, an attempt to `os.makedirs` is made, which breaks if there is no directory to even try to be made :smile: 

Fixed now, though. 