### PR TITLE
cli: sopel-plugins (basic version)

### DIFF
--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -20,6 +20,7 @@ configuration file unless one is provided using the ``-c``/``--config`` option.
     :local:
     :depth: 1
 
+
 The ``sopel`` command
 =====================
 
@@ -42,6 +43,18 @@ The ``sopel`` command
 .. autoprogram:: sopel.cli.run:build_parser()
     :prog: sopel
     :start_command: configure
+
+
+The ``sopel-config`` command
+============================
+
+.. versionadded:: 7.0
+
+   The command ``sopel-config`` and its subcommands have been added in
+   Sopel 7.0.
+
+.. autoprogram:: sopel.cli.config:build_parser()
+    :prog: sopel-config
 
 
 The ``sopel-plugins`` command

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -1,3 +1,4 @@
+=======================
 Command Line Interfaces
 =======================
 
@@ -15,6 +16,12 @@ to, and channels to join. By default, it creates the file
 Once this is done, the ``start`` subcommand runs the bot, using this
 configuration file unless one is provided using the ``-c``/``--config`` option.
 
+.. contents::
+    :local:
+    :depth: 1
+
+The ``sopel`` command
+=====================
 
 .. autoprogram:: sopel.cli.run:build_parser()
     :prog: sopel
@@ -35,3 +42,15 @@ configuration file unless one is provided using the ``-c``/``--config`` option.
 .. autoprogram:: sopel.cli.run:build_parser()
     :prog: sopel
     :start_command: configure
+
+
+The ``sopel-plugins`` command
+=============================
+
+.. versionadded:: 7.0
+
+   The command ``sopel-plugins`` and its subcommands have been added in
+   Sopel 7.0.
+
+.. autoprogram:: sopel.cli.plugins:build_parser()
+    :prog: sopel-plugins

--- a/setup.py
+++ b/setup.py
@@ -63,6 +63,7 @@ setup(
         'console_scripts': [
             'sopel = sopel.cli.run:main',
             'sopel-config = sopel.cli.config:main',
+            'sopel-plugins = sopel.cli.plugins:main',
         ],
     },
     python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, <4',

--- a/sopel/cli/plugins.py
+++ b/sopel/cli/plugins.py
@@ -190,9 +190,11 @@ def handle_show(options):
     }
 
     # option meta description from the plugin itself
+    loaded = False
     try:
         plugin.load()
         description.update(plugin.get_meta_description())
+        loaded = True
     except Exception as error:
         label = ('%s' % error) or 'unknown loading exception'
         error_status = 'error'
@@ -208,6 +210,15 @@ def handle_show(options):
     print('Type:', description['type'])
     print('Source:', description['source'])
     print('Label:', description['label'])
+
+    if not loaded:
+        print('Loading failed')
+        return 1
+
+    print('Loaded successfully')
+    print('Setup:', 'yes' if plugin.has_setup() else 'no')
+    print('Shutdown:', 'yes' if plugin.has_shutdown() else 'no')
+    print('Configure:', 'yes' if plugin.has_configure() else 'no')
 
 
 def handle_disable(options):

--- a/sopel/cli/plugins.py
+++ b/sopel/cli/plugins.py
@@ -4,7 +4,7 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 
 import argparse
 
-from sopel import plugins
+from sopel import plugins, tools
 
 from . import utils
 
@@ -50,6 +50,29 @@ def build_parser():
         action='store_true',
         default=False)
 
+    # sopel-plugin disable
+    disable_parser = subparsers.add_parser(
+        'disable',
+        help="Disable a Sopel plugins",
+        description="""
+            Disable a Sopel plugin by its name, no matter where it comes from.
+            It is not possible to disable the ``coretasks`` plugin.
+        """)
+    utils.add_common_arguments(disable_parser)
+    disable_parser.add_argument('name', help='Name of the plugin to disable')
+    disable_parser.add_argument(
+        '-f', '--force', action='store_true', default=False,
+        help="""
+            Force exclusion of the plugin. When ``core.enable`` is defined, a
+            plugin may be disabled without being excluded. In this case, use
+            this option to force its exclusion.
+        """)
+    disable_parser.add_argument(
+        '-r', '--remove', action='store_true', default=False,
+        help="""
+            Remove from ``core.enable`` list if applicable.
+        """)
+
     return parser
 
 
@@ -74,6 +97,60 @@ def handle_list(options):
             print(utils.red(name))
 
 
+def handle_disable(options):
+    """Disable a Sopel plugin"""
+    plugin_name = options.name
+    settings = utils.load_settings(options)
+    usable_plugins = plugins.get_usable_plugins(settings)
+    excluded = settings.core.exclude
+
+    # coretasks is sacred
+    if plugin_name == 'coretasks':
+        tools.stderr('Plugin coretasks cannot be disabled')
+        return 1
+
+    # plugin does not exist
+    if plugin_name not in usable_plugins:
+        tools.stderr('No plugin named %s' % plugin_name)
+        return 1
+
+    # remove from enabled if asked
+    if options.remove and plugin_name in settings.core.enable:
+        settings.core.enable = [
+            name
+            for name in settings.core.enable
+            if name != plugin_name
+        ]
+        settings.save()
+
+    # nothing left to do if already excluded
+    if plugin_name in excluded:
+        tools.stderr('Plugin %s already disabled' % plugin_name)
+        return 0
+
+    # recalculate state: at the moment, the plugin is not in the excluded list
+    # however, with options.remove, the enable list may be empty, so we have
+    # to compute the plugin's state here, and not use what comes from
+    # plugins.get_usable_plugins
+    is_enabled = (
+        not settings.core.enable or
+        plugin_name in settings.core.enable
+    )
+
+    # if not enabled at this point, exclude if options.force is used
+    if not is_enabled and not options.force:
+        tools.stderr(
+            'Plugin %s is disabled but not excluded; '
+            'use -f/--force to force its exclusion'
+            % plugin_name)
+        return 0
+
+    settings.core.exclude = excluded + [plugin_name]
+    settings.save()
+
+    print('Plugin %s disabled' % plugin_name)
+
+
 def main():
     """Console entry point for ``sopel-plugins``"""
     parser = build_parser()
@@ -86,3 +163,5 @@ def main():
 
     if action == 'list':
         return handle_list(options)
+    elif action == 'disable':
+        return handle_disable(options)

--- a/sopel/cli/plugins.py
+++ b/sopel/cli/plugins.py
@@ -1,0 +1,88 @@
+# coding=utf-8
+"""Sopel Plugins Command Line Interface (CLI): ``sopel-plugins``"""
+from __future__ import unicode_literals, absolute_import, print_function, division
+
+import argparse
+
+from sopel import plugins
+
+from . import utils
+
+
+def build_parser():
+    """Configure an argument parser for ``sopel-plugins``"""
+    parser = argparse.ArgumentParser(
+        description='Sopel plugins tool')
+
+    # Subparser: sopel-plugins <sub-parser> <sub-options>
+    subparsers = parser.add_subparsers(
+        help='Action to perform',
+        dest='action')
+
+    # sopel-plugins list
+    list_parser = subparsers.add_parser(
+        'list',
+        help="List available Sopel plugins",
+        description="""
+            List available Sopel plugins from all possible sources: built-in,
+            from ``sopel_modules.*``, from ``sopel.plugins`` entry points,
+            or Sopel's plugin directories. Enabled plugins are displayed in
+            green; disabled, in red.
+        """)
+    utils.add_common_arguments(list_parser)
+    list_parser.add_argument(
+        '-C', '--no-color',
+        help='Disable colors',
+        dest='no_color',
+        action='store_true',
+        default=False)
+    list_enable = list_parser.add_mutually_exclusive_group(required=False)
+    list_enable.add_argument(
+        '-e', '--enabled-only',
+        help='Display only enabled plugins',
+        dest='enabled_only',
+        action='store_true',
+        default=False)
+    list_enable.add_argument(
+        '-d', '--disabled-only',
+        help='Display only disabled plugins',
+        dest='disabled_only',
+        action='store_true',
+        default=False)
+
+    return parser
+
+
+def handle_list(options):
+    """List Sopel plugins"""
+    settings = utils.load_settings(options)
+    for name, info in plugins.get_usable_plugins(settings).items():
+        _, is_enabled = info
+
+        if options.enabled_only and not is_enabled:
+            # hide disabled plugins when displaying enabled only
+            continue
+        elif options.disabled_only and is_enabled:
+            # hide enabled plugins when displaying disabled only
+            continue
+
+        if options.no_color:
+            print(name)
+        elif is_enabled:
+            print(utils.green(name))
+        else:
+            print(utils.red(name))
+
+
+def main():
+    """Console entry point for ``sopel-plugins``"""
+    parser = build_parser()
+    options = parser.parse_args()
+    action = options.action
+
+    if not action:
+        parser.print_help()
+        return
+
+    if action == 'list':
+        return handle_list(options)

--- a/sopel/cli/plugins.py
+++ b/sopel/cli/plugins.py
@@ -49,6 +49,12 @@ def build_parser():
         dest='disabled_only',
         action='store_true',
         default=False)
+    list_parser.add_argument(
+        '-n', '--name-only',
+        help='Display only plugin names',
+        dest='name_only',
+        action='store_true',
+        default=False)
 
     # sopel-plugin disable
     disable_parser = subparsers.add_parser(
@@ -103,13 +109,18 @@ def build_parser():
 def handle_list(options):
     """List Sopel plugins"""
     settings = utils.load_settings(options)
+    no_color = options.no_color
+    name_only = options.name_only
+    enabled_only = options.enabled_only
+    disabled_only = options.disabled_only
+
     for name, info in plugins.get_usable_plugins(settings).items():
         plugin, is_enabled = info
 
-        if options.enabled_only and not is_enabled:
+        if enabled_only and not is_enabled:
             # hide disabled plugins when displaying enabled only
             continue
-        elif options.disabled_only and is_enabled:
+        elif disabled_only and is_enabled:
             # hide enabled plugins when displaying disabled only
             continue
 
@@ -124,7 +135,7 @@ def handle_list(options):
             description.update(plugin.get_meta_description())
 
             # colorize name for display purpose
-            if not options.no_color:
+            if not no_color:
                 if is_enabled:
                     description['name'] = utils.green(name)
                 else:
@@ -138,7 +149,7 @@ def handle_list(options):
                 'source': 'unknown',
                 'status': error_status,
             })
-            if not options.no_color:
+            if not no_color:
                 if is_enabled:
                     # yellow instead of green
                     description['name'] = utils.yellow(name)
@@ -148,6 +159,9 @@ def handle_list(options):
                 description['status'] = utils.red(error_status)
 
         template = '{name}/{type} {label} ({source}) [{status}]'
+        if name_only:
+            template = '{name}'
+
         print(template.format(**description))
 
 

--- a/sopel/cli/plugins.py
+++ b/sopel/cli/plugins.py
@@ -336,15 +336,12 @@ def _handle_disable_plugin(settings, plugin_name, force):
 
 def display_unknown_plugins(unknown_plugins):
     # at least one of the plugins does not exist
-    unknown_count = len(unknown_plugins)
-    if unknown_count == 1:
-        tools.stderr('No plugin named %s.' % unknown_plugins[0])
-    elif unknown_count == 2:
-        tools.stderr('No plugin named %s or %s.' % unknown_plugins)
-    else:
-        left = ', '.join(unknown_plugins[:-1])
-        last = unknown_plugins[-1]
-        tools.stderr('No plugin named %s, or %s.' % (left, last))
+    tools.stderr(utils.get_many_text(
+        unknown_plugins,
+        one='No plugin named {item}.',
+        two='No plugin named {first} or {second}.',
+        many='No plugin named {left}, or {last}.'
+    ))
 
 
 def handle_disable(options):
@@ -393,15 +390,12 @@ def handle_disable(options):
         return 0  # nothing to disable or save, but not an error case
 
     # display plugins actually disabled by the command
-    plugins_count = len(actually_disabled)
-    if plugins_count == 1:
-        print('Plugin %s disabled.' % actually_disabled[0])
-    elif plugins_count == 2:
-        print('Plugin %s and %s disabled.' % actually_disabled)
-    else:
-        left = ', '.join(actually_disabled[:-1])
-        last = actually_disabled[-1]
-        print('Plugin %s, and %s disabled.' % (left, last))
+    print(utils.get_many_text(
+        actually_disabled,
+        one='Plugin {item} disabled.',
+        two='Plugins {first} and {second} disabled.',
+        many='Plugins {left}, and {last} disabled.'
+    ))
 
     return 0
 
@@ -481,16 +475,12 @@ def handle_enable(options):
         return 0  # nothing to disable or save, but not an error case
 
     # display plugins actually disabled by the command
-    plugins_count = len(actually_enabled)
-    if plugins_count == 1:
-        print('Plugin %s enabled.' % actually_enabled[0])
-    elif plugins_count == 2:
-        print('Plugin %s and %s enabled.' % actually_enabled)
-    else:
-        left = ', '.join(actually_enabled[:-1])
-        last = actually_enabled[-1]
-        print('Plugin %s, and %s enabled.' % (left, last))
-
+    print(utils.get_many_text(
+        actually_enabled,
+        one='Plugin {item} enabled.',
+        two='Plugins {first} and {second} enabled.',
+        many='Plugins {left}, and {last} enabled.'
+    ))
     return 0
 
 

--- a/sopel/cli/plugins.py
+++ b/sopel/cli/plugins.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 import argparse
+import inspect
 
 from sopel import plugins, tools
 
@@ -22,34 +23,38 @@ def build_parser():
     # sopel-plugins show <name>
     show_parser = subparsers.add_parser(
         'show',
+        formatter_class=argparse.RawTextHelpFormatter,
         help="Show plugin details",
-        description="""
-            Show detailed information about a plugin.
-        """)
+        description="Show detailed information about a plugin.")
     utils.add_common_arguments(show_parser)
     show_parser.add_argument('name', help='Plugin name')
 
     # sopel-plugins configure <name>
     config_parser = subparsers.add_parser(
         'configure',
+        formatter_class=argparse.RawTextHelpFormatter,
         help="Configure plugin with a config wizard",
-        description="""
-            Run a config wizard to configure a plugin. This can be used whether
-            the plugin is enabled or not.
-        """)
+        description=inspect.cleandoc("""
+            Run a config wizard to configure a plugin.
+
+            This can be used whether the plugin is enabled or not.
+        """))
     utils.add_common_arguments(config_parser)
     config_parser.add_argument('name', help='Plugin name')
 
     # sopel-plugins list
     list_parser = subparsers.add_parser(
         'list',
+        formatter_class=argparse.RawTextHelpFormatter,
         help="List available Sopel plugins",
-        description="""
-            List available Sopel plugins from all possible sources: built-in,
-            from ``sopel_modules.*``, from ``sopel.plugins`` entry points,
-            or Sopel's plugin directories. Enabled plugins are displayed in
-            green; disabled, in red.
-        """)
+        description=inspect.cleandoc("""
+            List available Sopel plugins from all possible sources.
+
+            Plugin sources are: built-in, from ``sopel_modules.*``,
+            from ``sopel.plugins`` entry points, or Sopel's plugin directories.
+
+            Enabled plugins are displayed in green; disabled, in red.
+        """))
     utils.add_common_arguments(list_parser)
     list_parser.add_argument(
         '-C', '--no-color',
@@ -80,38 +85,42 @@ def build_parser():
     # sopel-plugin disable
     disable_parser = subparsers.add_parser(
         'disable',
+        formatter_class=argparse.RawTextHelpFormatter,
         help="Disable a Sopel plugins",
-        description="""
+        description=inspect.cleandoc("""
             Disable a Sopel plugin by its name, no matter where it comes from.
+
             It is not possible to disable the ``coretasks`` plugin.
-        """)
+        """))
     utils.add_common_arguments(disable_parser)
     disable_parser.add_argument('name', help='Name of the plugin to disable')
     disable_parser.add_argument(
         '-f', '--force', action='store_true', default=False,
-        help="""
-            Force exclusion of the plugin. When ``core.enable`` is defined, a
-            plugin may be disabled without being excluded. In this case, use
-            this option to force its exclusion.
-        """)
+        help=inspect.cleandoc("""
+            Force exclusion of the plugin.
+            When ``core.enable`` is defined, a plugin may be disabled without
+            being excluded. In this case, use this option to force
+            its exclusion.
+        """))
     disable_parser.add_argument(
         '-r', '--remove', action='store_true', default=False,
-        help="""
-            Remove from ``core.enable`` list if applicable.
-        """)
+        help="Remove from ``core.enable`` list if applicable.")
 
     # sopel-plugin enable
     enable_parser = subparsers.add_parser(
         'enable',
-        help="Enable a Sopel plugins",
-        description="""
+        formatter_class=argparse.RawTextHelpFormatter,
+        help="Enable a Sopel plugin",
+        description=inspect.cleandoc("""
             Enable a Sopel plugin by its name, no matter where it comes from.
-            The ``coretasks`` plugin is always enabled. By default, a plugin
-            that is not excluded is enabled, unless at least one plugin is
-            defined in the ``core.enable`` list. In that case, Sopel uses
-            a "allow-only" policy for plugins, and enabled plugins must be
-            added to this list.
-        """)
+
+            The ``coretasks`` plugin is always enabled.
+
+            By default, a plugin that is not excluded is enabled, unless at
+            least one plugin is defined in the ``core.enable`` list.
+            In that case, Sopel uses an "allow-only" policy for plugins, and
+            all desired plugins must be added to this list.
+        """))
     utils.add_common_arguments(enable_parser)
     enable_parser.add_argument('name', help='Name of the plugin to enable')
     enable_parser.add_argument(
@@ -119,10 +128,10 @@ def build_parser():
         dest='allow_only',
         action='store_true',
         default=False,
-        help="""
-            Enforce allow-only policy, adding the plugin to the ``core.enable``
-            list.
-        """)
+        help=inspect.cleandoc("""
+            Enforce allow-only policy.
+            It makes sure the plugin is added to the ``core.enable`` list.
+        """))
 
     return parser
 
@@ -150,7 +159,7 @@ def handle_list(options):
             'status': 'enabled' if is_enabled else 'disabled',
         }
 
-        # option meta description from the plugin itself
+        # optional meta description from the plugin itself
         try:
             plugin.load()
             description.update(plugin.get_meta_description())
@@ -203,7 +212,7 @@ def handle_show(options):
         'status': 'enabled' if is_enabled else 'disabled',
     }
 
-    # option meta description from the plugin itself
+    # optional meta description from the plugin itself
     loaded = False
     try:
         plugin.load()

--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -15,7 +15,44 @@ __all__ = [
     'redirect_outputs',
     'wizard',
     'plugins_wizard',
+    # colors
+    'green',
+    'red',
 ]
+
+
+RESET = '\033[0m'
+RED = '\033[31m'
+GREEN = '\033[32m'
+
+
+def _colored(text, color, reset=True):
+    text = color + text
+    if reset:
+        return text + RESET
+    return text
+
+
+def green(text, reset=True):
+    """Add ANSI escape sequences to make the text green in term
+
+    :param str text: text to colorized in green
+    :param bool reset: if the text color must be reset after (default ``True``)
+    :return: text with ANSI escape sequences for green color
+    :rtype: str
+    """
+    return _colored(text, GREEN, reset)
+
+
+def red(text, reset=True):
+    """Add ANSI escape sequences to make the text red in term
+
+    :param str text: text to colorized in green
+    :param bool reset: if the text color must be reset after (default ``True``)
+    :return: text with ANSI escape sequences for green color
+    :rtype: str
+    """
+    return _colored(text, RED, reset)
 
 
 def wizard(filename):

--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -339,3 +339,23 @@ def redirect_outputs(settings, is_quiet=False):
     logfile = os.path.os.path.join(settings.core.logdir, settings.basename + '.stdio.log')
     sys.stderr = tools.OutputRedirect(logfile, True, is_quiet)
     sys.stdout = tools.OutputRedirect(logfile, False, is_quiet)
+
+
+def get_many_text(items, one, two, many):
+    """Get the right text based on the number of ``items``."""
+    message = ''
+    if not items:
+        return message
+
+    items_count = len(items)
+
+    if items_count == 1:
+        message = one.format(item=items[0], items=items)
+    elif items_count == 2:
+        message = two.format(first=items[0], second=items[1], items=items)
+    else:
+        left = ', '.join(items[:-1])
+        last = items[-1]
+        message = many.format(left=left, last=last, items=items)
+
+    return message

--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -1,6 +1,7 @@
 # coding=utf-8
 from __future__ import unicode_literals, absolute_import, print_function, division
 
+import inspect
 import os
 import sys
 
@@ -272,11 +273,13 @@ def add_common_arguments(parser):
         default=None,
         metavar='filename',
         dest='config',
-        help='Use a specific configuration file. '
-             'A config name can be given and the configuration file will be '
-             'found in Sopel\'s homedir (defaults to ``~/.sopel/default.cfg``). '
-             'An absolute pathname can be provided instead to use an '
-             'arbitrary location.')
+        help=inspect.cleandoc("""
+            Use a specific configuration file.
+            A config name can be given and the configuration file will be
+            found in Sopel\'s homedir (defaults to ``~/.sopel/default.cfg``).
+            An absolute pathname can be provided instead to use an
+            arbitrary location.
+        """))
 
 
 def load_settings(options):

--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -17,6 +17,7 @@ __all__ = [
     'plugins_wizard',
     # colors
     'green',
+    'yellow',
     'red',
 ]
 
@@ -24,6 +25,7 @@ __all__ = [
 RESET = '\033[0m'
 RED = '\033[31m'
 GREEN = '\033[32m'
+YELLOW = '\033[33m'
 
 
 def _colored(text, color, reset=True):
@@ -44,12 +46,23 @@ def green(text, reset=True):
     return _colored(text, GREEN, reset)
 
 
+def yellow(text, reset=True):
+    """Add ANSI escape sequences to make the text yellow in term
+
+    :param str text: text to colorized in yellow
+    :param bool reset: if the text color must be reset after (default ``True``)
+    :return: text with ANSI escape sequences for yellow color
+    :rtype: str
+    """
+    return _colored(text, YELLOW, reset)
+
+
 def red(text, reset=True):
     """Add ANSI escape sequences to make the text red in term
 
-    :param str text: text to colorized in green
+    :param str text: text to colorized in red
     :param bool reset: if the text color must be reset after (default ``True``)
-    :return: text with ANSI escape sequences for green color
+    :return: text with ANSI escape sequences for red color
     :rtype: str
     """
     return _colored(text, RED, reset)

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -418,9 +418,18 @@ class EntryPointPlugin(PyModulePlugin):
         .. __: https://setuptools.readthedocs.io/en/stable/setuptools.html#dynamic-discovery-of-services-and-plugins
 
     """
+    PLUGIN_TYPE = 'setup-entrypoint'
+
     def __init__(self, entry_point):
         self.entry_point = entry_point
         super(EntryPointPlugin, self).__init__(entry_point.name)
 
     def load(self):
         self._module = self.entry_point.load()
+
+    def get_meta_description(self):
+        data = super(EntryPointPlugin, self).get_meta_description()
+        data.update({
+            'source': str(self.entry_point),
+        })
+        return data

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -87,6 +87,22 @@ class AbstractPluginHandler(object):
         """
         raise NotImplementedError
 
+    def get_meta_description(self):
+        """Retrieve a meta description for the plugin
+
+        :return: meta description information
+        :rtype: :class:`dict`
+
+        The expected keys are:
+
+        * name: a short name for the plugin
+        * label: a descriptive label for the plugin
+        * type: the plugin's type
+        * source: the plugin's source
+          (filesystem path, python import path, etc.)
+        """
+        raise NotImplementedError
+
     def is_loaded(self):
         """Tell if the plugin is loaded or not
 
@@ -192,6 +208,8 @@ class PyModulePlugin(AbstractPluginHandler):
         True
 
     """
+    PLUGIN_TYPE = 'python-module'
+
     def __init__(self, name, package=None):
         self.name = name
         self.package = package
@@ -211,6 +229,14 @@ class PyModulePlugin(AbstractPluginHandler):
 
         lines = inspect.cleandoc(module_doc).splitlines()
         return default_label if not lines else lines[0]
+
+    def get_meta_description(self):
+        return {
+            'label': self.get_label(),
+            'type': self.PLUGIN_TYPE,
+            'name': self.name,
+            'source': self.module_name,
+        }
 
     def load(self):
         self._module = importlib.import_module(self.module_name)
@@ -267,6 +293,8 @@ class PyFilePlugin(PyModulePlugin):
     In this example, the plugin ``custom`` is loaded from its filename despite
     not being in the Python path.
     """
+    PLUGIN_TYPE = 'python-file'
+
     def __init__(self, filename):
         good_file = (
             os.path.isfile(filename) and
@@ -318,6 +346,13 @@ class PyFilePlugin(PyModulePlugin):
             raise TypeError('Unsupported module type')
 
         return mod
+
+    def get_meta_description(self):
+        data = super(PyFilePlugin, self).get_meta_description()
+        data.update({
+            'source': self.path,
+        })
+        return data
 
     def load(self):
         self._module = self._load()

--- a/test/cli/test_cli_utils.py
+++ b/test/cli/test_cli_utils.py
@@ -8,7 +8,12 @@ import os
 
 import pytest
 
-from sopel.cli.utils import enumerate_configs, find_config, add_common_arguments
+from sopel.cli.utils import (
+    add_common_arguments,
+    enumerate_configs,
+    find_config,
+    get_many_text,
+)
 
 
 @contextmanager
@@ -124,3 +129,22 @@ def test_add_common_arguments_subparser():
 
     options = parser.parse_args(['sub', '--config', 'test-long'])
     assert options.config == 'test-long'
+
+
+MANY_TEXTS = (
+    ([], ''),
+    (['a'], 'the a element'),
+    (['a', 'b'], 'elements a and b'),
+    (['a', 'b', 'c'], 'elements a, b, and c'),
+    (['a', 'b', 'c', 'd'], 'elements a, b, c, and d'),
+)
+
+
+@pytest.mark.parametrize('items, expected', MANY_TEXTS)
+def test_get_many_text(items, expected):
+    result = get_many_text(
+        items,
+        'the {item} element',
+        'elements {first} and {second}',
+        'elements {left}, and {last}')
+    assert result == expected

--- a/test/plugins/test_plugins_handlers.py
+++ b/test/plugins/test_plugins_handlers.py
@@ -1,0 +1,58 @@
+# coding=utf-8
+"""Test for the ``sopel.plugins.handlers`` module."""
+from __future__ import unicode_literals, absolute_import, print_function, division
+
+import pytest
+
+from sopel.plugins import handlers
+
+
+MOCK_MODULE_CONTENT = """# coding=utf-8
+\"\"\"module label
+\"\"\"
+"""
+
+
+@pytest.fixture
+def plugin_tmpfile(tmpdir):
+    root = tmpdir.mkdir('loader_mods')
+    mod_file = root.join('file_mod.py')
+    mod_file.write(MOCK_MODULE_CONTENT)
+
+    return mod_file
+
+
+def test_get_label_pymodule():
+    plugin = handlers.PyModulePlugin('coretasks', 'sopel')
+    meta = plugin.get_meta_description()
+
+    assert 'name' in meta
+    assert 'label' in meta
+    assert 'type' in meta
+    assert 'source' in meta
+
+    assert meta['name'] == 'coretasks'
+    assert meta['label'] == 'coretasks module', 'Expecting default label'
+    assert meta['type'] == handlers.PyModulePlugin.PLUGIN_TYPE
+    assert meta['source'] == 'sopel.coretasks'
+
+
+def test_get_label_pyfile(plugin_tmpfile):
+    plugin = handlers.PyFilePlugin(plugin_tmpfile.strpath)
+    meta = plugin.get_meta_description()
+
+    assert meta['name'] == 'file_mod'
+    assert meta['label'] == 'file_mod module', 'Expecting default label'
+    assert meta['type'] == handlers.PyFilePlugin.PLUGIN_TYPE
+    assert meta['source'] == plugin_tmpfile.strpath
+
+
+def test_get_label_pyfile_loaded(plugin_tmpfile):
+    plugin = handlers.PyFilePlugin(plugin_tmpfile.strpath)
+    plugin.load()
+    meta = plugin.get_meta_description()
+
+    assert meta['name'] == 'file_mod'
+    assert meta['label'] == 'module label'
+    assert meta['type'] == handlers.PyFilePlugin.PLUGIN_TYPE
+    assert meta['source'] == plugin_tmpfile.strpath

--- a/test/plugins/test_plugins_handlers.py
+++ b/test/plugins/test_plugins_handlers.py
@@ -1,7 +1,11 @@
 # coding=utf-8
-"""Test for the ``sopel.plugins.handlers`` module."""
+"""Tests for the ``sopel.plugins.handlers`` module."""
 from __future__ import unicode_literals, absolute_import, print_function, division
 
+import os
+import sys
+
+import pkg_resources
 import pytest
 
 from sopel.plugins import handlers
@@ -56,3 +60,25 @@ def test_get_label_pyfile_loaded(plugin_tmpfile):
     assert meta['label'] == 'module label'
     assert meta['type'] == handlers.PyFilePlugin.PLUGIN_TYPE
     assert meta['source'] == plugin_tmpfile.strpath
+
+
+def test_get_label_entrypoint(plugin_tmpfile):
+    # generate setuptools Distribution object
+    distrib_dir = os.path.dirname(plugin_tmpfile.strpath)
+    distrib = pkg_resources.Distribution(distrib_dir)
+    sys.path.append(distrib_dir)
+
+    # load the entry point
+    try:
+        entry_point = pkg_resources.EntryPoint(
+            'test_plugin', 'file_mod', dist=distrib)
+        plugin = handlers.EntryPointPlugin(entry_point)
+        plugin.load()
+    finally:
+        sys.path.remove(distrib_dir)
+
+    meta = plugin.get_meta_description()
+    assert meta['name'] == 'test_plugin'
+    assert meta['label'] == 'module label'
+    assert meta['type'] == handlers.EntryPointPlugin.PLUGIN_TYPE
+    assert meta['source'] == 'test_plugin = file_mod'


### PR DESCRIPTION
Should fix #244 and fix #1519 at the same time.

This PR adds a new command line to Sopel: `sopel-plugins`.

This command line supports 4 actions:

* `list`, to list available plugins (all by default, or just enabled/disabled plugins)
* `show`, to show detailed information about a plugin
* `configure`, to run a config wizard for a plugin
* `enable`, to enable a plugin
* `disable`, to disable a plugin

In order to implement it, I had to update the plugin handlers, adding methods to get meta description. I think we could built from that to include other meta-data (such as version, author, etc.).

This is the first version of the command. I think it's better to stop here for now, let users test it, play with it, etc. and see what's asked.

In the future, I think we will need to rework how a plugin can expose the commands, URL callback, rules, and jobs to the outside world, but I don't want to do that in that PR, which is big enough as it is, and fairly usable to me. 

## sopel-plugins list

```
usage: sopel-plugins list [-h] [-c filename] [-C] [-e | -d] [-n]

List available Sopel plugins from all possible sources: built-in, from
``sopel_modules.*``, from ``sopel.plugins`` entry points, or Sopel's plugin
directories. Enabled plugins are displayed in green; disabled, in red.

optional arguments:
  -h, --help            show this help message and exit
  -c filename, --config filename
                        Use a specific configuration file
  -C, --no-color        Disable colors
  -e, --enabled-only    Display only enabled plugins
  -d, --disabled-only   Display only disabled plugins
  -n, --name-only       Display only plugin names
```

## sopel-plugins show <name>

```
usage: sopel-plugins show [-h] [-c filename] name

Show detailed information about a plugin.

positional arguments:
  name                  Plugin name

optional arguments:
  -h, --help            show this help message and exit
  -c filename, --config filename
                        Use a specific configuration file
```

## sopel-plugins configure <name>

```
usage: sopel-plugins configure [-h] [-c filename] name

Run a config wizard to configure a plugin. This can be used whether the plugin
is enabled or not.

positional arguments:
  name                  Plugin name

optional arguments:
  -h, --help            show this help message and exit
  -c filename, --config filename
                        Use a specific configuration file
```

## sopel-plugins enable

```
usage: sopel-plugins enable [-h] [-c filename] [-a] name

Enable a Sopel plugin by its name, no matter where it comes from. The
``coretasks`` plugin is always enabled. By default, a plugin that is not
excluded is enabled, unless at least one plugin is defined in the
``core.enable`` list. In that case, Sopel uses a "allow-only" policy for
plugins, and enabled plugins must be added to this list.

positional arguments:
  name                  Name of the plugin to enable

optional arguments:
  -h, --help            show this help message and exit
  -c filename, --config filename
                        Use a specific configuration file
  -a, --allow-only      Enforce allow-only policy, adding the plugin to the
                        ``core.enable`` list.
```

## sopel-plugins disable

```
usage: sopel-plugins disable [-h] [-c filename] [-f] [-r] name

Disable a Sopel plugin by its name, no matter where it comes from. It is not
possible to disable the ``coretasks`` plugin.

positional arguments:
  name                  Name of the plugin to disable

optional arguments:
  -h, --help            show this help message and exit
  -c filename, --config filename
                        Use a specific configuration file
  -f, --force           Force exclusion of the plugin. When ``core.enable`` is
                        defined, a plugin may be disabled without being
                        excluded. In this case, use this option to force its
                        exclusion.
  -r, --remove          Remove from ``core.enable`` list if applicable.
```