### PR TITLE
Fix up some docstrings for 6.6.x

### DIFF
--- a/sopel/formatting.py
+++ b/sopel/formatting.py
@@ -93,9 +93,10 @@ def _get_color(color):
 def color(text, fg=None, bg=None):
     """Return the text, with the given colors applied in IRC formatting.
 
-    The color can be a string of the color name, or an integer between 0 and
-    99. The known color names can be found in the `colors` class of this
-    module."""
+    The color can be a string of the color name, or an integer between 0 and 99.
+    The known color names can be found in the :class:`colors` class of this
+    module.
+    """
     if not fg and not bg:
         return text
 
@@ -133,7 +134,8 @@ def hex_color(text, fg=None, bg=None):
 
     The color can be provided with a string of either 3 or 6 hexadecimal digits.
     As in CSS, 3-digit colors will be interpreted as if they were 6-digit colors
-    with each digit repeated (e.g. color `c90` is identical to `cc9900`)."""
+    with each digit repeated (e.g. color ``c90`` is identical to ``cc9900``).
+    """
     if not fg and not bg:
         return text
 

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -389,7 +389,7 @@ class SopelMemory(dict):
 
     """A simple thread-safe dict implementation.
 
-    *Availability: 4.0; available as ``Sopel.SopelMemory`` in 3.1.0 - 3.2.0*
+    *Availability: 4.0; available as ``Willie.WillieMemory`` in 3.1.0 - 3.2.0*
 
     In order to prevent exceptions when iterating over the values and changing
     them at the same time from different threads, we use a blocking lock on

--- a/sopel/tools/_events.py
+++ b/sopel/tools/_events.py
@@ -5,8 +5,8 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 class events(object):
     """An enumeration of all the standardized and notable IRC numeric events
 
-    This allows you to do, for example, @module.event(events.RPL_WELCOME)
-    rather than @module.event('001')
+    This allows you to do, for example, ``@module.event(events.RPL_WELCOME)``
+    rather than ``@module.event('001')``
     """
     # ###################################################### Non-RFC / Non-IRCv3
     # Only add things here if they're actually in common use across multiple

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -19,11 +19,14 @@ class User(object):
         self.channels = {}
         """The channels the user is in.
 
-        This maps channel name ``Identifier``\\s to ``Channel`` objects."""
+        This maps channel name :class:`~sopel.tools.Identifier`\\s to
+        :class:`Channel` objects.
+        """
         self.account = None
         """The IRC services account of the user.
 
-        This relies on IRCv3 account tracking being enabled."""
+        This relies on IRCv3 account tracking being enabled.
+        """
         self.away = None
         """Whether the user is marked as away."""
 
@@ -52,12 +55,16 @@ class Channel(object):
         self.users = {}
         """The users in the channel.
 
-        This maps username ``Identifier``\\s to channel objects."""
+        This maps nickname :class:`~sopel.tools.Identifier`\\s to :class:`User`
+        objects.
+        """
         self.privileges = {}
         """The permissions of the users in the channel.
 
-        This maps username ``Identifier``s to bitwise integer values. This can
-        be compared to appropriate constants from ``sopel.module``."""
+        This maps nickname :class:`~sopel.tools.Identifier`\\s to bitwise
+        integer values. This can be compared to appropriate constants from
+        :mod:`sopel.module`.
+        """
         self.topic = ''
         """The topic of the channel."""
 


### PR DESCRIPTION
While I was using the live website over the weekend to reference Sopel's API docs, some annoyances jumped out at me in the page about other API features (formatting, various tools).

Today, I decided to fix them. Most of this is touching stuff that hasn't been overhauled (#1565) yet, but I'll probably have to deal with a merge conflict or two on stuff in `tools` that I did already fix in #1563. It's worth doing so our live site can have a bit better content—especially since I fixed an actual mistake!