### PR TITLE
Bot.say: Handle max_messages better

### DIFF
--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -193,38 +193,33 @@ def get_nickname_command_pattern(command):
 
 
 def get_sendable_message(text, max_length=400):
-    """Get a sendable ``text`` message, with its excess when needed.
-
-    :param str txt: text to send (expects Unicode-encoded string)
+    """Get a sendable ``text`` message list.
+    :param str txt: unicode string of text to send
     :param int max_length: maximum length of the message to be sendable
-    :return: a tuple of two values, the sendable text and its excess text
-    :rtype: (str, str)
-
+    :return: a list of strings
     We're arbitrarily saying that the max is 400 bytes of text when
     messages will be split. Otherwise, we'd have to account for the bot's
     hostmask, which is hard.
-
     The ``max_length`` is the max length of text in **bytes**, but we take
-    care of Unicode 2-byte characters by working on the Unicode string,
+    care of unicode 2-bytes characters, by working on the unicode string,
     then making sure the bytes version is smaller than the max length.
     """
-    unicode_max_length = max_length
-    excess = ''
+    text_list = []
 
     while len(text.encode('utf-8')) > max_length:
-        last_space = text.rfind(' ', 0, unicode_max_length)
+        last_space = text.rfind(' ', 0, max_length)
         if last_space == -1:
             # No last space, just split where it is possible
-            excess = text[unicode_max_length:] + excess
-            text = text[:unicode_max_length]
-            # Decrease max length for the unicode string
-            unicode_max_length = unicode_max_length - 1
+            text_list.append(text[:max_length])
+            text = text[max_length:]
         else:
             # Split at the last best space found
-            excess = text[last_space:]
-            text = text[:last_space]
+            text_list.append(text[:last_space])
+            text = text[last_space:]
+    if len(text.encode('utf-8')):
+        text_list.append(text)
 
-    return text, excess.lstrip()
+    return text_list
 
 
 def deprecated(old):

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -8,86 +8,72 @@ from sopel import tools
 
 def test_get_sendable_message_default():
     initial = 'aaaa'
-    text, excess = tools.get_sendable_message(initial)
+    text_list = tools.get_sendable_message(initial)
 
-    assert text == initial
-    assert excess == ''
+    assert text_list == [initial]
 
 
 def test_get_sendable_message_limit():
     initial = 'a' * 400
-    text, excess = tools.get_sendable_message(initial)
+    text_list = tools.get_sendable_message(initial)
 
-    assert text == initial
-    assert excess == ''
+    assert text_list == [initial]
 
 
 def test_get_sendable_message_excess():
     initial = 'a' * 401
-    text, excess = tools.get_sendable_message(initial)
+    text_list = tools.get_sendable_message(initial)
 
-    assert text == 'a' * 400
-    assert excess == 'a'
+    assert text_list == ['a' * 400, 'a']
 
 
 def test_get_sendable_message_excess_space():
     # aaa...aaa bbb...bbb
     initial = ' '.join(['a' * 200, 'b' * 200])
-    text, excess = tools.get_sendable_message(initial)
+    text_list = tools.get_sendable_message(initial)
 
-    assert text == 'a' * 200
-    assert excess == 'b' * 200
+    assert text_list == ['a' * 200, ' b' + 'b' * 199]
 
 
 def test_get_sendable_message_excess_space_limit():
     # aaa...aaa bbb...bbb
     initial = ' '.join(['a' * 400, 'b' * 200])
-    text, excess = tools.get_sendable_message(initial)
+    text_list = tools.get_sendable_message(initial)
 
-    assert text == 'a' * 400
-    assert excess == 'b' * 200
+    assert text_list == ['a' * 400, ' b' + 'b' * 199]
 
 
 def test_get_sendable_message_excess_bigger():
     # aaa...aaa bbb...bbb
     initial = ' '.join(['a' * 401, 'b' * 1000])
-    text, excess = tools.get_sendable_message(initial)
+    text_list = tools.get_sendable_message(initial)
 
-    assert text == 'a' * 400
-    assert excess == 'a ' + 'b' * 1000
+    assert text_list == ['a' * 400, 'a b' + 'b' * 197, 'b' * 400, 'b' * 202]
 
 
 def test_get_sendable_message_optional():
-    text, excess = tools.get_sendable_message('aaaa', 3)
-    assert text == 'aaa'
-    assert excess == 'a'
+    text_list = tools.get_sendable_message('aaaa', 3)
+    assert text_list == ['aaa', 'a']
 
-    text, excess = tools.get_sendable_message('aaa bbb', 3)
-    assert text == 'aaa'
-    assert excess == 'bbb'
+    text_list = tools.get_sendable_message('aaa bbb', 3)
+    assert text_list == ['aaa', 'bbb']
 
-    text, excess = tools.get_sendable_message('aa bb cc', 3)
-    assert text == 'aa'
-    assert excess == 'bb cc'
+    text_list = tools.get_sendable_message('aa bb cc', 3)
+    assert text_list == ['aa', 'bb cc']
 
 
 def test_get_sendable_message_two_bytes():
-    text, excess = tools.get_sendable_message('αααα', 4)
-    assert text == 'αα'
-    assert excess == 'αα'
+    text_list = tools.get_sendable_message('αααα', 4)
+    assert text_list == ['αα', 'αα']
 
-    text, excess = tools.get_sendable_message('αααα', 5)
-    assert text == 'αα'
-    assert excess == 'αα'
+    text_list = tools.get_sendable_message('αααα', 5)
+    assert text_list == ['αα', 'αα']
 
-    text, excess = tools.get_sendable_message('α ααα', 4)
-    assert text == 'α'
-    assert excess == 'ααα'
+    text_list = tools.get_sendable_message('α ααα', 4)
+    assert text_list == ['α', 'ααα']
 
-    text, excess = tools.get_sendable_message('αα αα', 4)
-    assert text == 'αα'
-    assert excess == 'αα'
+    text_list = tools.get_sendable_message('αα αα', 4)
+    assert text_list == ['αα', 'αα']
 
-    text, excess = tools.get_sendable_message('ααα α', 4)
-    assert text == 'αα'
-    assert excess == 'α α'
+    text_list = tools.get_sendable_message('ααα α', 4)
+    assert text_list == ['αα', 'α α']


### PR DESCRIPTION
What this PR aims to fix.

Currently, when there is `excess` text content, `bot.say` calls `bot.msg`, which cycles back to `bot.say`.
This is unnecessary and cyclical. This is amplified further when initially called from `bot.msg`.

These changes change `tools.get_sendable_message` to output a list of strings.
Doing so allows us to utilize `max_messages` more effectively.