### PR TITLE
bot: new setup sequence

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -153,7 +153,6 @@ class Sopel(irc.Bot):
             self.config.core.nick_blocks = []
         if not self.config.core.host_blocks:
             self.config.core.host_blocks = []
-        self.setup()
 
     @property
     def hostmask(self):

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -16,19 +16,18 @@ import sys
 import threading
 import time
 
-from sopel import irc, plugins, tools
+from sopel import irc, logger, plugins, tools
 from sopel.db import SopelDB
 from sopel.tools import stderr, Identifier, deprecated
 import sopel.tools.jobs
 from sopel.trigger import Trigger
 from sopel.module import NOLIMIT
-from sopel.logger import get_logger
 import sopel.loader
 
 
 __all__ = ['Sopel', 'SopelWrapper']
 
-LOGGER = get_logger(__name__)
+LOGGER = logger.get_logger(__name__)
 
 if sys.version_info.major >= 3:
     unicode = str
@@ -145,7 +144,7 @@ class Sopel(irc.Bot):
         """List of methods to call on shutdown."""
 
         self.scheduler = sopel.tools.jobs.JobScheduler(self)
-        self.scheduler.start()
+        """Job Scheduler. See :func:`sopel.module.interval`."""
 
         # Set up block lists
         # Default to empty
@@ -198,7 +197,23 @@ class Sopel(irc.Bot):
         irc.Bot.write(self, args, text=text)
 
     def setup(self):
-        """Set up the Sopel instance."""
+        """Set up Sopel bot before it can run
+
+        The setup phase manages to:
+
+        * setup logging (configure Python's built-in :mod:`logging`),
+        * setup the bot's plugins (load, setup, and register)
+        * start the job scheduler
+
+        """
+        self.setup_logging()
+        self.setup_plugins()
+        self.scheduler.start()
+
+    def setup_logging(self):
+        logger.setup_logging(self)
+
+    def setup_plugins(self):
         load_success = 0
         load_error = 0
         load_disabled = 0

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -218,7 +218,7 @@ class Sopel(irc.Bot):
         load_error = 0
         load_disabled = 0
 
-        stderr("Welcome to Sopel. Loading modules...")
+        stderr("Loading plugins...")
         usable_plugins = plugins.get_usable_plugins(self.config)
         for name, info in usable_plugins.items():
             plugin, is_enabled = info

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -18,7 +18,7 @@ import sys
 import time
 import traceback
 
-from sopel import bot, config, logger, tools, __version__
+from sopel import bot, config, tools, __version__
 from . import utils
 
 if sys.version_info < (2, 7):
@@ -73,7 +73,6 @@ def run(settings, pid_file, daemon=False):
             if hasattr(signal, 'SIGILL'):
                 signal.signal(signal.SIGILL, signal_handler)
             p.setup()
-            logger.setup_logging(p)
             p.run(settings.core.host, int(settings.core.port))
         except KeyboardInterrupt:
             break

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -72,6 +72,7 @@ def run(settings, pid_file, daemon=False):
                 signal.signal(signal.SIGUSR2, signal_handler)
             if hasattr(signal, 'SIGILL'):
                 signal.signal(signal.SIGILL, signal_handler)
+            p.setup()
             logger.setup_logging(p)
             p.run(settings.core.host, int(settings.core.port))
         except KeyboardInterrupt:

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -20,6 +20,27 @@ def tmpconfig(tmpdir):
     return config.Config(conf_file.strpath)
 
 
+def test_register_unregister_plugin(tmpconfig):
+    sopel = bot.Sopel(tmpconfig, daemon=False)
+    sopel.scheduler.stop()
+    sopel.scheduler.join(timeout=10)
+
+    # since `setup` hasn't been run, there is no registered plugin
+    assert not sopel.has_plugin('coretasks')
+
+    # register the plugin
+    plugin = plugins.handlers.PyModulePlugin('coretasks', 'sopel')
+    plugin.load()
+    plugin.register(sopel)
+
+    # and now there is!
+    assert sopel.has_plugin('coretasks')
+
+    # unregister it
+    plugin.unregister(sopel)
+    assert not sopel.has_plugin('coretasks')
+
+
 def test_remove_plugin_unknown_plugin(tmpconfig):
     sopel = bot.Sopel(tmpconfig, daemon=False)
     sopel.scheduler.stop()
@@ -34,12 +55,15 @@ def test_remove_plugin_unregistered_plugin(tmpconfig):
     sopel = bot.Sopel(tmpconfig, daemon=False)
     sopel.scheduler.stop()
     sopel.scheduler.join(timeout=10)
-    plugin = sopel._plugins.get('coretasks')
 
-    assert plugin is not None, 'coretasks should always be loaded'
+    # register the plugin
+    plugin = plugins.handlers.PyModulePlugin('coretasks', 'sopel')
+    plugin.load()
+    plugin.register(sopel)
 
     # Unregister the plugin
     plugin.unregister(sopel)
+
     # And now it must raise an exception
     with pytest.raises(plugins.exceptions.PluginNotRegistered):
         sopel.remove_plugin(plugin, [], [], [], [])
@@ -49,12 +73,15 @@ def test_reload_plugin_unregistered_plugin(tmpconfig):
     sopel = bot.Sopel(tmpconfig, daemon=False)
     sopel.scheduler.stop()
     sopel.scheduler.join(timeout=10)
-    plugin = sopel._plugins.get('coretasks')
 
-    assert plugin is not None, 'coretasks should always be loaded'
+    # register the plugin
+    plugin = plugins.handlers.PyModulePlugin('coretasks', 'sopel')
+    plugin.load()
+    plugin.register(sopel)
 
     # Unregister the plugin
     plugin.unregister(sopel)
+
     # And now it must raise an exception
     with pytest.raises(plugins.exceptions.PluginNotRegistered):
         sopel.reload_plugin(plugin.name)

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -22,8 +22,6 @@ def tmpconfig(tmpdir):
 
 def test_register_unregister_plugin(tmpconfig):
     sopel = bot.Sopel(tmpconfig, daemon=False)
-    sopel.scheduler.stop()
-    sopel.scheduler.join(timeout=10)
 
     # since `setup` hasn't been run, there is no registered plugin
     assert not sopel.has_plugin('coretasks')
@@ -43,8 +41,6 @@ def test_register_unregister_plugin(tmpconfig):
 
 def test_remove_plugin_unknown_plugin(tmpconfig):
     sopel = bot.Sopel(tmpconfig, daemon=False)
-    sopel.scheduler.stop()
-    sopel.scheduler.join(timeout=10)
 
     plugin = plugins.handlers.PyModulePlugin('admin', 'sopel.modules')
     with pytest.raises(plugins.exceptions.PluginNotRegistered):
@@ -53,8 +49,6 @@ def test_remove_plugin_unknown_plugin(tmpconfig):
 
 def test_remove_plugin_unregistered_plugin(tmpconfig):
     sopel = bot.Sopel(tmpconfig, daemon=False)
-    sopel.scheduler.stop()
-    sopel.scheduler.join(timeout=10)
 
     # register the plugin
     plugin = plugins.handlers.PyModulePlugin('coretasks', 'sopel')
@@ -71,8 +65,6 @@ def test_remove_plugin_unregistered_plugin(tmpconfig):
 
 def test_reload_plugin_unregistered_plugin(tmpconfig):
     sopel = bot.Sopel(tmpconfig, daemon=False)
-    sopel.scheduler.stop()
-    sopel.scheduler.join(timeout=10)
 
     # register the plugin
     plugin = plugins.handlers.PyModulePlugin('coretasks', 'sopel')


### PR DESCRIPTION
At first, I had to rework the Job Scheduler in order to test how Sopel registers and unregisters plugins, which was annoying. But then, the solution wasn't perfect: I didn't like to have to manually stop the scheduler for testing purpose—which is time consuming and a bad thing when your test suite grow a bit (a lot at the moment). Aside from that, it also means that plugins where loaded, even if I didn't want them to be, or even needed to be. **This is the first thing I fixed**, by moving the call to `Sopel.setup()` outside of `Sopel.__init__()`.

Then, I realized: wait a minute... why do we setup plugins inside Sopel, but not logging? I couldn't find a good reason, so I moved that into Sopel's setup sequence.

Eventually, I thought: why do I even bother with the scheduler? Why do we need it started before anything else is even loaded? Answer is: we don't. We don't need that, and we don't have to start it whenever we instantiate `Sopel`.

So here we go:

* setup logging
* setup plugins
* start the job scheduler

all wrapped nicely into the old but still relevant `Sopel.setup()` method.

**BONUS POINT**: now the tests are slightly faster, and it's one step closer to facilitate reusability of `sopel.bot.Sopel` class for testing purpose (and everything else).