### PR TITLE
admin: Also protect `owner_account` setting

### DIFF
--- a/sopel/modules/admin.py
+++ b/sopel/modules/admin.py
@@ -220,11 +220,11 @@ def set_config(bot, trigger):
         bot.reply("%s.%s = %s" % (section_name, option, value))
         return
 
-    # 'core.owner' cannot be set by the bot. Any changes to this setting must be
-    # made manually in the config file.
-    if section_name == 'core' and option == 'owner':
-        bot.say('\'core.owner\' cannot be set by the bot. '
-                'This setting must be changed manually in the configuration file.')
+    # Owner-related settings cannot be modified interactively. Any changes to these
+    # settings must be made directly in the config file.
+    if section_name == 'core' and option in ['owner', 'owner_account']:
+        bot.say("Changing '{}.{}' requires manually editing the configuration file."
+                .format(section_name, option))
         return
 
     # Otherwise, set the value to one given as argument 2.


### PR DESCRIPTION
If I hadn't rushed 6.6.8 out, this would have been fixed already, but I was too quick to approve and merge #1587 and didn't realize there was another setting that needed protection until it was too late.

I'm sure there will be more little things to fix, so I'm not gonna rush this one out. Very few networks actually support the IRCv3 capabilities Sopel needs to authenticate accounts, so it's not urgent.