### PR TITLE
build: modernize/expand job matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,8 +38,14 @@ script:
   - ./checkstyle.sh
   - coverage run -m py.test -v .
   - coverage report
+env:
+  - COVERALLS_PARALLEL=true
 after_success:
   coveralls
+notifications:
+  webhooks:
+    urls:
+      - https://coveralls.io/webhook
 deploy:
   provider: pypi
   username: dgw

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,20 @@
+dist: xenial  # required for newer (>= 3.7) Python versions
 language: python
-python:
-  - "2.7"
-  - "3.3"
-  - "3.4"
+matrix:
+  include:
+    - name: "Python 2.7 on Xenial"
+      python: 2.7
+    - name: "Python 3.3 on Trusty"
+      python: 3.3
+      dist: trusty  # xenial does not support py3.3
+    - name: "Python 3.4 on Xenial"
+      python: 3.4
+    - name: "Python 3.5 on Xenial"
+      python: 3.5
+    - name: "Python 3.6 on Xenial"
+      python: 3.6
+    - name: "Python 3.7 on Xenial"
+      python: 3.7
 git:
   submodules: false
 branches:
@@ -35,5 +47,5 @@ deploy:
     secure: U9XLRA5fYRmII/pyJGDIT0BQ4p0zP8yZJtxUSUO9arFKozgYZu0ldvoLjKnzPMPQNCGs+q4f0hNuXgN+u/FgfRPF/Q3wtUj58uIC4JFnn7u2D2pv7RqzZkGi9Hr8+SS7dChlx9bVbhC1Y0md0XlrsT6rbNKKW457Jei05+vpjvg=
   on:
     tags: true
-    python: "3.4"
+    python: "3.6"
   allow_failure: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,7 @@ addons:
 install:
   - pip install -r requirements.txt -r dev-requirements.txt
 script:
-  - ./checkstyle.sh
-  - coverage run -m py.test -v .
-  - coverage report
+  - make travis
 env:
   - COVERALLS_PARALLEL=true
 after_success:

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: quality test coverage clean_doc build_doc
+.PHONY: quality test coverage_html coverage_report travis clean_doc build_doc
 
 quality:
 	./checkstyle.sh
@@ -6,11 +6,17 @@ quality:
 test:
 	coverage run -m py.test -v .
 
-coverage:
+coverage_report:
 	coverage report
+
+coverage_html:
 	coverage html
 
-qa: quality test coverage
+coverages: coverage_report coverage_html
+
+qa: quality test coverages
+
+travis: quality test coverage_report
 
 clean_doc:
 	$(MAKE) -C docs clean


### PR DESCRIPTION
Testing the full range of Python versions Sopel claims to support is probably wise. Generating releases from one of the newer runtimes is, likewise, also probably wise.

Running releases on 3.6 is a nice compromise between bleeding-edge and platform stability.

We don't test Python 3.8 yet, because its first stable release isn't scheduled until October of this year (2019). Travis supports testing on 3.8-dev or nightly versions, but that's not necessary for us.

_(This is the part where I hope that Travis picks up these settings when building the PR, so I can make extra sure they work as expected. Serve me right if it still uses the matrix from `master`…)_