### PR TITLE
Deprecate usage of bot.msg to bot.say

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -18,7 +18,7 @@ import time
 
 from sopel import irc, plugins, tools
 from sopel.db import SopelDB
-from sopel.tools import stderr, Identifier
+from sopel.tools import stderr, Identifier, deprecated
 import sopel.tools.jobs
 from sopel.trigger import Trigger
 from sopel.module import NOLIMIT
@@ -359,8 +359,12 @@ class Sopel(irc.Bot):
         else:
             self.write(['JOIN', channel, password])
 
+    @deprecated
     def msg(self, recipient, text, max_messages=1):
-        # Deprecated, but way too much of a pain to remove.
+        """
+        .. deprecated:: v6.0.0a5
+            Will be removed in Sopel 8.
+        """
         self.say(text, recipient, max_messages)
 
     def say(self, text, recipient, max_messages=1):

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -426,7 +426,7 @@ class Sopel(irc.Bot):
         # Now that we've sent the first part, we need to send the rest. Doing
         # this recursively seems easier to me than iteratively
         if excess:
-            self.msg(recipient, excess, max_messages - 1)
+            self.say(excess, max_messages - 1, recipient)
 
     def notice(self, text, dest):
         """Send an IRC NOTICE to a user or a channel.

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -38,9 +38,9 @@ def auth_after_register(bot):
     """Do NickServ/AuthServ auth"""
     if bot.config.core.auth_method == 'nickserv':
         nickserv_name = bot.config.core.auth_target or 'NickServ'
-        bot.msg(
-            nickserv_name,
-            'IDENTIFY %s' % bot.config.core.auth_password
+        bot.say(
+            'IDENTIFY %s' % bot.config.core.auth_password,
+            nickserv_name
         )
 
     elif bot.config.core.auth_method == 'authserv':
@@ -63,8 +63,8 @@ def auth_after_register(bot):
         userserv_name = bot.config.core.auth_target or 'UserServ'
         account = bot.config.core.auth_username
         password = bot.config.core.auth_password
-        bot.msg(userserv_name, "LOGIN {account} {password}".format(
-                account=account, password=password))
+        bot.say("LOGIN {account} {password}".format(
+                account=account, password=password), userserv_name)
 
 
 @sopel.module.event(events.RPL_WELCOME, events.RPL_LUSERCLIENT)
@@ -115,7 +115,7 @@ def startup(bot, trigger):
             "more secure. If you'd like to do this, make sure you're logged in "
             "and reply with \"{}useserviceauth\""
         ).format(bot.config.core.help_prefix)
-        bot.msg(bot.config.core.owner, msg)
+        bot.say(msg, bot.config.core.owner)
 
 
 @sopel.module.require_privmsg()
@@ -321,7 +321,7 @@ def track_nicks(bot, trigger):
         debug_msg = ("Nick changed by server. "
             "This can cause unexpected behavior. Please restart the bot.")
         LOGGER.critical(debug_msg)
-        bot.msg(bot.config.core.owner, privmsg)
+        bot.say(privmsg, bot.config.core.owner)
         return
 
     for channel in bot.privileges:

--- a/sopel/irc.py
+++ b/sopel/irc.py
@@ -456,12 +456,12 @@ class Bot(asynchat.async_chat):
                 LOGGER.error("Could not save traceback from %s to file: %s", trigger.sender, str(e))
 
             if trigger and self.config.core.reply_errors and trigger.sender is not None:
-                self.msg(trigger.sender, signature)
+                self.say(signature, trigger.sender)
             if trigger:
                 LOGGER.error('Exception from {}: {} ({})'.format(trigger.sender, str(signature), trigger.raw))
         except Exception as e:
             if trigger and self.config.core.reply_errors and trigger.sender is not None:
-                self.msg(trigger.sender, "Got an error.")
+                self.say("Got an error.", trigger.sender)
             if trigger:
                 LOGGER.error('Exception from {}: {} ({})'.format(trigger.sender, str(e), trigger.raw))
 

--- a/sopel/logger.py
+++ b/sopel/logger.py
@@ -13,7 +13,7 @@ class IrcLoggingHandler(logging.Handler):
     def emit(self, record):
         try:
             msg = self.format(record)
-            self._bot.msg(self._channel, msg)
+            self._bot.say(msg, self._channel)
         except (KeyboardInterrupt, SystemExit):
             raise
         except Exception:  # TODO: Be specific

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -82,7 +82,7 @@ def interval(*args):
         @sopel.module.interval(5)
         def spam_every_5s(bot):
             if "#here" in bot.channels:
-                bot.msg("#here", "It has been five seconds!")
+                bot.say("It has been five seconds!", "#here")
 
     """
     def add_attribute(function):

--- a/sopel/modules/admin.py
+++ b/sopel/modules/admin.py
@@ -169,10 +169,10 @@ def quit(bot, trigger):
 
 @sopel.module.require_privmsg
 @sopel.module.require_admin
-@sopel.module.commands('msg')
+@sopel.module.commands('say', 'msg')
 @sopel.module.priority('low')
-@sopel.module.example('.msg #YourPants Does anyone else smell neurotoxin?')
-def msg(bot, trigger):
+@sopel.module.example('.say #YourPants Does anyone else smell neurotoxin?')
+def say(bot, trigger):
     """
     Send a message to a given channel or nick. Can only be done in privmsg by
     an admin.
@@ -185,7 +185,7 @@ def msg(bot, trigger):
     if not channel or not message:
         return
 
-    bot.msg(channel, message)
+    bot.say(message, channel)
 
 
 @sopel.module.require_privmsg
@@ -206,7 +206,7 @@ def me(bot, trigger):
         return
 
     msg = '\x01ACTION %s\x01' % action
-    bot.msg(channel, msg)
+    bot.say(msg, channel)
 
 
 @sopel.module.event('INVITE')

--- a/sopel/modules/announce.py
+++ b/sopel/modules/announce.py
@@ -18,5 +18,5 @@ from sopel.module import commands, example, require_admin
 def announce(bot, trigger):
     """Send an announcement to all channels the bot is in"""
     for channel in bot.channels:
-        bot.msg(channel, '[ANNOUNCEMENT] %s' % trigger.group(2))
+        bot.say('[ANNOUNCEMENT] %s' % trigger.group(2), channel)
     bot.reply('Announce complete.')

--- a/sopel/modules/etymology.py
+++ b/sopel/modules/etymology.py
@@ -77,7 +77,7 @@ def f_etymology(bot, trigger):
         result = etymology(word)
     except IOError:
         msg = "Can't connect to etymonline.com (%s)" % (ETYURI % web.quote(word))
-        bot.msg(trigger.sender, msg)
+        bot.say(msg, trigger.sender)
         return NOLIMIT
     except (AttributeError, TypeError):
         result = None
@@ -85,9 +85,9 @@ def f_etymology(bot, trigger):
         result = str(ve)
 
     if result is not None:
-        bot.msg(trigger.sender, result)
+        bot.say(result, trigger.sender)
     else:
         uri = ETYSEARCH % web.quote(word)
         msg = 'Can\'t find the etymology for "%s". Try %s' % (word, uri)
-        bot.msg(trigger.sender, msg)
+        bot.say(msg, trigger.sender)
         return NOLIMIT

--- a/sopel/modules/find_updates.py
+++ b/sopel/modules/find_updates.py
@@ -59,4 +59,4 @@ def check_version(bot):
     msg = message.format(latest, sopel.__version__, notes)
 
     if version < latest_version:
-        bot.msg(bot.config.core.owner, msg)
+        bot.say(msg, bot.config.core.owner)

--- a/sopel/modules/help.py
+++ b/sopel/modules/help.py
@@ -230,7 +230,7 @@ def help(bot, trigger):
                               'I\'m sending it to you in a private message.')
 
                 def msgfun(l):
-                    bot.msg(trigger.nick, l)
+                    bot.say(l, trigger.nick)
             else:
                 msgfun = bot.reply
 

--- a/sopel/modules/meetbot.py
+++ b/sopel/modules/meetbot.py
@@ -421,7 +421,7 @@ def take_comment(bot, trigger):
         meetings_dict[trigger.group(3)]['comments'].append((trigger.nick, message))
         bot.say("Your comment has been recorded. It will be shown when the"
                 " chairs tell me to show the comments.")
-        bot.msg(meetings_dict[trigger.group(3)]['head'], "A new comment has been recorded.")
+        bot.say("A new comment has been recorded.", meetings_dict[trigger.group(3)]['head'])
 
 
 @commands('comments')

--- a/sopel/modules/remind.py
+++ b/sopel/modules/remind.py
@@ -144,9 +144,9 @@ def remind_monitoring(bot):
         for oldtime in oldtimes:
             for (channel, nick, message) in bot.rdb[oldtime]:
                 if message:
-                    bot.msg(channel, nick + ': ' + message)
+                    bot.say(nick + ': ' + message, channel)
                 else:
-                    bot.msg(channel, nick + '!')
+                    bot.say(nick + '!', channel)
             del bot.rdb[oldtime]
         dump_database(bot.rfn, bot.rdb)
 

--- a/sopel/modules/tell.py
+++ b/sopel/modules/tell.py
@@ -147,7 +147,7 @@ def getReminders(bot, channel, key, tellee):
         try:
             del bot.memory['reminders'][key]
         except KeyError:
-            bot.msg(channel, 'Er…')
+            bot.say('Er…', channel)
     finally:
         bot.memory['tell_lock'].release()
     return lines
@@ -179,7 +179,7 @@ def message(bot, trigger):
     if reminders[MAXIMUM:]:
         bot.say('Further messages sent privately')
         for line in reminders[MAXIMUM:]:
-            bot.msg(tellee, line)
+            bot.say(line, tellee)
 
     if len(bot.memory['reminders'].keys()) != remkeys:
         dumpReminders(bot.tell_filename, bot.memory['reminders'], bot.memory['tell_lock'])  # @@ tell


### PR DESCRIPTION
This PR aims to deprecate the usage of bot.msg as per:

````
    def msg(self, recipient, text, max_messages=1):
        # Deprecated, but way too much of a pain to remove.
        self.say(text, recipient, max_messages)
````

As of right now, anything that calls `bot.msg` gets passed to `bot.say`. This skips that step.