### PR TITLE
bot: dispatch simplification and minor optimization

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -548,51 +548,60 @@ class Sopel(irc.Bot):
 
     def dispatch(self, pretrigger):
         args = pretrigger.args
-        event, args, text = pretrigger.event, args, args[-1] if args else ''
+        text = args[-1] if args else ''
+        event = pretrigger.event
+        intent = pretrigger.tags.get('intent')
+        nick = pretrigger.nick
+        is_echo_message = nick.lower() == self.nick.lower()
+        user_obj = self.users.get(nick)
+        account = user_obj.account if user_obj else None
 
         if self.config.core.nick_blocks or self.config.core.host_blocks:
             nick_blocked = self._nick_blocked(pretrigger.nick)
             host_blocked = self._host_blocked(pretrigger.host)
         else:
             nick_blocked = host_blocked = None
+        blocked = bool(nick_blocked or host_blocked)
 
         list_of_blocked_functions = []
         for priority in ('high', 'medium', 'low'):
-            items = self._callables[priority].items()
-
-            for regexp, funcs in items:
+            for regexp, funcs in self._callables[priority].items():
                 match = regexp.match(text)
                 if not match:
                     continue
-                user_obj = self.users.get(pretrigger.nick)
-                account = user_obj.account if user_obj else None
                 trigger = Trigger(self.config, pretrigger, match, account)
                 wrapper = SopelWrapper(self, trigger)
 
                 for func in funcs:
-                    if (not trigger.admin and
-                            not func.unblockable and
-                            (nick_blocked or host_blocked)):
+                    # check blocked nick/host
+                    if blocked and not func.unblockable and not trigger.admin:
                         function_name = "%s.%s" % (
                             func.__module__, func.__name__
                         )
                         list_of_blocked_functions.append(function_name)
                         continue
 
+                    # check event
                     if event not in func.event:
                         continue
+
+                    # check intents
                     if hasattr(func, 'intents'):
-                        if not trigger.tags.get('intent'):
+                        if not intent:
                             continue
-                        match = False
-                        for intent in func.intents:
-                            if intent.match(trigger.tags.get('intent')):
-                                match = True
+
+                        match = any(
+                            func_intent.match(intent)
+                            for func_intent in func.intents
+                        )
                         if not match:
                             continue
-                    if (trigger.nick.lower() == self.nick.lower() and
-                            not func.echo):
+
+                    # check echo-message feature
+                    if is_echo_message and not func.echo:
                         continue
+
+                    # call triggered function
                     if func.thread:
                         targs = (func, wrapper, trigger)
                         t = threading.Thread(target=self.call, args=targs)
@@ -610,7 +619,7 @@ class Sopel(irc.Bot):
             LOGGER.info(
                 "[%s]%s prevented from using %s.",
                 block_type,
-                trigger.nick,
+                nick,
                 ', '.join(list_of_blocked_functions)
             )
 

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -569,10 +569,10 @@ class Sopel(irc.Bot):
                 match = regexp.match(text)
                 if not match:
                     continue
-                trigger = Trigger(self.config, pretrigger, match, account)
-                wrapper = SopelWrapper(self, trigger)
 
                 for func in funcs:
+                    trigger = Trigger(self.config, pretrigger, match, account)
+
                     # check blocked nick/host
                     if blocked and not func.unblockable and not trigger.admin:
                         function_name = "%s.%s" % (
@@ -602,6 +602,7 @@ class Sopel(irc.Bot):
                         continue
 
                     # call triggered function
+                    wrapper = SopelWrapper(self, trigger)
                     if func.thread:
                         targs = (func, wrapper, trigger)
                         t = threading.Thread(target=self.call, args=targs)


### PR DESCRIPTION
Sometimes, the code is just too complicated for what it does. I prefer to streamline conditions, to use intermediate variable when it makes sense, take advantage of built-in function like `any(iterable)`. When something can be calculated once and reuse each iteration, that's fine.

The second commit brings some protection against side-effect and race conditions: it was, in theory, possible for a triggered function to alter the `Trigger` or the `SopelWrapper` objects, which could cause an unexpected behavior in another triggered function. Now, we guaranty that, at least, the `bot` and `trigger` arguments of any triggered function will be unique and tied to the function's invocation only.

Of course, it is still possible to mess with the bot itself (which is usually the purpose anyway), or with the pre-trigger object (yet it's an undocumented class). At some point, it might be interesting to dig further into immutability territory for the pre-trigger object, but that isn't the goal of this PR.