### PR TITLE
module: example online argument defaults to False

### DIFF
--- a/sopel/module.py
+++ b/sopel/module.py
@@ -554,7 +554,7 @@ class example(object):
     """
     def __init__(self, msg, result=None, privmsg=False, admin=False,
                  owner=False, repeat=1, re=False, ignore=None,
-                 user_help=False, online=True):
+                 user_help=False, online=False):
         # Wrap result into a list for get_example_test
         if isinstance(result, list):
             self.result = result


### PR DESCRIPTION
I think I didn't rebase properly and set `online=True` by default instead of `online=False` on the `example` decorator in #1555 