### PR TITLE
module: fix examples when pytest isn't installed

### DIFF
--- a/sopel/module.py
+++ b/sopel/module.py
@@ -584,13 +584,16 @@ class example(object):
             func.example = []
 
         import sys
-        import pytest
 
         import sopel.test_tools  # TODO: fix circular import with sopel.bot and sopel.test_tools
 
         # only inject test-related stuff if we're running tests
         # see https://stackoverflow.com/a/44595269/5991
         if 'pytest' in sys.modules and self.result:
+            # avoids doing `import pytest` and causing errors when
+            # dev-dependencies aren't installed
+            pytest = sys.modules['pytest']
+
             test = sopel.test_tools.get_example_test(
                 func, self.msg, self.result, self.privmsg, self.admin,
                 self.owner, self.repeat, self.use_re, self.ignore


### PR DESCRIPTION
This broke auto-documenting module commands on the website, at least. (Good thing I decided to spin up a 'preview' branch of that now, instead of waiting until after Sopel 7 released to test it out.)

Not really sure why it didn't seem to break running Sopel itself when pytest isn't installed, but since pytest is a dev-dependency it's safer to handle the case when it's not available anyway.

Specifically requesting review from Exirel, instead of just any old Rockstar, because it was his PR (#1555) that caused this to break in the first place. I want to know if he has a better idea, since I'm just patching this at midnight to get the aforementioned 'preview' site working properly.