### PR TITLE
test: register pytest "online" marker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ addons:
       - aspell-en
       - libaspell-dev
 install:
-  - pip install -r requirements.txt -r dev-requirements.txt
+  - pip install --upgrade -r requirements.txt -r dev-requirements.txt
 script:
   - make travis
 env:

--- a/conftest.py
+++ b/conftest.py
@@ -17,3 +17,10 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if 'online' in item.keywords:
             item.add_marker(skip_online)
+
+
+def pytest_configure(config):
+    config.addinivalue_line(
+        'markers',
+        'online: for tests that require online access. '
+        'Use --offline to skip them.')

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
-pytest
+pytest<3.3; python_version == '3.3'
+pytest>=4.6,<4.7; python_version != '3.3'
 coveralls
 flake8<3.6.0; python_version == '3.3'
 flake8>=3.6.0,<3.7.0; python_version != '3.3'


### PR DESCRIPTION
Per [pytest latest version documentation](https://docs.pytest.org/en/latest/writing_plugins.html#registering-markers) we should register the custom marker we use - for now, "online".

And for good measure, let's always update dependencies when running Travis.