### PR TITLE
Bump praw version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 xmltodict
 pytz
-praw>=4.0.0,<6.0.0
+praw>=4.0.0,<7.0.0
 geoip2
 aspell-python-py2; python_version < '3'
 aspell-python-py3; python_version >= '3'


### PR DESCRIPTION
I've been able to successfully run all the tests with praw-6.3.1. 

Upstreaming version bump after packaging this for nixpkgs.