### PR TITLE
db: add methods for values associated with a server

### DIFF
--- a/test/test_db.py
+++ b/test/test_db.py
@@ -269,3 +269,27 @@ def test_get_preferred_value(db):
     names = ['asdf', '#asdf']
     assert db.get_preferred_value(names, 'qwer') == 'poiu'
     assert db.get_preferred_value(names, 'lkjh') == '1234'
+
+
+def test_set_server_value(db):
+    conn = sqlite3.connect(db_filename)
+    db.set_server_value('freenode', 'qwer', 'zxcv')
+    result = conn.execute(
+        'SELECT value FROM server_values WHERE server = ? and key = ?',
+        ['freenode', 'qwer']).fetchone()[0]
+    assert result == '"zxcv"'
+
+
+def test_delete_server_value(db):
+    db.set_server_value('freenode', 'wasd', 'uldr')
+    assert db.get_server_value('freenode', 'wasd') == 'uldr'
+    db.delete_server_value('freenode', 'wasd')
+    assert db.get_server_value('freenode', 'wasd') is None
+
+
+def test_get_server_value(db):
+    conn = sqlite3.connect(db_filename)
+    conn.execute("INSERT INTO server_values VALUES ('freenode', 'qwer', '\"zxcv\"')")
+    conn.commit()
+    result = db.get_server_value('freenode', 'qwer')
+    assert result == 'zxcv'


### PR DESCRIPTION
I'm not assuming this PR will get much traction, as it is likely an edge-case.

Based on PR #1621, this time for storing values associated with a/the server.

I saw another python IRC bot with database entries for `server`, so I figured it couldn't hurt to toss something like this together.

With PR #1536 , this could potentially assume the `server` key as ISUPPORTs `"NETWORK": "freenode"`
