### PR TITLE
module: add action_commands decorator

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -396,6 +396,7 @@ class Sopel(irc.Bot):
         * a callable without rules (will match any triggers, such as events)
         * a callable with commands
         * a callable with nick commands
+        * a callable with action commands
 
         It is possible to have a callable with rules, commands, and nick
         commands configured. It should not be possible to have a callable with
@@ -411,6 +412,7 @@ class Sopel(irc.Bot):
             rules = getattr(callbl, 'rule', [])
             commands = getattr(callbl, 'commands', [])
             nick_commands = getattr(callbl, 'nickname_commands', [])
+            action_commands = getattr(callbl, 'action_commands', [])
             events = getattr(callbl, 'event', [])
             is_rule_only = rules and not commands and not nick_commands
 
@@ -434,6 +436,11 @@ class Sopel(irc.Bot):
                         'Nick command callable "%s" registered for "%s"',
                         callable_name,
                         '|'.join(nick_commands))
+                if action_commands:
+                    LOGGER.debug(
+                        'Action command callable "%s" registered for "%s"',
+                        callable_name,
+                        '|'.join(action_commands))
                 if events:
                     LOGGER.debug(
                         'Event callable "%s" registered for "%s"',

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -68,7 +68,7 @@ def clean_callable(func, config):
             func.rule = [func.rule]
         func.rule = [compile_rule(nick, rule, alias_nicks) for rule in func.rule]
 
-    if hasattr(func, 'commands') or hasattr(func, 'nickname_commands') or hasattr(func, 'action_commands'):
+    if any(hasattr(func, attr) for attr in ['commands', 'nickname_commands', 'action_commands']):
         func.rule = getattr(func, 'rule', [])
         for command in getattr(func, 'commands', []):
             regexp = get_command_regexp(prefix, command)

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -4,7 +4,8 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 import re
 import sys
 
-from sopel.tools import compile_rule, itervalues, get_command_regexp, get_nickname_command_regexp
+from sopel.tools import (compile_rule, itervalues, get_command_regexp,
+                         get_nickname_command_regexp, get_action_command_regexp)
 from sopel.config import core_section
 
 default_prefix = core_section.CoreSection.help_prefix.default
@@ -67,7 +68,7 @@ def clean_callable(func, config):
             func.rule = [func.rule]
         func.rule = [compile_rule(nick, rule, alias_nicks) for rule in func.rule]
 
-    if hasattr(func, 'commands') or hasattr(func, 'nickname_commands'):
+    if hasattr(func, 'commands') or hasattr(func, 'nickname_commands') or hasattr(func, 'action_commands'):
         func.rule = getattr(func, 'rule', [])
         for command in getattr(func, 'commands', []):
             regexp = get_command_regexp(prefix, command)
@@ -75,6 +76,10 @@ def clean_callable(func, config):
                 func.rule.append(regexp)
         for command in getattr(func, 'nickname_commands', []):
             regexp = get_nickname_command_regexp(nick, command, alias_nicks)
+            if regexp not in func.rule:
+                func.rule.append(regexp)
+        for command in getattr(func, 'action_commands', []):
+            regexp = get_action_command_regexp(command)
             if regexp not in func.rule:
                 func.rule.append(regexp)
         if hasattr(func, 'example'):
@@ -131,6 +136,7 @@ def is_triggerable(obj):
         'intents',
         'commands',
         'nickname_commands',
+        'action_commands',
     )
     allowed = any(hasattr(obj, attr) for attr in allowed_attrs)
 

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -115,9 +115,9 @@ def is_triggerable(obj):
     :return: ``True`` if ``obj`` can handle the bot's triggers
 
     A triggerable is a callable that will be used by the bot to handle a
-    particular trigger (i.e. an IRC message): it can be a regex rule, an event,
-    an intent, a command, or a nickname command. However, it must not be a job
-    or a URL callback.
+    particular trigger (i.e. an IRC message): it can be a regex rule, an
+    event, an intent, a command, a nickname command, or an action command.
+    However, it must not be a job or a URL callback.
 
     .. seealso::
 

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -261,6 +261,34 @@ def nickname_commands(*command_list):
     return add_attribute
 
 
+def action_commands(*command_list):
+    """Decorate a function to trigger on CTCP ACTION lines.
+
+    This decorator can be used multiple times to add multiple rules. The
+    resulting match object will have the command as the first group, rest of
+    the line, excluding leading whitespace, as the second group. Parameters 1
+    through 4, separated by whitespace, will be groups 3-6.
+
+    Args:
+        command: A string, which can be a regular expression.
+
+    Returns:
+        A function with a new regular expression appended to the rule
+        attribute. If there is no rule attribute, it is added.
+
+    Example:
+        @action_commands("hello!"):
+            Would trigger on "/me hello!"
+    """
+    def add_attribute(function):
+        function.intents = ['ACTION']
+        if not hasattr(function, "action_commands"):
+            function.action_commands = []
+        function.action_commands.extend(command_list)
+        return function
+    return add_attribute
+
+
 def priority(value):
     """Decorate a function to be executed with higher or lower priority.
 

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -15,6 +15,7 @@ __all__ = [
     # constants
     'NOLIMIT', 'VOICE', 'HALFOP', 'OP', 'ADMIN', 'OWNER',
     # decorators
+    'action_commands',
     'commands',
     'echo',
     'example',
@@ -282,9 +283,11 @@ def action_commands(*command_list):
     """
     def add_attribute(function):
         function.intents = ['ACTION']
-        if not hasattr(function, "action_commands"):
+        if not hasattr(function, 'action_commands'):
             function.action_commands = []
-        function.action_commands.extend(command_list)
+        for cmd in command_list:
+            if cmd not in function.action_commands:
+                function.action_commands.append(cmd)
         return function
     return add_attribute
 

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -178,6 +178,45 @@ def get_nickname_command_pattern(command):
         """.format(command=command)
 
 
+def get_action_command_regexp(command):
+    """Get a compiled regexp object that implements the command.
+
+    :param str command: the name of the command
+    :return: a compiled regexp object that implements the command
+    :rtype: :py:class:`re.Pattern`
+    """
+    pattern = get_action_command_pattern(command)
+    return re.compile(pattern, re.IGNORECASE | re.VERBOSE)
+
+
+def get_action_command_pattern(command):
+    """Get the uncompiled regex pattern for action commands.
+
+    :param str command: the command name
+    :return: a regex pattern that will match the given command
+    :rtype: str
+    """
+    # This regexp matches equivalently and produces the same
+    # groups 1 and 2 as the old regexp: r'^%s(%s)(?: +(.*))?$'
+    # The only differences should be handling all whitespace
+    # like spaces and the addition of groups 3-6.
+    return r"""
+        ({command}) # Command as group 1.
+        (?:\s+              # Whitespace to end command.
+        (                   # Rest of the line as group 2.
+        (?:(\S+))?          # Parameters 1-4 as groups 3-6.
+        (?:\s+(\S+))?
+        (?:\s+(\S+))?
+        (?:\s+(\S+))?
+        .*                  # Accept anything after the parameters.
+                            # Leave it up to the module to parse
+                            # the line.
+        ))?                 # Group 2 must be None, if there are no
+                            # parameters.
+        $                   # EoL, so there are no partial matches.
+        """.format(command=command)
+
+
 def get_sendable_message(text, max_length=400):
     """Get a sendable ``text`` message, with its excess when needed.
 

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -192,6 +192,8 @@ def test_clean_callable_default(tmpconfig, func):
     # Not added by default
     assert not hasattr(func, 'rule')
     assert not hasattr(func, 'commands')
+    assert not hasattr(func, 'nickname_commands')
+    assert not hasattr(func, 'action_commands')
     assert not hasattr(func, 'intents')
 
 
@@ -311,6 +313,26 @@ def test_clean_callable_nickname_command(tmpconfig, func):
     assert regex.match('TestBot, hello!')
     assert regex.match('TestBot: hello!')
     assert not regex.match('TestBot not hello')
+
+    # idempotency
+    loader.clean_callable(func, tmpconfig)
+    assert len(func.rule) == 1
+    assert regex in func.rule
+
+
+def test_clean_callable_action_command(tmpconfig, func):
+    setattr(func, 'action_commands', ['bots'])
+    loader.clean_callable(func, tmpconfig)
+
+    assert hasattr(func, 'action_commands')
+    assert len(func.action_commands) == 1
+    assert func.action_commands == ['bots']
+    assert hasattr(func, 'rule')
+    assert len(func.rule) == 1
+
+    regex = func.rule[0]
+    assert regex.match('bots bottingly')
+    assert not regex.match('spams spammingly')
 
     # idempotency
     loader.clean_callable(func, tmpconfig)

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -213,6 +213,32 @@ def test_nickname_commands_multiple():
     assert mock.nickname_commands == ['robot', 'bot', 'sopel']
 
 
+def test_action_commands():
+    @module.action_commands('sopel')
+    def mock(bot, trigger, match):
+        return True
+    assert mock.action_commands == ['sopel']
+    assert mock.intents == ['ACTION']
+
+
+def test_action_commands_args():
+    @module.action_commands('sopel', 'bot')
+    def mock(bot, trigger, match):
+        return True
+    assert mock.action_commands == ['sopel', 'bot']
+    assert mock.intents == ['ACTION']
+
+
+def test_action_commands_multiple():
+    @module.action_commands('sopel', 'bot')
+    @module.action_commands('bot')
+    @module.action_commands('robot')
+    def mock(bot, trigger, match):
+        return True
+    assert mock.action_commands == ['robot', 'bot', 'sopel']
+    assert mock.intents == ['ACTION']
+
+
 def test_priority():
     @module.priority('high')
     def mock(bot, trigger, match):


### PR DESCRIPTION
As per my idea in Issue #1658, this is my attempt to integrate an `action_commands` command structure to Sopel.

There are still things to work out here, I'm sure. I copied elements I saw in `intents`, `commands`, and `nickname_commands`. I am very well aware the docstrings will definitely need work, as well as tests added.

I'm also not happy with the import line adjusted, and will likely fix that with `()` later.

This is more/less a draft PR, but my brief tests were very successful.