### PR TITLE
coretasks: update away status based on values returned from WHO call

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -806,8 +806,9 @@ def _record_who(bot, channel, user, host, nick, account=None, away=None, modes=N
 @sopel.module.unblockable
 def recv_who(bot, trigger):
     channel, user, host, _, nick, status = trigger.args[1:7]
+    away = 'G' in status
     modes = ''.join([c for c in status if c in '~&@%+'])
-    _record_who(bot, channel, user, host, nick, modes=modes)
+    _record_who(bot, channel, user, host, nick, away=away, modes=modes)
 
 
 @sopel.module.event(events.RPL_ENDOFWHO)


### PR DESCRIPTION
When processing the return from a WHO request, it seems that Sopel is not updating the away information for the users.  This pull request adds that update to the user records.

This provides part of the solution to Issue #1659 : User's "away" status always "None"