### PR TITLE
tools.events: add alternate spelling of 462 numeric

### DIFF
--- a/sopel/tools/_events.py
+++ b/sopel/tools/_events.py
@@ -80,6 +80,7 @@ class events(object):
     ERR_NOTREGISTERED = '451'
     ERR_NEEDMOREPARAMS = '461'
     ERR_ALREADYREGISTRED = '462'
+    ERR_ALREADYREGISTERED = '462'  # corrected spelling used in some tutorials
     ERR_NOPERMFORHOST = '463'
     ERR_PASSWDMISMATCH = '464'
     ERR_YOUREBANNEDCREEP = '465'


### PR DESCRIPTION
I've seen some tutorials/docs around the web use the modern spelling of this numeric's name. In the interest of making working with Sopel as easy as possible, I think it's worth including both spellings.

This is akin to HTTP's "Referer", which is spelled incorrectly in the HTTP standard but is sometimes spelled correctly in related standards (for example, the DOM spec).

Because this change was so simple, I decided to just open a one-line PR instead of wasting time with an issue discussing the pros and cons. I'm interested in feedback from any and all parties as to whether this really seems like a good idea.