### PR TITLE
coretasks: Only update user 'away' value if value passed is not 'None'

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -780,7 +780,8 @@ def _record_who(bot, channel, user, host, nick, account=None, away=None, modes=N
         usr.account = None
     else:
         usr.account = account
-    usr.away = away
+    if away is not None:
+        usr.away = away
     priv = 0
     if modes:
         mapping = {


### PR DESCRIPTION
Only update the 'away' value for a user if the value passed to the `_record_who` function is not None.

See the discussion at https://github.com/sopel-irc/sopel/pull/1663