### PR TITLE
doc: fix misuse of py:module replaced by py:currentmodule

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -1,4 +1,4 @@
-.. py:module:: sopel.config.core_section
+.. py:currentmodule:: sopel.config.core_section
 
 ================================
 The [core] configuration section


### PR DESCRIPTION
Oops.