### PR TITLE
core: add inspircd operprefix !/+y channel mode

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -363,6 +363,7 @@ def track_modes(bot, trigger):
         "a": module.ADMIN,
         "q": module.OWNER,
         "y": module.OPER,
+        "Y": module.OPER,
     }
 
     # Parse modes before doing anything else

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -299,6 +299,7 @@ def handle_names(bot, trigger):
         "@": module.OP,
         "&": module.ADMIN,
         "~": module.OWNER,
+        "!": module.OPER,
     }
 
     for name in names:
@@ -361,6 +362,7 @@ def track_modes(bot, trigger):
         "o": module.OP,
         "a": module.ADMIN,
         "q": module.OWNER,
+        "y": module.OPER,
     }
 
     # Parse modes before doing anything else
@@ -904,7 +906,7 @@ def recv_whox(bot, trigger):
         return LOGGER.warning('While populating `bot.accounts` a WHO response was malformed.')
     _, _, channel, user, host, nick, status, account = trigger.args
     away = 'G' in status
-    modes = ''.join([c for c in status if c in '~&@%+'])
+    modes = ''.join([c for c in status if c in '~&@%+!'])
     _record_who(bot, channel, user, host, nick, account, away, modes)
 
 
@@ -935,6 +937,7 @@ def _record_who(bot, channel, user, host, nick, account=None, away=None, modes=N
             "@": module.OP,
             "&": module.ADMIN,
             "~": module.OWNER,
+            "!": module.OPER,
         }
         for c in modes:
             priv = priv | mapping[c]
@@ -952,7 +955,7 @@ def _record_who(bot, channel, user, host, nick, account=None, away=None, modes=N
 def recv_who(bot, trigger):
     channel, user, host, _, nick, status = trigger.args[1:7]
     away = 'G' in status
-    modes = ''.join([c for c in status if c in '~&@%+'])
+    modes = ''.join([c for c in status if c in '~&@%+!'])
     _record_who(bot, channel, user, host, nick, away=away, modes=modes)
 
 

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -15,7 +15,7 @@ import re
 
 __all__ = [
     # constants
-    'NOLIMIT', 'VOICE', 'HALFOP', 'OP', 'ADMIN', 'OWNER',
+    'NOLIMIT', 'VOICE', 'HALFOP', 'OP', 'ADMIN', 'OWNER', 'OPER',
     # decorators
     'action_commands',
     'commands',
@@ -79,6 +79,13 @@ OWNER = 16
 """Privilege level for the +q channel permission
 
 .. versionadded:: 4.1
+"""
+
+OPER = 32
+"""Privilege level for the +y channel permission
+Note: Sopel does not track OPER status except through the +y channel mode
+
+.. versionadded:: 7.0.0
 """
 
 

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -82,8 +82,8 @@ OWNER = 16
 """
 
 OPER = 32
-"""Privilege level for the +y channel permission
-Note: Sopel does not track OPER status except through the +y channel mode
+"""Privilege level for the +y/+Y channel permissions
+Note: Sopel does not track OPER status except through these channel modes
 
 .. versionadded:: 7.0.0
 """

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -83,7 +83,9 @@ OWNER = 16
 
 OPER = 32
 """Privilege level for the +y/+Y channel permissions
-Note: Sopel does not track OPER status except through these channel modes
+
+Note: Except for these (non-standard) channel modes, Sopel does not monitor or
+store any user's OPER status.
 
 .. versionadded:: 7.0.0
 """


### PR DESCRIPTION
On inspircd 3 with the operprefix module, as oper, create a channel. You'll have `!`. Add the bot. The bot sees you as having no modes (`0`), and you can't do anything until you +o yourself.

Might not be a 6.6.x thing, but if I don't open this now I'm not going to remember.

Future enhancements:
- Have the symbol/mode/constant stuff in one place instead of 5 (!)
- Just generate this stuff from what the server tells us when we connect