### PR TITLE
bot: only suppress echo for PRIVMSG and NOTICE

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -665,7 +665,10 @@ class Sopel(irc.Bot):
         event = pretrigger.event
         intent = pretrigger.tags.get('intent')
         nick = pretrigger.nick
-        is_echo_message = nick.lower() == self.nick.lower()
+        is_echo_message = (
+            nick.lower() == self.nick.lower() and
+            event in ["PRIVMSG", "NOTICE"]
+        )
         user_obj = self.users.get(nick)
         account = user_obj.account if user_obj else None
 


### PR DESCRIPTION
thijseigenwijs on IRC reported that the bot doesn't update privilege tracking when it's the one to change a mode. This is because the server's MODE message is ignored by the echo suppression. This PR changes the echo suppression to only suppress PRIVMSG and NOTICE events.

- Can we assume the event will always be upper case?
- Any others that should be suppressed?