### PR TITLE
dev-requirements: cap flake8-future-import version

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,7 +4,7 @@ coveralls
 flake8<3.6.0; python_version == '3.3'
 flake8>=3.7.0,<3.8.0; python_version != '3.3'
 flake8-coding
-flake8-future-import
+flake8-future-import<0.4.6
 setuptools<40.0; python_version == '3.3'
 sphinx
 sphinxcontrib-autoprogram


### PR DESCRIPTION
0.4.6 added warnings for the annotations feature (we don't care about it yet), and dropped Python 3.3 support (we care about that still).

We'll make sure to use 0.4.5 or lower in tests.

There haven't been any CI builds on this repo in the last few days, which is why this caused a surprise failure on #1675. `flake8-future-import` 0.4.6 was released only 2 days ago.