### PR TITLE
tools.web: add `unquote()` function

### DIFF
--- a/sopel/modules/calc.py
+++ b/sopel/modules/calc.py
@@ -14,14 +14,7 @@ from requests import get
 
 from sopel.module import commands, example
 from sopel.tools.calculation import eval_equation
-
-if sys.version_info.major < 3:
-    from urllib import quote as _quote
-
-    def quote(s):
-        return _quote(s.encode('utf-8')).decode('utf-8')
-else:
-    from urllib.parse import quote
+from sopel.tools.web import quote
 
 if sys.version_info.major >= 3:
     unichr = chr

--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -10,21 +10,12 @@ https://sopel.chat
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 import re
-import sys
 
 import requests
 import xmltodict
 
 from sopel.module import commands, example
 from sopel.tools import web
-
-if sys.version_info.major < 3:
-    from urllib import unquote as _unquote
-
-    def unquote(s):
-        return _unquote(s.encode('utf-8')).decode('utf-8')
-else:
-    from urllib.parse import unquote
 
 
 def formatnumber(n):
@@ -68,7 +59,7 @@ def duck_search(query):
         bytes = bytes.split('web-result')[1]
     m = r_duck.search(bytes)
     if m:
-        unquoted_m = unquote(m.group(1))
+        unquoted_m = web.unquote(m.group(1))
         return web.decode(unquoted_m)
 
 

--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -9,24 +9,12 @@ https://sopel.chat
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 import re
-import sys
 
 from requests import get
 
 from sopel.config.types import StaticSection, ValidatedAttribute
 from sopel.module import NOLIMIT, commands, example, url
-
-if sys.version_info.major < 3:
-    from urllib import quote as _quote
-    from urlparse import unquote as _unquote
-
-    def quote(s):
-        return _quote(s.encode('utf-8')).decode('utf-8')
-
-    def unquote(s):
-        return _unquote(s.encode('utf-8')).decode('utf-8')
-else:
-    from urllib.parse import quote, unquote
+from sopel.tools.web import quote, unquote
 
 
 REDIRECT = re.compile(r'^REDIRECT (.*)')

--- a/sopel/tools/web.py
+++ b/sopel/tools/web.py
@@ -36,6 +36,7 @@ __all__ = [
     'entity',
     'iri_to_uri',
     'quote',
+    'unquote',
     'quote_query',
     'search_urls',
     'trim_url',
@@ -75,6 +76,19 @@ def quote(string, safe='/'):
     else:
         string = urllib.parse.quote(str(string), safe)
     return string
+
+
+# six-like shim for Unicode safety
+def unquote(string):
+    """Decodes a URL-encoded string.
+
+    :param str string: the string to decode
+    :return str: the decoded ``string``
+    """
+    if sys.version_info.major < 3:
+        return urllib.unquote(string.encode('utf-8')).decode('utf-8')
+    else:
+        return urllib.parse.unquote(string)
 
 
 def quote_query(string):

--- a/sopel/tools/web.py
+++ b/sopel/tools/web.py
@@ -84,6 +84,10 @@ def unquote(string):
 
     :param str string: the string to decode
     :return str: the decoded ``string``
+
+    .. note::
+        This is a shim to make writing cross-compatible plugins for both
+        Python 2 and Python 3 easier.
     """
     if sys.version_info.major < 3:
         return urllib.unquote(string.encode('utf-8')).decode('utf-8')

--- a/test/tools/test_tools_web.py
+++ b/test/tools/test_tools_web.py
@@ -4,7 +4,28 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 
 import pytest
 
-from sopel.tools.web import search_urls, trim_url
+from sopel.tools.web import quote, search_urls, trim_url, unquote
+
+
+QUOTED_STRINGS = [
+    'C%C3%BA_Chulainn',
+    'Q%C4%B1zmeydan',
+    'G%C3%BCn%C9%99%C5%9Fli%2C_Saatly',
+    'Rozst%C4%99pniewo',
+]
+UNQUOTED_STRINGS = [
+    'Cú_Chulainn',
+    'Qızmeydan',
+    'Günəşli,_Saatly',
+    'Rozstępniewo',
+]
+QUOTE_PAIRS = tuple(zip(UNQUOTED_STRINGS, QUOTED_STRINGS))
+UNQUOTE_PAIRS = tuple(zip(QUOTED_STRINGS, UNQUOTED_STRINGS))
+
+
+@pytest.mark.parametrize('text, result', QUOTE_PAIRS)
+def test_quote(text, result):
+    assert quote(text) == result
 
 
 def test_search_urls():
@@ -168,3 +189,8 @@ def test_trim_url_trailing_char_and_enclosing(trailing_char, left, right):
     # assert the trailing char is kept if there is something else
     test_url = 'http://example.com/' + trailing_char
     assert test_url == trim_url(test_url + right)
+
+
+@pytest.mark.parametrize('text, result', UNQUOTE_PAIRS)
+def test_unquote(text, result):
+    assert unquote(text) == result

--- a/test/tools/test_tools_web.py
+++ b/test/tools/test_tools_web.py
@@ -12,12 +12,24 @@ QUOTED_STRINGS = [
     'Q%C4%B1zmeydan',
     'G%C3%BCn%C9%99%C5%9Fli%2C_Saatly',
     'Rozst%C4%99pniewo',
+    'Two%20Blank%20Spaces',
+    'with%2Bplus%2Bsigns',
+    'Exclamatory%21',
+    'either/or',
+    'questioning...%3F',
+    '100%25',
 ]
 UNQUOTED_STRINGS = [
     'Cú_Chulainn',
     'Qızmeydan',
     'Günəşli,_Saatly',
     'Rozstępniewo',
+    'Two Blank Spaces',
+    'with+plus+signs',
+    'Exclamatory!',
+    'either/or',
+    'questioning...?',
+    '100%',
 ]
 QUOTE_PAIRS = tuple(zip(UNQUOTED_STRINGS, QUOTED_STRINGS))
 UNQUOTE_PAIRS = tuple(zip(QUOTED_STRINGS, UNQUOTED_STRINGS))


### PR DESCRIPTION
Also added tests for the old `quote()` function/shim and the new `unquote()` thing. They're even using `@pytest.mark.parametrize`! (And also using a cheeky `zip()` trick that @Exirel might think is "not dumb enough" for using in a test file. 🤐)

Aside from the obvious hope that anyone else still thinks this is a good idea (it's been around for a _while_ in #1346), I also hope that this merges cleanly with #1669, without any need to rebase crap later. It's not a big deal, but I do like the `gitk` graphs we get from merging un-rebased PRs that were developed in staggered parallel and not necessarily merged in order. 😼