### PR TITLE
config: No more '#' or ';' comments; use '//' instead

### DIFF
--- a/contrib/sopel.cfg
+++ b/contrib/sopel.cfg
@@ -1,11 +1,11 @@
-# Default sopel configuration file for Fedora
-# For information related to possible configuration values see
-# https://sopel.chat/docs/config.html#the-core-configuration-section
-# https://sopel.chat/usage/module-configuration/
-#
-# IMPORTANT NOTE!
-# You must delete the not_configured line in order for the bot to work,
-# otherwise it will refuse to start.
+// Default sopel configuration file for Fedora
+// For information related to possible configuration values see
+// https://sopel.chat/docs/config.html#the-core-configuration-section
+// https://sopel.chat/usage/module-configuration/
+//
+// IMPORTANT NOTE!
+// You must delete the not_configured line in order for the bot to work,
+// otherwise it will refuse to start.
 [core]
 nick=sopel
 not_configured=True

--- a/sopel/config/__init__.py
+++ b/sopel/config/__init__.py
@@ -112,7 +112,8 @@ class Config(object):
         If the filename is ``freenode.config.cfg``, then the ``basename`` will
         be ``freenode.config``.
         """
-        self.parser = ConfigParser.RawConfigParser(allow_no_value=True)
+        self.parser = ConfigParser.RawConfigParser(
+            allow_no_value=True, comment_prefixes=('//'))
         self.parser.read(self.filename)
         self.define_section('core', core_section.CoreSection,
                             validate=validate)


### PR DESCRIPTION
Any alternative idea that would let us keep using `#` for comments is welcome, but as described in the relevant commit message I don't think that's possible without some very dirty monkey-patching.

'Documentation' label because I'll have to make _damn sure_ I include very prominent notes about this in the changelog and migration guide. If someone loads an old config with now-unrecognized comments, Sopel will explode with a very unhelpful traceback:

```
$ sopel
Traceback (most recent call last):
  File "/mnt/c/Users/dgw/github/sopel/sopel/config/types.py", line 55, in __init__
    getattr(self, value)
  File "/mnt/c/Users/dgw/github/sopel/sopel/config/types.py", line 384, in __get__
    this_section = getattr(main_config, instance._section_name)
  File "/mnt/c/Users/dgw/github/sopel/sopel/config/__init__.py", line 218, in __getattr__
    section = self.ConfigSection(name, items, self)  # Return a section
  File "/mnt/c/Users/dgw/github/sopel/sopel/config/__init__.py", line 187, in __init__
    value = item[1].strip()
AttributeError: 'NoneType' object has no attribute 'strip'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/bin/sopel", line 11, in <module>
    load_entry_point('sopel', 'console_scripts', 'sopel')()
  File "/mnt/c/Users/dgw/github/sopel/sopel/cli/run.py", line 680, in main
    return command(opts)
  File "/mnt/c/Users/dgw/github/sopel/sopel/cli/run.py", line 573, in command_legacy
    config_module = get_configuration(opts)
  File "/mnt/c/Users/dgw/github/sopel/sopel/cli/run.py", line 329, in get_configuration
    settings = utils.load_settings(options)
  File "/mnt/c/Users/dgw/github/sopel/sopel/cli/utils.py", line 338, in load_settings
    return config.Config(filename)
  File "/mnt/c/Users/dgw/github/sopel/sopel/config/__init__.py", line 119, in __init__
    validate=validate)
  File "/mnt/c/Users/dgw/github/sopel/sopel/config/__init__.py", line 173, in define_section
    setattr(self, name, cls_(self, name, validate=validate))
  File "/mnt/c/Users/dgw/github/sopel/sopel/config/types.py", line 65, in __init__
    value)
ValueError: Missing required value for core.ca_certs
```

(Side note: Manually cleaning up that copy-paste due to microsoft/terminal#1073 was _fun_.)