### PR TITLE
config: do not serialize empty ListAttribute to blank line

### DIFF
--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -299,6 +299,9 @@ class ListAttribute(BaseValidated):
         if not isinstance(value, (list, set)):
             raise ValueError('ListAttribute value must be a list.')
 
+        # empty list should not create a blank line in the config file
+        if not value:
+            return ''
         # we ensure to read a newline, even with only one value in the list
         # this way, comma will be ignored when the configuration file
         # is read again later


### PR DESCRIPTION
Tweaks the serialization behavior of empty `ListAttribute` to eliminate unnecessary whitespace in the saved config file after Sopel writes it out.

Before:

```
[section]
list_attribute = 
	
next_thing = foo bar baz
```

After:

```
[section]
list_attribute = 
next_thing = foo bar baz
```