### PR TITLE
config: support quoting ListAttribute values

### DIFF
--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -123,7 +123,7 @@ class CoreSection(StaticSection):
     ca_certs = FilenameAttribute('ca_certs', default=_find_certs())
     """The path of the CA certs pem file."""
 
-    channels = ListAttribute('channels')
+    channels = ListAttribute('channels', quote=True)
     """List of channels for the bot to join when it connects."""
 
     db_type = ChoiceAttribute('db_type', choices=[

--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -255,10 +255,11 @@ class ListAttribute(BaseValidated):
     """
     DELIMITER = ','
 
-    def __init__(self, name, strip=True, default=None):
+    def __init__(self, name, strip=True, quote=False, default=None):
         default = default or []
         super(ListAttribute, self).__init__(name, default=default)
         self.strip = strip
+        self.quote = quote
 
     def parse(self, value):
         """Parse ``value`` into a list.
@@ -289,6 +290,9 @@ class ListAttribute(BaseValidated):
             items = value.split(self.DELIMITER)
 
         value = list(filter(None, items))
+        if self.quote:
+            value = [v.strip('"') for v in value]
+
         if self.strip:  # deprecate strip option in Sopel 8.x
             return [v.strip() for v in value]
         else:
@@ -298,6 +302,10 @@ class ListAttribute(BaseValidated):
         """Serialize ``value`` into a multi-line string."""
         if not isinstance(value, (list, set)):
             raise ValueError('ListAttribute value must be a list.')
+
+        # either all values should be quoted, or none
+        if self.quote:
+            value = ['"{}"'.format(v) for v in value]
 
         # we ensure to read a newline, even with only one value in the list
         # this way, comma will be ignored when the configuration file

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -26,6 +26,10 @@ cheeses =
     cheddar
       reblochon   
   camembert
+beers = 
+    "Lager"
+  "Stout"     
+      "#pisswasser"
 """  # noqa (trailing whitespaces are intended)
 
 
@@ -43,6 +47,7 @@ class SpamSection(types.StaticSection):
     eggs = types.ListAttribute('eggs')
     bacons = types.ListAttribute('bacons', strip=False)
     cheeses = types.ListAttribute('cheeses')
+    beers = types.ListAttribute('beers', quote=True)
 
 
 @pytest.fixture
@@ -218,6 +223,11 @@ def test_configparser_multi_lines(multi_fakeconfig):
         'reblochon',
         'camembert',
     ]
+    assert multi_fakeconfig.spam.beers == [
+        'Lager',
+        'Stout',
+        '#pisswasser',
+    ]
 
 
 def test_save_unmodified_config(multi_fakeconfig):
@@ -257,6 +267,11 @@ def test_save_unmodified_config(multi_fakeconfig):
         'reblochon',
         'camembert',
     ]
+    assert saved_config.spam.beers == [
+        'Lager',
+        'Stout',
+        '#pisswasser',
+    ]
 
 
 def test_save_modified_config(multi_fakeconfig):
@@ -268,6 +283,11 @@ def test_save_modified_config(multi_fakeconfig):
     ]
     multi_fakeconfig.spam.cheeses = [
         'camembert, reblochon, and cheddar',
+    ]
+    multi_fakeconfig.spam.beers = [
+        'Dark Lager',
+        'Dark Stout',
+        '#pisswasser',
     ]
 
     multi_fakeconfig.save()
@@ -287,3 +307,8 @@ def test_save_modified_config(multi_fakeconfig):
         'ListAttribute with one line only, with commas, must *not* be split '
         'differently from what was expected, i.e. into one (and only one) value'
     )
+    assert saved_config.spam.beers == [
+        'Dark Lager',
+        'Dark Stout',
+        '#pisswasser',
+    ]


### PR DESCRIPTION
Likely a better alternative to #1687. Suggested by @Exirel a little while ago as he was heading to bed. I felt like doing something code-y, so here we are.

Most of the time I spent on this actually went into the docstring updates, which are separated into their own commit. That will make it easier to pull them out and (with minor tweaks) apply the same fixes in a separate PR if we ultimately go with a different solution to the `#` problem.

Of note: I removed a reference to some feature of `StaticSection.configure_setting()` that never worked (having `prompt` be an optional argument). See #864 & ab83a1f7.