### PR TITLE
loader: default rule for events

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -62,7 +62,6 @@ def auth_after_register(bot):
 
 
 @sopel.module.event(events.RPL_WELCOME, events.RPL_LUSERCLIENT)
-@sopel.module.rule('.*')
 @sopel.module.thread(False)
 @sopel.module.unblockable
 def startup(bot, trigger):
@@ -133,7 +132,6 @@ def enable_service_auth(bot, trigger):
 
 
 @sopel.module.event(events.ERR_NOCHANMODES)
-@sopel.module.rule('.*')
 @sopel.module.priority('high')
 def retry_join(bot, trigger):
     """Give NickServer enough time to identify on a +R channel.
@@ -295,7 +293,6 @@ def track_modes(bot, trigger):
             bot.channels[channel].privileges[nick] = priv
 
 
-@sopel.module.rule('.*')
 @sopel.module.event('NICK')
 @sopel.module.priority('high')
 @sopel.module.thread(False)
@@ -345,7 +342,6 @@ def track_part(bot, trigger):
     _remove_from_channel(bot, nick, channel)
 
 
-@sopel.module.rule('.*')
 @sopel.module.event('KICK')
 @sopel.module.priority('high')
 @sopel.module.thread(False)
@@ -403,7 +399,6 @@ def _send_who(bot, channel):
         bot.write(['WHO', channel])
 
 
-@sopel.module.rule('.*')
 @sopel.module.event('JOIN')
 @sopel.module.priority('high')
 @sopel.module.thread(False)
@@ -430,7 +425,6 @@ def track_join(bot, trigger):
         user.account = trigger.args[1]
 
 
-@sopel.module.rule('.*')
 @sopel.module.event('QUIT')
 @sopel.module.priority('high')
 @sopel.module.thread(False)
@@ -443,7 +437,6 @@ def track_quit(bot, trigger):
     bot.users.pop(trigger.nick, None)
 
 
-@sopel.module.rule('.*')
 @sopel.module.event('CAP')
 @sopel.module.thread(False)
 @sopel.module.priority('high')
@@ -625,7 +618,6 @@ def send_authenticate(bot, token):
 
 
 @sopel.module.event('AUTHENTICATE')
-@sopel.module.rule('.*')
 def auth_proceed(bot, trigger):
     if trigger.args[0] != '+':
         # How did we get here? I am not good with computer.
@@ -645,7 +637,6 @@ def auth_proceed(bot, trigger):
 
 
 @sopel.module.event(events.RPL_SASLSUCCESS)
-@sopel.module.rule('.*')
 def sasl_success(bot, trigger):
     bot.write(('CAP', 'END'))
 
@@ -737,7 +728,6 @@ def blocks(bot, trigger):
 
 
 @sopel.module.event('ACCOUNT')
-@sopel.module.rule('.*')
 def account_notify(bot, trigger):
     if trigger.nick not in bot.users:
         bot.users[trigger.nick] = User(trigger.nick, trigger.user, trigger.host)
@@ -748,7 +738,6 @@ def account_notify(bot, trigger):
 
 
 @sopel.module.event(events.RPL_WHOSPCRPL)
-@sopel.module.rule('.*')
 @sopel.module.priority('high')
 @sopel.module.unblockable
 def recv_whox(bot, trigger):
@@ -801,7 +790,6 @@ def _record_who(bot, channel, user, host, nick, account=None, away=None, modes=N
 
 
 @sopel.module.event(events.RPL_WHOREPLY)
-@sopel.module.rule('.*')
 @sopel.module.priority('high')
 @sopel.module.unblockable
 def recv_who(bot, trigger):
@@ -811,7 +799,6 @@ def recv_who(bot, trigger):
 
 
 @sopel.module.event(events.RPL_ENDOFWHO)
-@sopel.module.rule('.*')
 @sopel.module.priority('high')
 @sopel.module.unblockable
 def end_who(bot, trigger):
@@ -819,7 +806,6 @@ def end_who(bot, trigger):
         who_reqs.pop(trigger.args[1], None)
 
 
-@sopel.module.rule('.*')
 @sopel.module.event('AWAY')
 @sopel.module.priority('high')
 @sopel.module.thread(False)
@@ -831,7 +817,6 @@ def track_notify(bot, trigger):
     user.away = bool(trigger.args)
 
 
-@sopel.module.rule('.*')
 @sopel.module.event('TOPIC')
 @sopel.module.event(events.RPL_TOPIC)
 @sopel.module.priority('high')

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -104,7 +104,10 @@ def clean_callable(func, config):
 
 
 def is_triggerable(obj):
-    return any(hasattr(obj, attr) for attr in ('rule', 'intents', 'commands', 'nickname_commands'))
+    return any(
+        hasattr(obj, attr)
+        for attr in ('rule', 'event', 'intents', 'commands',
+                     'nickname_commands'))
 
 
 def clean_module(module, config):

--- a/sopel/modules/admin.py
+++ b/sopel/modules/admin.py
@@ -222,7 +222,6 @@ def me(bot, trigger):
 
 
 @sopel.module.event('INVITE')
-@sopel.module.rule('.*')
 @sopel.module.priority('low')
 def invite_join(bot, trigger):
     """Join a channel Sopel is invited to, if the inviter is an admin."""
@@ -232,7 +231,6 @@ def invite_join(bot, trigger):
 
 
 @sopel.module.event('KICK')
-@sopel.module.rule(r'.*')
 @sopel.module.priority('low')
 def hold_ground(bot, trigger):
     """

--- a/sopel/modules/find_updates.py
+++ b/sopel/modules/find_updates.py
@@ -32,7 +32,6 @@ unstable_message = (
 
 
 @sopel.module.event(sopel.tools.events.RPL_LUSERCLIENT)
-@sopel.module.rule('.*')
 def startup_version_check(bot, trigger):
     global startup_check_run
     if not startup_check_run:

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -86,9 +86,10 @@ def test_clean_module_commands(tmpdir, tmpconfig):
     callables, jobs, shutdowns, urls = loader.clean_module(
         test_mod, tmpconfig)
 
-    assert len(callables) == 2
+    assert len(callables) == 3
     assert test_mod.first_command in callables
     assert test_mod.second_command in callables
+    assert test_mod.on_topic_command in callables
     assert len(jobs) == 2
     assert test_mod.interval5s in jobs
     assert test_mod.interval10s in jobs
@@ -272,7 +273,7 @@ def test_clean_callable_events(tmpconfig, func):
     assert func.event == ['TOPIC', 'JOIN', 'NICK']
 
 
-def test_clean_callable_events_basetring(tmpconfig, func):
+def test_clean_callable_events_basestring(tmpconfig, func):
     setattr(func, 'event', 'topic')
     loader.clean_callable(func, tmpconfig)
 


### PR DESCRIPTION
Helped @deathbybandaid with `@event` decorators not working and realized that this specific problem comes up _a lot_, relatively speaking, when Sopel users have trouble writing custom plugins.

Obviously our documentation doesn't do a great job of making sure plugin devs know that `@rule` is required along with `@event`. But rather than fix the documentation, I decided to do the user-friendly (developer-friendly?) thing and make it so `event` is considered triggerable just like a command or rule, and so it will also get the default `.*` rule applied if necessary once registered.

An early version of this patch (pre-publication) also applied this default rule to intents, but:

  * There's only one meaningful intent value (`'ACTION'`), which almost always requires an explicit rule anyway.
  * We're probably going to deprecate and/or remove `@intents` pretty soon because it's obsolete (#1683).

Other rejected ideas were applying this to `@url` (not needed) and to `@echo` (immediately determined to be _the exact opposite_ of intuitive behavior once I gave it ten seconds of thought).

So here we are: A ±0 line patch (if we ignore tests & code formatting) to the loader that saves us almost 20 real-code lines of boilerplate. Not bad for a bit of afternoon hacking, if I do say so myself.