### PR TITLE
tell: use config to send reminders as private messages

### DIFF
--- a/test/modules/test_modules_tell.py
+++ b/test/modules/test_modules_tell.py
@@ -1,0 +1,155 @@
+# coding=utf-8
+"""Tests for Sopel's ``tell`` plugin"""
+from __future__ import unicode_literals, absolute_import, print_function, division
+
+import io
+import os
+
+from sopel.modules import tell
+
+
+def test_load_reminders_empty(tmpdir):
+    tmpfile = tmpdir.join('tell.db')
+    tmpfile.write('\n')
+    result = tell.load_reminders(tmpfile.strpath)
+
+    assert len(result.keys()) == 0, 'There should be no key at all.'
+
+
+def test_load_reminders_one_tellee(tmpdir):
+    tellee = 'Exirel'
+    teller = 'dgw'
+    verb = 'tell'
+    timenow = '1569488444'
+    msg_1 = 'You forgot an S in "élèves".'
+    msg_2 = 'You forgot another S  in "garçons".'
+    tmpfile = tmpdir.join('tell.db')
+
+    reminders = [
+        [tellee, teller, verb, timenow, msg_1],
+        [tellee, teller, verb, timenow, msg_2],
+    ]
+    tmpfile.write_text(
+        '\n'.join('\t'.join(items) for items in reminders),
+        encoding='utf-8')
+    result = tell.load_reminders(tmpfile.strpath)
+
+    assert len(result.keys()) == 1, (
+        'There should be one and only one key, found these instead: %s'
+        % ', '.join(result.keys())
+    )
+    assert 'Exirel' in result, (
+        'Tellee not found, found %s instead' % result.keys()[0])
+    assert len(result['Exirel']) == 2, (
+        'There should be two reminders, found %d instead'
+        % len(result['Exirel'])
+    )
+    reminder_1 = result['Exirel'][0]
+    reminder_2 = result['Exirel'][1]
+    assert reminder_1 == (teller, verb, timenow, msg_1)
+    assert reminder_2 == (teller, verb, timenow, msg_2)
+
+
+def test_load_reminders_multiple_tellees(tmpdir):
+    tellee_1 = 'Exirel'
+    tellee_2 = 'HumorBaby'
+    teller = 'dgw'
+    verb = 'tell'
+    timenow = '1569488444'
+    msg = 'Review requested for "àçé"'
+    tmpfile = tmpdir.join('tell.db')
+
+    reminders = [
+        [tellee_1, teller, verb, timenow, msg],
+        [tellee_2, teller, verb, timenow, msg],
+    ]
+    tmpfile.write_text(
+        '\n'.join('\t'.join(items) for items in reminders),
+        encoding='utf-8')
+    result = tell.load_reminders(tmpfile.strpath)
+
+    assert len(result.keys()) == 2, (
+        'There should be two keys, found these instead: %s'
+        % ', '.join(result.keys())
+    )
+    assert tellee_1 in result
+    assert tellee_2 in result
+    assert len(result[tellee_1]) == 1, (
+        'There should be one reminder for %s, found %d instead'
+        % (tellee_1, len(result[tellee_1]))
+    )
+    assert len(result[tellee_2]) == 1, (
+        'There should be one reminder for %s, found %d instead'
+        % (tellee_2, len(result[tellee_2]))
+    )
+    reminder_1 = result[tellee_1][0]
+    reminder_2 = result[tellee_2][0]
+    assert reminder_1 == (teller, verb, timenow, msg)
+    assert reminder_2 == (teller, verb, timenow, msg)
+
+
+def test_dump_reminders_empty(tmpdir):
+    tmpfile = tmpdir.join('tell.db')
+    tell.dump_reminders(tmpfile.strpath, {})
+
+    assert os.path.exists(tmpfile.strpath)
+
+    with io.open(tmpfile.strpath, 'r', encoding='utf-8') as fd:
+        data = fd.read()
+        assert not data, 'Data for empty tell should be empty'
+
+
+def test_dump_reminders_one_tellee(tmpdir):
+    tellee = 'Exirel'
+    teller = 'dgw'
+    verb = 'tell'
+    timenow = '1569488444'
+    msg_1 = 'You forgot an S in "élèves".'
+    msg_2 = 'You forgot another S  in "garçons".'
+
+    tmpfile = tmpdir.join('tell.db')
+    tell.dump_reminders(tmpfile.strpath, {
+        tellee: [
+            (teller, verb, timenow, msg_1),
+            (teller, verb, timenow, msg_2),
+        ]
+    })
+
+    assert os.path.exists(tmpfile.strpath)
+
+    results = tell.load_reminders(tmpfile.strpath)
+
+    assert len(results.keys()) == 1, 'There should be one key in results'
+    assert tellee in results
+    assert len(results[tellee]) == 2, 'There should be 2 messages in results'
+    assert (teller, verb, timenow, msg_1) in results[tellee]
+    assert (teller, verb, timenow, msg_2) in results[tellee]
+
+
+def test_dump_reminders_multiple_tellees(tmpdir):
+    tellee_1 = 'Exirel'
+    tellee_2 = 'HumorBaby'
+    teller = 'dgw'
+    verb = 'tell'
+    timenow = '1569488444'
+    msg = 'Review requested for "àçé"'
+
+    tmpfile = tmpdir.join('tell.db')
+    tell.dump_reminders(tmpfile.strpath, {
+        tellee_1: [(teller, verb, timenow, msg)],
+        tellee_2: [(teller, verb, timenow, msg)],
+    })
+
+    assert os.path.exists(tmpfile.strpath)
+
+    results = tell.load_reminders(tmpfile.strpath)
+
+    assert len(results.keys()) == 2, 'There should be two keys in results'
+    assert tellee_1 in results
+    assert tellee_2 in results
+    assert len(results[tellee_1]) == 1, (
+        'There should be 1 message for %s' % tellee_1)
+    assert len(results[tellee_2]) == 1, (
+        'There should be 1 message for %s' % tellee_2)
+    assert (teller, verb, timenow, msg) in results[tellee_1]
+    assert (teller, verb, timenow, msg) in results[tellee_2]


### PR DESCRIPTION
This fix #1151 

* `config.tell.use_private_reminder` (y/n) [n]: send tell/ask reminders as private messages
* `config.tell.maximum_public` [4]: maximum number of tell/ask reminders to send as public messages before sending them as private messages

As a bonus point: minor refactoring with unit tests.