### PR TITLE
module, bot: add `output_prefix` decorator & feature

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -985,6 +985,8 @@ class SopelWrapper(object):
     :type sopel: :class:`~sopel.bot.Sopel`
     :param trigger: IRC Trigger line
     :type trigger: :class:`sopel.trigger.Trigger`
+    :param string output_prefix: prefix for messages sent through this wrapper
+                                 (e.g. plugin tag)
 
     This wrapper will be used to call Sopel's triggered commands and rules as
     their ``bot`` argument. It acts as a proxy to :meth:`send messages<say>` to
@@ -1072,7 +1074,7 @@ class SopelWrapper(object):
             destination = self._trigger.sender
         if reply_to is None:
             reply_to = self._trigger.nick
-        self._bot.reply(self._out_pfx + message, destination, reply_to, notice)
+        self._bot.reply(message, destination, reply_to, notice)
 
     def kick(self, nick, channel=None, message=None):
         if channel is None:

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -53,6 +53,7 @@ def clean_callable(func, config):
     func.rate = getattr(func, 'rate', 0)
     func.channel_rate = getattr(func, 'channel_rate', 0)
     func.global_rate = getattr(func, 'global_rate', 0)
+    func.output_prefix = getattr(func, 'output_prefix', '')
 
     if not hasattr(func, 'event'):
         func.event = ['PRIVMSG']

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -21,6 +21,7 @@ __all__ = [
     'intent',
     'interval',
     'nickname_commands',
+    'output_prefix',
     'priority',
     'rate',
     'require_admin',
@@ -674,3 +675,22 @@ class example(object):
         }
         func.example.append(record)
         return func
+
+
+def output_prefix(prefix):
+    """Decorate a function to add a prefix on its output.
+
+    :param str prefix: the prefix to add (must include trailing whitespace if
+                       desired; Sopel does not assume it should add anything)
+
+    Prefix will be added to text sent through:
+
+    * :meth:`bot.say <sopel.bot.SopelWrapper.say>`
+    * :meth:`bot.reply <sopel.bot.SopelWrapper.reply>`
+    * :meth:`bot.notice <sopel.bot.SopelWrapper.notice>`
+
+    """
+    def add_attribute(function):
+        function.output_prefix = prefix
+        return function
+    return add_attribute

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -686,7 +686,6 @@ def output_prefix(prefix):
     Prefix will be added to text sent through:
 
     * :meth:`bot.say <sopel.bot.SopelWrapper.say>`
-    * :meth:`bot.reply <sopel.bot.SopelWrapper.reply>`
     * :meth:`bot.notice <sopel.bot.SopelWrapper.notice>`
 
     """

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -343,3 +343,11 @@ def test_example(bot, trigger):
     def mock(bot, trigger, match=None):
         return True
     assert mock(bot, trigger) is True
+
+
+def test_output_prefix():
+    @module.commands('mock')
+    @module.output_prefix('[MOCK] ')
+    def mock(bot, trigger, match):
+        return True
+    assert mock.output_prefix == '[MOCK] '


### PR DESCRIPTION
Decorated functions will have anything they output (via the `say` or `notice` wrapper methods; it doesn't make sense for `action` or `reply`) prefixed with the given string.

Closes #1352.