### PR TITLE
tools.time: fully utilize pytz to validate timezones

### DIFF
--- a/sopel/tools/time.py
+++ b/sopel/tools/time.py
@@ -35,8 +35,7 @@ def validate_timezone(zone):
         tz = pytz.timezone(zone)
     except pytz.exceptions.UnknownTimeZoneError:
         raise ValueError('Invalid time zone.')
-    else:
-        return tz.zone
+    return tz.zone
 
 
 def validate_format(tformat):
@@ -44,7 +43,7 @@ def validate_format(tformat):
     try:
         time = datetime.datetime.utcnow()
         time.strftime(tformat)
-    except Exception:  # TODO: Be specific
+    except (ValueError, TypeError):
         raise ValueError('Invalid time format.')
     return tformat
 

--- a/sopel/tools/time.py
+++ b/sopel/tools/time.py
@@ -39,7 +39,12 @@ def validate_timezone(zone):
 
 
 def validate_format(tformat):
-    """Returns the format, if valid, else None"""
+    """Validate a time format string.
+
+    :param string tformat: the format string to validate
+    :return: the format string, if valid
+    :raise ValueError: when ``tformat`` is not a valid time format string
+    """
     try:
         time = datetime.datetime.utcnow()
         time.strftime(tformat)

--- a/sopel/tools/time.py
+++ b/sopel/tools/time.py
@@ -20,15 +20,10 @@ def validate_timezone(zone):
     1. the string is split on ``', '``, the pieces reversed, and then joined
        with ``/`` (*"New York, America"* becomes *"America/New York"*)
     2. Remaining spaces are replaced with ``_``
-    3. Finally, strings longer than 4 characters are made title-case,
-       and those 4 characters and shorter are made upper-case.
 
     This means ``new york, america`` becomes ``America/New_York``, and ``utc``
-    becomes ``UTC``.
-
-    This is the expected case-insensitivity behavior in the majority of cases.
-    For example, ``edt`` and ``america/new_york`` will both return
-    ``America/New_York``.
+    becomes ``UTC``. In the majority of user-facing interactions, such
+    case-insensitivity will be expected.
 
     If the zone is not valid, ``ValueError`` will be raised.
     """
@@ -36,14 +31,12 @@ def validate_timezone(zone):
         return None
 
     zone = '/'.join(reversed(zone.split(', '))).replace(' ', '_')
-    if len(zone) <= 4:
-        zone = zone.upper()
+    try:
+        tz = pytz.timezone(zone)
+    except pytz.exceptions.UnknownTimeZoneError:
+        raise ValueError('Invalid time zone.')
     else:
-        zone = zone.title()
-    if zone in pytz.all_timezones:
-        return zone
-    else:
-        raise ValueError("Invalid time zone.")
+        return tz.zone
 
 
 def validate_format(tformat):
@@ -52,7 +45,7 @@ def validate_format(tformat):
         time = datetime.datetime.utcnow()
         time.strftime(tformat)
     except Exception:  # TODO: Be specific
-        raise ValueError('Invalid time format')
+        raise ValueError('Invalid time format.')
     return tformat
 
 
@@ -93,7 +86,7 @@ def get_channel_timezone(db, channel):
 
 
 def get_timezone(db=None, config=None, zone=None, nick=None, channel=None):
-    """Find, and return, the approriate timezone
+    """Find, and return, the appropriate timezone
 
     Time zone is pulled in the following priority:
 
@@ -107,7 +100,7 @@ def get_timezone(db=None, config=None, zone=None, nick=None, channel=None):
 
     If ``db`` is not given, or given but not set up, steps 2 and 3 will be
     skipped. If ``config`` is not given, step 4 will be skipped. If no step
-    yeilds a valid timezone, ``None`` is returned.
+    yields a valid timezone, ``None`` is returned.
 
     Valid timezones are those present in the IANA Time Zone Database.
 


### PR DESCRIPTION
Instead of trying to coerce zone names all the way into something we can throw into an `in pytz.all_timezones` statement, all we have to do is rearrange the bits just enough to let `pytz.timezone()` take over. Its built-in normalization routines are plenty comprehensive, and if we make use of them there's no need to reinvent the wheel.

Updated the docstring for `validate_timezone()` to match. We aren't expecting that zone names like "EDT" will actually work. Neither 6.6.x nor the code this replaces will match that example, so we're not losing any functionality. Most of the three- and four-letter zone abbreviations I tried, in fact, fail because they aren't specific enough (might refer to one of multiple zones around the world). This is why we have the `tz` page users can visit if they don't know their local zone name, anyway.

Bonus spelling fixes included because if I didn't make them now, I'd forget and possibly miss them when going over this module's docs later.