### PR TITLE
loader: is_triggerable rejects jobs

### DIFF
--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -104,10 +104,37 @@ def clean_callable(func, config):
 
 
 def is_triggerable(obj):
-    return any(
-        hasattr(obj, attr)
-        for attr in ('rule', 'event', 'intents', 'commands',
-                     'nickname_commands'))
+    """Check if ``obj`` can handle the bot's triggers.
+
+    :param obj: any :term:`function` to check
+    :return: ``True`` if ``obj`` can handle the bot's triggers
+
+    A triggerable is a callable that will be used by the bot to handle a
+    particular trigger (i.e. an IRC message): it can be a regex rule, an event,
+    an intent, a command, or a nickname command. However, it must not be a job
+    or a URL callback.
+
+    .. seealso::
+
+        Many of the decorators defined in :mod:`sopel.module` make the
+        decorated function a triggerable object.
+    """
+    forbidden_attrs = (
+        'interval',
+        'url_regex',
+    )
+    forbidden = any(hasattr(obj, attr) for attr in forbidden_attrs)
+
+    allowed_attrs = (
+        'rule',
+        'event',
+        'intents',
+        'commands',
+        'nickname_commands',
+    )
+    allowed = any(hasattr(obj, attr) for attr in allowed_attrs)
+
+    return allowed and not forbidden
 
 
 def clean_module(module, config):


### PR DESCRIPTION
When `clean_callable` runs on a callable, it automatically adds an `event` attribute: until now, the `is_triggerable` would return `True` for that callable after that. The problem is that, upon reloading the bot (after a timeout, a KILL message, etc.), the `event` attribute would cause job callables to be wrongly counted as triggerable. Thus, they would be registered with a 'match-any' rule, and throw errors on every message thereafter.

This bug is the result of a 5+ year old behavior (adding default `event` to all callables), plus a few-week-old change that would allow `event` to be considered as triggerable by default, without `rule`. We caught it because of a lucky Sopel Rockstar whose bot running from `master` happened to receive a KILL message.

This bug was only in master and didn't affect user of any official release. I'd still suggest to break the FIFO order for that one.