### PR TITLE
py: configurable endpoint

### DIFF
--- a/sopel/modules/py.py
+++ b/sopel/modules/py.py
@@ -11,10 +11,40 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 from requests import get
 
 from sopel import module
+from sopel.config.types import StaticSection, ValidatedAttribute
 from sopel.tools.web import quote
 
 
-BASE_TUMBOLIA_URI = 'https://oblique.sopel.chat/'
+class PySection(StaticSection):
+    oblique_instance = ValidatedAttribute('oblique_instance',
+                                          default='https://oblique.sopel.chat/')
+    """The Oblique instance to use when evaluating Python expressions"""
+
+
+def configure(config):
+    """
+    | name | example | purpose |
+    | ---- | ------- | ------- |
+    | oblique_instance | https://oblique.sopel.chat/ | The Oblique instance to use when evaluating Python expressions (see <https://github.com/sopel-irc/oblique>) |
+    """
+    config.define_section('py', PySection)
+    config.py.configure_setting(
+        'oblique_instance',
+        'Enter the base URL of a custom Oblique instance (optional): '
+    )
+
+
+def setup(bot):
+    bot.config.define_section('py', PySection)
+
+    if not any(
+        bot.config.py.oblique_instance.startswith(prot)
+        for prot in ['http://', 'https://']
+    ):
+        raise ValueError('Oblique instance URL must start with a protocol.')
+
+    if not bot.config.py.oblique_instance.endswith('/'):
+        bot.config.py.oblique_instance += '/'
 
 
 @module.commands('py')
@@ -26,7 +56,7 @@ def py(bot, trigger):
         return bot.reply('I need an expression to evaluate.')
 
     query = trigger.group(2)
-    uri = BASE_TUMBOLIA_URI + 'py/'
+    uri = bot.config.py.oblique_instance + 'py/'
     answer = get(uri + quote(query)).content.decode('utf-8')
     if answer:
         bot.say(answer)


### PR DESCRIPTION
Adds an option to configure the [Oblique](https://github.com/sopel-irc/oblique) endpoint Sopel should use for `.py` commands.

Based on #1710 branch, so will begin its life as a draft.

Note to self: Rescue the good bits from your last time implementing this (before deciding to split `.py` into its own file). See 0d4fc85a9d98327b6844565373b01a26ce43ca16, e16ae1fb01779f9807ebd0d2e38bc405fb74cb59, & abda3a61549f251b86a5b72d44b8709e8f156c10 from the forgotten `calc-config` branch.