### PR TITLE
search: don't unquote DDG result

### DIFF
--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -59,8 +59,7 @@ def duck_search(query):
         bytes = bytes.split('web-result')[1]
     m = r_duck.search(bytes)
     if m:
-        unquoted_m = web.unquote(m.group(1))
-        return web.decode(unquoted_m)
+        return web.decode(m.group(1))
 
 
 # Alias google_search to duck_search
@@ -92,7 +91,7 @@ def duck_api(query):
 # test for bad Unicode handling in py2
 @example(
     '.duck grandorder.wiki chulainn alter',
-    'https://grandorder.wiki/Cú_Chulainn_(Alter)',
+    r'https://grandorder.wiki/C%C3%BA_Chulainn_(Alter)',
     online=True)
 # the last example (in source line order) is what .help displays
 @example(


### PR DESCRIPTION
Bing doesn't need it. Unquoting breaks URLs that contain spaces.

#1265 and associated changes later in the 6.x cycle introduced this unquoting, without any clear reason why. It doesn't appear to fix anything (not that my suite of test queries is _that_ exhaustive).

As a bonus, we shed the entire block of py2/py3 shimming for `unquote`.

Also of note: This reduces the core plugin set's need for #1681, but it'll still be good to have.