### PR TITLE
config: add a default `logging_format`

### DIFF
--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -254,10 +254,19 @@ class CoreSection(StaticSection):
         default='[%(asctime)s] %(name)-20s %(levelname)-8s - %(message)s')
     """The logging format string to use for logs.
 
-    If not specified, the format is not provided, and logging will use
-    the Python default.
+    If not specified, the default format is::
+
+        [%(asctime)s] %(name)-20s %(levelname)-8s - %(message)s
+
+    which will output the timestamp, the package that generated the log line,
+    the log level of the line, and (finally) the actual message. For example::
+
+        [2019-10-21 12:47:44,272] sopel.irc            INFO     - Connected.
 
     .. versionadded:: 7.0
+    .. seealso::
+        Python's logging format documentation:
+        https://docs.python.org/3/library/logging.html#logrecord-attributes
     """
 
     logging_level = ChoiceAttribute('logging_level',

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -249,7 +249,9 @@ class CoreSection(StaticSection):
     .. versionadded:: 7.0
     """
 
-    logging_format = ValidatedAttribute('logging_format')
+    logging_format = ValidatedAttribute(
+        'logging_format',
+        default='[%(asctime)s] %(name)-20s %(levelname)-8s - %(message)s')
     """The logging format string to use for logs.
 
     If not specified, the format is not provided, and logging will use


### PR DESCRIPTION
Without this option specified, we get the Python default format, which is (among other problems) completely devoid of timestamp information.

This format, devised by @Exirel while refactoring the logging mechanism, outputs the timestamp, the package that generated the log line, the log level of the line, and (finally) the actual message.

We'll go from:

    Registered 42 plugins, 0 failed, 0 disabled

to:

    [2019-10-21 12:47:44,272] sopel.bot            INFO     - Registered 42 plugins, 0 failed, 0 disabled

Once this hits the stable release, it will become quite a bit easier to follow along with bug reports!