### PR TITLE
modules: Tweak some old examples to use new features

### DIFF
--- a/sopel/modules/admin.py
+++ b/sopel/modules/admin.py
@@ -117,7 +117,8 @@ def join(bot, trigger):
 @sopel.module.require_admin
 @sopel.module.commands('tmpjoin')
 @sopel.module.priority('low')
-@sopel.module.example('.tmpjoin #example or .tmpjoin #example key')
+@sopel.module.example('.tmpjoin #example key', user_help=True)
+@sopel.module.example('.tmpjoin #example', user_help=True)
 def temporary_join(bot, trigger):
     """Like ``join``, without saving. This is an admin-only command.
 
@@ -306,7 +307,7 @@ def parse_section_option_value(config, trigger):
 @sopel.module.require_privmsg("This command only works as a private message.")
 @sopel.module.require_admin("This command requires admin privileges.")
 @sopel.module.commands('set')
-@sopel.module.example('.set core.owner Me')
+@sopel.module.example('.set core.owner MyNick')
 def set_config(bot, trigger):
     """See and modify values of Sopel's config object.
 

--- a/sopel/modules/dice.py
+++ b/sopel/modules/dice.py
@@ -171,7 +171,7 @@ def _roll_dice(bot, dice_expression):
 @sopel.module.priority("medium")
 @sopel.module.example(".roll 3d1+1", 'You roll 3d1+1: (1+1+1)+1 = 4')
 @sopel.module.example(".roll 3d1v2+1", 'You roll 3d1v2+1: (1[+1+1])+1 = 2')
-@sopel.module.example(".roll 2d4", r'You roll 2d4: \(\d\+\d\) = \d', re=True)
+@sopel.module.example(".roll 2d4", r'You roll 2d4: \(\d\+\d\) = \d', re=True, user_help=True)
 @sopel.module.example(".roll 100d1", r'[^:]*: \(100x1\) = 100', re=True)
 @sopel.module.example(".roll 1001d1", 'I only have 1000 dice. =(')
 @sopel.module.example(".roll 1d1 + 1d1", 'You roll 1d1 + 1d1: (1) + (1) = 2')

--- a/sopel/modules/invite.py
+++ b/sopel/modules/invite.py
@@ -53,8 +53,8 @@ def invite_handler(bot, sender, user, channel):
 
 
 @module.commands('invite')
-@module.example('.invite jenny')
-@module.example('.invite converge #sopel')
+@module.example('.invite jenny', user_help=True)
+@module.example('.invite converge #sopel', user_help=True)
 def invite(bot, trigger):
     """
     Invite the given user to the current channel, or (with optional

--- a/sopel/modules/lmgtfy.py
+++ b/sopel/modules/lmgtfy.py
@@ -14,8 +14,8 @@ from sopel.tools.web import quote
 
 @commands('lmgtfy', 'lmgify', 'gify', 'gtfy')
 @example('.lmgtfy sopel', 'https://lmgtfy.com/?q=sopel')
-@example('.lmgtfy sopel bot', 'https://lmgtfy.com/?q=sopel+bot')
-@example('.lmgtfy', 'https://www.google.com/')
+@example('.lmgtfy sopel bot', 'https://lmgtfy.com/?q=sopel+bot', user_help=True)
+@example('.lmgtfy', 'https://www.google.com/', user_help=True)
 def googleit(bot, trigger):
     """Let me just… Google that for you."""
     if not trigger.group(2):  # No input

--- a/sopel/modules/meetbot.py
+++ b/sopel/modules/meetbot.py
@@ -187,8 +187,8 @@ def is_chair(nick, channel):
 
 # Start meeting (also performs all required sanity checks)
 @module.commands("startmeeting")
-@module.example(".startmeeting")
-@module.example(".startmeeting Meeting Title")
+@module.example(".startmeeting", user_help=True)
+@module.example(".startmeeting Meeting Title", user_help=True)
 @module.require_chanmsg("Meetings can only be started in channels")
 def startmeeting(bot, trigger):
     """

--- a/sopel/modules/unicode_info.py
+++ b/sopel/modules/unicode_info.py
@@ -44,8 +44,8 @@ def get_codepoint_name(char):
 
 
 @module.commands('u')
-@module.example('.u ‽', 'U+203D INTERROBANG (‽)')
-@module.example('.u 203D', 'U+203D INTERROBANG (‽)')
+@module.example('.u ‽', 'U+203D INTERROBANG (‽)', user_help=True)
+@module.example('.u 203D', 'U+203D INTERROBANG (‽)', user_help=True)
 def codepoint(bot, trigger):
     """Look up a Unicode character or a hexadecimal code point."""
     arg = trigger.group(2)


### PR DESCRIPTION
The ability to use multiple examples, for instance, means we don't need (or want) examples with "or" in them any more.

Also fixed some "weird" or unclear stuff while I was looking around.

Should resolve #1019.