### PR TITLE
find: optimizations

### DIFF
--- a/sopel/modules/find.py
+++ b/sopel/modules/find.py
@@ -36,6 +36,7 @@ def shutdown(bot):
 @module.rule('.*')
 @module.priority('low')
 @module.require_chanmsg
+@module.unblockable
 def collectlines(bot, trigger):
     """Create a temporary log of what people say"""
     # Add a log for the channel and nick, if there isn't already one
@@ -73,6 +74,7 @@ def _cleanup_nickname(bot, nick, channel=None):
 @module.echo
 @module.event('PART')
 @module.priority('low')
+@module.unblockable
 def part_cleanup(bot, trigger):
     """Clean up cached data when a user leaves a channel."""
     if trigger.nick == bot.nick:
@@ -86,6 +88,7 @@ def part_cleanup(bot, trigger):
 @module.echo
 @module.event('QUIT')
 @module.priority('low')
+@module.unblockable
 def quit_cleanup(bot, trigger):
     """Clean up cached data after a user quits IRC."""
     # If Sopel itself quits, shutdown() will handle the cleanup.
@@ -95,6 +98,7 @@ def quit_cleanup(bot, trigger):
 @module.echo
 @module.event('KICK')
 @module.priority('low')
+@module.unblockable
 def kick_cleanup(bot, trigger):
     """Clean up cached data when a user is kicked from a channel."""
     nick = Identifier(trigger.args[1])


### PR DESCRIPTION
This patch is _definitely_ easier to grok if you look at the commits separately. Together, they blend into confusing almost-overlapping changes.

The commit messages themselves are pretty self-explanatory. My main goal was improving the bot's long-term memory usage by making sure lines cached in `bot.memory` would get purged when no longer relevant. Along the way, I noticed some other years-old silliness that was impossible to resist fixing.

Saving 6 lines by optimizing out unnecessary temporary variables isn't much considering that I added ~~45~~ 48 (including whitespace) lines of cleanup handling, but… It felt good. 😛