### PR TITLE
irc.backends: fix behavior of `core.verify_ssl` setting

### DIFF
--- a/sopel/irc/backends.py
+++ b/sopel/irc/backends.py
@@ -175,7 +175,7 @@ class SSLAsynchatBackend(AsynchatBackend):
 
     def handle_connect(self):
         # handle potential TLS connection
-        if self.verify_ssl:
+        if not self.verify_ssl:
             self.ssl = ssl.wrap_socket(self.socket,
                                        do_handshake_on_connect=True,
                                        suppress_ragged_eofs=True)


### PR DESCRIPTION
Actual behavior was reversed from before: `verify_ssl = True` ignored things like self-signed certs, and `verify_ssl = False` threw errors for self-signed certs instead.

Requesting review directly from @Exirel because he literally wrote the entire affected file.