### PR TITLE
bot: don't spam logs about preventing run of unmatched funcs

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -571,14 +571,6 @@ class Sopel(irc.AbstractBot):
                 for func in funcs:
                     trigger = Trigger(self.config, pretrigger, match, account)
 
-                    # check blocked nick/host
-                    if blocked and not func.unblockable and not trigger.admin:
-                        function_name = "%s.%s" % (
-                            func.__module__, func.__name__
-                        )
-                        list_of_blocked_functions.append(function_name)
-                        continue
-
                     # check event
                     if event not in func.event:
                         continue
@@ -597,6 +589,17 @@ class Sopel(irc.AbstractBot):
 
                     # check echo-message feature
                     if is_echo_message and not func.echo:
+                        continue
+
+                    # check blocked nick/host
+                    # done after we know the trigger would have matched so we
+                    # don't spam logs with "prevented from using" entries about
+                    # functions that weren't going to run anyway
+                    if blocked and not func.unblockable and not trigger.admin:
+                        function_name = "%s.%s" % (
+                            func.__module__, func.__name__
+                        )
+                        list_of_blocked_functions.append(function_name)
                         continue
 
                     # call triggered function


### PR DESCRIPTION
The added comment describes this, but to recap: Checking if the trigger originator is blocked before knowing if the function passes all the run conditions leads to logging that the triggering user was "prevented from using" something they wouldn't have actually triggered.

Think PRIVMSG from ignored users printing out a list of "prevented" functions like AUTHENTICATE handlers from `coretasks`. That's silly.

----

I didn't want to put this in the commit message (it's kind of unnecessary to describe the problem), but here's a sample log line from my `master`-based bot:

````
[2019-10-26 14:36:46,763] sopel.bot            INFO     - [nick]Amatsukaze-chan prevented
from using unobot.uno_glue, sopel.coretasks.retry_join, sopel.modules.version.ctcp_source,
sopel.modules.version.ctcp_version, sopel.modules.version.ctcp_time,
sopel.modules.version.ctcp_ping, sopel.coretasks.auth_proceed, sopel.coretasks.sasl_success,
sopel.coretasks.account_notify, sopel.modules.tell.message,
sopel.modules.translate.collect_mangle_lines, sopel.modules.seen.note,
sopel.modules.meetbot.log_meeting, spongemock.cache_lines, sopel.modules.admin.invite_join,
sopel.modules.admin.hold_ground, spongemock.part_prune, spongemock.kick_prune,
spongemock.quit_prune, sopel.modules.find.collectlines.
````

It would be even longer, and fuller of irrelevant callables, with some of the pending changes in other PRs (like the extra event listeners added to `find.py` in #1721).