### PR TITLE
plugins: unblock background triggers

### DIFF
--- a/sopel/modules/seen.py
+++ b/sopel/modules/seen.py
@@ -13,7 +13,7 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 import datetime
 import time
 
-from sopel.module import commands, rule, priority, thread
+from sopel.module import commands, rule, priority, thread, unblockable
 from sopel.tools import Identifier
 from sopel.tools.time import seconds_to_human
 
@@ -58,6 +58,7 @@ def seen(bot, trigger):
 @thread(False)
 @rule('(.*)')
 @priority('low')
+@unblockable
 def note(bot, trigger):
     if not trigger.is_privmsg:
         bot.db.set_nick_value(trigger.nick, 'seen_timestamp', time.time())

--- a/sopel/modules/tell.py
+++ b/sopel/modules/tell.py
@@ -17,7 +17,7 @@ import threading
 from collections import defaultdict
 
 from sopel.config.types import StaticSection, ValidatedAttribute
-from sopel.module import commands, nickname_commands, rule, priority, example
+from sopel import module
 from sopel.tools import Identifier
 from sopel.tools.time import get_timezone, format_time
 
@@ -131,9 +131,9 @@ def shutdown(bot):
             pass
 
 
-@commands('tell', 'ask')
-@nickname_commands('tell', 'ask')
-@example('$nickname, tell dgw he broke something again.')
+@module.commands('tell', 'ask')
+@module.nickname_commands('tell', 'ask')
+@module.example('$nickname, tell dgw he broke something again.')
 def f_remind(bot, trigger):
     """Give someone a message the next time they're seen"""
     teller = trigger.nick
@@ -224,8 +224,9 @@ def nick_match_tellee(nick, tellee):
     return nick.lower() == tellee.lower()
 
 
-@rule('(.*)')
-@priority('low')
+@module.rule('(.*)')
+@module.priority('low')
+@module.unblockable
 def message(bot, trigger):
     nick = trigger.nick
 

--- a/sopel/modules/translate.py
+++ b/sopel/modules/translate.py
@@ -15,7 +15,7 @@ import sys
 
 import requests
 
-from sopel.module import rule, commands, priority, example
+from sopel.module import rule, commands, priority, example, unblockable
 from sopel.tools import web
 
 if sys.version_info.major >= 3:
@@ -210,6 +210,7 @@ def mangle(bot, trigger):
 
 @rule('(.*)')
 @priority('low')
+@unblockable
 def collect_mangle_lines(bot, trigger):
     global mangle_lines
     mangle_lines[trigger.sender.lower()] = "%s said '%s'" % (trigger.nick, (trigger.group(0).strip()))


### PR DESCRIPTION
The `tell`, `translate`, `seen`, and `meetbot` plugins all contain match-any rules to run something on any/every message received. Even with #1724 applied, they still cause log spam whenever any ignored user speaks.

Here, I have made the relevant callables in `tell`, `translate`, and `seen` into `unblockable` functions. There's no reason that ignored users shouldn't receive `tell` messages, and `translate` & `seen` only collect lines passively for use later when commanded by a non-ignored user.

I did *not* make `meetbot`'s callable unblockable, though. That would allow ignored users to appear in meeting logs despite being blocked from using any commands. Unfortunately this means we'll still get log spam on any instance with `meetbot` turned on, but when this is combined with #1721 (which makes `find`'s collect-all-lines function unblockable) `meetbot` will be the *only* core plugin that causes such a warning with default settings. We can decide to disable it by default, perhaps.

Bonus refactor of `translate` to use `bot.memory` instead of a (🤢) global variable.