### PR TITLE
tell: add relative timestamp format

### DIFF
--- a/sopel/modules/tell.py
+++ b/sopel/modules/tell.py
@@ -8,14 +8,16 @@ https://sopel.chat
 """
 from __future__ import unicode_literals, absolute_import, print_function, division
 
+import datetime
 import os
 import time
 import threading
 import sys
 
-from sopel.module import commands, nickname_commands, rule, priority, example
+from sopel.module import commands, nickname_commands, rule, priority, example, require_privilege, OP
+from sopel.config.types import StaticSection, ValidatedAttribute
 from sopel.tools import Identifier, iterkeys
-from sopel.tools.time import get_timezone, format_time
+from sopel.tools.time import get_timezone, format_time, seconds_to_human
 
 
 MAXIMUM = 4
@@ -32,10 +34,10 @@ def loadReminders(fn, lock):
                 line = line.decode('utf-8')
             if line:
                 try:
-                    tellee, teller, verb, timenow, msg = line.split('\t', 4)
+                    tellee, teller, verb, timenow, timestamp, msg = line.split('\t', 5)
                 except ValueError:
                     continue  # @@ hmm
-                result.setdefault(tellee, []).append((teller, verb, timenow, msg))
+                result.setdefault(tellee, []).append((teller, verb, timenow, timestamp, msg))
         f.close()
     finally:
         lock.release()
@@ -65,7 +67,26 @@ def dumpReminders(fn, data, lock):
     return True
 
 
+class FormatSection(StaticSection):
+    tell_format = ValidatedAttribute(
+        'tell_format',
+        default='relative')
+    """Show relative timestamps by default"""
+
+
+def configure(config):
+    """
+    | name        | example  | purpose                                       |
+    | ----------- | -------- | --------------------------------------------- |
+    | tell_format | absolute | Show absolute timestamp; defaults to relative |
+    """
+    config.define_section('tell', FormatSection)
+    config.tell.configure_setting(
+        'tell_format', 'Default timestamp format for messages sent later via tell/ask')
+
+
 def setup(bot):
+    bot.config.define_section('tell', FormatSection)
     fn = bot.nick + '-' + bot.config.core.host + '.tell.db'
     bot.tell_filename = os.path.join(bot.config.core.homedir, fn)
     if not os.path.exists(bot.tell_filename):
@@ -122,16 +143,18 @@ def f_remind(bot, trigger):
     if tellee not in (Identifier(teller), bot.nick, 'me'):
         tz = get_timezone(bot.db, bot.config, None, tellee)
         timenow = format_time(bot.db, bot.config, tz, tellee)
+        timestamp = datetime.datetime.timestamp(datetime.datetime.now())
+        timestamp = str(int(timestamp))
         bot.memory['tell_lock'].acquire()
         try:
             if tellee not in bot.memory['reminders']:
-                bot.memory['reminders'][tellee] = [(teller, verb, timenow, msg)]
+                bot.memory['reminders'][tellee] = [(teller, verb, timenow, timestamp, msg)]
             else:
-                bot.memory['reminders'][tellee].append((teller, verb, timenow, msg))
+                bot.memory['reminders'][tellee].append((teller, verb, timenow, timestamp, msg))
         finally:
             bot.memory['tell_lock'].release()
 
-        response = "I'll pass that on when %s is around." % tellee
+        response = "I'll %s %s that when they're around." % (verb, tellee)
 
         bot.reply(response)
     elif Identifier(teller) == tellee:
@@ -144,15 +167,38 @@ def f_remind(bot, trigger):
 
 def getReminders(bot, channel, key, tellee):
     lines = []
-    template = "%s: %s <%s> %s %s %s"
     today = time.strftime('%d %b', time.gmtime())
 
     bot.memory['tell_lock'].acquire()
     try:
-        for (teller, verb, datetime, msg) in bot.memory['reminders'][key]:
-            if datetime.startswith(today):
-                datetime = datetime[len(today) + 1:]
-            lines.append(template % (tellee, datetime, teller, verb, tellee, msg))
+        for (teller, verb, date_time, timestamp, msg) in bot.memory['reminders'][key]:
+            format_ = bot.db.get_nick_value(tellee, 'tell_format') or \
+                bot.db.get_channel_value(channel, 'tell_format') or \
+                bot.config.tell.tell_format or \
+                'relative'
+            template = "{destination}: "
+            if date_time.startswith(today):
+                date_time = date_time[len(today) + 1:]
+
+            if verb.lower() == "ask":
+                if format_ == "relative":
+                    template += "{sender} asked {msg} (sent {timedelta})"
+                else:
+                    template += "{date_time} {sender} asked {msg}"
+            else:
+                if format_ == "relative":
+                    template += "<{sender}> {msg} (sent {timedelta})"
+                else:
+                    template += "{date_time} <{sender}> {msg}"
+            timedelta = int(datetime.datetime.timestamp(datetime.datetime.now()) - int(timestamp))
+            timedelta = seconds_to_human(timedelta)
+            lines.append(template.format(
+                destination=tellee,
+                date_time=date_time,
+                timedelta=timedelta,
+                sender=teller,
+                msg=msg)
+            )
 
         try:
             del bot.memory['reminders'][key]
@@ -174,7 +220,10 @@ def message(bot, trigger):
         return
 
     reminders = []
-    remkeys = list(reversed(sorted(bot.memory['reminders'].keys())))
+    try:
+        remkeys = list(reversed(sorted(bot.memory['reminders'].keys())))
+    except KeyError:
+        return
 
     for remkey in remkeys:
         if not remkey.endswith('*') or remkey.endswith(':'):
@@ -193,3 +242,83 @@ def message(bot, trigger):
 
     if len(bot.memory['reminders'].keys()) != remkeys:
         dumpReminders(bot.tell_filename, bot.memory['reminders'], bot.memory['tell_lock'])  # @@ tell
+
+
+@commands('settellf', 'settellformat')
+@example('.settellf absolute')
+def update_user_tell_format(bot, trigger):
+    """Set your preferred tell timestamp format. (absolute or relative)
+    """
+    argument = trigger.group(2)
+    if not argument:
+        bot.reply("What format do you want to set?")
+        return
+
+    valid_formats = ['absolute', 'relative']
+
+    argument = argument.lower().strip()
+    if argument not in valid_formats:
+        return bot.reply("I need a valid format (relative or absolute)")
+
+    bot.db.set_nick_value(trigger.nick, 'tell_format', argument)
+
+    bot.reply('I have set the tell timestamp format for you to %s' % argument)
+
+
+@commands('gettellf', 'gettellformat')
+@example('.gettellf [nick]')
+def get_user_tell_format(bot, trigger):
+    """Gets a user's preferred tell timestamp format; will show yours if no user specified."""
+    nick = trigger.group(2)
+    if not nick:
+        nick = trigger.nick
+
+    nick = nick.strip()
+    format_ = bot.db.get_nick_value(nick, 'tell_format')
+
+    if format_:
+        bot.say('%s\'s tell timestamp format is %s.' % (nick, format_))
+    else:
+        bot.say('%s has not set their tell timestamp format' % nick)
+
+
+@commands('setchanneltellf', 'setctellf')
+@example('.setctellf absolute')
+@require_privilege(OP)
+def update_channel(bot, trigger):
+    """Set the preferred tell timestamp format for the channel."""
+    argument = trigger.group(2)
+    if not argument:
+        bot.reply("What format do you want to set?")
+        return
+
+    valid_formats = ['absolute', 'relative']
+
+    argument = argument.lower().strip()
+    if argument not in valid_formats:
+        return bot.reply("I need a valid format (relative or absolute)")
+
+    channel = trigger.sender
+    bot.db.set_channel_value(channel, 'tell_format', argument)
+
+    bot.reply('I have set the tell timestamp format for %s to %s' % (channel, argument))
+
+
+@commands('getchanneltellf', 'getctellf')
+@example('.getctellf [channel]')
+def get_channel_tell_format(bot, trigger):
+    """
+    Gets the channel's preferred tell timestamp format; returns the current channel's
+    if no channel name is given.
+    """
+    channel = trigger.group(2)
+    if not channel:
+        channel = trigger.sender
+
+    channel = channel.strip()
+    format_ = bot.db.get_channel_value(channel, 'tell_format')
+
+    if format_:
+        bot.say('%s\'s tell timestamp format: %s' % (channel, format_))
+    else:
+        bot.say('%s has no preferred tell timestamp format' % channel)


### PR DESCRIPTION
This adds the option for switching between relative and absolute timestamp formats for messages sent via `.tell` or `.ask` and also cleans up the output of each.

Users can set their own preference via `.settellformat`, channel operators can set a channel preference via `.setchanneltellformat`, and the bot admin can set a global preference via the configuration file / option.

Demo:
```
16:30:26 <@cottongin> `tell nottongin this is a tell message
16:30:26 <bot> cottongin: I'll tell nottongin that when they're around.
16:30:33 <@cottongin> `ask nottongin did the tell message work
16:30:33 <bot> cottongin: I'll ask nottongin that when they're around.
16:30:45 <nottongin> .
16:30:45 <bot> nottongin: 2019-10-26 - 21:30:26UTC <cottongin> this is a tell message
16:30:45 <bot> nottongin: 2019-10-26 - 21:30:33UTC cottongin asked did the tell message work
16:31:08 <nottongin> `tell cottongin yes the tell message worked
16:31:08 <bot> nottongin: I'll tell cottongin that when they're around.
16:31:21 <nottongin> bot: ask cottongin if that worked
16:31:21 <bot> nottongin: I'll ask cottongin that when they're around.
16:31:39 <@cottongin> .
16:31:39 <bot> cottongin: <nottongin> yes the tell message worked (sent 31 seconds ago)
16:31:39 <bot> cottongin: nottongin asked if that worked (sent 18 seconds ago)
```