### PR TITLE
module: fix `__all__` nonsense & docs for `event`

### DIFF
--- a/sopel/module.py
+++ b/sopel/module.py
@@ -18,6 +18,7 @@ __all__ = [
     'action_commands',
     'commands',
     'echo',
+    'event',
     'example',
     'intent',
     'interval',
@@ -314,9 +315,9 @@ def event(*event_list):
 
     This is one of a number of events, such as 'JOIN', 'PART', 'QUIT', etc.
     (More details can be found in RFC 1459.) When the Sopel bot is sent one of
-    these events, the function will execute. Note that functions with an event
-    must also be given a rule to match (though it may be '.*', which will
-    always match) or they will not be triggered.
+    these events, the function will execute. Note that the default
+    :meth:`rule` (``.*``) will match *any* line of the correct event type(s).
+    If any rule is explicitly specified, it overrides the default.
 
     :class:`sopel.tools.events` provides human-readable names for many of the
     numeric events, which may help your code be clearer.


### PR DESCRIPTION
Apparently `event` was left out of the `__all__` list. I question whether we should keep it, since it exports literally every name in the module anyway, but that's for another time.

Right now, the important thing is that `event` is now exported properly, and the docstring has been updated to account for the fact that a default `rule` is now set if an event callable does not have one.

How this didn't come up before, I have no idea. Being left out of `__all__` means that `event` wasn't included in the Sphinx docs, and things "should" break when trying to use e.g. `from sopel import module; @module.event('FOO')`… But Python's import machinery is fickle and likes to fill in module dictionaries based on other imports in the program. (Can't quickly find a reference page about this for linking, but I remember reading about it when the transition to using `__all__` came up.)