### PR TITLE
bot: fix race-condition in dispatch

### DIFF
--- a/sopel/module.py
+++ b/sopel/module.py
@@ -81,9 +81,24 @@ OWNER = 16
 
 
 def unblockable(function):
-    """Decorator which exempts the function from nickname and hostname blocking.
+    """Decorator to exempt ``function`` from nickname and hostname blocking.
 
-    This can be used to ensure events such as JOIN are always recorded.
+    This can be used to ensure events such as ``JOIN`` are always recorded::
+
+        from sopel import module
+
+        @module.event('JOIN')
+        @module.unblockable
+        def on_join_callable(bot, trigger):
+            # do something when a user JOIN a channel
+            # a blocked nickname or hostname *will* trigger this
+            pass
+
+    .. seealso::
+
+        Sopel's :meth:`~sopel.bot.Sopel.dispatch` and
+        :meth:`~sopel.bot.Sopel.get_triggered_callables` methods.
+
     """
     function.unblockable = True
     return function


### PR DESCRIPTION
The scenario is:

* dispatch is called for a pretrigger
* it looks into the list of callable by priority
* it triggers one of the first callables, which wants to remove a callable of the same priority
* because Python must not allow a dict to be modified while it is iterated over, Python raises an exception

If we put a lock here, Python won't raise the exception... but we'll get a deadlock. To prevent that, instead, we copy the list of callables, and return the ones that are triggered. If any of them wants to change the callables of the same priority, they won't raise an error, because we are not iterating anymore on the dict.

Hoo-ray!

@dgw have fun with my miserable grammar at 2am.