### PR TITLE
cleanup: remove things marked for version 7.0

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -69,7 +69,6 @@ class Sopel(irc.AbstractBot):
         self._command_groups = collections.defaultdict(list)
         """A mapping of module names to a list of commands in it."""
 
-        self.stats = {}  # deprecated, remove in 7.0
         self._times = {}
         """
         A dictionary mapping lowercased nicks to dictionaries which map

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -83,7 +83,7 @@ def clean_callable(func, config):
             if regexp not in func.rule:
                 func.rule.append(regexp)
         if hasattr(func, 'example'):
-            # If no examples are flagged as user-facing, just show the first one like Sopel<7 did
+            # If no examples are flagged as user-facing, just show the first one like Sopel<7.0 did
             examples = [rec["example"] for rec in func.example if rec["help"]] or [func.example[0]["example"]]
             for i, example in enumerate(examples):
                 example = example.replace('$nickname', nick)

--- a/sopel/test_tools.py
+++ b/sopel/test_tools.py
@@ -97,10 +97,6 @@ class MockSopel(object):
         self.memory = sopel.tools.SopelMemory()
         self.memory['url_callbacks'] = sopel.tools.SopelMemory()
 
-        self.ops = {}
-        self.halfplus = {}
-        self.voices = {}
-
         self.config = MockConfig()
         self._init_config()
 

--- a/sopel/web.py
+++ b/sopel/web.py
@@ -2,7 +2,7 @@
 """
 *Availability: 3+, deprecated in 6.2.0*
 
-This web class will be removed in Sopel 8.0. As of Sopel 7, non-deprecated
+This web class will be removed in Sopel 8.0. As of Sopel 7.0, non-deprecated
 functions are available in a new package, ``sopel.tools.web``.
 """
 # Copyright © 2008, Sean B. Palmer, inamidst.com


### PR DESCRIPTION
I decided to do a search of the code for things marked to remove for version 7.0

I don't see anywhere else in the repo where this .stats dictionary is used, so it may be as simple as killing this single line?

I also intend on going through the code to see if there are other things that should have been removed in prior releases (I doubt it though)