### PR TITLE
module: add `require account` feature

### DIFF
--- a/sopel/module.py
+++ b/sopel/module.py
@@ -385,18 +385,16 @@ def require_privmsg(message=None, reply=False):
     """
     def actual_decorator(function):
         @functools.wraps(function)
-        def _nop(*args, **kwargs):
-            # Assign trigger and bot for easy access later
-            bot, trigger = args[0:2]
+        def guarded(bot, trigger, *args, **kwargs):
             if trigger.is_privmsg:
-                return function(*args, **kwargs)
+                return function(bot, trigger, *args, **kwargs)
             else:
                 if message and not callable(message):
                     if reply:
                         bot.reply(message)
                     else:
                         bot.say(message)
-        return _nop
+        return guarded
 
     # Hack to allow decorator without parens
     if callable(message):
@@ -422,18 +420,16 @@ def require_chanmsg(message=None, reply=False):
     """
     def actual_decorator(function):
         @functools.wraps(function)
-        def _nop(*args, **kwargs):
-            # Assign trigger and bot for easy access later
-            bot, trigger = args[0:2]
+        def guarded(bot, trigger, *args, **kwargs):
             if not trigger.is_privmsg:
-                return function(*args, **kwargs)
+                return function(bot, trigger, *args, **kwargs)
             else:
                 if message and not callable(message):
                     if reply:
                         bot.reply(message)
                     else:
                         bot.say(message)
-        return _nop
+        return guarded
 
     # Hack to allow decorator without parens
     if callable(message):

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -43,6 +43,12 @@ def trigger_owner(bot):
 
 
 @pytest.fixture
+def trigger_account(bot):
+    line = '@account=egg :egg!egg@eg.gs PRIVMSG #Sopel :Hello, world'
+    return Trigger(bot.config, PreTrigger(Identifier('egg'), line), None, 'egg')
+
+
+@pytest.fixture
 def trigger(bot, pretrigger):
     return Trigger(bot.config, pretrigger, None)
 
@@ -325,6 +331,20 @@ def test_require_chanmsg(bot, trigger, trigger_pm):
         return True
     assert mock_(bot, trigger) is True
     assert mock_(bot, trigger_pm) is not True
+
+
+def test_require_account(bot, trigger, trigger_account):
+    @module.require_account('You need to authenticate to services first.')
+    def mock(bot, trigger, match=None):
+        return True
+    assert mock(bot, trigger) is not True
+    assert mock(bot, trigger_account) is True
+
+    @module.require_account
+    def mock_(bot, trigger, match=None):
+        return True
+    assert mock_(bot, trigger) is not True
+    assert mock_(bot, trigger_account) is True
 
 
 def test_require_privilege(bot, trigger):

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -323,8 +323,8 @@ def test_require_chanmsg(bot, trigger, trigger_pm):
     @module.require_chanmsg
     def mock_(bot, trigger, match=None):
         return True
-    assert mock(bot, trigger) is True
-    assert mock(bot, trigger_pm) is not True
+    assert mock_(bot, trigger) is True
+    assert mock_(bot, trigger_pm) is not True
 
 
 def test_require_privilege(bot, trigger):


### PR DESCRIPTION
Fresh from my well-rested (not really) keyboard\* comes this: a new plugin decorator. It lets you require that a user be authenticated to network services (NickServ or whatever) to use a given function.

I added a test for the new decorator, fixed a mistake in `require_chanmsg`'s test, and made all the `require_*` decorators consistent in terms of code structure. A couple of them were using a silly trick to get the `bot` and `trigger` args by name. Someone please take a good look at those changes too, to make sure I didn't forget something dumb (like how I almost forgot to pass `bot` and `trigger` to the actual function after checking the conditions and had to amend the commit).

Here's a rendered preview of the documentation for `@module.require_account`:

![Documentation preview for 'require_account' decorator](https://user-images.githubusercontent.com/164140/68092366-fd79cc00-fe4f-11e9-973c-bb0ba49d7dca.png)

This idea was inspired by an account-related question from @RhinosF1 on IRC, and encouraged by @deathbybandaid. (But honestly, dbb gets excited about _every_ idea. 😝)

----

\* — I said I'd do "less than last year" for Hacktoberfest (when I made a PR every day), and _technically_ I kept that promise. I made **one** PR less than last year.