### PR TITLE
remind: fix default_timezone in .at command when tz not specified

### DIFF
--- a/sopel/modules/remind.py
+++ b/sopel/modules/remind.py
@@ -384,7 +384,10 @@ def parse_regex_match(match, default_timezone=None):
     :rtype: :class:`TimeReminder`
     """
     try:
-        timezone = validate_timezone(match.group('tz') or 'UTC')
+        # Removing the `or` clause will BREAK the fallback to default_timezone!
+        # We need some invalid value other than None to trigger the ValueError.
+        # validate_timezone(None) excepting would be easier, but it doesn't.
+        timezone = validate_timezone(match.group('tz') or '')
     except ValueError:
         timezone = default_timezone or 'UTC'
 


### PR DESCRIPTION
With tz specified, it will be used if valid. If it's not valid, we fall back to either the user's default timezone (if set) or UTC (if not).

With tz not specified, this fixes UTC being used even if the user has a default timezone set.

Requesting @Exirel's review, as this directly relates to a previous patch of his (from #1590).