### PR TITLE
coretasks: fixing bot truncating users with same mode

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -270,9 +270,8 @@ def track_modes(bot, trigger):
         # than try to account for non-standard parameter-taking modes.
         _send_who(bot, channel)
         return
-    pairs = dict(zip(modes, nicks))
 
-    for (mode, nick) in pairs.items():
+    for (mode, nick) in zip(modes, nicks):
         priv = bot.channels[channel].privileges.get(nick, 0)
         # Log a warning if the two privilege-tracking data structures
         # get out of sync. That should never happen.


### PR DESCRIPTION
This fixes an issue with similar modes being truncated when the zip is converted into a dictionary.

```
In [1]: modes = ['-o', '-o', '-o']                                                                                                                                                                         
In [2]: nicks = ['a', 'b', 'c']

# Broken
In [3]: for (mode, nick) in dict(zip(modes, nicks)).items(): 
    ...:     print(mode, nick) 
    ...:                                                                                                                                                                                    
-o c

# Not broken
In [4]: for mode, nick in zip(modes, nicks): 
    ...:     print(mode, nick) 
    ...:                                                                                                                                                                                                    
-o a
-o b
-o c
```