### PR TITLE
cli: Fix plugin config duplicate y/n prompt

### DIFF
--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -167,7 +167,7 @@ def _plugins_wizard(settings):
 
 def _plugin_wizard(settings, plugin):
     plugin.load()
-    prompt = 'Configure {} (y/n)? [n]'.format(plugin.get_label())
+    prompt = "Configure {}".format(plugin.get_label())
     if plugin.has_configure() and settings.option(prompt):
         plugin.configure(settings)
 


### PR DESCRIPTION
Was:
```
Would you like to see if there are any modules that need configuring (y/n)? [n] y
Configure safety.py - Alerts about malicious URLs (y/n)? [n] (y/n)? [n]  
```
Now:
```
Would you like to see if there are any modules that need configuring (y/n)? [n] y
Configure safety.py - Alerts about malicious URLs (y/n)? [n] 
```