### PR TITLE
bot: Fix rule callable unload message argument error

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -328,7 +328,7 @@ class Sopel(irc.AbstractBot):
                 if obj in callb_list:
                     callb_list.remove(obj)
             LOGGER.debug(
-                'Rule callable "%s" unregistered',
+                'Rule callable "%s" unregistered for "%s"',
                 callable_name,
                 rule.pattern)
 


### PR DESCRIPTION
When `.reload`ing a bot, hundreds of lines of tracebacks would be logged:
```
--- Logging error ---
Traceback (most recent call last):
<snip>
  File "/usr/lib64/python3.7/logging/__init__.py", line 369, in getMessage
    msg = msg % self.args
TypeError: not all arguments converted during string formatting
Call stack:
<snip>
  File "sopel/sopel/bot.py", line 332, in unregister
    rule.pattern)
Message: 'Rule callable "%s" unregistered'
Arguments: ('handle_url_callbacks', '(?u).*(.+://\\S+).*')
```

I don't know if it's important to print the pattern that was unregistered, but it's a debug log so meh.