### PR TITLE
cli: replace 'module' by 'plugin'

### DIFF
--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -160,9 +160,9 @@ def add_legacy_options(parser):
                         dest='mod_wizard',
                         help=(
                             "Run the configuration wizard, but only for the "
-                            "module configuration options "
+                            "plugin configuration options "
                             "(deprecated, and will be removed in Sopel 8; "
-                            "use ``sopel configure --modules`` instead)"))
+                            "use ``sopel configure --plugins`` instead)"))
     parser.add_argument('-v', action="store_true",
                         dest='version_legacy',
                         help=(
@@ -222,10 +222,10 @@ def build_parser():
                     'a new configuration file or to update an existing one.',
         help='Sopel\'s Wizard tool')
     parser_configure.add_argument(
-        '--modules',
+        '--plugins',
         action='store_true',
         default=False,
-        dest='modules',
+        dest='plugins',
         help='Check for Sopel plugins that require configuration, and run '
              'their configuration wizards.')
     utils.add_common_arguments(parser_configure)
@@ -437,7 +437,7 @@ def command_start(opts):
 def command_configure(opts):
     """Sopel Configuration Wizard"""
     configpath = utils.find_config(opts.configdir, opts.config)
-    if opts.modules:
+    if opts.plugins:
         utils.plugins_wizard(configpath)
     else:
         utils.wizard(configpath)
@@ -561,7 +561,7 @@ def command_legacy(opts):
     if opts.mod_wizard:
         tools.stderr(
             'WARNING: option --configure-modules is deprecated; '
-            'use `sopel configure --modules` instead')
+            'use `sopel configure --plugins` instead')
         utils.plugins_wizard(configpath)
         return
 

--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -110,7 +110,7 @@ def wizard(filename):
           "to create your configuration file (%s):\n" % filename)
     config.core_section.configure(settings)
     if settings.option(
-        'Would you like to see if there are any modules '
+        'Would you like to see if there are any plugins '
         'that need configuring'
     ):
         _plugins_wizard(settings)
@@ -155,7 +155,7 @@ def _plugins_wizard(settings):
     usable_plugins = plugins.get_usable_plugins(settings)
     for plugin, is_enabled in usable_plugins.values():
         if not is_enabled:
-            # Do not configure non-enabled modules
+            # Do not configure non-enabled plugins
             continue
 
         name = plugin.name
@@ -185,9 +185,9 @@ def enumerate_configs(config_dir, extension='.cfg'):
 
         >>> from sopel import cli, config
         >>> os.listdir(config.DEFAULT_HOMEDIR)
-        ['config.cfg', 'extra.ini', 'module.cfg', 'README']
+        ['config.cfg', 'extra.ini', 'plugin.cfg', 'README']
         >>> cli.enumerate_configs(config.DEFAULT_HOMEDIR)
-        ['config.cfg', 'module.cfg']
+        ['config.cfg', 'plugin.cfg']
         >>> cli.enumerate_configs(config.DEFAULT_HOMEDIR, '.ini')
         ['extra.ini']
 
@@ -221,7 +221,7 @@ def find_config(config_dir, name, extension='.cfg'):
         >>> os.listdir()
         ['local.cfg', 'extra.ini']
         >>> os.listdir(config.DEFAULT_HOMEDIR)
-        ['config.cfg', 'extra.ini', 'module.cfg', 'README']
+        ['config.cfg', 'extra.ini', 'plugin.cfg', 'README']
         >>> run_script.find_config(config.DEFAULT_HOMEDIR, 'local.cfg')
         'local.cfg'
         >>> run_script.find_config(config.DEFAULT_HOMEDIR, 'local')

--- a/test/cli/test_cli_run.py
+++ b/test/cli/test_cli_run.py
@@ -318,11 +318,11 @@ def test_build_parser_configure():
     assert isinstance(options, argparse.Namespace)
     assert hasattr(options, 'config')
     assert hasattr(options, 'configdir')
-    assert hasattr(options, 'modules')
+    assert hasattr(options, 'plugins')
 
     assert options.config == 'default'
     assert options.configdir == config.DEFAULT_HOMEDIR
-    assert options.modules is False
+    assert options.plugins is False
 
 
 def test_build_parser_configure_config():
@@ -345,8 +345,8 @@ def test_build_parser_configure_configdir():
 def test_build_parser_configure_modules():
     parser = build_parser()
 
-    options = parser.parse_args(['configure', '--modules'])
-    assert options.modules is True
+    options = parser.parse_args(['configure', '--plugins'])
+    assert options.plugins is True
 
 
 def test_get_configuration(tmpdir):


### PR DESCRIPTION
Related to #1738: I replaced 'module' by 'plugin' where it makes sense to.