### PR TITLE
core: do not send TOPIC on join

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -433,8 +433,6 @@ def _periodic_send_who(bot):
 @sopel.module.unblockable
 def track_join(bot, trigger):
     if trigger.nick == bot.nick and trigger.sender not in bot.channels:
-        bot.write(('TOPIC', trigger.sender))
-
         bot.privileges[trigger.sender] = dict()
         bot.channels[trigger.sender] = Channel(trigger.sender)
         _send_who(bot, trigger.sender)


### PR DESCRIPTION
It's a very small change: as discussed in https://github.com/sopel-irc/sopel/issues/1069#issuecomment-548617872 the `TOPIC` command is not required since the server is supposed to send the required information when the bot joins a channel.

This won't fix the bigger problem, but it'll help in some cases.