### PR TITLE
isort: add isort to the QA tools

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,11 @@
 .PHONY: quality test coverage_html coverage_report travis clean_doc build_doc install-hooks uninstall-hooks
 
 quality:
+	isort -c -rc sopel
 	./checkstyle.sh
+
+isort:
+	isort -rc sopel
 
 test:
 	coverage run -m py.test -v .

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -8,3 +8,4 @@ flake8-future-import<0.4.6
 setuptools<40.0; python_version == '3.3'
 sphinx
 sphinxcontrib-autoprogram
+isort

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,3 +53,9 @@ exclude =
     contrib/*,
     conftest.py
 accept-encodings = utf-8
+
+[isort]
+not_skip = __init__.py
+line_length = 79
+multi_line_output = 3
+known_first_party = sopel

--- a/sopel/__init__.py
+++ b/sopel/__init__.py
@@ -10,13 +10,19 @@
 #
 # Licensed under the Eiffel Forum License 2.
 
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
-from collections import namedtuple
 import locale
-import pkg_resources
 import re
 import sys
+from collections import namedtuple
+
+import pkg_resources
 
 __all__ = [
     'bot',

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -6,26 +6,30 @@
 #
 # Licensed under the Eiffel Forum License 2.
 
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
-from ast import literal_eval
 import collections
-from datetime import datetime
 import itertools
 import logging
 import re
 import sys
 import threading
 import time
+from ast import literal_eval
+from datetime import datetime
 
+import sopel.loader
+import sopel.tools.jobs
 from sopel import irc, logger, plugins, tools
 from sopel.db import SopelDB
-from sopel.tools import Identifier, deprecated
-import sopel.tools.jobs
-from sopel.trigger import Trigger
 from sopel.module import NOLIMIT
-import sopel.loader
-
+from sopel.tools import Identifier, deprecated
+from sopel.trigger import Trigger
 
 __all__ = ['Sopel', 'SopelWrapper']
 

--- a/sopel/cli/__init__.py
+++ b/sopel/cli/__init__.py
@@ -1,5 +1,10 @@
 # coding=utf-8
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 # Shortcut imports
 from .utils import (  # noqa

--- a/sopel/cli/config.py
+++ b/sopel/cli/config.py
@@ -1,11 +1,17 @@
 # coding=utf-8
 """Sopel Config Command Line Interface (CLI): ``sopel-config``"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import argparse
 import os
 
 from sopel import tools
+
 from . import utils
 
 

--- a/sopel/cli/plugins.py
+++ b/sopel/cli/plugins.py
@@ -1,6 +1,11 @@
 # coding=utf-8
 """Sopel Plugins Command Line Interface (CLI): ``sopel-plugins``"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import argparse
 import inspect

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -8,7 +8,12 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import argparse
 import logging
@@ -18,7 +23,8 @@ import signal
 import sys
 import time
 
-from sopel import bot, config, logger, tools, __version__
+from sopel import __version__, bot, config, logger, tools
+
 from . import utils
 
 if sys.version_info < (2, 7):

--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -1,5 +1,10 @@
 # coding=utf-8
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import inspect
 import logging

--- a/sopel/config/__init__.py
+++ b/sopel/config/__init__.py
@@ -45,12 +45,18 @@ the :class:`Config` object is instantiated; it uses
 # Copyright © 2012, Elad Alfassa <elad@fedoraproject.org>
 # Licensed under the Eiffel Forum License 2.
 
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import os
 import sys
 
 from sopel import tools
+
 from . import core_section, types
 
 if sys.version_info.major < 3:

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -1,12 +1,21 @@
 # coding=utf-8
 
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import os.path
 
 from sopel.config.types import (
-    StaticSection, ValidatedAttribute, ListAttribute, ChoiceAttribute,
-    FilenameAttribute, NO_DEFAULT
+    NO_DEFAULT,
+    ChoiceAttribute,
+    FilenameAttribute,
+    ListAttribute,
+    StaticSection,
+    ValidatedAttribute
 )
 from sopel.tools import Identifier
 

--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -24,11 +24,17 @@ As an example, if one wanted to define the ``[spam]`` section as having an
     ValueError: ListAttribute value must be a list.
 """
 
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import os.path
 import re
 import sys
+
 from sopel.tools import get_input
 
 if sys.version_info.major >= 3:

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -1,14 +1,15 @@
 # coding=utf-8
-"""Tasks that allow the bot to run, but aren't user-facing functionality
+"""Tasks that allow the bot to run, but aren't user-facing functionality.
 
-This is written as a module to make it easier to extend to support more
-responses to standard IRC codes without having to shove them all into the
-dispatch function in bot.py and making it easier to maintain.
+This is written as a plugin to make it easier to extend to support more
+responses to standard IRC codes without having to shove them all into
+:class:`sopel.bot.Sopel` and making it easier to maintain.
 """
 # Copyright 2008-2011, Sean B. Palmer (inamidst.com) and Michael Yanovich
 # (yanovich.net)
 # Copyright © 2012, Elad Alfassa <elad@fedoraproject.org>
 # Copyright 2012-2015, Elsie Powell embolalia.com
+#
 # Licensed under the Eiffel Forum License 2.
 from __future__ import (
     absolute_import,
@@ -20,16 +21,14 @@ from __future__ import (
 import base64
 import datetime
 import logging
+import random
 import re
 import sys
 import time
-from random import randint
 
-import sopel
-import sopel.module
-import sopel.tools.web
+from sopel import module
 from sopel.irc.utils import CapReq
-from sopel.tools import Identifier, events, iteritems
+from sopel.tools import Identifier, events, iteritems, web
 from sopel.tools.target import Channel, User
 
 if sys.version_info.major >= 3:
@@ -68,9 +67,9 @@ def auth_after_register(bot):
                 auth_target or 'UserServ')
 
 
-@sopel.module.event(events.RPL_WELCOME, events.RPL_LUSERCLIENT)
-@sopel.module.thread(False)
-@sopel.module.unblockable
+@module.event(events.RPL_WELCOME, events.RPL_LUSERCLIENT)
+@module.thread(False)
+@module.unblockable
 def startup(bot, trigger):
     """Do tasks related to connecting to the network.
 
@@ -118,9 +117,9 @@ def startup(bot, trigger):
         bot.say(msg, bot.config.core.owner)
 
 
-@sopel.module.require_privmsg()
-@sopel.module.require_owner()
-@sopel.module.commands('useserviceauth')
+@module.require_privmsg()
+@module.require_owner()
+@module.commands('useserviceauth')
 def enable_service_auth(bot, trigger):
     if bot.config.core.owner_account:
         return
@@ -138,8 +137,8 @@ def enable_service_auth(bot, trigger):
             'owner.')
 
 
-@sopel.module.event(events.ERR_NOCHANMODES)
-@sopel.module.priority('high')
+@module.event(events.ERR_NOCHANMODES)
+@module.priority('high')
 def retry_join(bot, trigger):
     """Give NickServer enough time to identify on a +R channel.
 
@@ -162,11 +161,11 @@ def retry_join(bot, trigger):
     bot.join(channel)
 
 
-@sopel.module.rule('(.*)')
-@sopel.module.event(events.RPL_NAMREPLY)
-@sopel.module.priority('high')
-@sopel.module.thread(False)
-@sopel.module.unblockable
+@module.rule('(.*)')
+@module.event(events.RPL_NAMREPLY)
+@module.priority('high')
+@module.thread(False)
+@module.unblockable
 def handle_names(bot, trigger):
     """Handle NAMES response, happens when joining to channels."""
     names = trigger.split()
@@ -186,11 +185,11 @@ def handle_names(bot, trigger):
     # If this ever needs to be updated, remember to change the mode handling in
     # the WHO-handler functions below, too.
     mapping = {
-        "+": sopel.module.VOICE,
-        "%": sopel.module.HALFOP,
-        "@": sopel.module.OP,
-        "&": sopel.module.ADMIN,
-        "~": sopel.module.OWNER,
+        "+": module.VOICE,
+        "%": module.HALFOP,
+        "@": module.OP,
+        "&": module.ADMIN,
+        "~": module.OWNER,
     }
 
     for name in names:
@@ -211,11 +210,11 @@ def handle_names(bot, trigger):
         bot.channels[channel].add_user(user, privs=priv)
 
 
-@sopel.module.rule('(.*)')
-@sopel.module.event('MODE')
-@sopel.module.priority('high')
-@sopel.module.thread(False)
-@sopel.module.unblockable
+@module.rule('(.*)')
+@module.event('MODE')
+@module.priority('high')
+@module.thread(False)
+@module.unblockable
 def track_modes(bot, trigger):
     """Track usermode changes and keep our lists of ops up to date."""
     # Mode message format: <channel> *( ( "-" / "+" ) *<modes> *<modeparams> )
@@ -248,11 +247,11 @@ def track_modes(bot, trigger):
     nicks = [Identifier(nick) for nick in trigger.args[2:]]
 
     mapping = {
-        "v": sopel.module.VOICE,
-        "h": sopel.module.HALFOP,
-        "o": sopel.module.OP,
-        "a": sopel.module.ADMIN,
-        "q": sopel.module.OWNER,
+        "v": module.VOICE,
+        "h": module.HALFOP,
+        "o": module.OP,
+        "a": module.ADMIN,
+        "q": module.OWNER,
     }
 
     # Parse modes before doing anything else
@@ -299,10 +298,10 @@ def track_modes(bot, trigger):
             bot.channels[channel].privileges[nick] = priv
 
 
-@sopel.module.event('NICK')
-@sopel.module.priority('high')
-@sopel.module.thread(False)
-@sopel.module.unblockable
+@module.event('NICK')
+@module.priority('high')
+@module.thread(False)
+@module.unblockable
 def track_nicks(bot, trigger):
     """Track nickname changes and maintain our chanops list accordingly."""
     old = trigger.nick
@@ -337,21 +336,21 @@ def track_nicks(bot, trigger):
         bot.users[new] = bot.users.pop(old)
 
 
-@sopel.module.rule('(.*)')
-@sopel.module.event('PART')
-@sopel.module.priority('high')
-@sopel.module.thread(False)
-@sopel.module.unblockable
+@module.rule('(.*)')
+@module.event('PART')
+@module.priority('high')
+@module.thread(False)
+@module.unblockable
 def track_part(bot, trigger):
     nick = trigger.nick
     channel = trigger.sender
     _remove_from_channel(bot, nick, channel)
 
 
-@sopel.module.event('KICK')
-@sopel.module.priority('high')
-@sopel.module.thread(False)
-@sopel.module.unblockable
+@module.event('KICK')
+@module.priority('high')
+@module.thread(False)
+@module.unblockable
 def track_kick(bot, trigger):
     nick = Identifier(trigger.args[1])
     channel = trigger.sender
@@ -394,9 +393,9 @@ def _send_who(bot, channel):
         # Needed for accounts in who replies. The random integer is a param
         # to identify the reply as one from this command, because if someone
         # else sent it, we have no fucking way to know what the format is.
-        rand = str(randint(0, 999))
+        rand = str(random.randint(0, 999))
         while rand in who_reqs:
-            rand = str(randint(0, 999))
+            rand = str(random.randint(0, 999))
         who_reqs[rand] = channel
         bot.write(['WHO', channel, 'a%nuachtf,' + rand])
     else:
@@ -406,7 +405,7 @@ def _send_who(bot, channel):
     bot.channels[Identifier(channel)].last_who = datetime.datetime.utcnow()
 
 
-@sopel.module.interval(30)
+@module.interval(30)
 def _periodic_send_who(bot):
     """Periodically send a WHO request to keep user information up-to-date."""
     if 'away-notify' in bot.enabled_capabilities:
@@ -433,10 +432,10 @@ def _periodic_send_who(bot):
         _send_who(bot, selected_channel)
 
 
-@sopel.module.event('JOIN')
-@sopel.module.priority('high')
-@sopel.module.thread(False)
-@sopel.module.unblockable
+@module.event('JOIN')
+@module.priority('high')
+@module.thread(False)
+@module.unblockable
 def track_join(bot, trigger):
     if trigger.nick == bot.nick and trigger.sender not in bot.channels:
         bot.write(('TOPIC', trigger.sender))
@@ -459,10 +458,10 @@ def track_join(bot, trigger):
         user.account = trigger.args[1]
 
 
-@sopel.module.event('QUIT')
-@sopel.module.priority('high')
-@sopel.module.thread(False)
-@sopel.module.unblockable
+@module.event('QUIT')
+@module.priority('high')
+@module.thread(False)
+@module.unblockable
 def track_quit(bot, trigger):
     for chanprivs in bot.privileges.values():
         chanprivs.pop(trigger.nick, None)
@@ -471,10 +470,10 @@ def track_quit(bot, trigger):
     bot.users.pop(trigger.nick, None)
 
 
-@sopel.module.event('CAP')
-@sopel.module.thread(False)
-@sopel.module.priority('high')
-@sopel.module.unblockable
+@module.event('CAP')
+@module.thread(False)
+@module.priority('high')
+@module.unblockable
 def receive_cap_list(bot, trigger):
     cap = trigger.strip('-=~')
     # Server is listing capabilities
@@ -651,7 +650,7 @@ def send_authenticate(bot, token):
         bot.write(('AUTHENTICATE', '+'))
 
 
-@sopel.module.event('AUTHENTICATE')
+@module.event('AUTHENTICATE')
 def auth_proceed(bot, trigger):
     if trigger.args[0] != '+':
         # How did we get here? I am not good with computer.
@@ -670,7 +669,7 @@ def auth_proceed(bot, trigger):
     send_authenticate(bot, sasl_token)
 
 
-@sopel.module.event(events.RPL_SASLSUCCESS)
+@module.event(events.RPL_SASLSUCCESS)
 def sasl_success(bot, trigger):
     bot.write(('CAP', 'END'))
 
@@ -678,11 +677,11 @@ def sasl_success(bot, trigger):
 # Live blocklist editing
 
 
-@sopel.module.commands('blocks')
-@sopel.module.priority('low')
-@sopel.module.thread(False)
-@sopel.module.unblockable
-@sopel.module.require_admin
+@module.commands('blocks')
+@module.priority('low')
+@module.thread(False)
+@module.unblockable
+@module.require_admin
 def blocks(bot, trigger):
     """
     Manage Sopel's blocking features.\
@@ -761,7 +760,7 @@ def blocks(bot, trigger):
         bot.reply(STRINGS['huh'])
 
 
-@sopel.module.event('ACCOUNT')
+@module.event('ACCOUNT')
 def account_notify(bot, trigger):
     if trigger.nick not in bot.users:
         bot.users[trigger.nick] = User(trigger.nick, trigger.user, trigger.host)
@@ -771,9 +770,9 @@ def account_notify(bot, trigger):
     bot.users[trigger.nick].account = account
 
 
-@sopel.module.event(events.RPL_WHOSPCRPL)
-@sopel.module.priority('high')
-@sopel.module.unblockable
+@module.event(events.RPL_WHOSPCRPL)
+@module.priority('high')
+@module.unblockable
 def recv_whox(bot, trigger):
     if len(trigger.args) < 2 or trigger.args[1] not in who_reqs:
         # Ignored, some module probably called WHO
@@ -808,11 +807,11 @@ def _record_who(bot, channel, user, host, nick, account=None, away=None, modes=N
     priv = 0
     if modes:
         mapping = {
-            "+": sopel.module.VOICE,
-            "%": sopel.module.HALFOP,
-            "@": sopel.module.OP,
-            "&": sopel.module.ADMIN,
-            "~": sopel.module.OWNER,
+            "+": module.VOICE,
+            "%": module.HALFOP,
+            "@": module.OP,
+            "&": module.ADMIN,
+            "~": module.OWNER,
         }
         for c in modes:
             priv = priv | mapping[c]
@@ -824,9 +823,9 @@ def _record_who(bot, channel, user, host, nick, account=None, away=None, modes=N
     bot.privileges[channel][nick] = priv
 
 
-@sopel.module.event(events.RPL_WHOREPLY)
-@sopel.module.priority('high')
-@sopel.module.unblockable
+@module.event(events.RPL_WHOREPLY)
+@module.priority('high')
+@module.unblockable
 def recv_who(bot, trigger):
     channel, user, host, _, nick, status = trigger.args[1:7]
     away = 'G' in status
@@ -834,18 +833,18 @@ def recv_who(bot, trigger):
     _record_who(bot, channel, user, host, nick, away=away, modes=modes)
 
 
-@sopel.module.event(events.RPL_ENDOFWHO)
-@sopel.module.priority('high')
-@sopel.module.unblockable
+@module.event(events.RPL_ENDOFWHO)
+@module.priority('high')
+@module.unblockable
 def end_who(bot, trigger):
     if _whox_enabled(bot):
         who_reqs.pop(trigger.args[1], None)
 
 
-@sopel.module.event('AWAY')
-@sopel.module.priority('high')
-@sopel.module.thread(False)
-@sopel.module.unblockable
+@module.event('AWAY')
+@module.priority('high')
+@module.thread(False)
+@module.unblockable
 def track_notify(bot, trigger):
     if trigger.nick not in bot.users:
         bot.users[trigger.nick] = User(trigger.nick, trigger.user, trigger.host)
@@ -853,11 +852,11 @@ def track_notify(bot, trigger):
     user.away = bool(trigger.args)
 
 
-@sopel.module.event('TOPIC')
-@sopel.module.event(events.RPL_TOPIC)
-@sopel.module.priority('high')
-@sopel.module.thread(False)
-@sopel.module.unblockable
+@module.event('TOPIC')
+@module.event(events.RPL_TOPIC)
+@module.priority('high')
+@module.thread(False)
+@module.unblockable
 def track_topic(bot, trigger):
     if trigger.event != 'TOPIC':
         channel = trigger.args[1]
@@ -868,8 +867,8 @@ def track_topic(bot, trigger):
     bot.channels[channel].topic = trigger.args[-1]
 
 
-@sopel.module.rule(r'(?u).*(.+://\S+).*')
-@sopel.module.unblockable
+@module.rule(r'(?u).*(.+://\S+).*')
+@module.unblockable
 def handle_url_callbacks(bot, trigger):
     """Dispatch callbacks on URLs
 
@@ -878,7 +877,7 @@ def handle_url_callbacks(bot, trigger):
     """
     schemes = bot.config.core.auto_url_schemes
     # find URLs in the trigger
-    for url in sopel.tools.web.search_urls(trigger, schemes=schemes):
+    for url in web.search_urls(trigger, schemes=schemes):
         # find callbacks for said URL
         for function, match in bot.search_url_callbacks(url):
             # trigger callback defined by the `@url` decorator

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -10,21 +10,27 @@ dispatch function in bot.py and making it easier to maintain.
 # Copyright © 2012, Elad Alfassa <elad@fedoraproject.org>
 # Copyright 2012-2015, Elsie Powell embolalia.com
 # Licensed under the Eiffel Forum License 2.
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
-import logging
-from random import randint
+import base64
 import datetime
+import logging
 import re
 import sys
 import time
+from random import randint
+
 import sopel
 import sopel.module
 import sopel.tools.web
 from sopel.irc.utils import CapReq
-from sopel.tools import Identifier, iteritems, events
-from sopel.tools.target import User, Channel
-import base64
+from sopel.tools import Identifier, events, iteritems
+from sopel.tools.target import Channel, User
 
 if sys.version_info.major >= 3:
     unicode = str

--- a/sopel/db.py
+++ b/sopel/db.py
@@ -1,18 +1,23 @@
 # coding=utf-8
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import errno
 import json
 import os.path
 import sys
 
-from sopel.tools import Identifier
-
-from sqlalchemy import create_engine, Column, ForeignKey, Integer, String
+from sqlalchemy import Column, ForeignKey, Integer, String, create_engine
 from sqlalchemy.engine.url import URL
 from sqlalchemy.exc import OperationalError, SQLAlchemyError
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker
+
+from sopel.tools import Identifier
 
 if sys.version_info.major >= 3:
     unicode = str

--- a/sopel/formatting.py
+++ b/sopel/formatting.py
@@ -5,11 +5,15 @@
 """
 # Copyright 2014, Elsie Powell, embolalia.com
 # Licensed under the Eiffel Forum License 2.
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import string
 import sys
-
 
 __all__ = [
     # control chars

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -23,12 +23,25 @@ who should worry about :class:`sopel.bot.Sopel` only.
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
-import sys
-import time
-import os
 import logging
+import os
+import sys
+import threading
+import time
+from datetime import datetime
+
+from sopel import tools
+from sopel.trigger import PreTrigger
+
+from .backends import AsynchatBackend, SSLAsynchatBackend
+from .utils import CapReq, safe
 
 try:
     import ssl
@@ -43,14 +56,6 @@ except ImportError:
     # no SSL support
     has_ssl = False
 
-import threading
-from datetime import datetime
-
-from sopel import tools
-from sopel.trigger import PreTrigger
-
-from .backends import AsynchatBackend, SSLAsynchatBackend
-from .utils import safe, CapReq
 
 if sys.version_info.major >= 3:
     unicode = str

--- a/sopel/irc/abstract_backends.py
+++ b/sopel/irc/abstract_backends.py
@@ -2,7 +2,12 @@
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import threading
 

--- a/sopel/irc/backends.py
+++ b/sopel/irc/backends.py
@@ -4,7 +4,12 @@
 # Licensed under the Eiffel Forum License 2.
 # When working on core IRC protocol related features, consult protocol
 # documentation at http://www.irchelp.org/irchelp/rfc/
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import asynchat
 import asyncore
@@ -15,7 +20,8 @@ import os
 import socket
 import sys
 
-from sopel.tools.jobs import JobScheduler, Job
+from sopel.tools.jobs import Job, JobScheduler
+
 from .abstract_backends import AbstractIRCBackend
 from .utils import get_cnames
 

--- a/sopel/irc/utils.py
+++ b/sopel/irc/utils.py
@@ -2,10 +2,16 @@
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import sys
-from dns import resolver, rdtypes
+
+from dns import rdtypes, resolver
 
 if sys.version_info.major >= 3:
     unicode = str

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -1,12 +1,22 @@
 # coding=utf-8
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import re
 import sys
 
-from sopel.tools import (compile_rule, itervalues, get_command_regexp,
-                         get_nickname_command_regexp, get_action_command_regexp)
 from sopel.config import core_section
+from sopel.tools import (
+    compile_rule,
+    get_action_command_regexp,
+    get_command_regexp,
+    get_nickname_command_regexp,
+    itervalues
+)
 
 default_prefix = core_section.CoreSection.help_prefix.default
 del core_section

--- a/sopel/logger.py
+++ b/sopel/logger.py
@@ -1,5 +1,10 @@
 # coding=utf-8
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import logging
 import os

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -6,7 +6,12 @@
 # Copyright 2013, Lior Ramati <firerogue517@gmail.com>
 # Licensed under the Eiffel Forum License 2.
 
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import functools
 import re

--- a/sopel/modules/__init__.py
+++ b/sopel/modules/__init__.py
@@ -1,2 +1,7 @@
 # coding=utf-8
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)

--- a/sopel/modules/admin.py
+++ b/sopel/modules/admin.py
@@ -10,12 +10,19 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
-
-from sopel.config.types import (
-    StaticSection, ValidatedAttribute, FilenameAttribute
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
 )
+
 import sopel.module
+from sopel.config.types import (
+    FilenameAttribute,
+    StaticSection,
+    ValidatedAttribute
+)
 
 
 class AdminSection(StaticSection):

--- a/sopel/modules/adminchannel.py
+++ b/sopel/modules/adminchannel.py
@@ -7,13 +7,24 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import re
 
 from sopel import formatting
 from sopel.module import (
-    commands, example, priority, OP, HALFOP, require_privilege, require_chanmsg
+    HALFOP,
+    OP,
+    commands,
+    example,
+    priority,
+    require_chanmsg,
+    require_privilege
 )
 from sopel.tools import Identifier
 

--- a/sopel/modules/announce.py
+++ b/sopel/modules/announce.py
@@ -7,7 +7,12 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 from sopel.module import commands, example, require_admin
 

--- a/sopel/modules/bugzilla.py
+++ b/sopel/modules/bugzilla.py
@@ -6,7 +6,12 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import logging
 import re
@@ -14,9 +19,8 @@ import re
 import requests
 import xmltodict
 
-from sopel.config.types import StaticSection, ListAttribute
+from sopel.config.types import ListAttribute, StaticSection
 from sopel.module import rule
-
 
 regex = None
 LOGGER = logging.getLogger(__name__)

--- a/sopel/modules/calc.py
+++ b/sopel/modules/calc.py
@@ -6,7 +6,12 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import sys
 

--- a/sopel/modules/choose.py
+++ b/sopel/modules/choose.py
@@ -9,7 +9,12 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import random
 

--- a/sopel/modules/clock.py
+++ b/sopel/modules/clock.py
@@ -7,7 +7,12 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 from sopel import module, tools
 from sopel.tools.time import (

--- a/sopel/modules/countdown.py
+++ b/sopel/modules/countdown.py
@@ -6,11 +6,16 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import datetime
 
-from sopel.module import commands, NOLIMIT
+from sopel.module import NOLIMIT, commands
 
 
 @commands('countdown')

--- a/sopel/modules/currency.py
+++ b/sopel/modules/currency.py
@@ -7,7 +7,12 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import logging
 import re
@@ -16,8 +21,7 @@ import time
 import requests
 
 from sopel.config.types import StaticSection, ValidatedAttribute
-from sopel.module import commands, example, NOLIMIT, rule
-
+from sopel.module import NOLIMIT, commands, example, rule
 
 FIAT_URL = 'https://api.exchangeratesapi.io/latest?base=EUR'
 FIXER_URL = 'http://data.fixer.io/api/latest?base=EUR&access_key={}'

--- a/sopel/modules/dice.py
+++ b/sopel/modules/dice.py
@@ -7,7 +7,12 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import operator
 import random

--- a/sopel/modules/emoticons.py
+++ b/sopel/modules/emoticons.py
@@ -6,7 +6,12 @@ Licensed under the Eiffel Forum License 2
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 from sopel.module import commands, example
 

--- a/sopel/modules/etymology.py
+++ b/sopel/modules/etymology.py
@@ -7,13 +7,18 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 from re import sub
 
 from requests import get
 
-from sopel.module import commands, example, NOLIMIT
+from sopel.module import NOLIMIT, commands, example
 from sopel.tools import web
 
 try:

--- a/sopel/modules/find.py
+++ b/sopel/modules/find.py
@@ -11,12 +11,18 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import re
-from sopel.tools import Identifier, SopelMemory
-from sopel.module import rule, priority, echo
+
 from sopel.formatting import bold
+from sopel.module import echo, priority, rule
+from sopel.tools import Identifier, SopelMemory
 
 
 def setup(bot):

--- a/sopel/modules/find_updates.py
+++ b/sopel/modules/find_updates.py
@@ -9,14 +9,18 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import requests
 
 import sopel
 import sopel.module
 import sopel.tools
-
 
 wait_time = 24 * 60 * 60  # check once per day
 startup_check_run = False

--- a/sopel/modules/help.py
+++ b/sopel/modules/help.py
@@ -10,20 +10,28 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
-import re
 import collections
 import logging
+import re
 import socket
 import textwrap
 
 import requests
 
-from sopel.config.types import ChoiceAttribute, ValidatedAttribute, StaticSection
-from sopel.module import commands, rule, example, priority
+from sopel.config.types import (
+    ChoiceAttribute,
+    StaticSection,
+    ValidatedAttribute
+)
+from sopel.module import commands, example, priority, rule
 from sopel.tools import SopelMemory
-
 
 SETTING_CACHE_NAMESPACE = 'help-setting-cache'  # Set top-level memory key name
 LOGGER = logging.getLogger(__name__)

--- a/sopel/modules/instagram.py
+++ b/sopel/modules/instagram.py
@@ -6,10 +6,15 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
-from datetime import datetime
 import logging
+from datetime import datetime
 
 from requests import get
 

--- a/sopel/modules/invite.py
+++ b/sopel/modules/invite.py
@@ -7,10 +7,14 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 from sopel import module, tools
-
 
 MIN_PRIV = module.HALFOP
 

--- a/sopel/modules/ip.py
+++ b/sopel/modules/ip.py
@@ -8,7 +8,12 @@ Licensed under the Eiffel Forum License 2.
 https://sopel.chat
 """
 
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import logging
 import os

--- a/sopel/modules/isup.py
+++ b/sopel/modules/isup.py
@@ -6,7 +6,12 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import requests
 from requests import exceptions as request_errors

--- a/sopel/modules/lmgtfy.py
+++ b/sopel/modules/lmgtfy.py
@@ -6,7 +6,12 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat/
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 from sopel.module import commands, example
 from sopel.tools.web import quote

--- a/sopel/modules/meetbot.py
+++ b/sopel/modules/meetbot.py
@@ -7,7 +7,12 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import absolute_import, division, print_function, unicode_literals
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import codecs
 import collections
@@ -17,10 +22,12 @@ import time
 from string import punctuation, whitespace
 
 from sopel import formatting, module, tools
-from sopel.config.types import (FilenameAttribute, StaticSection,
-                                ValidatedAttribute)
+from sopel.config.types import (
+    FilenameAttribute,
+    StaticSection,
+    ValidatedAttribute
+)
 from sopel.modules.url import find_title
-
 
 UNTITLED_MEETING = "Untitled meeting"
 

--- a/sopel/modules/ping.py
+++ b/sopel/modules/ping.py
@@ -5,11 +5,16 @@ Copyright 2008 (?), Sean B. Palmer, inamidst.com
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import random
 
-from sopel.module import rule, priority, thread
+from sopel.module import priority, rule, thread
 
 
 @rule(r'(?i)(hi|hello|hey),? $nickname[ \t]*$')

--- a/sopel/modules/pronouns.py
+++ b/sopel/modules/pronouns.py
@@ -6,10 +6,14 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 from sopel.module import commands, example
-
 
 # Copied from pronoun.is, leaving a *lot* out. If
 # https://github.com/witch-house/pronoun.is/pull/96 gets merged, using that

--- a/sopel/modules/rand.py
+++ b/sopel/modules/rand.py
@@ -6,7 +6,12 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import random
 import sys

--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -7,7 +7,12 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import datetime as dt
 import re
@@ -17,7 +22,7 @@ import praw
 import prawcore
 
 from sopel.formatting import bold, color, colors
-from sopel.module import commands, example, require_chanmsg, url, NOLIMIT, OP
+from sopel.module import NOLIMIT, OP, commands, example, require_chanmsg, url
 from sopel.tools import time
 from sopel.tools.web import USER_AGENT
 

--- a/sopel/modules/reload.py
+++ b/sopel/modules/reload.py
@@ -6,14 +6,18 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import logging
 import subprocess
 
 import sopel.module
 from sopel import plugins
-
 
 LOGGER = logging.getLogger(__name__)
 

--- a/sopel/modules/remind.py
+++ b/sopel/modules/remind.py
@@ -7,21 +7,25 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import codecs
 import collections
-from datetime import datetime
 import logging
 import os
 import re
 import time
+from datetime import datetime
 
 import pytz
 
-from sopel import tools, module
-from sopel.tools.time import get_timezone, format_time, validate_timezone
-
+from sopel import module, tools
+from sopel.tools.time import format_time, get_timezone, validate_timezone
 
 LOGGER = logging.getLogger(__name__)
 

--- a/sopel/modules/safety.py
+++ b/sopel/modules/safety.py
@@ -6,7 +6,12 @@ Licensed under the Eiffel Forum License 2.
 
 This module uses virustotal.com
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import logging
 import os.path
@@ -16,10 +21,10 @@ import time
 
 import requests
 
-from sopel.config.types import StaticSection, ValidatedAttribute, ListAttribute
-from sopel.formatting import color, bold
-from sopel.module import OP
 import sopel.tools
+from sopel.config.types import ListAttribute, StaticSection, ValidatedAttribute
+from sopel.formatting import bold, color
+from sopel.module import OP
 
 try:
     # This is done separately from the below version if/else because JSONDecodeError

--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -7,7 +7,12 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import re
 

--- a/sopel/modules/seen.py
+++ b/sopel/modules/seen.py
@@ -8,12 +8,17 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import datetime
 import time
 
-from sopel.module import commands, rule, priority, thread
+from sopel.module import commands, priority, rule, thread
 from sopel.tools import Identifier
 from sopel.tools.time import seconds_to_human
 

--- a/sopel/modules/tell.py
+++ b/sopel/modules/tell.py
@@ -7,20 +7,24 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import io
 import logging
 import os
-import time
 import threading
+import time
 from collections import defaultdict
 
 from sopel.config.types import StaticSection, ValidatedAttribute
-from sopel.module import commands, nickname_commands, rule, priority, example
+from sopel.module import commands, example, nickname_commands, priority, rule
 from sopel.tools import Identifier
-from sopel.tools.time import get_timezone, format_time
-
+from sopel.tools.time import format_time, get_timezone
 
 LOGGER = logging.getLogger(__name__)
 

--- a/sopel/modules/tld.py
+++ b/sopel/modules/tld.py
@@ -6,7 +6,12 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import re
 import sys

--- a/sopel/modules/translate.py
+++ b/sopel/modules/translate.py
@@ -7,7 +7,12 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import json
 import random
@@ -15,7 +20,7 @@ import sys
 
 import requests
 
-from sopel.module import rule, commands, priority, example
+from sopel.module import commands, example, priority, rule
 from sopel.tools import web
 
 if sys.version_info.major >= 3:

--- a/sopel/modules/unicode_info.py
+++ b/sopel/modules/unicode_info.py
@@ -7,7 +7,12 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import sys
 import unicodedata

--- a/sopel/modules/units.py
+++ b/sopel/modules/units.py
@@ -7,12 +7,16 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import re
 
-from sopel.module import commands, example, NOLIMIT
-
+from sopel.module import NOLIMIT, commands, example
 
 find_temp = re.compile(r'(-?[0-9]*\.?[0-9]*)[ °]*(K|C|F)', re.IGNORECASE)
 find_length = re.compile(r'([0-9]*\.?[0-9]*)[ ]*(mile[s]?|mi|inch|in|foot|feet|ft|yard[s]?|yd|(?:milli|centi|kilo|)meter[s]?|[mkc]?m|ly|light-year[s]?|au|astronomical unit[s]?|parsec[s]?|pc)', re.IGNORECASE)

--- a/sopel/modules/uptime.py
+++ b/sopel/modules/uptime.py
@@ -6,7 +6,12 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import datetime
 

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -9,12 +9,17 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
+import ipaddress
 import re
 
 import dns.resolver
-import ipaddress
 import requests
 
 from sopel import __version__, module, tools

--- a/sopel/modules/version.py
+++ b/sopel/modules/version.py
@@ -7,11 +7,16 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
+import platform
 from datetime import datetime
 from os import path
-import platform
 
 from sopel import __version__ as release
 from sopel.module import commands, intent, rate

--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -6,7 +6,12 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import re
 
@@ -15,7 +20,6 @@ from requests import get
 from sopel.config.types import StaticSection, ValidatedAttribute
 from sopel.module import NOLIMIT, commands, example, url
 from sopel.tools.web import quote, unquote
-
 
 REDIRECT = re.compile(r'^REDIRECT (.*)')
 WIKIPEDIA_REGEX = r'/([a-z]+\.wikipedia\.org)/wiki/((?!File\:)[^ ]+)'

--- a/sopel/modules/wiktionary.py
+++ b/sopel/modules/wiktionary.py
@@ -6,7 +6,12 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import re
 
@@ -14,7 +19,6 @@ import requests
 
 from sopel.module import commands, example
 from sopel.tools import web
-
 
 uri = 'https://en.wiktionary.org/w/index.php?title=%s&printable=yes'
 r_sup = re.compile(r'<sup[^>]+>.+</sup>')  # Superscripts that are references only, not ordinal indicators, etc...

--- a/sopel/modules/xkcd.py
+++ b/sopel/modules/xkcd.py
@@ -8,16 +8,20 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import random
 import re
 
 import requests
 
-from sopel.modules.search import bing_search
 from sopel.module import commands, url
-
+from sopel.modules.search import bing_search
 
 ignored_sites = [
     # For searching the web

--- a/sopel/plugins/__init__.py
+++ b/sopel/plugins/__init__.py
@@ -27,7 +27,12 @@ exist for each type of plugin.
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import collections
 import imp

--- a/sopel/plugins/exceptions.py
+++ b/sopel/plugins/exceptions.py
@@ -3,7 +3,12 @@
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 
 class PluginError(Exception):

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -31,14 +31,20 @@ away from the rest of the application.
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
-import inspect
 import imp
 import importlib
+import inspect
 import os
 
 from sopel import loader
+
 from . import exceptions
 
 try:

--- a/sopel/test_tools.py
+++ b/sopel/test_tools.py
@@ -7,25 +7,30 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import os
 import re
 import sys
 import tempfile
 
-try:
-    import ConfigParser
-except ImportError:
-    import configparser as ConfigParser
-
-from sopel.bot import SopelWrapper
-from sopel.irc.abstract_backends import AbstractIRCBackend
 import sopel.config
 import sopel.config.core_section
 import sopel.tools
 import sopel.tools.target
 import sopel.trigger
+from sopel.bot import SopelWrapper
+from sopel.irc.abstract_backends import AbstractIRCBackend
+
+try:
+    import ConfigParser
+except ImportError:
+    import configparser as ConfigParser
 
 
 __all__ = [

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -12,7 +12,12 @@
 
 # https://sopel.chat
 
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import codecs
 import functools

--- a/sopel/tools/_events.py
+++ b/sopel/tools/_events.py
@@ -1,5 +1,10 @@
 # coding=utf-8
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 
 class events(object):

--- a/sopel/tools/calculation.py
+++ b/sopel/tools/calculation.py
@@ -1,11 +1,16 @@
 # coding=utf-8
 """Tools to help safely do calculations from user input"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
-import time
+import ast
 import numbers
 import operator
-import ast
+import time
 
 __all__ = ['eval_equation']
 

--- a/sopel/tools/jobs.py
+++ b/sopel/tools/jobs.py
@@ -10,13 +10,17 @@
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import datetime
 import logging
 import threading
 import time
-
 
 LOGGER = logging.getLogger(__name__)
 

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -1,7 +1,13 @@
 # coding=utf-8
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import functools
+
 from sopel.tools import Identifier
 
 

--- a/sopel/tools/time.py
+++ b/sopel/tools/time.py
@@ -1,6 +1,11 @@
 # coding=utf-8
 """Tools for getting and displaying the time."""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import datetime
 

--- a/sopel/tools/web.py
+++ b/sopel/tools/web.py
@@ -17,7 +17,12 @@ applications, APIs, or websites in your plugins.
 # Copyright © 2019, dgw, technobabbl.es
 # Licensed under the Eiffel Forum License 2.
 
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import re
 import sys

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -1,13 +1,17 @@
 # coding=utf-8
 """Sopel IRC Trigger Lines"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
+import datetime
 import re
 import sys
-import datetime
 
 from sopel import tools
-
 
 __all__ = [
     'PreTrigger',

--- a/sopel/web.py
+++ b/sopel/web.py
@@ -12,31 +12,35 @@ functions are available in a new package, ``sopel.tools.web``.
 # Copyright © 2019, dgw, technobabbl.es
 # Licensed under the Eiffel Forum License 2.
 
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import (
+    absolute_import,
+    division,
+    print_function,
+    unicode_literals
+)
 
 import sys
 
 import requests
 
 from .tools import deprecated
+# Imports to facilitate transition from sopel.web to sopel.tools.web
+from .tools.web import DEFAULT_HEADERS as default_headers  # noqa
+from .tools.web import (
+    USER_AGENT,
+    decode,
+    entity,
+    iri_to_uri,
+    quote,
+    quote_query,
+    urlencode,
+    urlencode_non_ascii
+)
 
 if sys.version_info.major < 3:
     import httplib
 else:
     import http.client as httplib
-
-# Imports to facilitate transition from sopel.web to sopel.tools.web
-from .tools.web import (  # noqa
-    USER_AGENT,
-    DEFAULT_HEADERS as default_headers,
-    entity,
-    decode,
-    quote,
-    quote_query,
-    urlencode_non_ascii,
-    iri_to_uri,
-    urlencode,
-)
 
 __all__ = [
     'USER_AGENT',


### PR DESCRIPTION
This is a "DO ALL THE THING" kind of PR.

I know I used a very opinionated config for isort, but I stand by it. After a while, you just stop caring about your imports: isort does it for you.

In our case:

1. add some imports
2. run `make isort`
3. run `make quality`

And voilà. Your imports will be sorted and checked for quality with isort and flake8.

Note: I'm fully prepared to rebase and fix every merge conflict that will eventually happen next.
I'm ready.

:fr: :rage1: 