### PR TITLE
Prepare Sopel to adapt its output when py2 officially dies

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Sopel requires ``backports.ssl_match_hostname`` to be installed. Use
 ``yum install python-backports.ssl_match_hostname`` to install it, or download
 and install it manually `from PyPI <https://pypi.org/project/backports.ssl_match_hostname>`_.
 
-Note: Python 2.x is near end of life. Sopel support at that point is TBD.
+Note: Python 2.x is near end of life. Sopel will drop support in version 8.0.
 
 In the source directory (whether cloned or from the tarball) run
 ``setup.py install``. You can then run ``sopel`` to configure and start the

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 import sys
+import time
 
 try:
     from setuptools import setup, __version__ as setuptools_version
@@ -38,7 +39,11 @@ if sys.version_info < (2, 7) or (
     # this fucking question, and if you get here you should go RTGDMFM.
     raise ImportError('Sopel requires Python 2.7+ or 3.3+.')
 if sys.version_info.major == 2:
-    print('Warning: Python 2.x is near end of life. Sopel support at that point is TBD.', file=sys.stderr)
+    if time.time() >= 1577836800:  # 2020-01-01 00:00:00 UTC
+        state = 'is near end of life'
+    else:
+        state = 'has reached end of life and will receive no further updates'
+    print('Warning: Python 2.x %s. Sopel will drop support in version 8.0.' % state, file=sys.stderr)
 
 
 def read_reqs(path):

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -25,7 +25,11 @@ if sys.version_info < (2, 7):
     tools.stderr('Error: Requires Python 2.7 or later. Try python2.7 sopel')
     sys.exit(1)
 if sys.version_info.major == 2:
-    tools.stderr('Warning: Python 2.x is near end of life. Sopel support at that point is TBD.')
+    if time.time() >= 1577836800:  # 2020-01-01 00:00:00 UTC
+        state = 'is near end of life'
+    else:
+        state = 'has reached end of life and will receive no further updates'
+    tools.stderr('Warning: Python 2.x %s. Sopel will drop support in version 8.0.' % state)
 if sys.version_info.major == 3 and sys.version_info.minor < 3:
     tools.stderr('Error: When running on Python 3, Python 3.3 is required.')
     sys.exit(1)


### PR DESCRIPTION
Kind of magic-number-y, but I'd rather this than duplicating `datetime` code in two places.

No, I do not feel like optimizing this out into a function that we'll remove as soon as we start on 8.0.