### PR TITLE
core: handle 005 RPL_ISUPPORT event

### DIFF
--- a/docs/source/irc.rst
+++ b/docs/source/irc.rst
@@ -43,6 +43,13 @@ Backends
     :show-inheritance:
 
 
+ISUPPORT
+========
+
+.. automodule:: sopel.irc.isupport
+    :members:
+
+
 Utility
 =======
 

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -50,6 +50,7 @@ from sopel import tools
 from sopel.trigger import PreTrigger
 
 from .backends import AsynchatBackend, SSLAsynchatBackend
+from .isupport import ISupport
 from .utils import safe, CapReq
 
 if sys.version_info.major >= 3:
@@ -67,6 +68,7 @@ class AbstractBot(object):
         self._nick = tools.Identifier(settings.core.nick)
         self._user = settings.core.user
         self._name = settings.core.name
+        self._isupport = ISupport()
 
         self.backend = None
         """IRC Connection Backend."""
@@ -107,6 +109,14 @@ class AbstractBot(object):
         """The :class:`sopel.config.Config` for the current Sopel instance."""
         # TODO: Deprecate config, replaced by settings
         return self.settings
+
+    @property
+    def isupport(self):
+        """Features advertised by the server.
+
+        :type: :class:`~.isupport.ISupport` instance
+        """
+        return self._isupport
 
     # Connection
 

--- a/sopel/irc/isupport.py
+++ b/sopel/irc/isupport.py
@@ -222,13 +222,16 @@ class ISupport(object):
             False
 
         """
-        kwargs_ci = dict((key.upper(), value) for key, value in kwargs.items())
+        kwargs_upper = dict(
+            (key.upper(), value)
+            for key, value in kwargs.items()
+        )
         kept = (
             (key, value)
             for key, value in self.__isupport.items()
-            if ('-%s' % key) not in kwargs_ci
+            if ('-%s' % key) not in kwargs_upper
         )
-        updated = dict(itertools.chain(kept, kwargs_ci.items()))
+        updated = dict(itertools.chain(kept, kwargs_upper.items()))
 
         return self.__class__(**updated)
 

--- a/sopel/irc/isupport.py
+++ b/sopel/irc/isupport.py
@@ -101,7 +101,7 @@ def _parse_prefix(value):
     return tuple(sorted(zip(modes, prefixes)))
 
 
-ISUPPORT_PARSER = {
+ISUPPORT_PARSERS = {
     'AWAYLEN': int,
     'CASEMAPPING': str,
     'CHANLIMIT': _map_items(int),
@@ -140,7 +140,7 @@ def parse_parameter(arg):
         # ignore value for removed parameters
         return (key, None)
 
-    parser = ISUPPORT_PARSER.get(key, _optional(str))
+    parser = ISUPPORT_PARSERS.get(key, _optional(str))
     return (key, parser(value))
 
 

--- a/sopel/irc/isupport.py
+++ b/sopel/irc/isupport.py
@@ -1,0 +1,363 @@
+# coding=utf-8
+"""IRC Tools for ISUPPORT management.
+
+When a server wants to advertise its features and settings, it can use the
+``RPL_ISUPPORT`` command with a list of arguments.
+
+.. seealso::
+
+    https://modern.ircdocs.horse/#rplisupport-005
+
+"""
+# Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
+#
+# Licensed under the Eiffel Forum License 2.
+from __future__ import unicode_literals, absolute_import, print_function, division
+
+import functools
+import itertools
+import re
+
+
+def _optional(parser, default=None):
+    # set a parser as optional: will always return the default value provided
+    # if there is no value (empty or None)
+    @functools.wraps(parser)
+    def wrapped(value):
+        if not value:
+            return default
+        return parser(value)
+    return wrapped
+
+
+def _no_value(value):
+    # always ignore the value
+    return None
+
+
+def _single_character(value):
+    if len(value) > 1:
+        raise ValueError('Too many characters: %r.' % value)
+
+    return value
+
+
+def _map_items(parser=str, map_separator=',', item_separator=':'):
+    @functools.wraps(parser)
+    def wrapped(value):
+        items = sorted(
+            item.split(item_separator)
+            for item in value.split(map_separator))
+
+        return tuple(
+            (k, parser(v) if v else None)
+            for k, v in items
+        )
+    return wrapped
+
+
+def _parse_chanmodes(value):
+    items = value.split(',')
+
+    if len(items) < 4:
+        raise ValueError('Not enough channel types to unpack from %r.' % value)
+
+    # add extra channel type's modes to their own tuple
+    # result in (A, B, C, D, (E, F, G, H, ..., Z))
+    # where A, B, C, D = result[:4]
+    # and extras = result[4]
+    return tuple(items[:4]) + (tuple(items[4:]),)
+
+
+def _parse_elist(value):
+    # letters are case-insensitives
+    return tuple(sorted(set(letter.upper() for letter in value)))
+
+
+def _parse_extban(value):
+    args = value.split(',')
+
+    if len(args) < 2:
+        raise ValueError('Invalid value for EXTBAN: %r.' % value)
+
+    prefix = args[0] or None
+    items = tuple(sorted(set(args[1])))
+
+    return (prefix, items)
+
+
+def _parse_prefix(value):
+    result = re.match(r'\((?P<modes>\S+)\)(?P<prefixes>\S+)', value)
+
+    if not result:
+        raise ValueError('Invalid value for PREFIX: %r' % value)
+
+    modes = result.group('modes')
+    prefixes = result.group('prefixes')
+
+    if len(modes) != len(prefixes):
+        raise ValueError('Mode list does not match for PREFIX: %r' % value)
+
+    return tuple(sorted(zip(modes, prefixes)))
+
+
+ISUPPORT_PARSER = {
+    'AWAYLEN': int,
+    'CASEMAPPING': str,
+    'CHANLIMIT': _map_items(int),
+    'CHANMODES': _parse_chanmodes,
+    'CHANNELLEN': int,
+    'CHANTYPES': _optional(tuple),
+    'ELIST': _parse_elist,
+    'EXCEPTS': _optional(_single_character, default='e'),
+    'EXTBAN': _parse_extban,
+    'HOSTLEN': int,
+    'INVEX': _optional(_single_character, default='I'),
+    'KICKLEN': int,
+    'MAXLIST': _map_items(int),
+    'MAXTARGETS': _optional(int),
+    'MODES': _optional(int),
+    'NETWORK': str,
+    'NICKLEN': int,
+    'PREFIX': _optional(_parse_prefix),
+    'SAFELIST': _no_value,
+    'SILENCE': _optional(int),
+    'STATUSMSG': _optional(tuple),
+    'TARGMAX': _optional(_map_items(int)),
+    'TOPICLEN': int,
+    'USERLEN': int,
+}
+
+
+def parse_parameter(arg):
+    items = arg.split('=', 1)
+    if len(items) == 2:
+        key, value = items
+    else:
+        key, value = items[0], None
+
+    if key.startswith('-'):
+        # ignore value for removed parameters
+        return (key, None)
+
+    parser = ISUPPORT_PARSER.get(key, str)
+    return (key, parser(value))
+
+
+class ISupport(object):
+    """Storage class for IRC's ``ISUPPORT`` feature.
+
+    An instance of ``ISupport`` can be used as a read-only dict, to store
+    features advertised by the IRC server::
+
+        >>> isupport = ISupport(chanlimit=(('&', None), ('#', 70)))
+        >>> isupport['CHANLIMIT']
+        (('&', None) ('#', 70))
+        >>> isupport.CHANLIMIT  # some parameters are also properties
+        {
+            '&': None,
+            '#': 70,
+        }
+        >>> 'chanlimit' in isupport  # case-insensitive
+        True
+        >>> 'chanmode' in isupport
+        False
+        >>> isupport.CHANMODE  # not advertised by the server!
+        Traceback (most recent call last):
+          File "<stdin>", line 1, in <module>
+        AttributeError: 'ISupport' object has no attribute 'CHANMODE'
+
+    The list of possible parameters can be found at
+    `modern.ircdocs.horse's RPL_ISUPPORT Parameters`__.
+
+    .. __: https://modern.ircdocs.horse/#rplisupport-parameters
+    """
+    def __init__(self, **kwargs):
+        self.__isupport = dict(
+            (key.upper(), value)
+            for key, value in kwargs.items()
+            if not key.startswith('-'))
+
+    def __getitem__(self, key):
+        key_ci = key.upper()
+        if key_ci not in self.__isupport:
+            raise KeyError(key_ci)
+        return self.__isupport[key_ci]
+
+    def __contains__(self, key):
+        return key.upper() in self.__isupport
+
+    def apply(self, **kwargs):
+        """Build a new instance of :class:`ISupport`.
+
+        :return: a new instance, updated with the latest advertised features
+        :rtype: :class:`ISupport`
+
+        This method applies the latest advertised features from the server:
+        the result contains the new and updated parameters, and doesn't contain
+        the removed parameters (marked by ``-{PARAMNAME}``)::
+
+            >>> updated = {'-AWAYLEN': None, 'NICKLEN': 25, 'CHANNELLEN': 10}
+            >>> new = isupport.apply(**updated)
+            >>> 'CHANNELLEN' in new
+            True
+            >>> 'AWAYLEN' in new
+            False
+
+        """
+        kwargs_ci = dict((key.upper(), value) for key, value in kwargs.items())
+        kept = (
+            (key, value)
+            for key, value in self.__isupport.items()
+            if ('-%s' % key) not in kwargs_ci
+        )
+        updated = dict(itertools.chain(kept, kwargs_ci.items()))
+
+        return self.__class__(**updated)
+
+    @property
+    def CHANLIMIT(self):
+        """Expose ``CHANLIMIT`` as a dict, if advertised by the server.
+
+        This exposes information about the maximum number of channels that the
+        bot can join for each prefix::
+
+            >>> isupport.CHANLIMIT
+            {
+                '#': 70,
+                '&': None,
+            }
+
+        In that example, the bot may join 70 ``#`` channels and any number of
+        ``&`` channels.
+
+        This attribute is not available if the server does not provide the
+        right information, and accessing it will raise an
+        :exc:`AttributeError`.
+
+        .. seealso::
+
+            https://modern.ircdocs.horse/#chanlimit-parameter
+
+        """
+        if 'CHANLIMIT' not in self:
+            raise AttributeError('CHANLIMIT')
+
+        return dict(self['CHANLIMIT'])
+
+    @property
+    def CHANMODES(self):
+        """Expose ``CHANMODES`` as a dict, if advertised by the server.
+
+        This exposes information about 4 types of channel::
+
+            >>> isupport.CHANMODES
+            {
+                'A': 'b',
+                'B': 'k',
+                'C': 'l',
+                'D': 'imnpst',
+            }
+
+        This attribute is not available if the server does not provide the
+        right information, and accessing it will raise an
+        :exc:`AttributeError`.
+
+        .. seealso::
+
+            https://modern.ircdocs.horse/#chanmodes-parameter
+
+        """
+        if 'CHANMODES' not in self:
+            raise AttributeError('CHANMODES')
+
+        return dict(zip('ABCD', self['CHANMODES'][:4]))
+
+    @property
+    def MAXLIST(self):
+        """Expose ``MAXLIST`` as a dict, if advertised by the server.
+
+        This exposes information about maximum combination of modes::
+
+            >>> isupport.MAXLIST
+            {
+                'beI': 100,
+                'q': 50,
+                'b': 50,
+            }
+
+        This attribute is not available if the server does not provide the
+        right information, and accessing it will raise an
+        :exc:`AttributeError`.
+
+        .. seealso::
+
+            https://modern.ircdocs.horse/#maxlist-parameter
+
+        """
+        if 'MAXLIST' not in self:
+            raise AttributeError('MAXLIST')
+
+        return dict(self['MAXLIST'])
+
+    @property
+    def PREFIX(self):
+        """Expose ``PREFIX`` as a dict, if advertised by the server.
+
+        This exposes information about prefix used for user privileges::
+
+            >>> isupport.PREFIX
+            {
+                'q': '~',
+                'a': '&',
+                'o': '@',
+                'h': '%',
+                'v': '+',
+            }
+
+        This attribute is not available if the server does not provide the
+        right information, and accessing it will raise an
+        :exc:`AttributeError`.
+
+        .. seealso::
+
+            https://modern.ircdocs.horse/#prefix-parameter
+
+        """
+        if 'PREFIX' not in self:
+            raise AttributeError('PREFIX')
+
+        return dict(self['PREFIX'])
+
+    @property
+    def TARGMAX(self):
+        """Expose ``TARGMAX`` as a dict, if advertised by the server.
+
+        This exposes information about the maximum number of arguments for
+        each command::
+
+            >>> isupport.TARGMAX
+            {
+                'JOIN': None,
+                'PRIVMSG': 3,
+                'WHOIS': 1,
+            }
+
+        This attribute is not available if the server does not provide the
+        right information, and accessing it will raise an
+        :exc:`AttributeError`.
+
+        .. seealso::
+
+            https://modern.ircdocs.horse/#targmax-parameter
+
+        """
+        if 'TARGMAX' not in self:
+            raise AttributeError('TARGMAX')
+
+        targmax = self['TARGMAX']
+
+        if targmax is None:
+            return {}
+
+        return dict(self['TARGMAX'] or [])

--- a/test/irc/test_irc_isupport.py
+++ b/test/irc/test_irc_isupport.py
@@ -1,0 +1,487 @@
+# coding=utf-8
+"""Tests for core ``sopel.irc.isupport``"""
+from __future__ import unicode_literals, absolute_import, print_function, division
+
+import pytest
+
+from sopel.irc import isupport
+
+
+def test_isupport_apply():
+    instance = isupport.ISupport()
+
+    assert 'AWAYLEN' not in instance
+
+    new = instance.apply(awaylen=50)
+
+    assert 'AWAYLEN' not in instance
+    assert 'AWAYLEN' in new
+    assert new['AWAYLEN'] == 50
+
+    new_removed = new.apply(**{'-AWAYLEN': None, 'NICKLEN': 31})
+
+    assert 'AWAYLEN' not in instance
+    assert 'AWAYLEN' in new
+    assert 'AWAYLEN' not in new_removed
+    assert new['AWAYLEN'] == 50, 'original instance must not be modified'
+
+    assert 'NICKLEN' in new_removed
+    assert new_removed['NICKLEN'] == 31
+
+
+def test_isupport_apply_ci():
+    """Test removed parameters are case-insensitives."""
+    instance = isupport.ISupport()
+    new = instance.apply(awaylen=50, NICKLEN=31, channellen=16)
+    new_removed = new.apply(**{
+        '-awaylen': None,
+        '-NICKLEN': None,
+        'channellen': 24,
+    })
+
+    assert 'AWAYLEN' in new
+    assert 'AWAYLEN' not in new_removed
+
+    assert 'NICKLEN' in new
+    assert 'NICKLEN' not in new_removed
+
+    assert 'CHANNELLEN' in new
+    assert 'CHANNELLEN' in new_removed
+    assert new['CHANNELLEN'] == 16
+    assert new_removed['CHANNELLEN'] == 24
+
+    new_removed_ci = new.apply(**{
+        '-AWAYLEN': None,
+        '-nicklen': None,
+        'CHANNELLEN': 34,
+    })
+
+    assert 'AWAYLEN' in new
+    assert 'AWAYLEN' not in new_removed_ci
+
+    assert 'NICKLEN' in new
+    assert 'NICKLEN' not in new_removed_ci
+
+    assert 'CHANNELLEN' in new
+    assert 'CHANNELLEN' in new_removed_ci
+    assert new['CHANNELLEN'] == 16
+    assert new_removed_ci['CHANNELLEN'] == 34
+
+
+def test_isupport_removed_parameter():
+    """Test removed parameters are ignored."""
+    instance = isupport.ISupport(**{'-AWAYLEN': 50})
+
+    assert 'AWAYLEN' not in instance
+    assert '-AWAYLEN' not in instance
+
+
+def test_isupport_getitem():
+    """Test basic parameter access."""
+    instance = isupport.ISupport(AWAYLEN=50)
+
+    assert 'AWAYLEN' in instance
+    assert 'UNKNOWN' not in instance
+    assert instance['AWAYLEN'] == 50
+
+    with pytest.raises(KeyError):
+        instance['UNKNOWN']
+
+
+def test_isupport_getitem_ci():
+    """Test access to parameters is case insensitive."""
+    instance = isupport.ISupport(awaylen=50)
+
+    assert 'AWAYLEN' in instance
+    assert 'awaylen' in instance
+    assert instance['AWAYLEN'] == 50
+    assert instance['awaylen'] == 50
+
+
+def test_isupport_setitem():
+    """Test you can't set a key."""
+    instance = isupport.ISupport(awaylen=50)
+
+    with pytest.raises(TypeError):
+        instance['AWAYLEN'] = 10
+
+
+def test_isupport_chanlimit():
+    instance = isupport.ISupport(chanlimit=(('#', 50), ('$', 10)))
+    assert '#' in instance.CHANLIMIT
+    assert '$' in instance.CHANLIMIT
+    assert instance.CHANLIMIT['#'] == 50
+    assert instance.CHANLIMIT['$'] == 10
+
+    with pytest.raises(AttributeError):
+        instance.CHANLIMIT = 'something'
+
+
+def test_isupport_chanlimit_undefined():
+    instance = isupport.ISupport()
+
+    assert not hasattr(instance, 'CHANLIMIT')
+
+    with pytest.raises(AttributeError):
+        instance.CHANLIMIT
+
+
+def test_isupport_chanmodes():
+    instance = isupport.ISupport(chanmodes=('b', 'k', 'l', 'imnpst', tuple()))
+
+    assert 'A' in instance.CHANMODES
+    assert 'B' in instance.CHANMODES
+    assert 'C' in instance.CHANMODES
+    assert 'D' in instance.CHANMODES
+
+    with pytest.raises(AttributeError):
+        instance.CHANMODES = 'something'
+
+
+def test_isupport_chanmodes_undefined():
+    instance = isupport.ISupport()
+
+    assert not hasattr(instance, 'CHANMODES')
+
+    with pytest.raises(AttributeError):
+        instance.CHANMODES
+
+
+def test_isupport_maxlist():
+    instance = isupport.ISupport(maxlist=(('Z', 10), ('beI', 25)))
+    assert 'Z' in instance.MAXLIST
+    assert 'beI' in instance.MAXLIST
+    assert instance.MAXLIST['Z'] == 10
+    assert instance.MAXLIST['beI'] == 25
+
+    with pytest.raises(AttributeError):
+        instance.MAXLIST = 'something'
+
+
+def test_isupport_maxlist_undefined():
+    instance = isupport.ISupport()
+
+    assert not hasattr(instance, 'MAXLIST')
+
+    with pytest.raises(AttributeError):
+        instance.MAXLIST
+
+
+def test_isupport_prefix():
+    instance = isupport.ISupport(prefix=(('o', '@'), ('v', '+')))
+    assert 'o' in instance.PREFIX
+    assert 'v' in instance.PREFIX
+    assert instance.PREFIX['o'] == '@'
+    assert instance.PREFIX['v'] == '+'
+
+    with pytest.raises(AttributeError):
+        instance.PREFIX = 'something'
+
+
+def test_isupport_prefix_undefined():
+    instance = isupport.ISupport()
+
+    assert not hasattr(instance, 'PREFIX')
+
+    with pytest.raises(AttributeError):
+        instance.PREFIX
+
+
+def test_isupport_targmax():
+    instance = isupport.ISupport(
+        targmax=(('JOIN', None), ('PRIVMSG', 3), ('WHOIS', 1)))
+    assert 'JOIN' in instance.TARGMAX
+    assert 'PRIVMSG' in instance.TARGMAX
+    assert 'WHOIS' in instance.TARGMAX
+    assert instance.TARGMAX['JOIN'] is None
+    assert instance.TARGMAX['PRIVMSG'] == 3
+    assert instance.TARGMAX['WHOIS'] == 1
+
+    with pytest.raises(AttributeError):
+        instance.TARGMAX = 'something'
+
+
+def test_isupport_targmax_optional():
+    instance = isupport.ISupport(targmax=None)
+
+    assert instance.TARGMAX == {}
+
+
+def test_isupport_targmax_undefined():
+    instance = isupport.ISupport()
+
+    assert not hasattr(instance, 'TARGMAX')
+
+    with pytest.raises(AttributeError):
+        instance.TARGMAX
+
+
+# these parameters with basic parsing
+VALID_PARSE_VALUE = (
+    ('AWAYLEN=50', ('AWAYLEN', 50)),
+    ('CASEMAPPING=ascii', ('CASEMAPPING', 'ascii')),
+    ('CHANNELLEN=31', ('CHANNELLEN', 31)),
+    ('CHANTYPES=#~', ('CHANTYPES', ('#', '~'))),
+    ('EXCEPTS=d', ('EXCEPTS', 'd')),
+    ('HOSTLEN=64', ('HOSTLEN', 64)),
+    ('INVEX=J', ('INVEX', 'J')),
+    ('KICKLEN=307', ('KICKLEN', 307)),
+    ('MAXTARGETS=5', ('MAXTARGETS', 5)),
+    ('MODES=5', ('MODES', 5)),
+    ('NETWORK=Freenode', ('NETWORK', 'Freenode')),
+    ('NICKLEN=31', ('NICKLEN', 31)),
+    ('SILENCE=5', ('SILENCE', 5)),
+    ('STATUSMSG', ('STATUSMSG', None)),
+    ('STATUSMSG=ABCD', ('STATUSMSG', ('A', 'B', 'C', 'D'))),
+    ('TOPICLEN=5', ('TOPICLEN', 5)),
+    ('USERLEN=5', ('USERLEN', 5)),
+)
+
+
+@pytest.mark.parametrize('arg, expected', VALID_PARSE_VALUE)
+def test_parse_parameter(arg, expected):
+    key, value = isupport.parse_parameter(arg)
+
+    assert (key, value) == expected
+
+
+# these parameters don't require a value
+VALID_PARSE_OPTIONAL = (
+    ('CHANTYPES', ('CHANTYPES', None)),
+    ('EXCEPTS', ('EXCEPTS', 'e')),
+    ('INVEX', ('INVEX', 'I')),
+    ('MAXTARGETS', ('MAXTARGETS', None)),
+    ('MODES', ('MODES', None)),
+    ('SILENCE', ('SILENCE', None)),
+)
+
+
+@pytest.mark.parametrize('arg, expected', VALID_PARSE_OPTIONAL)
+def test_parse_parameter_optional(arg, expected):
+    key, value = isupport.parse_parameter(arg)
+
+    assert (key, value) == expected
+
+
+# these parameters don't accept value
+VALID_PARSE_NO_VALUE = (
+    ('SAFELIST', ('SAFELIST', None)),
+)
+
+
+@pytest.mark.parametrize('arg, expected', VALID_PARSE_NO_VALUE)
+def test_parse_parameter_no_value(arg, expected):
+    key, value = isupport.parse_parameter(arg)
+
+    assert (key, value) == expected
+
+
+# single-letter parameters parsing must raise when more than one character
+INVALID_PARSE_SINGLE_LETTER = (
+    'EXCEPTS=ed',
+    'EXCEPTS=edoui',
+    'INVEX=IJ',
+    'INVEX=IJKLMNOP',
+)
+
+
+@pytest.mark.parametrize('arg', INVALID_PARSE_SINGLE_LETTER)
+def test_parse_parameter_single_letter_raise(arg):
+    with pytest.raises(ValueError):
+        isupport.parse_parameter(arg)
+
+
+# every parameter can be removed
+VALID_PARSE_REMOVED = (
+    '-AWAYLEN',
+    '-CASEMAPPING',
+    '-CHANLIMIT',
+    '-CHANMODES',
+    '-CHANNELLEN',
+    '-CHANTYPES',
+    '-ELIST',
+    '-EXCEPTS',
+    '-EXTBAN',
+    '-HOSTLEN',
+    '-INVEX',
+    '-KICKLEN',
+    '-MAXLIST',
+    '-MAXTARGETS',
+    '-MODES',
+    '-NETWORK',
+    '-NICKLEN',
+    '-PREFIX',
+    '-SAFELIST',
+    '-SILENCE',
+    '-STATUSMSG',
+    '-TARGMAX',
+    '-TOPICLEN',
+    '-USERLEN',
+)
+
+
+@pytest.mark.parametrize('arg', VALID_PARSE_REMOVED)
+def test_parse_parameter_removed(arg):
+    key, value = isupport.parse_parameter(arg)
+
+    assert value is None
+    assert key == arg
+
+
+def test_parse_parameter_chanlimit_single():
+    key, value = isupport.parse_parameter('CHANLIMIT=#:50')
+
+    assert key == 'CHANLIMIT'
+    assert value == (('#', 50),)
+
+
+def test_parse_parameter_chanlimit_many():
+    key, value = isupport.parse_parameter('CHANLIMIT=#:50,$:10')
+
+    assert key == 'CHANLIMIT'
+    assert value == (('#', 50), ('$', 10))
+
+
+def test_parse_parameter_chanlimit_limit_optional():
+    key, value = isupport.parse_parameter('CHANLIMIT=#:50,$:10,~:')
+
+    assert key == 'CHANLIMIT'
+    assert value == (('#', 50), ('$', 10), ('~', None))
+
+
+def test_parse_parameter_chanmode():
+    key, value = isupport.parse_parameter('CHANMODES=b,k,l,imnpst')
+
+    assert key == 'CHANMODES'
+    assert value == ('b', 'k', 'l', 'imnpst', tuple())
+
+
+def test_parse_parameter_chanmode_extra():
+    key, value = isupport.parse_parameter('CHANMODES=b,k,l,imnpst,bkl')
+
+    assert key == 'CHANMODES'
+    assert value == ('b', 'k', 'l', 'imnpst', ('bkl',))
+
+
+def test_parse_parameter_chanmode_extra_many():
+    key, value = isupport.parse_parameter('CHANMODES=b,k,l,imnpst,bkl,imnpst')
+
+    assert key == 'CHANMODES'
+    assert value == ('b', 'k', 'l', 'imnpst', ('bkl', 'imnpst'))
+
+
+def test_parse_parameter_chanmode_raise():
+    with pytest.raises(ValueError):
+        isupport.parse_parameter('CHANMODES=b,k,l')
+
+
+def test_parse_parameter_elist():
+    key, value = isupport.parse_parameter('ELIST=C')
+
+    assert key == 'ELIST'
+    assert value == ('C',)
+
+
+def test_parse_parameter_elist_many():
+    key, value = isupport.parse_parameter('ELIST=CMNTU')
+
+    assert key == 'ELIST'
+    assert value == ('C', 'M', 'N', 'T', 'U')
+
+
+def test_parse_parameter_elist_many_sorted():
+    key, value = isupport.parse_parameter('ELIST=MTCUN')
+
+    assert key == 'ELIST'
+    assert value == ('C', 'M', 'N', 'T', 'U')
+
+
+def test_parse_parameter_extban():
+    key, value = isupport.parse_parameter('EXTBAN=~,qjncrRa')
+
+    assert key == 'EXTBAN'
+    assert value == ('~', ('R', 'a', 'c', 'j', 'n', 'q', 'r'))
+
+
+def test_parse_parameter_extban_no_prefix():
+    key, value = isupport.parse_parameter('EXTBAN=,ABCNOcjmp')
+
+    assert key == 'EXTBAN'
+    assert value == (None, ('A', 'B', 'C', 'N', 'O', 'c', 'j', 'm', 'p'))
+
+
+def test_parse_parameter_extban_invalid():
+    with pytest.raises(ValueError):
+        isupport.parse_parameter('EXTBAN=ABCNOcjmp')
+
+
+def test_parse_parameter_maxlist():
+    key, value = isupport.parse_parameter('MAXLIST=beI:25')
+
+    assert key == 'MAXLIST'
+    assert value == (('beI', 25),)
+
+
+def test_parse_parameter_maxlist_many():
+    key, value = isupport.parse_parameter('MAXLIST=b:60,e:40,I:50')
+
+    assert key == 'MAXLIST'
+    assert value == (('I', 50), ('b', 60), ('e', 40))
+
+
+def test_parse_parameter_maxlist_many_mixed():
+    key, value = isupport.parse_parameter('MAXLIST=beI:25,Z:10')
+
+    assert key == 'MAXLIST'
+    assert value == (('Z', 10), ('beI', 25))
+
+
+def test_parse_parameter_maxlist_many_mixed_override():
+    key, value = isupport.parse_parameter('MAXLIST=b:10,beI:25,Z:10,I:40')
+
+    assert key == 'MAXLIST'
+    assert value == (('I', 40), ('Z', 10), ('b', 10), ('beI', 25))
+
+
+def test_parse_parameter_maxlist_invalid():
+    with pytest.raises(ValueError):
+        isupport.parse_parameter('MAXLIST=b:60,e,I:50')
+
+
+def test_parse_parameter_prefix():
+    key, value = isupport.parse_parameter('PREFIX=(ov)@+')
+
+    assert key == 'PREFIX'
+    assert value == (('o', '@'), ('v', '+'))
+
+
+def test_parse_parameter_prefix_invalid_format():
+    with pytest.raises(ValueError):
+        isupport.parse_parameter('PREFIX=ov@+')
+
+    with pytest.raises(ValueError):
+        isupport.parse_parameter('PREFIX=(ov)@')
+
+    with pytest.raises(ValueError):
+        isupport.parse_parameter('PREFIX=(o)@+')
+
+
+def test_parse_parameter_targmax():
+    key, value = isupport.parse_parameter('TARGMAX=PRIVMSG:3')
+
+    assert key == 'TARGMAX'
+    assert value == (('PRIVMSG', 3),)
+
+
+def test_parse_parameter_targmax_many():
+    key, value = isupport.parse_parameter('TARGMAX=PRIVMSG:3,WHOIS:1')
+
+    assert key == 'TARGMAX'
+    assert value == (('PRIVMSG', 3), ('WHOIS', 1))
+
+
+def test_parse_parameter_targmax_many_optional():
+    key, value = isupport.parse_parameter('TARGMAX=PRIVMSG:3,JOIN:,WHOIS:1')
+
+    assert key == 'TARGMAX'
+    assert value == (('JOIN', None), ('PRIVMSG', 3), ('WHOIS', 1))

--- a/test/irc/test_irc_isupport.py
+++ b/test/irc/test_irc_isupport.py
@@ -29,8 +29,8 @@ def test_isupport_apply():
     assert new_removed['NICKLEN'] == 31
 
 
-def test_isupport_apply_ci():
-    """Test removed parameters are case-insensitives."""
+def test_isupport_apply_case_insensitive():
+    """Test removed parameters are case-insensitive."""
     instance = isupport.ISupport()
     new = instance.apply(awaylen=50, NICKLEN=31, channellen=16)
     new_removed = new.apply(**{
@@ -88,7 +88,7 @@ def test_isupport_getitem():
         instance['UNKNOWN']
 
 
-def test_isupport_getitem_ci():
+def test_isupport_getitem_case_insensitive():
     """Test access to parameters is case insensitive."""
     instance = isupport.ISupport(awaylen=50)
 
@@ -96,6 +96,27 @@ def test_isupport_getitem_ci():
     assert 'awaylen' in instance
     assert instance['AWAYLEN'] == 50
     assert instance['awaylen'] == 50
+
+
+def test_isupport_getattr():
+    """Test using ISUPPORT parameters as read-only attributes."""
+    instance = isupport.ISupport(awaylen=50)
+
+    assert hasattr(instance, 'AWAYLEN')
+    assert not hasattr(instance, 'awaylen'), 'attributes are ALL_UPPERCASE'
+    assert not hasattr(instance, 'UNKNOWN')
+
+    assert instance.AWAYLEN == 50
+
+    # you can't set attributes yourself
+    with pytest.raises(AttributeError):
+        instance.AWAYLEN = 20
+
+    with pytest.raises(AttributeError):
+        instance.awaylen = 20
+
+    with pytest.raises(AttributeError):
+        instance.UNKNOWN = 'not possible'
 
 
 def test_isupport_setitem():

--- a/test/test_coretasks.py
+++ b/test/test_coretasks.py
@@ -148,3 +148,75 @@ def test_execute_perform_replaces_nickname(mockbot):
 
     coretasks._execute_perform(mockbot)
     assert mockbot.backend.message_sent == rawlist(sent_command)
+
+
+def test_handle_isupport(mockbot):
+    mockbot.on_message(
+        ':irc.example.com 005 Sopel '
+        'CHANTYPES=# EXCEPTS INVEX CHANMODES=eIbq,k,flj,CFLMPQScgimnprstz '
+        'CHANLIMIT=#:120 PREFIX=(ov)@+ MAXLIST=bqeI:100 MODES=4 '
+        'NETWORK=example STATUSMSG=@+ CALLERID=g CASEMAPPING=rfc1459 '
+        ':are supported by this server')
+
+    assert hasattr(mockbot, 'isupport')
+    assert 'CHANTYPES' in mockbot.isupport
+    assert 'EXCEPTS' in mockbot.isupport
+    assert 'INVEX' in mockbot.isupport
+    assert 'CHANMODES' in mockbot.isupport
+    assert 'CHANLIMIT' in mockbot.isupport
+    assert 'PREFIX' in mockbot.isupport
+    assert 'NETWORK' in mockbot.isupport
+    assert 'STATUSMSG' in mockbot.isupport
+    assert 'CALLERID' in mockbot.isupport
+    assert 'CASEMAPPING' in mockbot.isupport
+
+    assert mockbot.isupport['CHANTYPES'] == ('#',)
+    assert mockbot.isupport['EXCEPTS'] == 'e'
+    assert mockbot.isupport['INVEX'] == 'I'
+    assert mockbot.isupport['CHANMODES'] == (
+        'eIbq', 'k', 'flj', 'CFLMPQScgimnprstz', tuple())
+    assert hasattr(mockbot.isupport, 'CHANMODES')
+    assert mockbot.isupport.CHANMODES == {
+        'A': 'eIbq',
+        'B': 'k',
+        'C': 'flj',
+        'D': 'CFLMPQScgimnprstz',
+    }
+    assert mockbot.isupport['CHANLIMIT'] == (('#', 120),)
+    assert mockbot.isupport['PREFIX'] == (('o', '@'), ('v', '+'))
+    assert mockbot.isupport['NETWORK'] == 'example'
+
+    # not yet advertised
+    assert 'CHARSET' not in mockbot.isupport
+
+    # update
+    mockbot.on_message(
+        ':irc.example.com 005 Sopel '
+        'CHARSET=ascii NICKLEN=16 CHANNELLEN=50 TOPICLEN=390 DEAF=D FNC '
+        'TARGMAX=NAMES:1,LIST:1,KICK:1,WHOIS:1,PRIVMSG:4,NOTICE:4,ACCEPT:,'
+        'MONITOR: EXTBAN=$,ajrxz CLIENTVER=3.0 ETRACE WHOX KNOCK '
+        ':are supported by this server')
+
+    # now they are advertised
+    assert 'CHARSET' in mockbot.isupport
+    assert 'NICKLEN' in mockbot.isupport
+    assert 'CHANNELLEN' in mockbot.isupport
+    assert 'TOPICLEN' in mockbot.isupport
+    assert 'DEAF' in mockbot.isupport
+    assert 'FNC' in mockbot.isupport
+    assert 'TARGMAX' in mockbot.isupport
+    assert 'EXTBAN' in mockbot.isupport
+    assert 'CLIENTVER' in mockbot.isupport
+    assert 'ETRACE' in mockbot.isupport
+    assert 'WHOX' in mockbot.isupport
+    assert 'KNOCK' in mockbot.isupport
+
+    mockbot.on_message(
+        ':irc.example.com 005 Sopel '
+        'SAFELIST ELIST=CTU CPRIVMSG CNOTICE '
+        ':are supported by this server')
+
+    assert 'SAFELIST' in mockbot.isupport
+    assert 'ELIST' in mockbot.isupport
+    assert 'CPRIVMSG' in mockbot.isupport
+    assert 'CNOTICE' in mockbot.isupport


### PR DESCRIPTION
WIP to show a bit of the ISupport thing: my idea is to have a storage structure with the basic parsing tools at first. Then, I'll implement an actual callable, triggered by the event `RPL_ISUPPORT`, with the proper machinery to parse, update, and remove ISupport data.

This Draft version aims to open a small conversation about the design and the usability of the ISupport class.

Quick note: the ISupport class will generate immutable object. There is no good reason to mess with that, as every bit of information comes from the server itself.