### PR TITLE
bot: fix bug in blocked user detection

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -655,7 +655,7 @@ class Sopel(irc.AbstractBot):
         # list of commands running in separate threads for this dispatch
         running_triggers = []
         # nickname/hostname blocking
-        nick_blocked = host_blocked = self._is_pretrigger_blocked(pretrigger)
+        nick_blocked, host_blocked = self._is_pretrigger_blocked(pretrigger)
         blocked = bool(nick_blocked or host_blocked)
         list_of_blocked_functions = []
 


### PR DESCRIPTION
Assigning the tuple returned by `_is_pretrigger_blocked()` to both vars instead of unpacking the values makes both of them always evaluate to `True` in Boolean contexts. Which magically blocks everyone from doing anything, unless `get_triggered_callables()` decides they're unblockable by virtue of `trigger.admin` being `True` (or if the function is marked unblockable, of course). Fun times!

Introduced by #1728 — `.blame Exirel`! I share no responsibility for missing this in code review. Nope, none at all. :P (I'm requesting his review specifically, instead of just any available Rockstar, because I want him to see this stupid little bug that he made and I missed. 😹)

Let this be a lesson to us all: Test things as a non-admin sometimes. Just in case. (New testing infrastructure should help us catch this sort of thing automatically in a lot of cases, once our unit tests have been updated to use the new mocks.)