### PR TITLE
reddit: cleanup & various fixes

### DIFF
--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -81,7 +81,11 @@ def image_info(bot, trigger, match):
         .subreddit('all')
         .search('url:{}'.format(url), sort='new', params={'include_over_18': 'on'})
     )
-    oldest = results[-1]
+    try:
+        oldest = results[-1]
+    except IndexError:
+        # Fail silently if the image link can't be mapped to a submission
+        return NOLIMIT
     return say_post_info(bot, trigger, oldest.id)
 
 
@@ -95,7 +99,7 @@ def video_info(bot, trigger, match):
         return say_post_info(bot, trigger, re.match(post_url, url).group(1))
     except AttributeError:
         # Fail silently if we can't map the video link to a submission
-        pass
+        return NOLIMIT
 
 
 @url(post_url)

--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -39,12 +39,12 @@ else:
 
 domain = r'https?://(?:www\.|old\.|pay\.|ssl\.|[a-z]{2}\.)?reddit\.com'
 subreddit_url = r'%s/r/([\w-]+)/?$' % domain
-post_url = r'%s/r/.*?/comments/([\w-]+)/?$' % domain
-short_post_url = r'https?://redd.it/([\w-]+)'
-user_url = r'%s/u(ser)?/([\w-]+)' % domain
-comment_url = r'%s/r/.*?/comments/.*?/.*?/([\w-]+)' % domain
-image_url = r'https?://i.redd.it/\S+'
-video_url = r'https?://v.redd.it/([\w-]+)'
+post_url = r'%s/r/\S+?/comments/([\w-]+)(?:/[\w]+)?/?$' % domain
+short_post_url = r'https?://redd\.it/([\w-]+)'
+user_url = r'%s/u(?:ser)?/([\w-]+)' % domain
+comment_url = r'%s/r/\S+?/comments/\S+?/\S+?/([\w-]+)' % domain
+image_url = r'https?://i\.redd\.it/\S+'
+video_url = r'https?://v\.redd\.it/([\w-]+)'
 
 
 def setup(bot):
@@ -91,7 +91,11 @@ def video_info(bot, trigger, match):
     url = requests.head(
         'https://www.reddit.com/video/{}'.format(match.group(1)),
         timeout=(10.0, 4.0)).headers['Location']
-    return say_post_info(bot, trigger, re.match(post_url, url).group(1))
+    try:
+        return say_post_info(bot, trigger, re.match(post_url, url).group(1))
+    except AttributeError:
+        # Fail silently if we can't map the video link to a submission
+        pass
 
 
 @url(post_url)
@@ -280,7 +284,7 @@ def redditor_info(bot, trigger, match, commanded=False):
 
 @url(user_url)
 def auto_redditor_info(bot, trigger, match):
-    redditor_info(bot, trigger, match.group(2))
+    redditor_info(bot, trigger, match.group(1))
 
 
 @url(subreddit_url)

--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -79,7 +79,7 @@ def image_info(bot, trigger, match):
     results = list(
         bot.memory['reddit_praw']
         .subreddit('all')
-        .search('url:{}'.format(url), sort='new')
+        .search('url:{}'.format(url), sort='new', params={'include_over_18': 'on'})
     )
     oldest = results[-1]
     return say_post_info(bot, trigger, oldest.id)


### PR DESCRIPTION
This is a regular laundry list, honestly.

* `post_url` was end-anchored to prevent matching the same links as `comment_url`, but didn't allow for the `/post_title_slug/` usually included after the submission ID.
* `comment_url` & `post_url` used `.*` where they should have had `\S+` (whitespace is never present in reddit URLs, nor will any compenent of the link ever contain zero characters).
* `user_url` unnecessarily captured "ser" (or "") as group 1.
* So many unescaped `.`s everywhere!

Fixes post links failing to match and falling back to `url.py` title fetching, and possibly some other silly bugs. I take full responsibility for breaking `post_url` in #1720. Whoops.

Also adds error handling in `video_info()`, in case the hacky hack it uses to get the post URL fails. The errors I saw in testing that led to this whole patch were probably just because the `post_url` pattern was broken (see above), but... why not handle the error case anyway?

**Edit:** Also fixed some image-handler stuff (it couldn't find NSFW source posts).