### PR TITLE
bot, reload: log/show plugin source when reloading

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -311,6 +311,20 @@ class Sopel(irc.AbstractBot):
         """Tell if the bot has registered this plugin by its name"""
         return name in self._plugins
 
+    def get_plugin_meta(self, name):
+        """Get info about a registered plugin by its name.
+
+        :param str name: name of the plugin about which to get info
+        :return: the plugin's metadata
+                 (see :meth:`~.plugins.handlers.AbstractPluginHandler.get_meta_description`)
+        :rtype: :class:`dict`
+        :raise PluginNotRegistered: when there is no ``name`` plugin registered
+        """
+        if not self.has_plugin(name):
+            raise plugins.exceptions.PluginNotRegistered(name)
+
+        return self._plugins[name].get_meta_description()
+
     def unregister(self, obj):
         """Unregister a callable.
 

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -257,7 +257,9 @@ class Sopel(irc.AbstractBot):
         plugin.reload()
         plugin.setup(self)
         plugin.register(self)
-        LOGGER.info('Reloaded plugin %s', name)
+        meta = plugin.get_meta_description()
+        LOGGER.info('Reloaded %s plugin %s from %s',
+                    meta['type'], name, meta['source'])
 
     def reload_plugins(self):
         """Reload all plugins
@@ -278,7 +280,9 @@ class Sopel(irc.AbstractBot):
             plugin.reload()
             plugin.setup(self)
             plugin.register(self)
-            LOGGER.info('Reloaded plugin %s', name)
+            meta = plugin.get_meta_description()
+            LOGGER.info('Reloaded %s plugin %s from %s',
+                        meta['type'], name, meta['source'])
 
     def add_plugin(self, plugin, callables, jobs, shutdowns, urls):
         """Add a loaded plugin to the bot's registry"""

--- a/sopel/modules/reload.py
+++ b/sopel/modules/reload.py
@@ -46,7 +46,9 @@ def f_reload(bot, trigger):
         return bot.reply('"%s" not loaded, try the `load` command' % name)
 
     bot.reload_plugin(name)
-    return bot.reply('done: %s reloaded' % name)
+    plugin_meta = bot.get_plugin_meta(name)
+    return bot.reply('done: %s reloaded (%s from %s)' %
+                     (name, plugin_meta['type'], plugin_meta['source']))
 
 
 @sopel.module.nickname_commands('update')

--- a/sopel/modules/reload.py
+++ b/sopel/modules/reload.py
@@ -74,24 +74,26 @@ def f_load(bot, trigger):
         return bot.reply('Load what?')
 
     if bot.has_plugin(name):
-        return bot.reply('Module already loaded, use reload')
+        return bot.reply('Plugin already loaded, use reload')
 
     usable_plugins = plugins.get_usable_plugins(bot.config)
     if name not in usable_plugins:
-        bot.reply('Module %s not found' % name)
+        bot.reply('Plugin %s not found' % name)
         return
 
     plugin, is_enabled = usable_plugins[name]
     if not is_enabled:
-        bot.reply('Module %s is disabled' % name)
+        bot.reply('Plugin %s is disabled' % name)
         return
 
     try:
         _load(bot, plugin)
     except Exception as error:
-        bot.reply('Could not load module %s: %s' % (name, error))
+        bot.reply('Could not load plugin %s: %s' % (name, error))
     else:
-        bot.reply('Module %s loaded' % name)
+        meta = bot.get_plugin_meta(name)
+        bot.reply('Plugin %s loaded (%s from %s)' %
+                  (name, meta['type'], meta['source']))
 
 
 # Catch private messages


### PR DESCRIPTION
This would have saved me a good half-hour of confusion tonight, by showing me that my bot was using an (outdated) plugin file in `.sopel/modules` that shadowed the built-in plugin from `sopel.modules.*`.

I think the added `bot.get_plugin_meta()` function is helpful, and it was necessary to implement the output I wanted in `reload`, but there could be a reason I haven't thought of that makes it a bad idea. Definitely tell me if so!

Even just having the reloaded plugin's metadata in logs, and not on IRC, would have helped. I added it back to `reload` because 1) it used to show the file path before the plugin system rework, and 2) I like not having to check my terminal/log-files for things. 😛

Note: I'm putting this in 7.0 because let's face it: a lot of people are going to make updates to their plugins for this release, to take advantage of new features and/or fix compatibility problems. We should make it easy for them to verify that the correct file/module is being loaded during development, even if `.reload` is still buggy for some plugin types.