### PR TITLE
bot, irc: doc overhaul

### DIFF
--- a/docs/source/trigger.rst
+++ b/docs/source/trigger.rst
@@ -1,5 +1,15 @@
 Triggers
 ========
 
+A :class:`Trigger` is the main type of user input plugins will see.
+
+Sopel uses :class:`PreTrigger`\s internally while processing incoming IRC
+messages. Plugin authors can reasonably expect that their code will never
+receive one. They are documented here for completeness, and for the aid of
+Sopel's core development.
+
 .. autoclass:: sopel.trigger.Trigger
+    :members:
+
+.. autoclass:: sopel.trigger.PreTrigger
     :members:

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -131,13 +131,6 @@ class Sopel(irc.AbstractBot):
         self.scheduler = sopel.tools.jobs.JobScheduler(self)
         """Job Scheduler. See :func:`sopel.module.interval`."""
 
-        # Set up block lists
-        # Default to empty
-        if not self.settings.core.nick_blocks:
-            self.settings.core.nick_blocks = []
-        if not self.settings.core.host_blocks:
-            self.settings.core.host_blocks = []
-
     @property
     def command_groups(self):
         """A mapping of plugin names to a list of commands in it."""

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -69,7 +69,7 @@ class Sopel(irc.AbstractBot):
         """
 
         self._command_groups = collections.defaultdict(list)
-        """A mapping of plugin names to a list of commands in it."""
+        """A mapping of plugin names to lists of their commands."""
 
         self._times = {}
         """
@@ -91,9 +91,9 @@ class Sopel(irc.AbstractBot):
         """A dictionary of channels to their users and privilege levels.
 
         The value associated with each channel is a dictionary of
-        :class:`sopel.tools.Identifier`\\s to
-        a bitwise integer value, determined by combining the appropriate
-        constants from :mod:`sopel.module`.
+        :class:`sopel.tools.Identifier`\\s to a bitwise integer value,
+        determined by combining the appropriate constants from
+        :mod:`sopel.module`.
 
         .. deprecated:: 6.2.0
             Use :attr:`channels` instead. Will be removed in Sopel 8.
@@ -112,8 +112,7 @@ class Sopel(irc.AbstractBot):
 
         The keys are :class:`sopel.tools.Identifier`\\s of the nicknames, and
         map to :class:`sopel.tools.target.User` instances. In order for Sopel
-        to be aware of a user, it must be in at least one channel which they
-        are also in.
+        to be aware of a user, it must share at least one mutual channel.
         """
 
         self.db = SopelDB(config)
@@ -133,8 +132,8 @@ class Sopel(irc.AbstractBot):
 
     @property
     def command_groups(self):
-        """A mapping of plugin names to a list of commands in it."""
-        # This was supposed to be deprecated, but the help command uses this
+        """A mapping of plugin names to lists of their commands."""
+        # This was supposed to be deprecated, but the built-in help plugin needs it
         return self._command_groups
 
     @property
@@ -152,20 +151,20 @@ class Sopel(irc.AbstractBot):
         return self.users.get(self.nick).hostmask
 
     def setup(self):
-        """Set up Sopel bot before it can run
+        """Set up Sopel bot before it can run.
 
-        The setup phase manages to:
+        The setup phase is in charge of:
 
-        * setup logging (configure Python's built-in :mod:`logging`),
-        * setup the bot's plugins (load, setup, and register)
-        * start the job scheduler
-
+        * setting up logging (configure Python's built-in :mod:`logging`)
+        * setting up the bot's plugins (load, setup, and register)
+        * starting the job scheduler
         """
         self.setup_logging()
         self.setup_plugins()
         self.scheduler.start()
 
     def setup_logging(self):
+        """Set up logging based on config options."""
         logger.setup_logging(self.settings)
         base_level = self.settings.core.logging_level or 'INFO'
         base_format = self.settings.core.logging_format
@@ -190,6 +189,7 @@ class Sopel(irc.AbstractBot):
             LOGGER.addHandler(handler)
 
     def setup_plugins(self):
+        """Load plugins into the bot."""
         load_success = 0
         load_error = 0
         load_disabled = 0
@@ -230,13 +230,14 @@ class Sopel(irc.AbstractBot):
             LOGGER.warning("Warning: Couldn't load any plugins")
 
     def reload_plugin(self, name):
-        """Reload a plugin
+        """Reload a plugin.
 
         :param str name: name of the plugin to reload
         :raise PluginNotRegistered: when there is no ``name`` plugin registered
 
-        It runs the plugin's shutdown routine and unregisters it. Then it
-        reloads it, runs its setup routines, and registers it again.
+        This function runs the plugin's shutdown routine and unregisters the
+        plugin from the bot. Then this function reloads the plugin, runs its
+        setup routines, and registers it again.
         """
         if not self.has_plugin(name):
             raise plugins.exceptions.PluginNotRegistered(name)
@@ -253,11 +254,11 @@ class Sopel(irc.AbstractBot):
         LOGGER.info('Reloaded plugin %s', name)
 
     def reload_plugins(self):
-        """Reload all plugins
+        """Reload all registered plugins.
 
-        First, run all plugin shutdown routines and unregister all plugins.
-        Then reload all plugins, run their setup routines, and register them
-        again.
+        First, this function runs all plugin shutdown routines and unregisters
+        all plugins. Then it reloads all plugins, runs their setup routines, and
+        registers them again.
         """
         registered = list(self._plugins.items())
         # tear down all plugins
@@ -274,12 +275,42 @@ class Sopel(irc.AbstractBot):
             LOGGER.info('Reloaded plugin %s', name)
 
     def add_plugin(self, plugin, callables, jobs, shutdowns, urls):
-        """Add a loaded plugin to the bot's registry"""
+        """Add a loaded plugin to the bot's registry.
+
+        :param plugin: loaded plugin to add
+        :type plugin: :class:`sopel.plugins.handlers.AbstractPluginHandler`
+        :param callables: an iterable of callables from the ``plugin``
+        :type callables: :term:`iterable`
+        :param jobs: an iterable of functions from the ``plugin`` that are
+                     periodically invoked
+        :type jobs: :term:`iterable`
+        :param shutdowns: an iterable of functions from the ``plugin`` that
+                          should be called on shutdown
+        :type shutdowns: :term:`iterable`
+        :param urls: an iterable of functions from the ``plugin`` to call when
+                     matched against a URL
+        :type urls: :term:`iterable`
+        """
         self._plugins[plugin.name] = plugin
         self.register(callables, jobs, shutdowns, urls)
 
     def remove_plugin(self, plugin, callables, jobs, shutdowns, urls):
-        """Remove a loaded plugin from the bot's registry"""
+        """Remove a loaded plugin from the bot's registry.
+
+        :param plugin: loaded plugin to remove
+        :type plugin: :class:`sopel.plugins.handlers.AbstractPluginHandler`
+        :param callables: an iterable of callables from the ``plugin``
+        :type callables: :term:`iterable`
+        :param jobs: an iterable of functions from the ``plugin`` that are
+                     periodically invoked
+        :type jobs: :term:`iterable`
+        :param shutdowns: an iterable of functions from the ``plugin`` that
+                          should be called on shutdown
+        :type shutdowns: :term:`iterable`
+        :param urls: an iterable of functions from the ``plugin`` to call when
+                     matched against a URL
+        :type urls: :term:`iterable`
+        """
         name = plugin.name
         if not self.has_plugin(name):
             raise plugins.exceptions.PluginNotRegistered(name)
@@ -301,7 +332,12 @@ class Sopel(irc.AbstractBot):
         del self._plugins[name]
 
     def has_plugin(self, name):
-        """Tell if the bot has registered this plugin by its name"""
+        """Check if the bot has registered a plugin of the specified name.
+
+        :param str name: name of the plugin to check for
+        :return: whether the bot has a plugin named ``name`` registered
+        :rtype: bool
+        """
         return name in self._plugins
 
     def unregister(self, obj):
@@ -355,8 +391,7 @@ class Sopel(irc.AbstractBot):
 
         It is possible to have a callable with rules, commands, and nick
         commands configured. It should not be possible to have a callable with
-        commands or nick commands but without rules. Callables without rules
-        are usually event handlers.
+        commands or nick commands but without rules.
         """
         # Append plugin's shutdown function to the bot's list of functions to
         # call on shutdown
@@ -443,16 +478,25 @@ class Sopel(irc.AbstractBot):
                     callable_name,
                     regex)
 
-    @deprecated
+    @deprecated(
+        reason="Replaced by `say` method.",
+        version='6.0',
+        removed_in='8.0')
     def msg(self, recipient, text, max_messages=1):
-        """
+        """Old way to make the bot say something on IRC.
+
+        :param str recipient: nickname or channel to which to send message
+        :param str text: message to send
+        :param int max_messages: split ``text`` into at most this many messages
+                                 if it is too long to fit in one (optional)
+
         .. deprecated:: 6.0
             Use :meth:`say` instead. Will be removed in Sopel 8.
         """
         self.say(text, recipient, max_messages)
 
     def call(self, func, sopel, trigger):
-        """Call a function, applying any rate-limiting or restrictions.
+        """Call a function, applying any rate limits or other restrictions.
 
         :param func: the function to call
         :type func: :term:`function`
@@ -546,9 +590,9 @@ class Sopel(irc.AbstractBot):
         :rtype: :class:`tuple`
 
         This methods retrieves all triggered callables for this ``priority``
-        level. It yields each function with its
-        :class:`trigger<sopel.trigger.Trigger>` object and a boolean
-        flag to tell if this callable is blocked or not.
+        level. It yields each function with its :class:`trigger
+        <sopel.trigger.Trigger>` object and a boolean flag to tell if this
+        callable is blocked or not.
 
         To be triggered, a callable must match the ``pretrigger`` using a regex
         pattern. Then it must comply with other criteria (if any) such as
@@ -628,9 +672,10 @@ class Sopel(irc.AbstractBot):
     def dispatch(self, pretrigger):
         """Dispatch a parsed message to any registered callables.
 
-        :param PreTrigger pretrigger: a parsed message from the server
+        :param pretrigger: a parsed message from the server
+        :type pretrigger: :class:`~sopel.trigger.PreTrigger`
 
-        The ``pretrigger`` (a parsed message) is used to find matching callables:
+        The ``pretrigger`` (a parsed message) is used to find matching callables;
         it will retrieve them by order of priority, and run them. It runs
         triggered callables in separate threads, unless they are marked
         otherwise with the :func:`sopel.module.thread` decorator.
@@ -698,8 +743,10 @@ class Sopel(irc.AbstractBot):
     def running_triggers(self):
         """Current active threads for triggers.
 
-        This read-only list contains the currently running thread processing
-        a trigger. This is for testing and debugging purposes only.
+        :return: the running thread(s) currently processing trigger(s)
+        :rtype: :term:`iterable`
+
+        This is for testing and debugging purposes only.
         """
         with self._running_triggers_lock:
             return [t for t in self._running_triggers if t.is_alive()]
@@ -707,14 +754,14 @@ class Sopel(irc.AbstractBot):
     def _update_running_triggers(self, running_triggers):
         """Update list of running triggers.
 
-        :param list running_triggers: new started threads
+        :param list running_triggers: newly started threads
 
         We want to keep track of running triggers, mostly for testing and
         debugging purposes. For instance, it'll help make sure, in tests, that
         a bot plugin has finished processing a trigger, by manually joining
         all running threads.
 
-        This is kept private, as this is pure internal machinery and isn't
+        This is kept private, as it's purely internal machinery and isn't
         meant to be manipulated by outside code.
         """
         # update bot's global running triggers
@@ -726,23 +773,39 @@ class Sopel(irc.AbstractBot):
     def on_scheduler_error(self, scheduler, exc):
         """Called when the Job Scheduler fails.
 
+        :param scheduler: the JobScheduler that errored
+        :type scheduler: :class:`sopel.tools.jobs.JobScheduler`
+        :param Exception exc: the raised exception
+
         .. seealso::
 
-            :meth:`error`
+            :meth:`Sopel.error`
         """
         self.error(exception=exc)
 
     def on_job_error(self, scheduler, job, exc):
         """Called when a job from the Job Scheduler fails.
 
+        :param scheduler: the JobScheduler responsible for the errored ``job``
+        :type scheduler: :class:`sopel.tools.jobs.JobScheduler`
+        :param job: the Job that errored
+        :type job: :class:`sopel.tools.jobs.Job`
+        :param Exception exc: the raised exception
+
         .. seealso::
 
-            :meth:`error`
+            :meth:`Sopel.error`
         """
         self.error(exception=exc)
 
     def error(self, trigger=None, exception=None):
-        """Called internally when a plugin causes an error."""
+        """Called internally when a plugin causes an error.
+
+        :param trigger: the ``Trigger``\\ing line (if available)
+        :type trigger: :class:`sopel.trigger.Trigger`
+        :param Exception exception: the exception raised by the error (if
+                                    available)
+        """
         message = 'Unexpected error'
         if exception:
             message = '{} ({})'.format(message, exception)
@@ -758,6 +821,10 @@ class Sopel(irc.AbstractBot):
             self.say(message, trigger.sender)
 
     def _host_blocked(self, host):
+        """Check if a hostname is blocked.
+
+        :param str host: the hostname to check
+        """
         bad_masks = self.config.core.host_blocks
         for bad_mask in bad_masks:
             bad_mask = bad_mask.strip()
@@ -769,6 +836,10 @@ class Sopel(irc.AbstractBot):
         return False
 
     def _nick_blocked(self, nick):
+        """Check if a nickname is blocked.
+
+        :param str nick: the nickname to check
+        """
         bad_nicks = self.config.core.nick_blocks
         for bad_nick in bad_nicks:
             bad_nick = bad_nick.strip()
@@ -780,6 +851,7 @@ class Sopel(irc.AbstractBot):
         return False
 
     def _shutdown(self):
+        """Internal bot shutdown method."""
         # Stop Job Scheduler
         LOGGER.info('Stopping the Job Scheduler.')
         self.scheduler.stop()
@@ -834,6 +906,8 @@ class Sopel(irc.AbstractBot):
                 regex = re.compile(r'http://example.com/path/.*')
                 bot.register_url_callback(regex, callback)
 
+        It's also possible to completely avoid manual management of URL
+        callbacks through the use of :func:`sopel.module.url`.
         """
         if 'url_callbacks' not in self.memory:
             self.memory['url_callbacks'] = tools.SopelMemory()
@@ -865,6 +939,8 @@ class Sopel(irc.AbstractBot):
                 regex = re.compile(r'http://example.com/path/.*')
                 bot.unregister_url_callback(regex)
 
+        It's also possible to completely avoid manual management of URL
+        callbacks through the use of :func:`sopel.module.url`.
         """
         if 'url_callbacks' not in self.memory:
             # nothing to unregister
@@ -879,7 +955,7 @@ class Sopel(irc.AbstractBot):
             pass
 
     def search_url_callbacks(self, url):
-        """Yield callbacks found for ``url`` matching their regex pattern.
+        """Yield callbacks whose regex pattern matches the ``url``.
 
         :param str url: URL found in a trigger
         :return: yield 2-value tuples of ``(callback, match)``
@@ -912,24 +988,27 @@ class Sopel(irc.AbstractBot):
                 yield function, match
 
     def restart(self, message):
-        """Disconnect from IRC and restart the bot."""
+        """Disconnect from IRC and restart the bot.
+
+        :param str message: QUIT message to send (e.g. "Be right back!")
+        """
         self.wantsrestart = True
         self.quit(message)
 
 
 class SopelWrapper(object):
-    """Wrapper around a Sopel instance and a Trigger
+    """Wrapper around a Sopel instance and a Trigger.
 
     :param sopel: Sopel instance
     :type sopel: :class:`~sopel.bot.Sopel`
     :param trigger: IRC Trigger line
-    :type trigger: :class:`sopel.trigger.Trigger`
-    :param string output_prefix: prefix for messages sent through this wrapper
-                                 (e.g. plugin tag)
+    :type trigger: :class:`~sopel.trigger.Trigger`
+    :param str output_prefix: prefix for messages sent through this wrapper
+                              (e.g. plugin tag)
 
     This wrapper will be used to call Sopel's triggered commands and rules as
-    their ``bot`` argument. It acts as a proxy to :meth:`send messages<say>` to
-    the sender (either a channel or in a private message) and even to
+    their ``bot`` argument. It acts as a proxy to :meth:`send messages<say>`
+    to the sender (either a channel or in a private message) and even to
     :meth:`reply to someone<reply>` in a channel.
     """
     def __init__(self, sopel, trigger, output_prefix=''):
@@ -955,11 +1034,13 @@ class SopelWrapper(object):
         return setattr(self._bot, attr, value)
 
     def say(self, message, destination=None, max_messages=1):
-        """Override ``Sopel.say`` to send message to sender
+        """Override ``Sopel.say`` to use trigger source by default.
 
         :param str message: message to say
-        :param str destination: channel or person; defaults to trigger's sender
-        :param int max_messages: max number of message splits
+        :param str destination: channel or nickname; defaults to
+            :attr:`trigger.sender <sopel.trigger.Trigger.sender>`
+        :param int max_messages: split ``text`` into at most this many messages
+                                 if it is too long to fit in one (optional)
 
         The ``destination`` will default to the channel in which the
         trigger happened (or nickname, if received in a private message).
@@ -973,10 +1054,11 @@ class SopelWrapper(object):
         self._bot.say(self._out_pfx + message, destination, max_messages)
 
     def action(self, message, destination=None):
-        """Override ``Sopel.action`` to send action to sender
+        """Override ``Sopel.action`` to use trigger source by default.
 
         :param str message: action message
-        :param str destination: channel or person; defaults to trigger's sender
+        :param str destination: channel or nickname; defaults to
+            :attr:`trigger.sender <sopel.trigger.Trigger.sender>`
 
         The ``destination`` will default to the channel in which the
         trigger happened (or nickname, if received in a private message).
@@ -990,10 +1072,11 @@ class SopelWrapper(object):
         self._bot.action(message, destination)
 
     def notice(self, message, destination=None):
-        """Override ``Sopel.notice`` to send a notice to sender
+        """Override ``Sopel.notice`` to use trigger source by default.
 
         :param str message: notice message
-        :param str destination: channel or person; defaults to trigger's sender
+        :param str destination: channel or nickname; defaults to
+            :attr:`trigger.sender <sopel.trigger.Trigger.sender>`
 
         The ``destination`` will default to the channel in which the
         trigger happened (or nickname, if received in a private message).
@@ -1007,11 +1090,13 @@ class SopelWrapper(object):
         self._bot.notice(self._out_pfx + message, destination)
 
     def reply(self, message, destination=None, reply_to=None, notice=False):
-        """Override ``Sopel.reply`` to reply to someone
+        """Override ``Sopel.reply`` to ``reply_to`` sender by default.
 
         :param str message: reply message
-        :param str destination: channel or person; defaults to trigger's sender
-        :param str reply_to: person to reply to; defaults to trigger's nick
+        :param str destination: channel or nickname; defaults to
+            :attr:`trigger.sender <sopel.trigger.Trigger.sender>`
+        :param str reply_to: person to reply to; defaults to
+            :attr:`trigger.nick <sopel.trigger.Trigger.nick>`
         :param bool notice: reply as an IRC notice or with a simple message
 
         The ``destination`` will default to the channel in which the

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -61,7 +61,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class AbstractBot(object):
-    """Abstract definition of the Sopel's interface."""
+    """Abstract definition of Sopel's interface."""
     def __init__(self, settings):
         # private properties: access as read-only properties
         self._nick = tools.Identifier(settings.core.nick)
@@ -99,7 +99,7 @@ class AbstractBot(object):
 
     @property
     def name(self):
-        """Sopel's "real name", as used for whois."""
+        """Sopel's "real name", to be displayed in WHOIS responses."""
         return self._name
 
     @property
@@ -111,6 +111,12 @@ class AbstractBot(object):
     # Connection
 
     def get_irc_backend(self):
+        """Set up the IRC backend based on the bot's settings.
+
+        :return: the initialized IRC backend object
+        :rtype: an object implementing the interface of
+                :class:`~sopel.irc.abstract_backends.AbstractIRCBackend`
+        """
         timeout = int(self.settings.core.timeout)
         ping_timeout = timeout / 2
         backend_class = AsynchatBackend
@@ -135,7 +141,11 @@ class AbstractBot(object):
         return backend_class(*backend_args, **backend_kwargs)
 
     def run(self, host, port=6667):
-        """Connect to IRC Server then run the bot forever."""
+        """Connect to IRC server and run the bot forever.
+
+        :param str host: the IRC server hostname
+        :param int port: the IRC server port
+        """
         source_address = ((self.settings.core.bind_host, 0)
                           if self.settings.core.bind_host else None)
 
@@ -150,6 +160,7 @@ class AbstractBot(object):
     # Connection Events
 
     def on_connect(self):
+        """Handle successful establishment of IRC connection."""
         # Request list of server capabilities. IRCv3 servers will respond with
         # CAP * LS (which we handle in coretasks). v2 servers will respond with
         # 421 Unknown command, which we'll ignore
@@ -167,6 +178,10 @@ class AbstractBot(object):
         LOGGER.info('Connected.')
 
     def on_message(self, message):
+        """Handle an incoming IRC message.
+
+        :param str message: the received raw IRC message
+        """
         self.last_raw_line = message
 
         pretrigger = PreTrigger(self.nick, message)
@@ -223,7 +238,7 @@ class AbstractBot(object):
             self.dispatch(pretrigger)
 
     def on_error(self):
-        """Handle any uncaptured error in the core.
+        """Handle any uncaptured error in the bot itself.
 
         This method is an override of :meth:`asyncore.dispatcher.handle_error`,
         the :class:`asynchat.async_chat` being a subclass of
@@ -257,15 +272,33 @@ class AbstractBot(object):
         self._shutdown()
 
     def _shutdown(self):
+        """Handle shutdown tasks.
+
+        Must be overridden by subclasses to do anything useful.
+        """
         pass
 
     # Features
 
     def dispatch(self, pretrigger):
+        """Handle running the appropriate callables for an incoming message.
+
+        :param pretrigger: Sopel PreTrigger object
+        :type pretrigger: :class:`sopel.trigger.PreTrigger`
+        :raise NotImplementedError: if the subclass does not implement this
+                                    required method
+
+        .. important::
+            This method **MUST** be implemented by concrete subclasses.
+        """
         raise NotImplementedError
 
     def log_raw(self, line, prefix):
-        """Log raw line to the raw log."""
+        """Log raw line to the raw log.
+
+        :param str line: the raw line
+        :param str prefix: additional information to prepend to the log line
+        """
         if not self.settings.core.log_raw:
             return
         logger = logging.getLogger('sopel.raw')
@@ -277,7 +310,7 @@ class AbstractBot(object):
 
         :param str module_name: the module requesting the capability
         :param str capability: the capability requested, optionally prefixed
-                               with ``+`` or ``=``
+                               with ``-`` or ``=``
         :param str arg: arguments for the capability request
         :param failure_callback: a function that will be called if the
                                  capability request fails
@@ -304,12 +337,12 @@ class AbstractBot(object):
         The actual capability request to the server is handled after the
         completion of this function. In the event that the server denies a
         request, the ``failure_callback`` function will be called, if provided.
-        The arguments will be a :class:`sopel.bot.Sopel` object, and the
+        The arguments will be a :class:`~sopel.bot.Sopel` object, and the
         capability which was rejected. This can be used to disable callables
         which rely on the capability. It will be be called either if the server
         NAKs the request, or if the server enabled it and later DELs it.
 
-        The ``success_callback`` function will be called upon acknowledgement
+        The ``success_callback`` function will be called upon acknowledgment
         of the capability from the server, whether during the initial
         capability negotiation, or later.
 
@@ -360,8 +393,8 @@ class AbstractBot(object):
 
         ``args`` is an iterable of strings, which are joined by spaces.
         ``text`` is treated as though it were the final item in ``args``, but
-        is preceded by a ``:``. This is a special case which  means that
-        ``text``, unlike the items in ``args`` may contain spaces (though this
+        is preceded by a ``:``. This is a special case which means that
+        ``text``, unlike the items in ``args``, may contain spaces (though this
         constraint is not checked by ``write``).
 
         In other words, both ``sopel.write(('PRIVMSG',), 'Hello, world!')``
@@ -374,8 +407,8 @@ class AbstractBot(object):
 
         .. seealso::
 
-            The connection backend is responsible to format and send the
-            message through the IRC connection. See the
+            The connection backend is responsible for formatting and sending
+            the message through the IRC connection. See the
             :meth:`sopel.irc.abstract_backends.AbstractIRCBackend.send_command`
             method for more information.
 
@@ -442,13 +475,13 @@ class AbstractBot(object):
         """Disconnect from IRC and close the bot."""
         self.backend.send_quit(reason=message)
         self.hasquit = True
-        # Wait for acknowledgement from the server. By RFC 2812 it should be
-        # an ERROR msg, but many servers just close the connection. Either way
-        # is fine by us.
-        # Closing the connection now would mean that stuff in the buffers that
-        # has not yet been processed would never be processed. It would also
-        # release the main thread, which is problematic because whomever called
-        # quit might still want to do something before main thread quits.
+        # Wait for acknowledgment from the server. Per RFC 2812 it should be
+        # an ERROR message, but many servers just close the connection.
+        # Either way is fine by us. Closing the connection now would mean that
+        # stuff in the buffers that has not yet been processed would never be
+        # processed. It would also release the main thread, which is
+        # problematic because whomever called quit might still want to do
+        # something before the main thread quits.
 
     def reply(self, text, dest, reply_to, notice=False):
         """Send a PRIVMSG to a user or channel, prepended with ``reply_to``.
@@ -475,22 +508,24 @@ class AbstractBot(object):
 
         :param str text: the text to send
         :param str recipient: the message recipient
-        :param int max_messages: the maximum number of messages to break the
-                                 text into
+        :param int max_messages: split ``text`` into at most this many messages
+                                 if it is too long to fit in one (optional)
 
         By default, this will attempt to send the entire ``text`` in one
         message. If the text is too long for the server, it may be truncated.
+
         If ``max_messages`` is given, the ``text`` will be split into at most
         that many messages, each no more than 400 bytes. The split is made at
-        the last space character before the 400th byte, or at the 400th byte if
-        no such space exists. If the ``text`` is too long to fit into the
-        specified number of messages using the above splitting, the final
-        message will contain the entire remainder, which may be truncated by
-        the server.
+        the last space character before the 400th byte, or at the 400th byte
+        if no such space exists.
+
+        If the ``text`` is too long to fit into the specified number of
+        messages using the above splitting, the final message will contain the
+        entire remainder, which may be truncated by the server.
         """
         excess = ''
         if not isinstance(text, unicode):
-            # Make sure we are dealing with unicode string
+            # Make sure we are dealing with a Unicode string
             text = text.decode('utf-8')
 
         if max_messages > 1:

--- a/sopel/irc/abstract_backends.py
+++ b/sopel/irc/abstract_backends.py
@@ -10,6 +10,14 @@ from .utils import safe
 
 
 class AbstractIRCBackend(object):
+    """Abstract class defining the interface and basic logic of an IRC backend.
+
+    :param bot: a Sopel instance
+    :type bot: :class:`sopel.bot.Sopel`
+
+    Some methods of this class **MUST** be overridden by a subclass, or the
+    backend implementation will not function correctly.
+    """
     def __init__(self, bot):
         self.bot = bot
         self.writing_lock = threading.RLock()
@@ -18,7 +26,7 @@ class AbstractIRCBackend(object):
         """Send a command through the IRC connection.
 
         :param * args: IRC command to send with its argument(s)
-        :param str text: optional keyword argument; text to send
+        :param str text: the text to send (optional keyword argument)
 
         Example::
 
@@ -57,7 +65,7 @@ class AbstractIRCBackend(object):
             provision for continuation of message lines.
 
         The length in the RFC refers to the length in *bytes*, which can be
-        bigger than the length of the unicode string. This method cuts the
+        bigger than the length of the Unicode string. This method cuts the
         message until its length fits within this limit of 510 bytes.
 
         The returned message contains the CR-LF pair required at the end,
@@ -70,9 +78,9 @@ class AbstractIRCBackend(object):
             raw_command = '{args} :{text}'.format(args=raw_command,
                                                   text=safe(text))
 
-        # The max length of 512 is in bytes, not unicode:
-        # we can't cut the message in bytes, or we may cut in the middle of a
-        # multi bytes characters.
+        # The max length of 512 is in bytes, not Unicode characters:
+        # we can't split the message on bytes, or we may cut in the middle of a
+        # multi-byte character.
         while len(raw_command.encode('utf-8')) > max_length:
             raw_command = raw_command[:unicode_max_length]
             unicode_max_length = unicode_max_length - 1
@@ -95,7 +103,7 @@ class AbstractIRCBackend(object):
 
         :param str host: IRC server host
 
-        A ``PONG`` command must be sent each time the server send a ``PING``
+        A ``PONG`` command must be sent each time the server sends a ``PING``
         command to the client.
         """
         self.send_command('PONG', safe(host))

--- a/sopel/irc/utils.py
+++ b/sopel/irc/utils.py
@@ -42,6 +42,26 @@ def safe(string):
 
 
 class CapReq(object):
+    """Represents a pending CAP REQ request.
+
+    :param str prefix: either ``=`` (must be enabled)
+                       or ``-`` (must **not** be enabled)
+    :param str module: the requesting package/module name
+    :param failure: function to call if this capability request fails
+    :type failure: :term:`function`
+    :param str arg: optional capability value; the request will fail if
+                    the server's value is different
+    :param success: function to call if this capability request succeeds
+    :type success: :term:`function`
+
+    The ``success`` and ``failure`` callbacks must accept two arguments:
+    ``bot`` (a :class:`~sopel.bot.Sopel` instance) and ``cap`` (the name of
+    the requested capability, as a string).
+
+    .. seealso::
+        For more information on how capability requests work, see the
+        documentation for :meth:`sopel.irc.AbstractBot.cap_req`.
+    """
     def __init__(self, prefix, module, failure=None, arg=None, success=None):
         def nop(bot, cap):
             pass


### PR DESCRIPTION
Overhauled docs for both of these modules at once because they're rather intertwined.

Touches the `trigger` docs a bit because some cross-references weren't working without `PreTrigger` being published in the built docs.

Fixed a mistake in the CAP REQ docs telling users to use the wrong prefix for required capabilities.

Even tweaked the code for loading block lists from the config, because it annoyed me that we weren't using the `ListAttribute` type's `default` kwarg. (This change is easy to back out, in case I overlooked a good reason things worked the way they did, as it's a separate commit.)

Of course, lots of other tweaks & fixes, too!