### PR TITLE
db: fix get_uri() to return the actual connection URI

### DIFF
--- a/sopel/db.py
+++ b/sopel/db.py
@@ -188,7 +188,7 @@ class SopelDB(object):
 
     def get_uri(self):
         """Returns a URL for the database, usable to connect with SQLAlchemy."""
-        return 'sqlite:///{}'.format(self.filename)
+        return self.url
 
     # NICK FUNCTIONS
 


### PR DESCRIPTION
We can tweak the docstrings and/or attribute names for consistency later. The point is, the function should now work fine no matter the `db_type`.

Closes #1745.