### PR TITLE
db, docs: overhaul docstrings & add SQLAlchemy to intersphinx mappings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -33,7 +33,10 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinxcontrib.autoprogram',
 ]
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3/', None),
+    'sqlalchemy': ('https://docs.sqlalchemy.org/en/13/', None),
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']


### PR DESCRIPTION
Some of the stuff in `SopelDB` needed to reference SQLAlchemy docs, and adding those intersphinx mappings was trivially easy, so it was done.