### PR TITLE
config: doc overhaul

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -30,10 +30,14 @@ from sopel import __version__
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx.ext.autosectionlabel',
     'sphinx.ext.intersphinx',
     'sphinxcontrib.autoprogram',
 ]
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3/', None),
+    'sqlalchemy': ('https://docs.sqlalchemy.org/en/13/', None),
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -103,7 +103,7 @@ by :attr:`~CoreSection.admin_accounts` or by :attr:`~CoreSection.admins`. If
 
 Both ``owner_account`` and ``admin_accounts`` are safer to use than
 nick-based matching, but the IRC server must support accounts.
-(Most, sadly, do not as of mid-2019.)
+(Most, sadly, do not as of late 2019.)
 
 
 IRC Server

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -14,7 +14,8 @@ from sopel.tools import Identifier
 def _find_certs():
     """Find the TLS root CA store.
 
-    :returns: str (path to file)
+    :returns: path to CA store file
+    :rtype: str
     """
     # check if the root CA store is at a known location
     locations = [
@@ -34,6 +35,11 @@ def _find_certs():
 
 
 def configure(config):
+    """Interactively configure the bot's ``[core]`` config section.
+
+    :param config: the bot's config object
+    :type config: :class:`~.config.Config`
+    """
     config.core.configure_setting('nick', 'Enter the nickname for your bot.')
     config.core.configure_setting('host', 'Enter the server to connect to.')
     config.core.configure_setting('use_ssl', 'Should the bot connect with SSL?')
@@ -56,7 +62,11 @@ def configure(config):
 
 
 class CoreSection(StaticSection):
-    """The config section used for configuring the bot itself."""
+    """The config section used for configuring the bot itself.
+
+    .. important::
+        All **Required** values must be specified, or Sopel will fail to start.
+    """
 
     admins = ListAttribute('admins')
     """The list of people (other than the owner) who can administer the bot."""
@@ -67,46 +77,64 @@ class CoreSection(StaticSection):
     Each account is allowed to administer the bot and can perform commands
     that are restricted to admins.
 
-    This should not be set for networks that do not support IRCv3 account
-    capabilities.
+    .. important::
+        This should not be set for networks that do not support IRCv3 account
+        capabilities.
     """
 
     alias_nicks = ListAttribute('alias_nicks')
-    """List of alternate names for regex substitutions.
+    """List of alternate names users may call the bot.
 
-    These aliases are used as the bot's nick for ``$nick`` and ``$nickname``
-    regex substitutions.
+    These aliases are used along with the bot's nick for ``$nick`` and
+    ``$nickname`` regex substitutions.
+
+    For example, a bot named "William" (its :attr:`nick`) could have aliases
+    "Bill", "Will", and "Liam". This would then allow both "William: Hi!" and
+    "Bill: Hi!" to work with :func:`~sopel.module.nickname_commands`.
     """
 
     auth_method = ChoiceAttribute('auth_method', choices=[
         'nickserv', 'authserv', 'Q', 'sasl', 'server', 'userserv'])
     """Simple method to authenticate with the server.
 
-    Can be ``nickserv``, ``authserv``, ``Q``, ``sasl``, or ``server`` or
+    Can be one of ``nickserv``, ``authserv``, ``Q``, ``sasl``, ``server``, or
     ``userserv``.
 
     This allows only a single authentication method; to use both a server-based
-    authentication method as well as a nick-based authentication method, see
-    ``server_auth_method`` and ``nick_auth_method``.
+    authentication method *and* a nick-based authentication method, see
+    :attr:`server_auth_method` and :attr:`nick_auth_method`.
 
-    If this is specified, ``nick_auth_method`` will be ignored, and it takes
-    precedence over ``server_auth_method``.
+    For more information about these methods, see :ref:`Authentication`.
+
+    .. note::
+        If this is specified, :attr:`nick_auth_method` will be ignored, and this
+        value will override :attr:`server_auth_method`.
     """
 
     auth_password = ValidatedAttribute('auth_password')
-    """The password to use to authenticate with the server."""
+    """The password to use to authenticate with the :attr:`auth_method`.
+
+    See :ref:`Authentication`.
+    """
 
     auth_target = ValidatedAttribute('auth_target')
-    """The user to use for nickserv authentication, or the SASL mechanism.
+    """Target for authentication.
 
-    May not apply, depending on ``auth_method``. Defaults to NickServ for
-    nickserv auth, and PLAIN for SASL auth.
+    :default:
+        * ``NickServ`` if using the ``nickserv`` :attr:`auth_method`
+        * ``PLAIN`` if using the ``sasl`` :attr:`auth_method`
+
+    The nickname of the NickServ service, or the name of the desired SASL
+    mechanism, if :attr:`auth_method` is set to one of these methods. This value
+    is otherwise ignored.
+
+    See :ref:`Authentication`.
     """
 
     auth_username = ValidatedAttribute('auth_username')
-    """The username/account to use to authenticate with the server.
+    """The user/account name to use when authenticating.
 
-    May not apply, depending on ``auth_method``.
+    May not apply, depending on :attr:`auth_method`. See :ref:`Authentication`.
     """
 
     auto_url_schemes = ListAttribute(
@@ -115,120 +143,290 @@ class CoreSection(StaticSection):
         default=['http', 'https', 'ftp'])
     """List of URL schemes that will trigger URL callbacks.
 
-    Used by the URL callbacks feature; see :func:`sopel.module.url` decorator
-    for plugins.
+    :default: ``['http', 'https', 'ftp']``
+
+    Used by the URL callbacks feature to call plugins when links are posted in
+    chat; see the :func:`sopel.module.url` decorator.
 
     The default value allows ``http``, ``https``, and ``ftp``.
     """
 
     bind_host = ValidatedAttribute('bind_host')
-    """Bind the connection to a specific IP."""
+    """Bind the connection to a specific IP.
+
+    :default: ``0.0.0.0`` (all interfaces)
+    """
 
     ca_certs = FilenameAttribute('ca_certs', default=_find_certs())
-    """The path of the CA certs pem file."""
+    """The path to the CA certs ``.pem`` file.
+
+    If not specified, Sopel will try to find the certificate trust store itself.
+    """
 
     channels = ListAttribute('channels')
     """List of channels for the bot to join when it connects."""
 
-    db_type = ChoiceAttribute('db_type', choices=[
-        'sqlite', 'mysql', 'postgres', 'mssql', 'oracle', 'firebird', 'sybase'], default='sqlite')
-    """The type of database to use for Sopel's database.
+    commands_on_connect = ListAttribute('commands_on_connect')
+    """A list of commands to send upon successful connection to the IRC server.
 
-    mysql - pip install mysql-python (Python 2) or pip install mysqlclient (Python 3)
-    postgres - pip install psycopg2
-    mssql - pip install pymssql
+    Each line is a message that will be sent to the server once connected.
+    Example::
 
-    See https://docs.sqlalchemy.org/en/latest/dialects/ for a full list of
-    dialects.
+        commands_on_connect =
+            PRIVMSG Q@CServe.quakenet.org :AUTH my_username MyPassword,@#$%!
+            PRIVMSG MyOwner :I'm here!
+
+    ``$nickname`` can be used in a command as a placeholder, and will be
+    replaced with the bot's :attr:`nick`. For example, if the bot's nick is
+    ``Sopel``, ``MODE $nickname +Xxw`` will be expanded to ``MODE Sopel +Xxw``.
+
+    .. versionadded:: 7.0
     """
 
-    db_filename = ValidatedAttribute('db_filename')
-    """The filename for Sopel's database. (SQLite only)"""
-
     db_driver = ValidatedAttribute('db_driver')
-    """The driver for Sopel's database.
+    """The driver to use for connecting to the database.
 
     This is optional, but can be specified if user wants to use a different
-    driver.
+    driver than the default for the chosen :attr:`db_type`.
 
     .. seealso::
 
-        https://docs.sqlalchemy.org/en/latest/core/engines.html
+        Refer to :ref:`SQLAlchemy's documentation <engines_toplevel>` for more
+        information.
+
+    """
+
+    db_filename = ValidatedAttribute('db_filename')
+    """The filename for Sopel's database.
+
+    Used only for SQLite. Ignored for all other :attr:`db_type` values.
+    """
+
+    db_host = ValidatedAttribute('db_host')
+    """The host for Sopel's database.
+
+    Ignored when using SQLite.
+    """
+
+    db_name = ValidatedAttribute('db_name')
+    """The name of Sopel's database.
+
+    Ignored when using SQLite.
+    """
+
+    db_pass = ValidatedAttribute('db_pass')
+    """The password for Sopel's database.
+
+    Ignored when using SQLite.
+    """
+
+    db_port = ValidatedAttribute('db_port')
+    """The port for Sopel's database.
+
+    Ignored when using SQLite.
+    """
+
+    db_type = ChoiceAttribute('db_type', choices=[
+        'sqlite', 'mysql', 'postgres', 'mssql', 'oracle', 'firebird', 'sybase'], default='sqlite')
+    """The type of database Sopel should connect to.
+
+    :default: ``sqlite`` (part of Python's standard library)
+
+    The full list of values Sopel recognizes is:
+
+    * ``firebird``
+    * ``mssql``
+    * ``mysql``
+    * ``oracle``
+    * ``postgres``
+    * ``sqlite``
+    * ``sybase``
+
+    Here are the additional PyPI packages you may need to install to use one of
+    the most commonly requested alternatives:
+
+    mysql
+      ``pip install mysql-python`` (Python 2)
+
+      ``pip install mysqlclient`` (Python 3)
+
+    postgres
+      ``pip install psycopg2``
+
+    mssql
+      ``pip install pymssql``
+
+    .. seealso::
+
+        Refer to :ref:`SQLAlchemy's documentation <dialect_toplevel>` for more
+        information about the different dialects it supports.
+
     """
 
     db_user = ValidatedAttribute('db_user')
-    """The user for Sopel's database."""
+    """The user for Sopel's database.
 
-    db_pass = ValidatedAttribute('db_pass')
-    """The password for Sopel's database."""
-
-    db_host = ValidatedAttribute('db_host')
-    """The host for Sopel's database."""
-
-    db_port = ValidatedAttribute('db_port')
-    """The port for Sopel's database."""
-
-    db_name = ValidatedAttribute('db_name')
-    """The name of Sopel's database."""
+    Ignored when using SQLite.
+    """
 
     default_time_format = ValidatedAttribute('default_time_format',
                                              default='%Y-%m-%d - %T%Z')
-    """The default format to use for time in messages."""
+    """The default format to use for time in messages.
+
+    :default: ``%Y-%m-%d - %T%Z``
+
+    Used when plugins format times with :func:`sopel.tools.time.format_time`.
+
+    .. seealso::
+
+        Time format reference is available in the documentation for Python's
+        :func:`time.strftime` function.
+
+    """
 
     default_timezone = ValidatedAttribute('default_timezone', default='UTC')
-    """The default timezone to use for time in messages."""
+    """The default timezone to use for time in messages.
+
+    :default: ``UTC``
+
+    Used when plugins format times with :func:`sopel.tools.time.format_time`.
+    """
 
     enable = ListAttribute('enable')
-    """A whitelist of the only plugins you want to enable."""
+    """A list of the only plugins you want to enable.
+
+    If set, Sopel will *only* load the plugins named here. All other available
+    plugins will be ignored.
+
+    To load *all* available plugins, clear this setting.
+
+    To disable only a few plugins, see :attr:`exclude`.
+
+    See :ref:`Plugins` for an overview of all plugin-related settings.
+    """
 
     exclude = ListAttribute('exclude')
-    """A list of plugins which should not be loaded."""
+    """A list of plugins which should not be loaded.
+
+    If set, Sopel will load all available plugins *except* those named here.
+
+    A plugin named both here and in :attr:`enable` **will not** be loaded;
+    :attr:`exclude` takes priority.
+
+    See :ref:`Plugins` for an overview of all plugin-related settings.
+    """
 
     extra = ListAttribute('extra')
-    """A list of other directories you'd like to include plugins from."""
+    """A list of other directories in which to search for plugin files.
+
+    See :ref:`Plugins` for an overview of all plugin-related settings.
+    """
+
+    flood_burst_lines = ValidatedAttribute('flood_burst_lines', int, default=4)
+    """How many messages can be sent in burst mode.
+
+    :default: ``4``
+
+    See :ref:`Flood Prevention` to learn what each flood-related setting does.
+
+    .. versionadded:: 7.0
+    """
+
+    flood_empty_wait = ValidatedAttribute('flood_empty_wait', float, default=0.7)
+    """How long to wait between sending messages when not in burst mode, in seconds.
+
+    :default: ``0.7``
+
+    See :ref:`Flood Prevention` to learn what each flood-related setting does.
+
+    .. versionadded:: 7.0
+    """
+
+    flood_refill_rate = ValidatedAttribute('flood_refill_rate', int, default=1)
+    """How quickly burst mode recovers, in messages per second.
+
+    :default: ``1``
+
+    See :ref:`Flood Prevention` to learn what each flood-related setting does.
+
+    .. versionadded:: 7.0
+    """
 
     help_prefix = ValidatedAttribute('help_prefix', default='.')
-    """The prefix to use in help output."""
+    """The prefix to use in help output.
+
+    :default: ``.``
+
+    If :attr:`prefix` is changed from the default, this setting **must** be
+    updated to reflect the prefix your bot will actually respond to, or the
+    built-in ``help`` functionality will provide incorrect example usage.
+    """
 
     @property
     def homedir(self):
         """The directory in which various files are stored at runtime.
 
-        By default, this is the same directory as the config. It can not be
+        By default, this is the same directory as the config file. It cannot be
         changed at runtime.
         """
         return self._parent.homedir
 
-    host = ValidatedAttribute('host', default='irc.dftba.net')
-    """The server to connect to."""
+    host = ValidatedAttribute('host', default='chat.freenode.net')
+    """The IRC server to connect to.
+
+    :default: ``chat.freenode.net``
+
+    **Required.**
+    """
 
     host_blocks = ListAttribute('host_blocks')
-    """A list of hostmasks which Sopel should ignore.
+    """A list of hostnames which Sopel should ignore.
 
-    Regular expression syntax is used.
+    Messages from any user whose connection hostname matches one of these values
+    will be ignored. :ref:`Regular expression syntax <re-syntax>` is supported.
+
+    Also see the :attr:`nick_blocks` list.
     """
 
     log_raw = ValidatedAttribute('log_raw', bool, default=False)
-    """Whether a log of raw lines as sent and received should be kept."""
+    """Whether a log of raw lines as sent and received should be kept.
+
+    See :ref:`Raw Logs`.
+    """
 
     logdir = FilenameAttribute('logdir', directory=True, default='logs')
-    """Directory in which to place logs."""
+    """Directory in which to place logs.
+
+    See :ref:`Logging`.
+    """
 
     logging_channel = ValidatedAttribute('logging_channel', Identifier)
-    """The channel to send logging messages to."""
+    """The channel to send logging messages to.
+
+    See :ref:`Log to a Channel`.
+    """
 
     logging_channel_datefmt = ValidatedAttribute('logging_channel_datefmt')
-    """The logging format string to use for timestamps in IRC channel logs.
+    """The format string to use for timestamps in IRC channel logs.
 
-    If not specified, this falls back to using ``logging_datefmt``.
+    If not specified, this falls back to using :attr:`logging_datefmt`.
+
+    See :ref:`Log to a Channel`.
 
     .. versionadded:: 7.0
+    .. seealso::
+
+        Time format reference is available in the documentation for Python's
+        :func:`time.strftime` function.
+
     """
 
     logging_channel_format = ValidatedAttribute('logging_channel_format')
     """The logging format string to use in IRC channel logs.
 
-    If not specified, this falls back to using ``logging_format``.
+    If not specified, this falls back to using :attr:`logging_format`.
+
+    See :ref:`Log to a Channel`.
 
     .. versionadded:: 7.0
     """
@@ -239,18 +437,25 @@ class CoreSection(StaticSection):
                                             'WARNING')
     """The lowest severity of logs to display in IRC channel logs.
 
-    If not specified, this falls back to using ``logging_level``.
+    If not specified, this falls back to using :attr:`logging_level`.
+
+    See :ref:`Log to a Channel`.
 
     .. versionadded:: 7.0
     """
 
     logging_datefmt = ValidatedAttribute('logging_datefmt')
-    """The logging format string to use for timestamps in logs.
+    """The format string to use for timestamps in logs.
 
-    If not specified, the datefmt is not provided, and logging will use
-    the Python default.
+    If not set, the ``datefmt`` argument is not provided, and :mod:`logging`
+    will use the Python default.
 
     .. versionadded:: 7.0
+    .. seealso::
+
+        Time format reference is available in the documentation for Python's
+        :func:`time.strftime` function.
+
     """
 
     logging_format = ValidatedAttribute(
@@ -258,19 +463,17 @@ class CoreSection(StaticSection):
         default='[%(asctime)s] %(name)-20s %(levelname)-8s - %(message)s')
     """The logging format string to use for logs.
 
-    If not specified, the default format is::
+    :default: ``[%(asctime)s] %(name)-20s %(levelname)-8s - %(message)s``
 
-        [%(asctime)s] %(name)-20s %(levelname)-8s - %(message)s
-
-    which will output the timestamp, the package that generated the log line,
-    the log level of the line, and (finally) the actual message. For example::
+    The default log line format will output the timestamp, the package that
+    generated the log line, the log level of the line, and (finally) the actual
+    message. For example::
 
         [2019-10-21 12:47:44,272] sopel.irc            INFO     - Connected.
 
     .. versionadded:: 7.0
     .. seealso::
-        Python's logging format documentation:
-        https://docs.python.org/3/library/logging.html#logrecord-attributes
+        Python's logging format documentation: :ref:`logrecord-attributes`
     """
 
     logging_level = ChoiceAttribute('logging_level',
@@ -279,23 +482,47 @@ class CoreSection(StaticSection):
                                     'INFO')
     """The lowest severity of logs to display.
 
-    If not specified, this defaults to ``INFO``.
+    :default: ``INFO``
+
+    Valid values sorted by increasing verbosity:
+
+    * ``CRITICAL``
+    * ``ERROR``
+    * ``WARNING``
+    * ``INFO``
+    * ``DEBUG``
     """
 
     modes = ValidatedAttribute('modes', default='B')
-    """User modes to be set on connection."""
+    """User modes to be set on connection.
 
-    name = ValidatedAttribute('name', default='Sopel: https://sopel.chat')
-    """The "real name" of your bot for ``WHOIS`` responses."""
+    :default: ``B``
+
+    Include only the mode letters; this value is automatically prefixed with
+    ``+`` before Sopel sends the MODE command to IRC.
+    """
+
+    name = ValidatedAttribute('name', default='Sopel: https://sopel.chat/')
+    """The "real name" of your bot for ``WHOIS`` responses.
+
+    :default: ``Sopel: https://sopel.chat/``
+    """
 
     nick = ValidatedAttribute('nick', Identifier, default=Identifier('Sopel'))
-    """The nickname for the bot."""
+    """The nickname for the bot.
+
+    :default: ``Sopel``
+
+    **Required.**
+    """
 
     nick_auth_method = ChoiceAttribute('nick_auth_method', choices=[
         'nickserv', 'authserv', 'Q', 'userserv'])
     """The nick authentication method.
 
-    Can be ``nickserv``, ``authserv``, ``Q``, or ``userserv``.
+    Can be one of ``nickserv``, ``authserv``, ``Q``, or ``userserv``.
+
+    See :ref:`Authentication` for more details.
 
     .. versionadded:: 7.0
     """
@@ -303,16 +530,19 @@ class CoreSection(StaticSection):
     nick_auth_password = ValidatedAttribute('nick_auth_password')
     """The password to use to authenticate the bot's nick.
 
+    See :ref:`Authentication` for more details.
+
     .. versionadded:: 7.0
     """
 
     nick_auth_target = ValidatedAttribute('nick_auth_target')
     """The target user for nick authentication.
 
-    May not apply, depending on ``nick_auth_method``.
+    :default: ``NickServ`` for ``nickserv`` authentication; ``UserServ`` for
+              ``userserv`` authentication
 
-    Defaults to ``NickServ`` for ``nickserv``, and ``UserServ`` for
-    ``userserv``.
+    May not apply, depending on the chosen :attr:`nick_auth_method`. See
+    :ref:`Authentication` for more details.
 
     .. versionadded:: 7.0
     """
@@ -320,9 +550,10 @@ class CoreSection(StaticSection):
     nick_auth_username = ValidatedAttribute('nick_auth_username')
     """The username/account to use for nick authentication.
 
-    May not apply, depending on ``nick_auth_method``.
+    :default: the value of :attr:`nick`
 
-    Defaults to the value of ``nick``.
+    May not apply, depending on the chosen :attr:`nick_auth_method`. See
+    :ref:`Authentication` for more details.
 
     .. versionadded:: 7.0
     """
@@ -330,19 +561,27 @@ class CoreSection(StaticSection):
     nick_blocks = ListAttribute('nick_blocks')
     """A list of nicks which Sopel should ignore.
 
-    Regular expression syntax is used.
+    Messages from any user whose nickname matches one of these values will be
+    ignored. :ref:`Regular expression syntax <re-syntax>` is supported.
+
+    Also see the :attr:`host_blocks` list.
     """
 
     not_configured = ValidatedAttribute('not_configured', bool, default=False)
     """For package maintainers. Not used in normal configurations.
 
+    :default: ``False``
+
     This allows software packages to install a default config file, with this
-    set to true, so that the bot will not run until it has been properly
-    configured.
+    option set to ``True``, so that the bot will not run until it has been
+    properly configured.
     """
 
     owner = ValidatedAttribute('owner', default=NO_DEFAULT)
-    """The IRC name of the owner of the bot."""
+    """The IRC name of the owner of the bot.
+
+    **Required** even if :attr:`owner_account` is set.
+    """
 
     owner_account = ValidatedAttribute('owner_account')
     """The services account name of the owner of the bot.
@@ -351,42 +590,48 @@ class CoreSection(StaticSection):
     capabilities.
     """
 
-    commands_on_connect = ListAttribute('commands_on_connect')
-    """A list of commands to perform upon successful connection to IRC server.
-
-    Each line is a message that will be sent to the server once connected.
-    Example::
-
-        PRIVMSG Q@CServe.quakenet.org :AUTH my_username MyPassword,@#$%!
-        PRIVMSG MyOwner :I'm here!
-
-    ``$nickname`` can be used in a command as a placeholder, and it will be
-    replaced with the bot's :attr:`~CoreSection.nick`. For example when the
-    nick is ``Sopel``, then this ``MODE $nickname +Xxw`` will become
-    ``MODE Sopel +Xxw``.
-
-    .. versionadded:: 7.0
-    """
-
     pid_dir = FilenameAttribute('pid_dir', directory=True, default='.')
     """The directory in which to put the file Sopel uses to track its process ID.
+
+    :default: ``.``
+
+    If the given value is not an absolute path, it will be interpreted relative
+    to the directory containing the config file with which Sopel was started.
 
     You probably do not need to change this unless you're managing Sopel with
     ``systemd`` or similar.
     """
 
     port = ValidatedAttribute('port', int, default=6667)
-    """The port to connect on."""
+    """The port to connect on.
+
+    :default: ``6667`` normally; ``6697`` if :attr:`use_ssl` is ``True``
+
+    **Required.**
+    """
 
     prefix = ValidatedAttribute('prefix', default='\\.')
     """The prefix to add to the beginning of commands.
+
+    :default: ``\\.``
+
+    **Required.**
 
     It is a regular expression (so the default, ``\\.``, means commands start
     with a period), though using capturing groups will create problems.
     """
 
     reply_errors = ValidatedAttribute('reply_errors', bool, default=True)
-    """Whether to message the sender of a message that triggered an error with the exception."""
+    """Whether to reply to the sender of a message that triggered an error.
+
+    :default: ``True``
+
+    If ``True``, Sopel will send information about the triggered exception to
+    the sender of the message that caused the error.
+
+    If ``False``, Sopel will only log the error and will appear to fail silently
+    from the triggering IRC user's perspective.
+    """
 
     server_auth_method = ChoiceAttribute('server_auth_method', choices=['sasl', 'server'])
     """The server authentication method.
@@ -405,7 +650,7 @@ class CoreSection(StaticSection):
     server_auth_sasl_mech = ValidatedAttribute('server_auth_sasl_mech')
     """The SASL mechanism.
 
-    Defaults to PLAIN.
+    :default: ``PLAIN``
 
     .. versionadded:: 7.0
     """
@@ -419,25 +664,30 @@ class CoreSection(StaticSection):
     throttle_join = ValidatedAttribute('throttle_join', int, default=0)
     """Slow down the initial join of channels to prevent getting kicked.
 
+    :default: ``0``
+
     Sopel will only join this many channels at a time, sleeping for a second
-    between each batch. This is unnecessary on most networks.
+    between each batch to avoid getting kicked for joining too quickly. This is
+    unnecessary on most networks.
 
     If not set, or set to 0, Sopel won't slow down the initial join.
 
     .. seealso::
 
-       :attr:`throttle_wait` controls the time Sopel waits between batches
-       of channels.
+        :attr:`throttle_wait` controls Sopel's waiting time between joining
+        batches of channels.
 
     """
 
     throttle_wait = ValidatedAttribute('throttle_wait', int, default=1)
-    """Time in seconds Sopel waits at the initial join of channels.
+    """Time in seconds Sopel waits between joining batches of channels.
 
-    By default, it waits 1s between batches.
+    :default: ``1``
 
     For example, with ``throttle_join = 2`` and ``throttle_wait = 5`` it will
     wait 5s every 2 channels it joins.
+
+    If :attr:`throttle_join` is ``0``, this setting has no effect.
 
     .. seealso::
 
@@ -446,31 +696,27 @@ class CoreSection(StaticSection):
     """
 
     timeout = ValidatedAttribute('timeout', int, default=120)
-    """The amount of time acceptable between pings before timing out."""
+    """The number of seconds acceptable between pings before timing out.
+
+    :default: ``120``
+    """
 
     use_ssl = ValidatedAttribute('use_ssl', bool, default=False)
-    """Whether to use a SSL secured connection."""
+    """Whether to use a SSL/TLS encrypted connection.
+
+    :default: ``False``
+    """
 
     user = ValidatedAttribute('user', default='sopel')
-    """The "user" for your bot (the part before the @ in the hostname)."""
+    """The "user" for your bot (the part before the ``@`` in the hostname).
+
+    :default: ``sopel``
+
+    **Required.**
+    """
 
     verify_ssl = ValidatedAttribute('verify_ssl', bool, default=True)
-    """Whether to require a trusted SSL certificate for SSL connections."""
+    """Whether to require a trusted certificate for encrypted connections.
 
-    flood_burst_lines = ValidatedAttribute('flood_burst_lines', int, default=4)
-    """How many messages can be sent in burst mode.
-
-    .. versionadded:: 7.0
-    """
-
-    flood_empty_wait = ValidatedAttribute('flood_empty_wait', float, default=0.7)
-    """How long to wait between sending messages when not in burst mode, in seconds.
-
-    .. versionadded:: 7.0
-    """
-
-    flood_refill_rate = ValidatedAttribute('flood_refill_rate', int, default=1)
-    """How quickly burst mode recovers, in messages per second.
-
-    .. versionadded:: 7.0
+    :default: ``True``
     """


### PR DESCRIPTION
Besides the absolute ton of new documentation stuff, this deprecates `config.ConfigSection.get_list()` (which is ancient, unused, and made obsolete by the `ListAttribute` type).

The same intersphinx mapping addition had to be made here as in #1776 to enable easy links to the SQLAlchemy documentation. I'll deal with the merge conflict when the time comes, if Git isn't smart enough to realize that both patches have the same result.

This also enables Sphinx's built-in `autosectionlabel` extension, which turns every section heading into a `:ref:` name in exchange for keeping every section title unique across the whole documentation project. I think it's more than a fair trade.

**Related:** #1565.

**Potential conflict:** #1751 — @Exirel, if you would, please tweak the format of those CoreSection docstring updates when you have time to address the pending change requests on that PR! 😸)

----

As an aside, I'm pretty proud of how this turned out. It's almost certainly my longest documentation overhaul to date, if memory serves, clocking in at over 4 hours spent messing with these two files to get them looking _just right_ and double-check all the inline references.