### PR TITLE
test: test_tools's mocks are obsolete

### DIFF
--- a/test/modules/test_modules_remind.py
+++ b/test/modules/test_modules_remind.py
@@ -8,17 +8,18 @@ import os
 import pytest
 import pytz
 
-from sopel import test_tools
 from sopel.modules import remind
 
 
-@pytest.fixture
-def sopel():
-    bot = test_tools.MockSopel('Sopel')
-    bot.config.basename = 'default'
-    bot.config.core.owner = 'Admin'
-    bot.config.core.host = 'chat.freenode.net'
-    return bot
+TMP_CONFIG = """
+[core]
+owner = Admin
+nick = Sopel
+enable =
+    coretasks
+    remind
+host = chat.freenode.net
+"""
 
 
 WEIRD_MESSAGE = (
@@ -313,10 +314,13 @@ def test_timereminder_get_duration_error(date1, date2, date3):
         reminder.get_duration(test_today)
 
 
-def test_get_filename(sopel):
-    filename = remind.get_filename(sopel)
+def test_get_filename(configfactory, botfactory):
+    tmpconfig = configfactory('default.ini', TMP_CONFIG)
+    mockbot = botfactory(tmpconfig)
+
+    filename = remind.get_filename(mockbot)
     assert filename == os.path.join(
-        sopel.config.core.homedir,
+        mockbot.config.core.homedir,
         'default.reminders.db')
 
 

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -15,7 +15,6 @@ import tempfile
 import pytest
 
 from sopel.db import SopelDB
-from sopel.test_tools import MockConfig
 from sopel.tools import Identifier
 
 db_filename = tempfile.mkstemp()[1]
@@ -31,11 +30,18 @@ else:
     iterkeys = dict.iterkeys
 
 
+TMP_CONFIG = """
+[core]
+owner = Embolalia
+db_filename = {db_filename}
+"""
+
+
 @pytest.fixture
-def db():
-    config = MockConfig()
-    config.core.db_filename = db_filename
-    db = SopelDB(config)
+def db(configfactory):
+    content = TMP_CONFIG.format(db_filename=db_filename)
+    settings = configfactory('default.cfg', content)
+    db = SopelDB(settings)
     # TODO add tests to ensure db creation works properly, too.
     return db
 

--- a/test/tools/test_tools_jobs.py
+++ b/test/tools/test_tools_jobs.py
@@ -5,21 +5,20 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 import datetime
 import time
 
-import pytest
-
-from sopel import test_tools
 from sopel.tools import jobs
 
 
-@pytest.fixture
-def sopel():
-    bot = test_tools.MockSopel('Sopel')
-    bot.config.core.owner = 'Bar'
-    return bot
+TMP_CONFIG = """
+[core]
+owner = Bar
+nick = Sopel
+enable = coretasks
+"""
 
 
-def test_jobscheduler_stop(sopel):
-    scheduler = jobs.JobScheduler(sopel)
+def test_jobscheduler_stop(configfactory, botfactory):
+    mockbot = botfactory(configfactory('config.cfg', TMP_CONFIG))
+    scheduler = jobs.JobScheduler(mockbot)
     assert not scheduler.stopping.is_set(), 'Stopping must not be set at init'
 
     scheduler.stop()


### PR DESCRIPTION
This PR makes test_tools's mocks obsolete, adding deprecation warning on `MockConfig`, `MockSopel`, and `MockSopelWrapper` - replaced by the `configfactory` fixture, the `botfactory` fixture, and by the `sopel.bot.SopelWrapper` class respectively.

As far as I'm concerned, Sopel's codebase doesn't use `MockSopel` nor `MockConfig`, making sure that no part of Sopel assumes `~/.sopel/` as the homedir. We may close issue #946 once this is merged.