### PR TITLE
trigger: doc overhaul

### DIFF
--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -136,9 +136,9 @@ class PreTrigger(object):
         #             print(text)    # '+i'
         #             print(args)    # ['irc.freenode.net', 'MODE', 'Sopel', '+i']
         if ' :' in line:
-            argstr, text = line.split(' :', 1)
+            argstr, self.text = line.split(' :', 1)
             self.args = argstr.split(' ')
-            self.args.append(text)
+            self.args.append(self.text)
         else:
             self.args = line.split(' ')
             self.text = self.args[-1]

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Sopel IRC Trigger Lines"""
+"""Triggers are how Sopel tells callables about their runtime context."""
 from __future__ import unicode_literals, absolute_import, print_function, division
 
 import re
@@ -20,15 +20,82 @@ if sys.version_info.major >= 3:
 
 
 class PreTrigger(object):
-    """A parsed message from the server, which has not been matched against
-    any rules."""
+    """A parsed raw message from the server.
+
+    :param str own_nick: the bot's own IRC nickname
+    :param str line: the full line from the server
+
+    At the :class:`PreTrigger` stage, the line has not been matched against any
+    rules yet. This is what Sopel uses to perform matching.
+
+    ``own_nick`` is needed to correctly parse who sent the line (Sopel or
+    someone else).
+
+    ``line`` can also be a simulated echo-message, useful if the connected
+    server does not support the capability.
+
+    .. py:attribute:: args
+
+        The IRC command's arguments.
+
+        These are split on spaces, per the IRC protocol.
+
+    .. py:attribute:: event
+
+        The IRC command name or numeric value.
+
+        See :class:`sopel.tools.events` for a built-in mapping of names to
+        numeric values.
+
+    .. py:attribute:: host
+
+        The sender's hostname.
+
+    .. py:attribute:: hostmask
+
+        The sender's hostmask, as sent by the IRC server.
+
+    .. py:attribute:: line
+
+        The raw line received from the server.
+
+    .. py:attribute:: nick
+
+        The nickname that sent this command.
+
+    .. py:attribute:: sender
+
+        Channel name or query where this message was received.
+
+    .. py:attribute:: tags
+
+        Any IRCv3 message tags attached to the line, as a :class:`dict`.
+
+    .. py:attribute:: text
+
+        The last argument of the IRC command.
+
+        If the line contains ``:``, :attr:`text` will be the text following it.
+
+        For lines that do *not* contain ``:``, :attr:`text` will be the last
+        argument in :attr:`args` instead.
+
+    .. py:attribute:: time
+
+        The time when the message was received.
+
+        If the IRC server sent a message tag indicating when *it* received the
+        message, that is used instead of the time when Sopel received it.
+
+    .. py:attribute:: user
+
+        The sender's local username.
+
+    """
     component_regex = re.compile(r'([^!]*)!?([^@]*)@?(.*)')
     intent_regex = re.compile('\x01(\\S+) ?(.*)\x01')
 
     def __init__(self, own_nick, line):
-        """own_nick is the bot's nick, needed to correctly parse sender.
-        line is the full line from the server or from simulated echo
-        message."""
         line = line.strip('\r\n')
         self.line = line
 
@@ -112,71 +179,173 @@ class PreTrigger(object):
 class Trigger(unicode):
     """A line from the server, which has matched a callable's rules.
 
-    Note that CTCP messages (`PRIVMSG`es and `NOTICE`es which start and end
-    with `'\\x01'`) will have the `'\\x01'` bytes stripped, and the command
-    (e.g. `ACTION`) placed mapped to the `'intent'` key in `Trigger.tags`.
+    :param config: Sopel's current configuration settings object
+    :type config: :class:`~sopel.config.Config`
+    :param message: the message that matched the callable
+    :type message: :class:`PreTrigger`
+    :param match: what *in* the message matched
+    :type match: :ref:`Match object <match-objects>`
+    :param str account: services account name of the ``message``'s sender
+                        (optional; only applies on networks with the
+                        ``account-tag`` capability enabled)
+
+    A :class:`Trigger` object itself can be used as a string; when used in
+    this way, it represents the matching line's full text.
+
+    The ``match`` is based on the matching regular expression rule; Sopel's
+    command decorators auto-generate rules containing specific numbered groups
+    that are documented separately. (See :attr:`group` below.)
+
+    Note that CTCP messages (``PRIVMSG``\\es and ``NOTICE``\\es which start
+    and end with ``'\\x01'``) will have the ``'\\x01'`` bytes stripped, and
+    the command (e.g. ``ACTION``) placed mapped to the ``'intent'`` key in
+    :attr:`Trigger.tags`.
     """
     sender = property(lambda self: self._pretrigger.sender)
-    """The channel from which the message was sent.
+    """Where the message arrived from.
 
-    In a private message, this is the nick that sent the message."""
+    :type: :class:`~.tools.Identifier`
+
+    This will be a channel name for "regular" (channel) messages, or the nick
+    that sent a private message.
+    """
     time = property(lambda self: self._pretrigger.time)
-    """A datetime object at which the message was received by the IRC server.
+    """When the message was received.
 
-    If the server does not support server-time, then `time` will be the time
-    that the message was received by Sopel"""
+    :type: :class:`~datetime.datetime` object
+
+    If the IRC server supports ``server-time``, :attr:`time` will give that
+    value. Otherwise, :attr:`time` will use the time when the message was
+    received by Sopel.
+    """
     raw = property(lambda self: self._pretrigger.line)
-    """The entire message, as sent from the server. This includes the CTCP
-    \\x01 bytes and command, if they were included."""
+    """The entire raw IRC message, as sent from the server.
+
+    :type: str
+
+    This includes the CTCP ``\\x01`` bytes and command, if they were included.
+    """
     is_privmsg = property(lambda self: self._is_privmsg)
-    """True if the trigger is from a user, False if it's from a channel."""
+    """Whether the message was triggered in a private message.
+
+    :type: bool
+
+    ``True`` if the trigger was received in a private message; ``False`` if it
+    came from a channel.
+    """
     hostmask = property(lambda self: self._pretrigger.hostmask)
-    """Hostmask of the person who sent the message as <nick>!<user>@<host>"""
+    """Hostmask of the person who sent the message as ``<nick>!<user>@<host>``.
+
+    :type: str:
+    """
     user = property(lambda self: self._pretrigger.user)
-    """Local username of the person who sent the message"""
+    """Local username of the person who sent the message.
+
+    :type: str
+    """
     nick = property(lambda self: self._pretrigger.nick)
-    """The :class:`sopel.tools.Identifier` of the person who sent the message.
+    """The nickname who sent the message.
+
+    :type: :class:`~.tools.Identifier`
     """
     host = property(lambda self: self._pretrigger.host)
-    """The hostname of the person who sent the message"""
+    """The hostname of the person who sent the message.
+
+    :type: str
+    """
     event = property(lambda self: self._pretrigger.event)
-    """The IRC event (e.g. ``PRIVMSG`` or ``MODE``) which triggered the
-    message."""
+    """The IRC event which triggered the message.
+
+    :type: str
+
+    Most plugin :func:`callables <callable>` primarily need to deal with
+    ``PRIVMSG``. Other event types like ``NOTICE``, ``NICK``, ``TOPIC``,
+    ``KICK``, etc. must be requested using :func:`.module.event`.
+    """
     match = property(lambda self: self._match)
-    """The regular expression :class:`re.MatchObject` for the triggering line.
+    """The :ref:`Match object <match-objects>` for the triggering line.
+
+    :type: :ref:`Match object <match-objects>`
     """
     group = property(lambda self: self._match.group)
-    """The ``group`` function of the ``match`` attribute.
+    """The ``group()`` function of the :attr:`match` attribute.
 
-    See Python :mod:`re` documentation for details."""
-    groups = property(lambda self: self._match.groups)
-    """The ``groups`` function of the ``match`` attribute.
+    :type: :term:`method`
+    :rtype: str
 
-    See Python :mod:`re` documentation for details."""
-    groupdict = property(lambda self: self._match.groupdict)
-    """The ``groupdict`` function of the ``match`` attribute.
+    Any regular-expression :func:`rules <.module.rule>` attached to the
+    triggered :func:`callable` may define numbered or named groups that can be
+    retrieved through this property.
 
-    See Python :mod:`re` documentation for details."""
-    args = property(lambda self: self._pretrigger.args)
+    Sopel's command decorators each define a predetermined set of numbered
+    groups containing fragments of the line that plugins commonly use.
+
+    .. seealso::
+
+       For more information on predefined numbered match groups in commands,
+       see :func:`.module.commands`, :func:`.module.action_commands`, and
+       :func:`.module.nickname_commands`.
+
+       Also see Python's :meth:`re.Match.group` documentation for details
+       about this method's behavior.
+
     """
-    A tuple containing each of the arguments to an event. These are the
-    strings passed between the event name and the colon. For example,
-    setting ``mode -m`` on the channel ``#example``, args would be
-    ``('#example', '-m')``
+    groups = property(lambda self: self._match.groups)
+    """The ``groups()`` function of the :attr:`match` attribute.
+
+    :type: :term:`method`
+    :rtype: tuple
+
+    See Python's :meth:`re.Match.groups` documentation for details.
+    """
+    groupdict = property(lambda self: self._match.groupdict)
+    """The ``groupdict()`` function of the :attr:`match` attribute.
+
+    :type: :term:`method`
+    :rtype: dict
+
+    See Python's :meth:`re.Match.groupdict` documentation for details.
+    """
+    args = property(lambda self: self._pretrigger.args)
+    """A tuple containing each of the arguments to an event.
+
+    :type: tuple
+
+    These are the strings passed between the event name and the colon. For
+    example, when setting ``mode -m`` on the channel ``#example``, args would
+    be ``('#example', '-m')``
     """
     tags = property(lambda self: self._pretrigger.tags)
-    """A map of the IRCv3 message tags on the message."""
+    """A map of the IRCv3 message tags on the message.
+
+    :type: dict
+    """
     admin = property(lambda self: self._admin)
-    """True if the nick which triggered the command is one of the bot's admins.
+    """Whether the triggering :attr:`nick` is one of the bot's admins.
+
+    :type: bool
+
+    ``True`` if the triggering :attr:`nick` is a Sopel admin; ``False`` if not.
+
+    Note that Sopel's :attr:`~.config.core_section.CoreSection.owner` is also
+    considered to be an admin.
     """
     owner = property(lambda self: self._owner)
-    """True if the nick which triggered the command is the bot's owner."""
-    account = property(lambda self: self.tags.get('account') or self._account)
-    """The account name of the user sending the message.
+    """Whether the :attr:`nick` which triggered the command is the bot's owner.
 
-    This is only available if either the account-tag or the account-notify and
-    extended-join capabilities are available. If this isn't the case, or the user
-    sending the message isn't logged in, this will be None.
+    :type: bool
+
+    ``True`` if the triggering :attr:`nick` is Sopel's owner; ``False`` if not.
+    """
+    account = property(lambda self: self.tags.get('account') or self._account)
+    """The services account name of the user sending the message.
+
+    :type: str or None
+
+    Note: This is only available if the ``account-tag`` capability or *both*
+    the ``account-notify`` and ``extended-join`` capabilities are available on
+    the connected IRC network. If this is not the case, or if the user sending
+    the message isn't logged in to services, this property will be ``None``.
     """
 
     def __new__(cls, config, message, match, account=None):

--- a/test/test_trigger.py
+++ b/test/test_trigger.py
@@ -23,6 +23,7 @@ def test_basic_pretrigger(nick):
     assert pretrigger.hostmask == 'Foo!foo@example.com'
     assert pretrigger.line == line
     assert pretrigger.args == ['#Sopel', 'Hello, world']
+    assert pretrigger.text == 'Hello, world'
     assert pretrigger.event == 'PRIVMSG'
     assert pretrigger.nick == Identifier('Foo')
     assert pretrigger.user == 'foo'
@@ -37,6 +38,7 @@ def test_pm_pretrigger(nick):
     assert pretrigger.hostmask == 'Foo!foo@example.com'
     assert pretrigger.line == line
     assert pretrigger.args == ['Sopel', 'Hello, world']
+    assert pretrigger.text == 'Hello, world'
     assert pretrigger.event == 'PRIVMSG'
     assert pretrigger.nick == Identifier('Foo')
     assert pretrigger.user == 'foo'
@@ -51,6 +53,7 @@ def test_quit_pretrigger(nick):
     assert pretrigger.hostmask == 'Foo!foo@example.com'
     assert pretrigger.line == line
     assert pretrigger.args == ['quit message text']
+    assert pretrigger.text == 'quit message text'
     assert pretrigger.event == 'QUIT'
     assert pretrigger.nick == Identifier('Foo')
     assert pretrigger.user == 'foo'
@@ -65,6 +68,7 @@ def test_join_pretrigger(nick):
     assert pretrigger.hostmask == 'Foo!foo@example.com'
     assert pretrigger.line == line
     assert pretrigger.args == ['#Sopel']
+    assert pretrigger.text == '#Sopel'
     assert pretrigger.event == 'JOIN'
     assert pretrigger.nick == Identifier('Foo')
     assert pretrigger.user == 'foo'
@@ -81,6 +85,7 @@ def test_tags_pretrigger(nick):
     assert pretrigger.hostmask == 'Foo!foo@example.com'
     assert pretrigger.line == line
     assert pretrigger.args == ['#Sopel', 'Hello, world']
+    assert pretrigger.text == 'Hello, world'
     assert pretrigger.event == 'PRIVMSG'
     assert pretrigger.nick == Identifier('Foo')
     assert pretrigger.user == 'foo'
@@ -95,6 +100,7 @@ def test_intents_pretrigger(nick):
     assert pretrigger.hostmask == 'Foo!foo@example.com'
     assert pretrigger.line == line
     assert pretrigger.args == ['#Sopel', 'Hello, world']
+    assert pretrigger.text == 'Hello, world'
     assert pretrigger.event == 'PRIVMSG'
     assert pretrigger.nick == Identifier('Foo')
     assert pretrigger.user == 'foo'
@@ -109,6 +115,7 @@ def test_unusual_pretrigger(nick):
     assert pretrigger.hostmask is None
     assert pretrigger.line == line
     assert pretrigger.args == []
+    assert pretrigger.text == 'PING'
     assert pretrigger.event == 'PING'
 
 
@@ -119,6 +126,7 @@ def test_ctcp_intent_pretrigger(nick):
     assert pretrigger.hostmask == 'Foo!foo@example.com'
     assert pretrigger.line == line
     assert pretrigger.args == ['Sopel', '']
+    assert pretrigger.text == '\x01VERSION\x01'
     assert pretrigger.event == 'PRIVMSG'
     assert pretrigger.nick == Identifier('Foo')
     assert pretrigger.user == 'foo'
@@ -133,6 +141,7 @@ def test_ctcp_data_pretrigger(nick):
     assert pretrigger.hostmask == 'Foo!foo@example.com'
     assert pretrigger.line == line
     assert pretrigger.args == ['Sopel', '1123321']
+    assert pretrigger.text == '\x01PING 1123321\x01'
     assert pretrigger.event == 'PRIVMSG'
     assert pretrigger.nick == Identifier('Foo')
     assert pretrigger.user == 'foo'
@@ -147,6 +156,7 @@ def test_ircv3_extended_join_pretrigger(nick):
     assert pretrigger.hostmask == 'Foo!foo@example.com'
     assert pretrigger.line == line
     assert pretrigger.args == ['#Sopel', 'bar', 'Real Name']
+    assert pretrigger.text == 'Real Name'
     assert pretrigger.event == 'JOIN'
     assert pretrigger.nick == Identifier('Foo')
     assert pretrigger.user == 'foo'


### PR DESCRIPTION
This is pretty self-explanatory. I'm opening it early to get feedback on my approach to documenting `PreTrigger` (which wasn't really documented before).

Note I'm still working over the existing docstrings in `Trigger` as of PR opening. Y'all can expect force-pushes to this branch as I find more time to work on these updates.

I expect this to be the last major documentation overhaul I do before 7.0, especially since I'm leaving the country for two weeks later this month; the few remaining submodules in #1565 are much less important (either recently written or purely internal) and can wait until 7.1.