### PR TITLE
db: migrate to connectionless execution for raw sql

### DIFF
--- a/sopel/db.py
+++ b/sopel/db.py
@@ -183,8 +183,7 @@ class SopelDB(object):
 
         Returns a cursor object, on which things like `.fetchall()` can be
         called per PEP 249."""
-        with self.connect() as conn:
-            return conn.execute(*args, **kwargs)
+        return self.engine.execute(*args, **kwargs)
 
     def get_uri(self):
         """Returns a URL for the database, usable to connect with SQLAlchemy."""


### PR DESCRIPTION
I really hate being able to execute raw SQL against the database, but this should fix the issue for anyone needing to do it