### PR TITLE
url: Ignore more invalid URLs

### DIFF
--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -288,7 +288,11 @@ def find_title(url, verify=True):
         # Need to close the connection because we have not read all
         # the data
         response.close()
-    except requests.exceptions.ConnectionError:
+    except (
+        requests.exceptions.ConnectionError,
+        requests.exceptions.InvalidURL,  # e.g. http:///
+        UnicodeError,  # e.g. http://.example.com
+    ):
         return None
 
     # Some cleanup that I don't really grok, but was in the original, so

--- a/test/modules/test_modules_url.py
+++ b/test/modules/test_modules_url.py
@@ -1,0 +1,20 @@
+# coding=utf-8
+"""Tests for Sopel's ``url`` plugin"""
+from __future__ import unicode_literals, absolute_import, print_function, division
+
+import pytest
+
+from sopel.modules import url
+
+
+INVALID_URLS = (
+    "http://.example.com/",  # empty label
+    "http://example..com/",  # empty label
+    "http://?",  # no host
+)
+
+
+@pytest.mark.parametrize("site", INVALID_URLS)
+def test_find_title_invalid(site):
+    # All local for invalid ones
+    assert url.find_title(site) is None


### PR DESCRIPTION
Silently ignores invalid URLs like `http:///` and `http://.example.com`. Includes tests.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No (new...) issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
