### PR TITLE
adminchannel: hostmask configuration fix

### DIFF
--- a/sopel/modules/adminchannel.py
+++ b/sopel/modules/adminchannel.py
@@ -141,6 +141,9 @@ def configureHostMask(mask):
     m = re.match('^([^!@]+)!(^[!@]+)@?$', mask)
     if m is not None:
         return '%s!%s@*' % (m.group(1), m.group(2))
+
+    if re.match(r'^\S+[!]\S+[@]\S+$', mask) is not None:
+        return mask
     return ''
 
 


### PR DESCRIPTION
The regex cascade in the configureHostMask function is a little messy.
This adds support for the case in the example:
`.kickban [#chan] user1 user!*@* get out of here`