### PR TITLE
setup: fix/update python version checks

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,16 +34,22 @@ else:
         sys.exit(1)
 
 if sys.version_info < (2, 7) or (
-        sys.version_info[0] > 3 and sys.version_info < (3, 3)):
-    # Maybe not the cleanest or best way to do this, but I'm tired of answering
-    # this fucking question, and if you get here you should go RTGDMFM.
+    sys.version_info.major >= 3 and sys.version_info < (3, 3)
+):
+    # Maybe not the best way to do this, but this question is tiring.
     raise ImportError('Sopel requires Python 2.7+ or 3.3+.')
+# Py2 EOL: https://www.python.org/dev/peps/pep-0373/#maintenance-releases
 if sys.version_info.major == 2:
     if time.time() >= 1577836800:  # 2020-01-01 00:00:00 UTC
         state = 'is near end of life'
     else:
-        state = 'has reached end of life and will receive no further updates'
-    print('Warning: Python 2.x %s. Sopel will drop support in version 8.0.' % state, file=sys.stderr)
+        state = "has reached end of life"
+    if time.time() >= 1588291200:  # 2020-05-01 00:00:00 UTC
+        state += " and will receive no further updates"
+    print(
+        "Warning: Python 2 %s. Sopel 8.0 will drop support for it." % state,
+        file=sys.stderr,
+    )
 
 
 def read_reqs(path):


### PR DESCRIPTION
The check for python 3.3+ was broken, and python 2's last maintenance release is [now](https://mail.python.org/archives/list/python-dev@python.org/thread/APWHFYQDKNVYQAK3HZMBGQIZHAVRHCV2/) [scheduled](https://www.python.org/dev/peps/pep-0373/#maintenance-releases) for "mid-april" 2020.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No (related) issues are reported by `make qa`
- [x] I have tested the functionality of the things this change touches
