### PR TITLE
safety: properly check whether cache is too big

### DIFF
--- a/sopel/modules/safety.py
+++ b/sopel/modules/safety.py
@@ -232,7 +232,7 @@ def _clean_cache(bot):
                 bot.memory['safety_cache'].pop(key, None)
 
             # clean up more values if the cache is still too big
-            overage = bot.memory['safety_cache'] - cache_limit
+            overage = len(bot.memory['safety_cache']) - cache_limit
             if overage > 0:
                 extra_keys = sorted(
                     (data.fetched, key)


### PR DESCRIPTION
This fixes the following error when sopel tries to clean up the
`safety_cache`:

ERROR    - Unexpected error (unsupported operand type(s) for -: 'SopelMemory' and 'int')

Signed-off-by: Rafael Fonseca <r4f4rfs@gmail.com>

### Checklist
- [X] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [X] I can and do license this contribution under the EFLv2
- [X] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [X] I have tested the functionality of the things this change touches
