### PR TITLE
bot: Support multiple handlers for a URL pattern

### DIFF
--- a/sopel/test_tools.py
+++ b/sopel/test_tools.py
@@ -77,7 +77,7 @@ class MockSopel(object):
         self.privileges = sopel.tools.SopelMemory()
 
         self.memory = sopel.tools.SopelMemory()
-        self.memory['url_callbacks'] = sopel.tools.SopelMemory()
+        self._url_callbacks = sopel.tools.SopelMemory()
 
         self.config = MockConfig()
         self._init_config()
@@ -107,15 +107,17 @@ class MockSopel(object):
         if isinstance(pattern, basestring):
             pattern = re.compile(pattern)
 
-        self.memory['url_callbacks'][pattern] = callback
+        if pattern not in self._url_callbacks:
+            self._url_callbacks[pattern] = []
+        self._url_callbacks[pattern].append(callback)
 
     def unregister_url_callback(self, pattern, callback):
         if isinstance(pattern, basestring):
             pattern = re.compile(pattern)
 
         try:
-            del self.memory['url_callbacks'][pattern]
-        except KeyError:
+            self._url_callbacks[pattern].remove(callback)
+        except ValueError:
             pass
 
     def search_url_callbacks(self, url):


### PR DESCRIPTION
### Description
Implements #1804

This introduces `Sopel._url_callbacks`, changes the *_url_callback functions to use it, and returns both Sopel._url_callbacks and bot.memory["url_callbacks"] results in a search, maintaining the legacy functionality.

Because Sopel doesn't have a SopelMemory-type object for lists, this may have minor concurrency issues, but url_callbacks updates are infrequent enough I don't think it's deadly.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa`
- [x] I have tested the functionality of the things this change touches