### PR TITLE
coretasks: make handle_url_callbacks blockable

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -996,7 +996,6 @@ def track_topic(bot, trigger):
 
 
 @module.rule(r'(?u).*(.+://\S+).*')
-@module.unblockable
 def handle_url_callbacks(bot, trigger):
     """Dispatch callbacks on URLs
 


### PR DESCRIPTION
### Description
This allows `.block` to prevent a user from using URL handling.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa`
- [x] I have tested the functionality of the things this change touches
