### PR TITLE
requirements: tighten up version ranges

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -219,6 +219,7 @@ Core changes
     * `version`: the version in which the deprecation happened
     * `removed_in`: the version in which the deprecated item will be removed
 * The end-of-life warning for users on Python 2.x is now date-aware [[#1756][]]
+* Tightened up some more dependency version specifiers [[#1807][]]
 
 API changes
 -----------
@@ -564,6 +565,7 @@ API changes
 [#1797]: https://github.com/sopel-irc/sopel/pull/1797
 [#1800]: https://github.com/sopel-irc/sopel/pull/1800
 [#1802]: https://github.com/sopel-irc/sopel/pull/1802
+[#1807]: https://github.com/sopel-irc/sopel/pull/1807
 
 [api-docs]: https://sopel.chat/docs/
 [auth-config-docs]: https://sopel.chat/docs/configure.html#Authentication

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
-xmltodict
+xmltodict<0.12.0; python_version == '3.3'
+xmltodict==0.12; python_version != '3.3'
 pytz
 praw>=4.0.0,<6.0.0
-geoip2
+geoip2<3.0.0
 ipaddress<2.0; python_version < '3.3'
 requests>=2.0.0,<3.0.0
-dnspython<2.0; python_version >= '2.7' and python_version < '3.0'
+dnspython<2.0; python_version == '2.7'
 dnspython<1.16.0; python_version == '3.3'
 dnspython<3.0; python_version >= '3.4'
 sqlalchemy<1.3; python_version == '3.3'


### PR DESCRIPTION
`xmltodict` technically dropped Python 3.3 in 0.12, and while it likely doesn't matter, we should try to ask for what's correct. We're also asking for 0.12.x specifically on all other versions because we don't know when upcoming EOL Python releases (e.g. 3.5) will get dropped.

`geoip2` killed off Python 3.3 & 3.4 in its 3.0.0 release. Nobody could tell from the CI tests, which kept humming along and passing (yes, THEY DO test our `ip` plugin, which uses geoip2) on all Python versions somehow, but let's be safe. We don't need any of the minor new features in geoip2 3.x, and a future release could actually break things. Being more specific about Python versions here is a non-starter for me, given that the maintainers have already shown they're willing to drop Python versions in "minor" versions (see geoip2 2.8.0).

Note that `pytz` remains unpinned. This package hasn't shown any signs of dropping support for Python versions at all, yet, and we want users to get the updated timezone info if at all possible. We can cross the bridge later by providing individual support later, if it does drop one of our supported Python releases at some point.

Simplified `dnspython` version specifier, as well.