### PR TITLE
Final 7.0 docs cleanup

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -177,8 +177,7 @@ Core changes
   * Variable naming format: `SOPEL_SECTION_OPTION`
   * Underscores in `SECTION` and `OPTION` names are preserved, e.g.
     `SOPEL_CORE_AUTH_PASSWORD`
-* Example service unit files now include a multi-instance template for systemd
-  [[#1059][]]
+* Example multi-instance systemd template is now available [[#1059][]]
 * Example systemd unit files wait until networking is connected before starting
   Sopel [[#1511][]]
 * Running Sopel on an unknown OS platform will output a warning encouraging the
@@ -230,7 +229,7 @@ API changes
 * [API documentation][api-docs] has been almost entirely overhauled [[#1563][],
   [#1566][], [#1646][], [#1668][], [#1669][], [#1680][], [#1719][], [#1727][],
   [#1735][], [#1750][], [#1766][], [#1770][], [#1771][], [#1772][], [#1775][],
-  [#1776][], [#1778][], [#1782][]]
+  [#1776][], [#1778][], [#1782][], [#1813][]]
   * Nearly every file, both for the public API and Sopel's internals, was
     reviewed in its entirety to make these improvements globally:
     * More consistent style
@@ -575,6 +574,7 @@ API changes
 [#1807]: https://github.com/sopel-irc/sopel/pull/1807
 [#1808]: https://github.com/sopel-irc/sopel/pull/1808
 [#1811]: https://github.com/sopel-irc/sopel/pull/1811
+[#1813]: https://github.com/sopel-irc/sopel/pull/1813
 
 [api-docs]: https://sopel.chat/docs/
 [auth-config-docs]: https://sopel.chat/docs/configure.html#Authentication

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -23,6 +23,8 @@ sopel.tools.web
 .. automodule:: sopel.tools.web
    :members:
 
+   .. autodata:: r_entity
+
 sopel.tools.time
 ----------------
 .. automodule:: sopel.tools.time

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -39,6 +39,19 @@ intersphinx_mapping = {
     'sqlalchemy': ('https://docs.sqlalchemy.org/en/13/', None),
 }
 
+# Make Sphinx warn for references (methods, functions, etc.) it can't find
+nitpicky = True
+# Except for certain not-actually-reference things that aren't published in the
+# docs or don't actually exist except as shorthand for the reader
+nitpick_ignore = [
+    ('py:class', 'callable'),
+    ('py:class', 'depends on subclass'),
+    ('py:class', 'mixed'),
+    ('py:class', 'sopel.tools.jobs.Job'),
+    ('py:class', 'sopel.tools.jobs.JobScheduler'),
+    ('py:exc', 'plugins.exceptions.PluginNotRegistered'),
+]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/docs/source/trigger.rst
+++ b/docs/source/trigger.rst
@@ -1,12 +1,12 @@
 Triggers
 ========
 
-A :class:`Trigger` is the main type of user input plugins will see.
+A :class:`~.trigger.Trigger` is the main type of user input plugins will see.
 
-Sopel uses :class:`PreTrigger`\s internally while processing incoming IRC
-messages. Plugin authors can reasonably expect that their code will never
-receive one. They are documented here for completeness, and for the aid of
-Sopel's core development.
+Sopel uses :class:`~.trigger.PreTrigger`\s internally while processing
+incoming IRC messages. Plugin authors can reasonably expect that their code
+will never receive one. They are documented here for completeness, and for the
+aid of Sopel's core development.
 
 .. autoclass:: sopel.trigger.Trigger
     :members:

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -233,7 +233,8 @@ class Sopel(irc.AbstractBot):
         """Reload a plugin.
 
         :param str name: name of the plugin to reload
-        :raise PluginNotRegistered: when there is no ``name`` plugin registered
+        :raise plugins.exceptions.PluginNotRegistered: when there is no
+            ``name`` plugin registered
 
         This function runs the plugin's shutdown routine and unregisters the
         plugin from the bot. Then this function reloads the plugin, runs its
@@ -351,7 +352,8 @@ class Sopel(irc.AbstractBot):
         :return: the plugin's metadata
                  (see :meth:`~.plugins.handlers.AbstractPluginHandler.get_meta_description`)
         :rtype: :class:`dict`
-        :raise PluginNotRegistered: when there is no ``name`` plugin registered
+        :raise plugins.exceptions.PluginNotRegistered: when there is no
+            ``name`` plugin registered
         """
         if not self.has_plugin(name):
             raise plugins.exceptions.PluginNotRegistered(name)

--- a/sopel/config/__init__.py
+++ b/sopel/config/__init__.py
@@ -141,13 +141,13 @@ class Config(object):
         self.define_section('core', core_section.CoreSection,
                             validate=validate)
         self.get = self.parser.get
-        """Shortcut to :meth:`parser.get`."""
+        """Shortcut to :meth:`parser.get <configparser.ConfigParser.get>`."""
 
     @property
     def homedir(self):
         """The config file's home directory.
 
-        If the :meth:`core.homedir <.core_section.CoreSection.homedir>` setting
+        If the :attr:`core.homedir <.core_section.CoreSection.homedir>` setting
         is available, that value is used. Otherwise, the default ``homedir`` is
         the directory portion of the :class:`Config`'s :attr:`filename`.
         """

--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -108,9 +108,9 @@ class BaseValidated(object):
     """The base type for a setting descriptor in a :class:`StaticSection`.
 
     :param str name: the attribute name to use in the config file
-    :param default: the value to be returned if the setting has no value;
-                    if not specified, defaults to :obj:`None`
-    :type default: str, optional
+    :param default: the value to be returned if the setting has no value
+                    (optional; defaults to :obj:`None`)
+    :type default: str
 
     ``default`` also can be set to :const:`sopel.config.types.NO_DEFAULT`, if
     the value *must* be configured by the user (i.e. there is no suitable
@@ -200,13 +200,13 @@ class ValidatedAttribute(BaseValidated):
 
     :param str name: the attribute name to use in the config file
     :param parse: a function to be used to read the string and create the
-                  appropriate object; the string value will be returned
-                  as-is if not set
-    :type parse: :term:`function`, optional
+                  appropriate object (optional; the string value will be
+                  returned as-is if not set)
+    :type parse: :term:`function`
     :param serialize: a function that, given an object, should return a string
-                      that can be written to the config file safely; defaults
-                      to :class:`str`
-    :type serialize: :term:`function`, optional
+                      that can be written to the config file safely (optional;
+                      defaults to :class:`str`)
+    :type serialize: :term:`function`
     """
     def __init__(self, name, parse=None, serialize=None, default=None):
         super(ValidatedAttribute, self).__init__(name, default=default)
@@ -248,14 +248,14 @@ class ListAttribute(BaseValidated):
     """A config attribute containing a list of string values.
 
     :param str name: the attribute name to use in the config file
-    :param strip: whether to strip whitespace from around each value (applies
-                  only to legacy comma-separated lists; multi-line lists are
-                  always stripped)
-    :type strip: bool, optional
+    :param strip: whether to strip whitespace from around each value
+                  (optional; applies only to legacy comma-separated lists;
+                  multi-line lists are always stripped)
+    :type strip: bool
     :param default: the default value if the config file does not define a
                     value for this option; to require explicit configuration,
-                    use :const:`sopel.config.types.NO_DEFAULT`
-    :type default: list, optional
+                    use :const:`sopel.config.types.NO_DEFAULT` (optional)
+    :type default: list
 
     From this :class:`StaticSection`::
 
@@ -436,8 +436,8 @@ class ChoiceAttribute(BaseValidated):
     :type choices: list or tuple
     :param default: which choice to use if none is set in the config file; to
                     require explicit configuration, use
-                    :const:`sopel.config.types.NO_DEFAULT`
-    :type default: str, optional
+                    :const:`sopel.config.types.NO_DEFAULT` (optional)
+    :type default: str
     """
     def __init__(self, name, choices, default=None):
         super(ChoiceAttribute, self).__init__(name, default=default)
@@ -475,15 +475,16 @@ class FilenameAttribute(BaseValidated):
 
     :param str name: the attribute name to use in the config file
     :param relative: whether the path should be relative to the location of
-                     the config file (absolute paths will still be absolute)
-    :type relative: bool, optional
+                     the config file (optional; note that absolute paths will
+                     always be interpreted as absolute)
+    :type relative: bool
     :param directory: whether the path should indicate a directory, rather
-                      than a file
-    :type directory: bool, optional
+                      than a file (optional)
+    :type directory: bool
     :param default: the value to use if none is defined in the config file; to
                     require explicit configuration, use
-                    :const:`sopel.config.types.NO_DEFAULT`
-    :type default: str, optional
+                    :const:`sopel.config.types.NO_DEFAULT` (optional)
+    :type default: str
     """
     def __init__(self, name, relative=True, directory=False, default=None):
         super(FilenameAttribute, self).__init__(name, default=default)

--- a/sopel/db.py
+++ b/sopel/db.py
@@ -190,12 +190,20 @@ class SopelDB(object):
 
         .. important::
 
-           The :attr:`database backend <sopel.config.core_section.db_type>` in
-           use can change how the raw connection object behaves. Unless you're
-           writing (or updating) a plugin that needs to be compatible with
-           Sopel versions older than 7.0, or can get away with supporting only
-           one type of database, you probably want to use :meth:`session` and
-           build (or convert) your plugin to use the SQLAlchemy ORM.
+           The :attr:`~sopel.config.core_section.CoreSection.db_type` in use
+           can change how the raw connection object behaves. You probably want
+           to use :meth:`session` and the SQLAlchemy ORM in new plugins, and
+           officially support only Sopel 7.0+.
+
+           Note that :meth:`session` is not available in Sopel versions prior
+           to 7.0. If your plugin needs to be compatible with older Sopel
+           releases, your code *should* use SQLAlchemy via :meth:`session` if
+           it is available (Sopel 7.0+) and fall back to direct SQLite access
+           via :meth:`connect` if it is not (Sopel 6.x).
+
+           We discourage *publishing* plugins that don't work with all
+           supported databases, but you're obviously welcome to take shortcuts
+           and support only the engine(s) you need in *private* plugins.
 
         """
         if self.type != 'sqlite':
@@ -219,9 +227,9 @@ class SopelDB(object):
 
         .. note::
 
-           If your plugin needs to run on Sopel versions prior to 7.0, you can
-           use :meth:`connect` to get a raw connection. See its documentation
-           for relevant warnings and compatibility caveats.
+           If your plugin needs to remain compatible with Sopel versions prior
+           to 7.0, you can use :meth:`connect` to get a raw connection. See
+           its documentation for relevant warnings and compatibility caveats.
 
         """
         return self.ssession()

--- a/sopel/irc/abstract_backends.py
+++ b/sopel/irc/abstract_backends.py
@@ -25,7 +25,7 @@ class AbstractIRCBackend(object):
     def send_command(self, *args, **kwargs):
         """Send a command through the IRC connection.
 
-        :param * args: IRC command to send with its argument(s)
+        :param args: IRC command to send with its argument(s)
         :param str text: the text to send (optional keyword argument)
 
         Example::

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -527,7 +527,7 @@ def require_account(message=None, reply=False):  # lgtm [py/similar-function]
     .. seealso::
 
         The value of the :class:`trigger<.trigger.Trigger>`'s
-        :meth:`account<.trigger.Trigger.account>` property determines whether
+        :attr:`account <.trigger.Trigger.account>` property determines whether
         this requirement is satisfied, and the property's documentation
         includes up-to-date details on what features a network must
         support to allow Sopel to fetch account information.
@@ -736,14 +736,18 @@ class example(object):
     :param bool user_help: whether this example should be included in
                            user-facing help output such as `.help command`
                            (optional; default ``False``; see below)
-    :param bool online: if ``True``, :mod:`pytest` will mark this example as
-                        "online" (optional; default ``False``; see below)
+    :param bool online: if ``True``, |pytest|_ will mark this
+                        example as "online" (optional; default ``False``; see
+                        below)
 
-    ``msg`` must use the default :attr:`~sopel.config.core_section.help_prefix`
-    if it is a prefixed command, for compatibility with the built-in help
-    plugin. Other command types should give example invocations that work with
-    Sopel on its default settings, especially if using the "example test"
-    functionality to automatically generate a test(s) for the function.
+    .. |pytest| replace:: ``pytest``
+    .. _pytest: https://pypi.org/project/pytest/
+
+    For compatibility with the built-in help plugin, ``msg`` must use the
+    default :attr:`~sopel.config.core_section.CoreSection.help_prefix` if it
+    is a prefixed command. Other command types should give example invocations
+    that work with Sopel's default settings, especially if using the "example
+    test" functionality to automatically generate a test(s) for the function.
 
     The presence of a ``result`` will generate tests automatically when Sopel's
     test suite is run, using ``msg`` as input. The exact behavior of the tests

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -110,7 +110,7 @@ class AbstractPluginHandler(object):
         """Tell if the plugin is loaded or not
 
         :return: ``True`` if the plugin is loaded, ``False`` otherwise
-        :rtype: boolean
+        :rtype: bool
 
         This must return ``True`` if the :meth:`load` method has been called
         with success.
@@ -129,7 +129,7 @@ class AbstractPluginHandler(object):
         """Tell if the plugin has a setup action
 
         :return: ``True`` if the plugin has a setup, ``False`` otherwise
-        :rtype: boolean
+        :rtype: bool
         """
         raise NotImplementedError
 
@@ -162,7 +162,7 @@ class AbstractPluginHandler(object):
 
         :return: ``True`` if the plugin has a ``shutdown`` action, ``False``
                  otherwise
-        :rtype: boolean
+        :rtype: bool
         """
         raise NotImplementedError
 
@@ -181,7 +181,7 @@ class AbstractPluginHandler(object):
 
         :return: ``True`` if the plugin has a ``configure`` action, ``False``
                  otherwise
-        :rtype: boolean
+        :rtype: bool
         """
         raise NotImplementedError
 

--- a/sopel/test_tools.py
+++ b/sopel/test_tools.py
@@ -135,7 +135,7 @@ def get_example_test(tested_func, msg, results, privmsg, admin,
     """Get a function that calls ``tested_func`` with fake wrapper and trigger.
 
     :param callable tested_func: a Sopel callable that accepts a
-                                 ``SopelWrapper`` and a ``Trigger``
+        :class:`~.bot.SopelWrapper` and a :class:`~.trigger.Trigger`
     :param str msg: message that is supposed to trigger the command
     :param list results: expected output from the callable
     :param bool privmsg: if ``True``, make the message appear to have arrived
@@ -148,7 +148,7 @@ def get_example_test(tested_func, msg, results, privmsg, admin,
     :param bool use_regexp: pass ``True`` if ``results`` are in regexp format
     :param list ignore: strings to ignore
     :return: a test function for ``tested_func``
-    :rtype: ``callable``
+    :rtype: :term:`function`
     """
     def test(configfactory, botfactory, ircfactory):
         test_config = TEST_CONFIG.format(

--- a/sopel/tests/factories.py
+++ b/sopel/tests/factories.py
@@ -26,9 +26,9 @@ class BotFactory(object):
         :rtype: :class:`sopel.bot.Sopel`
 
         This will instantiate a :class:`~sopel.bot.Sopel` object, replace its
-        backend with a :class:`~MockIRCBackend`, and then preload plugins.
-        This will automatically load the ``coretasks`` plugin, and every other
-        plugin from ``preloads``::
+        backend with a :class:`~.mocks.MockIRCBackend`, and then preload
+        plugins. This will automatically load the ``coretasks`` plugin, and
+        every other plugin from ``preloads``::
 
             factory = BotFactory()
             bot = factory.with_autoloads(settings, ['emoticons', 'remind'])

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -66,7 +66,7 @@ def compile_rule(nick, pattern, alias_nicks):
                              instead of ``nick``
     :return: the compiled regex ``pattern``, with placeholders for ``$nick`` and
              ``$nickname`` filled in
-    :rtype: :py:class:`re.Pattern`
+    :rtype: :ref:`re.Pattern <python:re-objects>`
 
     Will not recompile an already compiled pattern.
     """
@@ -96,7 +96,7 @@ def get_command_regexp(prefix, command):
     :param str prefix: the command prefix (interpreted as regex)
     :param str command: the name of the command
     :return: a compiled regexp object that implements the command
-    :rtype: :py:class:`re.Pattern`
+    :rtype: :ref:`re.Pattern <python:re-objects>`
     """
     # Escape all whitespace with a single backslash. This ensures that regexp
     # in the prefix is treated as it was before the actual regexp was changed
@@ -144,7 +144,7 @@ def get_nickname_command_regexp(nick, command, alias_nicks):
     :param list alias_nicks: a list of alternatives that should also be accepted
                              instead of ``nick``
     :return: a compiled regex pattern that implements the given nickname command
-    :rtype: :py:class:`re.Pattern`
+    :rtype: :ref:`re.Pattern <python:re-objects>`
     """
     if isinstance(alias_nicks, unicode):
         alias_nicks = [alias_nicks]
@@ -183,7 +183,7 @@ def get_action_command_regexp(command):
 
     :param str command: the name of the command
     :return: a compiled regexp object that implements the command
-    :rtype: :py:class:`re.Pattern`
+    :rtype: :ref:`re.Pattern <python:re-objects>`
     """
     pattern = get_action_command_pattern(command)
     return re.compile(pattern, re.IGNORECASE | re.VERBOSE)
@@ -587,7 +587,7 @@ def get_hostmask_regex(mask):
 
     :param str mask: the hostmask that the pattern should match
     :return: a compiled regex pattern matching the given ``mask``
-    :rtype: :py:class:`re.Pattern`
+    :rtype: :ref:`re.Pattern <python:re-objects>`
     """
     mask = re.escape(mask)
     mask = mask.replace(r'\*', '.*')

--- a/sopel/tools/time.py
+++ b/sopel/tools/time.py
@@ -10,7 +10,7 @@ import pytz
 def validate_timezone(zone):
     """Return an IETF timezone from the given IETF zone or common abbreviation.
 
-    :param string zone: in a strict or a human-friendly format
+    :param str zone: in a strict or a human-friendly format
     :return: the valid IETF timezone properly formatted
     :raise ValueError: when ``zone`` is not a valid timezone
 
@@ -41,7 +41,7 @@ def validate_timezone(zone):
 def validate_format(tformat):
     """Validate a time format string.
 
-    :param string tformat: the format string to validate
+    :param str tformat: the format string to validate
     :return: the format string, if valid
     :raise ValueError: when ``tformat`` is not a valid time format string
     """

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -236,7 +236,7 @@ class Trigger(unicode):
     hostmask = property(lambda self: self._pretrigger.hostmask)
     """Hostmask of the person who sent the message as ``<nick>!<user>@<host>``.
 
-    :type: str:
+    :type: str
     """
     user = property(lambda self: self._pretrigger.user)
     """Local username of the person who sent the message.


### PR DESCRIPTION
After updating the preview site to build with 7.0.0 RC2, I noticed a broken cross-reference in the new docstring for `db.connect()`. So of course, I went in search of a way to make Sphinx check for broken references and warn about them automatically. And of course, that led to fixing all the other broken or wrongly formatted references in our documentation.

Perfectionism at its finest? 😁

The only thing that I don't really love is that hack to link `pytest` *with monospace formatting* in `module.py`. Such a shame reST doesn't support nested inline markup…