### PR TITLE
cli.run: Show loaded config file at startup

### DIFF
--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -53,6 +53,8 @@ def run(settings, pid_file, daemon=False):
 
     # Acts as a welcome message, showing the program and platform version at start
     print_version()
+    # Also show the location of the config file used to load settings
+    print("\nLoaded config file: {}".format(settings.filename))
 
     if not settings.core.ca_certs:
         tools.stderr(


### PR DESCRIPTION
We can bikeshed exact wording or placement of blank lines, if anyone has a better idea.

Example output:
```
$ sopel
Sopel 7.0.1.dev0 (running on Python 3.6.9)
https://sopel.chat/

Loaded config file: /home/dgw/.sopel/default.cfg
[2020-03-18 19:22:05,142] sopel.bot    INFO     - Loading plugins...
[startup sequence continues]
```

Note: This will need to be done somewhere else, later in the sequence, if we want the config file to appear in logs. It could be worth delaying all the startup messaging (welcome, version number, etc.) until logging has been set up, to be fair.