### PR TITLE
clock: add feedback to `.setchanneltz` if not OP

### DIFF
--- a/sopel/modules/clock.py
+++ b/sopel/modules/clock.py
@@ -222,7 +222,7 @@ def get_user_format(bot, trigger):
 
 @module.commands('setchanneltz', 'setctz')
 @module.example('.setctz America/New_York')
-@module.require_privilege(module.OP)
+@module.require_privilege(module.OP, message='Changing the channel timezone requires OP privileges.')
 def update_channel(bot, trigger):
     """Set the preferred timezone for the channel."""
     argument = trigger.group(2)


### PR DESCRIPTION
### Description
Adds an error message to the setchanneltz function if you are not opped up.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [ ] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [ ] I have tested the functionality of the things this change touches
