### PR TITLE
units: fix mass when given exactly 1 pound

### DIFF
--- a/sopel/modules/units.py
+++ b/sopel/modules/units.py
@@ -174,8 +174,8 @@ def mass(bot, trigger):
     pound = int(ounce) // 16
     ounce = ounce - (pound * 16)
 
-    if pound > 1:
-        stupid_part = '{} pounds'.format(pound)
+    if pound >= 1:
+        stupid_part = '{} {}'.format(pound, 'pound' if pound == 1 else 'pounds')
         if ounce > 0.01:
             stupid_part += ' {:.2f} ounces'.format(ounce)
     else:


### PR DESCRIPTION
Reported on IRC by sukil.

### Description
Before:

```
<dgw> .mass 16 oz
<Sopel> dgw: 453.60g = 0.00 oz
<dgw> .mass 17 oz
<Sopel> dgw: 481.95g = 1.00 oz
```

After:

```
<dgw> .mass 16oz
<SopelTest> dgw: 453.60g = 1 pound
<dgw> .mass 17oz
<SopelTest> dgw: 481.95g = 1 pound 1.00 ounces
```

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - Relying on Travis for this. My local `make quality` reports a _ton_ of errors because I'm in the middle of adding another style-checking plugin. 😁
- [x] I have tested the functionality of the things this change touches
