### PR TITLE
remind: fix loading DB when a reminder contains italics

### DIFF
--- a/sopel/modules/remind.py
+++ b/sopel/modules/remind.py
@@ -9,9 +9,9 @@ https://sopel.chat
 """
 from __future__ import unicode_literals, absolute_import, print_function, division
 
-import codecs
 import collections
 from datetime import datetime
+import io  # don't use `codecs` for loading the DB; it will split lines on some IRC formatting
 import logging
 import os
 import re
@@ -70,7 +70,7 @@ def load_database(filename):
         return {}
 
     data = {}
-    with codecs.open(filename, 'r', encoding='utf-8') as database:
+    with io.open(filename, 'r', encoding='utf-8') as database:
         for line in database:
             unixtime, channel, nick, message = line.split('\t', 3)
             message = message.rstrip('\n')
@@ -94,7 +94,7 @@ def dump_database(filename, data):
 
     If the file does not exist, it is created.
     """
-    with codecs.open(filename, 'w', encoding='utf-8') as database:
+    with io.open(filename, 'w', encoding='utf-8') as database:
         for unixtime, reminders in tools.iteritems(data):
             for channel, nick, message in reminders:
                 line = '%s\t%s\t%s\t%s\n' % (unixtime, channel, nick, message)

--- a/sopel/modules/tell.py
+++ b/sopel/modules/tell.py
@@ -9,7 +9,7 @@ https://sopel.chat
 """
 from __future__ import unicode_literals, absolute_import, print_function, division
 
-import io
+import io  # don't use `codecs` for loading the DB; it will split lines on some IRC formatting
 import logging
 import os
 import time

--- a/test/modules/test_modules_remind.py
+++ b/test/modules/test_modules_remind.py
@@ -384,6 +384,23 @@ def test_load_database_weirdo(tmpdir):
     assert ('#sopel', 'Admin', weird_message) in result[523549810]
 
 
+def test_load_database_irc_formatting(tmpdir):
+    tmpfile = tmpdir.join('remind.db')
+    formatted_message = (
+        'This message has italics, bold, underline, '
+        'strikethrough, and monospace.')
+    tmpfile.write_text(
+        '523549810.0\t#sopel\tAdmin\t%s\n' % formatted_message,
+        encoding='utf-8')
+
+    result = remind.load_database(tmpfile.strpath)
+    assert len(result.keys()) == 1
+    # first timestamp
+    assert 523549810 in result
+    assert len(result[523549810]) == 1
+    assert ('#sopel', 'Admin', formatted_message) in result[523549810]
+
+
 def test_load_multiple_reminders_same_timestamp(tmpdir):
     tmpfile = tmpdir.join('remind.db')
     tmpfile.write(

--- a/test/modules/test_modules_remind.py
+++ b/test/modules/test_modules_remind.py
@@ -335,7 +335,9 @@ def test_load_database(tmpdir):
         '523549810.0\t#sopel\tAdmin\tmessage\n'
         '839169010.0\t#sopel\tAdmin\tanother message\n')
     result = remind.load_database(tmpfile.strpath)
-    assert len(result.keys()) == 2
+    assert len(result.keys()) == 2, (
+        'There should be only two keys: 523549810, 839169010; found %s'
+        % (', '.join(result.keys())))
 
     # first timestamp
     assert 523549810 in result
@@ -354,7 +356,9 @@ def test_load_database_tabs(tmpdir):
         '523549810.0\t#sopel\tAdmin\tmessage\n'
         '839169010.0\t#sopel\tAdmin\tmessage\textra\n')
     result = remind.load_database(tmpfile.strpath)
-    assert len(result.keys()) == 2
+    assert len(result.keys()) == 2, (
+        'There should be only two keys: 523549810, 839169010; found %s'
+        % (', '.join(result.keys())))
     # first timestamp
     assert 523549810 in result
     assert len(result[523549810]) == 1
@@ -377,7 +381,9 @@ def test_load_database_weirdo(tmpdir):
         encoding='utf-8')
 
     result = remind.load_database(tmpfile.strpath)
-    assert len(result.keys()) == 1
+    assert len(result.keys()) == 1, (
+        'There should be only one key: 523549810; found %s'
+        % (', '.join(result.keys())))
     # first timestamp
     assert 523549810 in result
     assert len(result[523549810]) == 1
@@ -387,14 +393,18 @@ def test_load_database_weirdo(tmpdir):
 def test_load_database_irc_formatting(tmpdir):
     tmpfile = tmpdir.join('remind.db')
     formatted_message = (
-        'This message has italics, bold, underline, '
-        'strikethrough, and monospace.')
+        'This message has \x0301,04colored text\x03, \x0400ff00hex-colored '
+        'text\x04, \x02bold\x02, \x1ditalics\x1d, \x1funderline\x1f, '
+        '\x11monospace\x11, \x16reverse\x16, \x1estrikethrough or\x0f '
+        'strikethrough and normal text.')
     tmpfile.write_text(
         '523549810.0\t#sopel\tAdmin\t%s\n' % formatted_message,
         encoding='utf-8')
 
     result = remind.load_database(tmpfile.strpath)
-    assert len(result.keys()) == 1
+    assert len(result.keys()) == 1, (
+        'There should be only one key: 523549810; found %s'
+        % (', '.join(result.keys())))
     # first timestamp
     assert 523549810 in result
     assert len(result[523549810]) == 1

--- a/test/modules/test_modules_tell.py
+++ b/test/modules/test_modules_tell.py
@@ -23,7 +23,7 @@ def test_load_reminders_one_tellee(tmpdir):
     verb = 'tell'
     timenow = '1569488444'
     msg_1 = 'You forgot an S in "élèves".'
-    msg_2 = 'You forgot another S  in "garçons".'
+    msg_2 = 'You forgot another S in "garçons".'
     tmpfile = tmpdir.join('tell.db')
 
     reminders = [
@@ -31,7 +31,7 @@ def test_load_reminders_one_tellee(tmpdir):
         [tellee, teller, verb, timenow, msg_2],
     ]
     tmpfile.write_text(
-        '\n'.join('\t'.join(items) for items in reminders),
+        '\n'.join('\t'.join(item) for item in reminders),
         encoding='utf-8')
     result = tell.load_reminders(tmpfile.strpath)
 
@@ -65,7 +65,7 @@ def test_load_reminders_multiple_tellees(tmpdir):
         [tellee_2, teller, verb, timenow, msg],
     ]
     tmpfile.write_text(
-        '\n'.join('\t'.join(items) for items in reminders),
+        '\n'.join('\t'.join(item) for item in reminders),
         encoding='utf-8')
     result = tell.load_reminders(tmpfile.strpath)
 
@@ -87,6 +87,40 @@ def test_load_reminders_multiple_tellees(tmpdir):
     reminder_2 = result[tellee_2][0]
     assert reminder_1 == (teller, verb, timenow, msg)
     assert reminder_2 == (teller, verb, timenow, msg)
+
+
+def test_load_reminders_irc_formatting(tmpdir):
+    tellee = 'Exirel'
+    teller = 'dgw'
+    verb = 'tell'
+    timenow = '1569488444'
+    formatted_message = (
+        'This message has \x0301,04colored text\x03, \x0400ff00hex-colored '
+        'text\x04, \x02bold\x02, \x1ditalics\x1d, \x1funderline\x1f, '
+        '\x11monospace\x11, \x16reverse\x16, \x1estrikethrough or\x0f '
+        'strikethrough and normal text.')
+    tmpfile = tmpdir.join('tell.db')
+
+    reminders = [
+        [tellee, teller, verb, timenow, formatted_message],
+    ]
+    tmpfile.write_text(
+        '\n'.join('\t'.join(item) for item in reminders),
+        encoding='utf-8')
+    result = tell.load_reminders(tmpfile.strpath)
+
+    assert len(result.keys()) == 1, (
+        'There should be one and only one key, found these instead: %s'
+        % ', '.join(result.keys())
+    )
+    assert 'Exirel' in result, (
+        'Tellee not found, found %s instead' % result.keys()[0])
+    assert len(result['Exirel']) == 1, (
+        'There should be one reminder, found %d instead'
+        % len(result['Exirel'])
+    )
+    reminder = result['Exirel'][0]
+    assert reminder == (teller, verb, timenow, formatted_message)
 
 
 def test_dump_reminders_empty(tmpdir):


### PR DESCRIPTION
### Description
I don't get the satisfaction of tagging this "closes #&lt;number&gt;", but it does fix a bug with loading stored reminders when certain IRC formatting (I encountered it with italics) is included in the message.

@Exirel will be glad to see I added a test for this bug to help keep it from being reintroduced. :)

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
