### PR TITLE
Patch `version` variable not being used in regex

### DIFF
--- a/sopel/__init__.py
+++ b/sopel/__init__.py
@@ -46,7 +46,7 @@ __version__ = pkg_resources.get_distribution('sopel').version
 
 def _version_info(version=__version__):
     regex = re.compile(r'(\d+)\.(\d+)\.(\d+)(?:(a|b|rc)(\d+))?.*')
-    version_groups = regex.match(__version__).groups()
+    version_groups = regex.match(version).groups()
     major, minor, micro = (int(piece) for piece in version_groups[0:3])
     level = version_groups[3]
     serial = int(version_groups[4] or 0)


### PR DESCRIPTION
### Description
This patches the `_version_info` function to ACTUALLY use the version variable passed to it in the regex match.

This should make the `find_updates` module do a better job checking that `version < latest_version`.

The current situation would always compare the local version to itself.


### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
