### PR TITLE
bot: fix per-channel configuration by plugin names

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -574,16 +574,28 @@ class Sopel(irc.AbstractBot):
 
                 # if "*" is used, we are disabling all plugins on provided channel
                 if '*' in disabled_plugins:
+                    LOGGER.debug(
+                        "All plugins disabled in %s; skipping execution of %s.%s",
+                        trigger.sender, func.plugin_name, func.__name__
+                    )
                     return
-                if func.__module__ in disabled_plugins:
+                if func.plugin_name in disabled_plugins:
+                    LOGGER.debug(
+                        "Plugin %s is disabled in %s; skipping execution of %s",
+                        func.plugin_name, trigger.sender, func.__name__
+                    )
                     return
 
             # disable chosen methods from plugins
             if 'disable_commands' in channel_config:
                 disabled_commands = literal_eval(channel_config.disable_commands)
 
-                if func.__module__ in disabled_commands:
-                    if func.__name__ in disabled_commands[func.__module__]:
+                if func.plugin_name in disabled_commands:
+                    if func.__name__ in disabled_commands[func.plugin_name]:
+                        LOGGER.debug(
+                            "Skipping execution of %s.%s in %s: disabled_commands matched",
+                            func.plugin_name, func.__name__, trigger.sender
+                        )
                         return
 
         try:

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -36,6 +36,7 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 import inspect
 import imp
 import importlib
+import itertools
 import os
 
 from sopel import loader
@@ -259,6 +260,10 @@ class PyModulePlugin(AbstractPluginHandler):
 
     def register(self, bot):
         relevant_parts = loader.clean_module(self._module, bot.config)
+        for part in itertools.chain(*relevant_parts):
+            # annotate all callables in relevant_parts with `plugin_name`
+            # attribute to make per-channel config work; see #1839
+            setattr(part, 'plugin_name', self.name)
         bot.add_plugin(self, *relevant_parts)
 
     def unregister(self, bot):


### PR DESCRIPTION
### Description
Annotate callables with the source plugin name during plugin registration. Use that name when applying per-channel configuration settings instead of the Python module name.

Old solution: ~~Translates plugin names given in the config to the module names that would/will be returned by `func.__module__`, and uses those when filtering per-channel configuration.~~

Resolves #1839.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [ ] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - I can't reasonably run `make quality` locally due to other long-term work on adding new flake8 checks that currently generate hundreds of warnings, so I'll leave this unchecked even though `make test` does pass.
- [x] I have tested the functionality of the things this change touches
  - ~~Most of it. I made sure it works for core plugins and entry-point plugins, and the debug log output of module names I used to get this far tells me it _should_ also work for `sopel_modules` plugins and single-file plugins (a few of which I have on my test install). The only wildcard should be folder plugins.~~ This disclaimer does not apply to the replacement `plugin_name` attribute solution.

### Other
_The below comments are no longer relevant, but are kept for posterity._

~~I fully expect at least one method name to get bikeshedded. That's fine. My primary concern is making sure that the base principle of this change isn't complete lunacy. 😹~~

~~I'm also fully aware that @Exirel disagrees with this approach on principle—but I'm hoping that having a PR in which to discuss it will at least push us toward either accepting this one (perhaps with modifications) or developing a different kind of fix that we can ship relatively soon.~~