### PR TITLE
tools.time: zero is a special case for `seconds_to_human()`

### DIFF
--- a/sopel/tools/time.py
+++ b/sopel/tools/time.py
@@ -226,30 +226,35 @@ def seconds_to_human(secs):
     secs = int(secs)
     secs = abs(secs)
 
-    years = secs // 31536000
-    months = (secs - years * 31536000) // 2635200
-    days = (secs - years * 31536000 - months * 2635200) // 86400
-    hours = (secs - years * 31536000 - months * 2635200 - days * 86400) // 3600
-    minutes = (secs - years * 31536000 - months * 2635200 - days * 86400 - hours * 3600) // 60
-    seconds = secs - years * 31536000 - months * 2635200 - days * 86400 - hours * 3600 - minutes * 60
+    if secs == 0:
+        # zero is a special case that the algorithm below won't handle correctly (#1841)
+        result = "0 seconds"
+    else:
+        years = secs // 31536000
+        months = (secs - years * 31536000) // 2635200
+        days = (secs - years * 31536000 - months * 2635200) // 86400
+        hours = (secs - years * 31536000 - months * 2635200 - days * 86400) // 3600
+        minutes = (secs - years * 31536000 - months * 2635200 - days * 86400 - hours * 3600) // 60
+        seconds = secs - years * 31536000 - months * 2635200 - days * 86400 - hours * 3600 - minutes * 60
 
-    years_text = "year{}".format("s" if years != 1 else "")
-    months_text = "month{}".format("s" if months != 1 else "")
-    days_text = "day{}".format("s" if days != 1 else "")
-    hours_text = "hour{}".format("s" if hours != 1 else "")
-    minutes_text = "minute{}".format("s" if minutes != 1 else "")
-    seconds_text = "second{}".format("s" if seconds != 1 else "")
+        years_text = "year{}".format("s" if years != 1 else "")
+        months_text = "month{}".format("s" if months != 1 else "")
+        days_text = "day{}".format("s" if days != 1 else "")
+        hours_text = "hour{}".format("s" if hours != 1 else "")
+        minutes_text = "minute{}".format("s" if minutes != 1 else "")
+        seconds_text = "second{}".format("s" if seconds != 1 else "")
 
-    result = ", ".join(filter(lambda x: bool(x), [
-        "{0} {1}".format(years, years_text) if years else "",
-        "{0} {1}".format(months, months_text) if months else "",
-        "{0} {1}".format(days, days_text) if days else "",
-        "{0} {1}".format(hours, hours_text) if hours else "",
-        "{0} {1}".format(minutes, minutes_text) if minutes else "",
-        "{0} {1}".format(seconds, seconds_text) if seconds else ""
-    ]))
-    # Granularity
-    result = ", ".join(result.split(", ")[:2])
+        result = ", ".join(filter(lambda x: bool(x), [
+            "{0} {1}".format(years, years_text) if years else "",
+            "{0} {1}".format(months, months_text) if months else "",
+            "{0} {1}".format(days, days_text) if days else "",
+            "{0} {1}".format(hours, hours_text) if hours else "",
+            "{0} {1}".format(minutes, minutes_text) if minutes else "",
+            "{0} {1}".format(seconds, seconds_text) if seconds else ""
+        ]))
+        # Granularity
+        result = ", ".join(result.split(", ")[:2])
+
     if future is False:
         result += " ago"
     else:


### PR DESCRIPTION
Patch looks big, but that's because Python doesn't have braces. 😏 (Just kidding, I'd update the indentation even if it did. I'm not a monster.)

### Description
Fixes #1841.

Setup:
```
>>> from sopel.tools.time import seconds_to_human
```

Before:
```
>>> seconds_to_human(0)
' ago'
```

After:
```
>>> seconds_to_human(0)
'0 seconds ago'
``` 

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - Caveats apply as with all my recent PRs: `make quality` is currently useless in my local environment
- [x] I have tested the functionality of the things this change touches
