### PR TITLE
docs: modify channel config examples to show password/key usage

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -183,7 +183,7 @@ join is configured by :attr:`~CoreSection.channels`::
     [core]
     channels =
         "#sopel"
-        "#sopelunkers"
+        "#sopelunkers isP@ssw0rded"
 
 It is possible to slow down the initial joining of channels using
 :attr:`~CoreSection.throttle_join` and :attr:`~CoreSection.throttle_wait`, for
@@ -193,7 +193,7 @@ quickly::
     [core]
     channels =
         "#sopel"
-        "#sopelunkers"
+        "#sopelunkers isP@ssw0rded"
         # ... too many channels ...
         "#justonemore"
     throttle_join = 4

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -164,7 +164,11 @@ class CoreSection(StaticSection):
     """
 
     channels = ListAttribute('channels')
-    """List of channels for the bot to join when it connects."""
+    """List of channels for the bot to join when it connects.
+
+    If a channel key needs to be provided, separate it from the channel name
+    with a space, e.g. ``"#channel password"``.
+    """
 
     commands_on_connect = ListAttribute('commands_on_connect')
     """A list of commands to send upon successful connection to the IRC server.

--- a/sopel/tools/time.py
+++ b/sopel/tools/time.py
@@ -208,7 +208,9 @@ def seconds_to_human(secs):
     Inspiration for function structure from:
     https://gist.github.com/Highstaker/280a09591df4a5fb1363b0bbaf858f0d
 
-    Example outputs are::
+    Example outputs are:
+
+    .. code-block:: text
 
         2 years, 1 month ago
         in 4 hours, 45 minutes


### PR DESCRIPTION
### Description
Someone asked on IRC if Sopel supports channel "keywords", which I took to mean `+k` "key" or password. I noticed the documentation didn't show any examples of that, so I made some tweaks.

Whether that was the right interpretation of the question or not, we should include keys in the docs.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - Kinda N/A; doesn't touch code. I tested the docs build locally.
- [x] I have tested the functionality of the things this change touches
