### PR TITLE
bot: route URL callbacks through `bot.call()` too

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -567,6 +567,10 @@ class Sopel(irc.AbstractBot):
         # if channel has its own config section, check for excluded plugins/plugin methods
         if trigger.sender in self.config:
             channel_config = self.config[trigger.sender]
+            LOGGER.debug(
+                "Evaluating configuration for %s.%s in channel %s",
+                func.plugin_name, func.__name__, trigger.sender
+            )
 
             # disable listed plugins completely on provided channel
             if 'disable_plugins' in channel_config:

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -17,6 +17,7 @@ from __future__ import unicode_literals, absolute_import, print_function, divisi
 import base64
 import collections
 import datetime
+import functools
 import logging
 import re
 import sys
@@ -1009,4 +1010,9 @@ def handle_url_callbacks(bot, trigger):
         for function, match in bot.search_url_callbacks(url):
             # trigger callback defined by the `@url` decorator
             if hasattr(function, 'url_regex'):
-                function(bot, trigger, match=match)
+                # bake the `match` argument in before passing the callback on
+                @functools.wraps(function)
+                def decorated(bot, trigger):
+                    return function(bot, trigger, match=match)
+
+                bot.call(decorated, bot, trigger)


### PR DESCRIPTION
### Description
With this change, URL callbacks are no longer called outside the enforcement area of rate-limits, per-channel configuration, etc.

See #1812.

I'm initially ignoring the checklist below because I expect @Exirel will look at this Soon™. He'll either use it as a starting point and add tests, or propose an alternative implementation (and add tests).

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
