### PR TITLE
xkcd: suppress link if triggered by a URL match

### DIFF
--- a/sopel/modules/xkcd.py
+++ b/sopel/modules/xkcd.py
@@ -96,7 +96,7 @@ def xkcd(bot, trigger):
     say_result(bot, requested)
 
 
-def numbered_result(bot, query, latest):
+def numbered_result(bot, query, latest, commanded=True):
     max_int = latest['num']
     if query > max_int:
         bot.say(("Sorry, comic #{} hasn't been posted yet. "
@@ -117,16 +117,18 @@ def numbered_result(bot, query, latest):
         # Negative: go back that many from current
         requested = get_info(max_int + query)
 
-    say_result(bot, requested)
+    say_result(bot, requested, commanded)
 
 
-def say_result(bot, result):
-    message = '{} | {} | Alt-text: {}'.format(result['url'], result['title'],
-                                              result['alt'])
+def say_result(bot, result, commanded=True):
+    message = '{}{} | Alt-text: {}'.format(
+        result['url'] + ' | ' if commanded else '',
+        result['title'], result['alt']
+    )
     bot.say(message)
 
 
 @url(r'xkcd.com/(\d+)')
 def get_url(bot, trigger, match):
     latest = get_info()
-    numbered_result(bot, int(match.group(1)), latest)
+    numbered_result(bot, int(match.group(1)), latest, commanded=False)


### PR DESCRIPTION
This is the smallest patch I could devise, at the expense of being kinda messy. Ideally only one function would need to handle the `commanded` argument, but due to how the code is already structured it has to get passed around a bit first.

We could probably do with a small rewrite of this plugin, but not for a bugfix release. It might happen later if someone feels like it.

Closes #1847.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - [Insert my recent standard disclaimer about local flake8 warnings]
- [x] I have tested the functionality of the things this change touches
