### PR TITLE
docs: remove duplicate entries for `bot.{name,nick,user}`

### DIFF
--- a/docs/source/bot.rst
+++ b/docs/source/bot.rst
@@ -5,18 +5,5 @@ The bot and its state
     :members:
     :inherited-members:
 
-    .. py:attribute:: nick
-
-        Sopel's current nick. Changing this while Sopel is running is unsupported.
-
-    .. py:attribute:: user
-
-        Sopel's user/ident.
-
-    .. py:attribute:: name
-
-        Sopel's "real name", as used for whois.
-
-
 .. autoclass:: sopel.bot.SopelWrapper
     :members:

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -92,7 +92,10 @@ class AbstractBot(object):
 
     @property
     def nick(self):
-        """Sopel's current ``Identifier``."""
+        """Sopel's current nick.
+
+        Changing this while Sopel is running is unsupported.
+        """
         return self._nick
 
     @property
@@ -102,7 +105,7 @@ class AbstractBot(object):
 
     @property
     def name(self):
-        """Sopel's "real name", to be displayed in WHOIS responses."""
+        """Sopel's "real name", as used for WHOIS responses."""
         return self._name
 
     @property


### PR DESCRIPTION
### Description
Sphinx 3 started complaining about duplicate object descriptions. I'm too lazy to keep updating my local Sphinx (was still on 1.8.x until today), but I spotted the warnings in Netlify site build logs.

Resolves these warnings (taken from the sopel-irc/sopel.chat#29 merge build on Netlify):
```
6:45:58 AM: /opt/build/repo/_sopel/sopel/bot.py:docstring of sopel.bot.Sopel.name:1:
WARNING: duplicate object description of sopel.bot.Sopel.name, other instance in bot,
use :noindex: for one of them
6:45:58 AM: /opt/build/repo/_sopel/sopel/bot.py:docstring of sopel.bot.Sopel.nick:1:
WARNING: duplicate object description of sopel.bot.Sopel.nick, other instance in bot,
use :noindex: for one of them
6:45:58 AM: /opt/build/repo/_sopel/sopel/bot.py:docstring of sopel.bot.Sopel.user:1:
WARNING: duplicate object description of sopel.bot.Sopel.user, other instance in bot,
use :noindex: for one of them
```

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
This commit can be cherry-picked to the `7.0.x` maintenance branch just in case we actually release another patch version, but I don't think anything is actually _broken_ because of this. The definitions in `docs/source/bot.rst` just make these three properties appear at the top of the built HTML page, instead of in alphabetical order with the rest of the things. (The duplicate rST defs came from b567c72c4182e134324a8a9e5ccedd66eeafb41c, over four years ago. I think we're past needing them.)