### PR TITLE
xkcd: Parse latest comic when base URL is linked

### DIFF
--- a/sopel/modules/xkcd.py
+++ b/sopel/modules/xkcd.py
@@ -134,7 +134,7 @@ def get_url(bot, trigger, match):
     numbered_result(bot, int(match.group(1)), latest, commanded=False)
 
 
-@url(r'xkcd.com/?$')
+@url(r'https?://xkcd\.com/?$')
 def xkcd_main_page(bot, trigger, match):
     latest = get_info()
     numbered_result(bot, 0, latest, commanded=False)

--- a/sopel/modules/xkcd.py
+++ b/sopel/modules/xkcd.py
@@ -132,3 +132,9 @@ def say_result(bot, result, commanded=True):
 def get_url(bot, trigger, match):
     latest = get_info()
     numbered_result(bot, int(match.group(1)), latest, commanded=False)
+
+
+@url(r'xkcd.com/?$')
+def xkcd_main_page(bot, trigger, match):
+    latest = get_info()
+    numbered_result(bot, 0, latest, commanded=False)


### PR DESCRIPTION
Add a special rule to respond to vanilla `https://xkcd.com` links with data for the latest comic.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
