### PR TITLE
docs: add examples for owner/admins config values

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -101,6 +101,22 @@ The same instance can have multiple admins. Similarly, it can be configured
 by :attr:`~CoreSection.admin_accounts` or by :attr:`~CoreSection.admins`. If
 ``admin_accounts`` is set, ``admins`` will be ignored.
 
+Example owner & admin configurations::
+
+    # Using nickname matching
+    [core]
+    owner = dgw
+    admins =
+            Exirel
+            HumorBaby
+
+    # Using account matching
+    [core]
+    owner_account = dgw
+    admin_accounts =
+            Exirel
+            HumorBaby
+
 Both ``owner_account`` and ``admin_accounts`` are safer to use than
 nick-based matching, but the IRC server must support accounts.
 (Most, sadly, do not as of late 2019.)


### PR DESCRIPTION
### Description
Tin.

Current (as of 7.0.3):
![image](https://user-images.githubusercontent.com/164140/81506365-5a50b600-92bb-11ea-9fd8-54f00497cc79.png)

New (this PR):
![image](https://user-images.githubusercontent.com/164140/81506372-676da500-92bb-11ea-8fa8-75bb38ebf97e.png)

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - This doesn't touch code.
- [x] I have tested the functionality of the things this change touches
  - Ditto.
