### PR TITLE
bot: fix plugin name in _command_groups

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -470,7 +470,7 @@ class Sopel(irc.AbstractBot):
                         callable_name)
 
             if commands:
-                plugin_name = callbl.__module__.rsplit('.', 1)[-1]
+                plugin_name = callbl.plugin_name
                 # TODO doc and make decorator for this. Not sure if this is how
                 # it should work yet, so not making it public for 6.0.
                 category = getattr(callbl, 'category', plugin_name)


### PR DESCRIPTION
### Description

The "_command_groups" attribute is used to generate the documentation for plugin's command (there is an old piece of code for some undocumented feature here but that's something else).

The problem is that it tries to derive the plugin's name from the Python module the callable come from, instead of, you know, the actual plugin's name.

Since we added the "plugin_name" attribute on all callable back in 8776354b7aae7087f090a0989181400899f6c0d0 (see #1840) we can now use it safely for the command group.

One-line fix for you all!

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
