### PR TITLE
Add flake8-import-order

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,6 +5,8 @@ flake8<3.6.0; python_version == '3.3'
 flake8>=3.7.0,<3.8.0; python_version != '3.3'
 flake8-coding
 flake8-future-import<0.4.6
+flake8-import-order; python_version > '3.3'
+flake8-import-order<=1.18.1; python_version <= '3.3'
 setuptools<40.0; python_version == '3.3'
 sphinx
 sphinxcontrib-autoprogram

--- a/pytest_run.py
+++ b/pytest_run.py
@@ -11,7 +11,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 if __name__ == "__main__":
     import sys

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,6 +40,8 @@ pytest11 =
 
 [flake8]
 max-line-length = 79
+application-import-names = sopel
+import-order-style = google
 ignore =
     # Line length limit. Acceptable (for now).
     E501,

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
 import time

--- a/sopel.py
+++ b/sopel.py
@@ -1,7 +1,10 @@
 #!/usr/bin/env python3
 # coding=utf-8
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
+
 import sys
+
 # Different from setuptools script, because we want the one in this dir.
 from sopel.cli import run
+
 sys.exit(run.main())

--- a/sopel/__init__.py
+++ b/sopel/__init__.py
@@ -10,13 +10,14 @@
 #
 # Licensed under the Eiffel Forum License 2.
 
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from collections import namedtuple
 import locale
-import pkg_resources
 import re
 import sys
+
+import pkg_resources
 
 __all__ = [
     'bot',

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -6,7 +6,7 @@
 #
 # Licensed under the Eiffel Forum License 2.
 
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from ast import literal_eval
 import collections
@@ -20,11 +20,11 @@ import time
 
 from sopel import irc, logger, plugins, tools
 from sopel.db import SopelDB
-from sopel.tools import Identifier, deprecated
+import sopel.loader
+from sopel.module import NOLIMIT
+from sopel.tools import deprecated, Identifier
 import sopel.tools.jobs
 from sopel.trigger import Trigger
-from sopel.module import NOLIMIT
-import sopel.loader
 
 
 __all__ = ['Sopel', 'SopelWrapper']

--- a/sopel/cli/__init__.py
+++ b/sopel/cli/__init__.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 # Shortcut imports
 from .utils import (  # noqa

--- a/sopel/cli/config.py
+++ b/sopel/cli/config.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Sopel Config Command Line Interface (CLI): ``sopel-config``"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import argparse
 import os

--- a/sopel/cli/plugins.py
+++ b/sopel/cli/plugins.py
@@ -1,13 +1,12 @@
 # coding=utf-8
 """Sopel Plugins Command Line Interface (CLI): ``sopel-plugins``"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import argparse
 import inspect
 import operator
 
 from sopel import plugins, tools
-
 from . import utils
 
 

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -8,7 +8,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import argparse
 import logging
@@ -18,7 +18,7 @@ import signal
 import sys
 import time
 
-from sopel import bot, config, logger, tools, __version__
+from sopel import __version__, bot, config, logger, tools
 from . import utils
 
 # This is in case someone somehow manages to install Sopel on an old version

--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import inspect
 import logging

--- a/sopel/config/__init__.py
+++ b/sopel/config/__init__.py
@@ -48,7 +48,7 @@ the :class:`Config` object is instantiated; it uses
 # Copyright © 2012, Elad Alfassa <elad@fedoraproject.org>
 # Licensed under the Eiffel Forum License 2.
 
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
 import sys

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -1,12 +1,16 @@
 # coding=utf-8
 
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os.path
 
 from sopel.config.types import (
-    StaticSection, ValidatedAttribute, ListAttribute, ChoiceAttribute,
-    FilenameAttribute, NO_DEFAULT
+    ChoiceAttribute,
+    FilenameAttribute,
+    ListAttribute,
+    NO_DEFAULT,
+    StaticSection,
+    ValidatedAttribute,
 )
 from sopel.tools import Identifier
 

--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -24,11 +24,12 @@ As an example, if one wanted to define the ``[spam]`` section as having an
     ValueError: ListAttribute value must be a list.
 """
 
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os.path
 import re
 import sys
+
 from sopel.tools import get_input
 
 if sys.version_info.major >= 3:

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -12,22 +12,22 @@ dispatch function in bot.py and making it easier to maintain.
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import base64
 import collections
 import datetime
 import functools
 import logging
+from random import randint
 import re
 import sys
 import time
-from random import randint
 
 from sopel import loader, module
 from sopel.irc import isupport
 from sopel.irc.utils import CapReq, MyInfo
-from sopel.tools import Identifier, events, iteritems, jobs, target, web
+from sopel.tools import events, Identifier, iteritems, jobs, target, web
 
 
 if sys.version_info.major >= 3:

--- a/sopel/db.py
+++ b/sopel/db.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import errno
 import json
@@ -8,13 +8,13 @@ import os.path
 import sys
 import traceback
 
-from sopel.tools import Identifier
-
-from sqlalchemy import create_engine, Column, ForeignKey, Integer, String
+from sqlalchemy import Column, create_engine, ForeignKey, Integer, String
 from sqlalchemy.engine.url import URL
 from sqlalchemy.exc import OperationalError, SQLAlchemyError
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker
+
+from sopel.tools import Identifier
 
 if sys.version_info.major >= 3:
     unicode = str

--- a/sopel/formatting.py
+++ b/sopel/formatting.py
@@ -6,7 +6,7 @@
 # Copyright 2014, Elsie Powell, embolalia.com
 # Copyright 2019, dgw, technobabbl.es
 # Licensed under the Eiffel Forum License 2.
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import string
 import sys

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -23,12 +23,14 @@ who should worry about :class:`sopel.bot.Sopel` only.
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
-import sys
-import time
-import os
+from datetime import datetime
 import logging
+import os
+import sys
+import threading
+import time
 
 try:
     import ssl
@@ -43,15 +45,11 @@ except ImportError:
     # no SSL support
     has_ssl = False
 
-import threading
-from datetime import datetime
-
 from sopel import tools
 from sopel.trigger import PreTrigger
-
 from .backends import AsynchatBackend, SSLAsynchatBackend
 from .isupport import ISupport
-from .utils import safe, CapReq
+from .utils import CapReq, safe
 
 if sys.version_info.major >= 3:
     unicode = str

--- a/sopel/irc/abstract_backends.py
+++ b/sopel/irc/abstract_backends.py
@@ -2,7 +2,7 @@
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import threading
 

--- a/sopel/irc/backends.py
+++ b/sopel/irc/backends.py
@@ -4,7 +4,7 @@
 # Licensed under the Eiffel Forum License 2.
 # When working on core IRC protocol related features, consult protocol
 # documentation at http://www.irchelp.org/irchelp/rfc/
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import asynchat
 import asyncore
@@ -16,7 +16,7 @@ import socket
 import sys
 from threading import current_thread
 
-from sopel.tools.jobs import JobScheduler, Job
+from sopel.tools.jobs import Job, JobScheduler
 from .abstract_backends import AbstractIRCBackend
 from .utils import get_cnames
 

--- a/sopel/irc/isupport.py
+++ b/sopel/irc/isupport.py
@@ -12,7 +12,7 @@ When a server wants to advertise its features and settings, it can use the
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import functools
 import itertools

--- a/sopel/irc/utils.py
+++ b/sopel/irc/utils.py
@@ -2,11 +2,12 @@
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import collections
 import sys
-from dns import resolver, rdtypes
+
+from dns import rdtypes, resolver
 
 if sys.version_info.major >= 3:
     unicode = str

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -1,12 +1,17 @@
 # coding=utf-8
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import re
 import sys
 
-from sopel.tools import (compile_rule, itervalues, get_command_regexp,
-                         get_nickname_command_regexp, get_action_command_regexp)
 from sopel.config import core_section
+from sopel.tools import (
+    compile_rule,
+    get_action_command_regexp,
+    get_command_regexp,
+    get_nickname_command_regexp,
+    itervalues,
+)
 
 default_prefix = core_section.CoreSection.help_prefix.default
 del core_section

--- a/sopel/logger.py
+++ b/sopel/logger.py
@@ -1,9 +1,9 @@
 # coding=utf-8
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
-import os
 from logging.config import dictConfig
+import os
 
 from sopel import tools
 

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -8,7 +8,7 @@
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 # Licensed under the Eiffel Forum License 2.
 
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import functools
 import re

--- a/sopel/modules/__init__.py
+++ b/sopel/modules/__init__.py
@@ -1,2 +1,2 @@
 # coding=utf-8
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals

--- a/sopel/modules/admin.py
+++ b/sopel/modules/admin.py
@@ -10,10 +10,10 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from sopel.config.types import (
-    StaticSection, ValidatedAttribute, FilenameAttribute
+    FilenameAttribute, StaticSection, ValidatedAttribute
 )
 import sopel.module
 

--- a/sopel/modules/adminchannel.py
+++ b/sopel/modules/adminchannel.py
@@ -7,13 +7,13 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import re
 
 from sopel import formatting
 from sopel.module import (
-    commands, example, priority, OP, HALFOP, require_privilege, require_chanmsg
+    commands, example, HALFOP, OP, priority, require_chanmsg, require_privilege
 )
 from sopel.tools import Identifier
 

--- a/sopel/modules/announce.py
+++ b/sopel/modules/announce.py
@@ -7,7 +7,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from sopel.module import commands, example, require_admin
 

--- a/sopel/modules/bugzilla.py
+++ b/sopel/modules/bugzilla.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
 import re
@@ -14,7 +14,7 @@ import re
 import requests
 import xmltodict
 
-from sopel.config.types import StaticSection, ListAttribute
+from sopel.config.types import ListAttribute, StaticSection
 from sopel.module import rule
 
 

--- a/sopel/modules/calc.py
+++ b/sopel/modules/calc.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from sopel.module import commands, example
 from sopel.tools.calculation import eval_equation

--- a/sopel/modules/choose.py
+++ b/sopel/modules/choose.py
@@ -9,7 +9,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import random
 

--- a/sopel/modules/clock.py
+++ b/sopel/modules/clock.py
@@ -7,7 +7,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from sopel import module, tools
 from sopel.tools.time import (

--- a/sopel/modules/countdown.py
+++ b/sopel/modules/countdown.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime
 

--- a/sopel/modules/currency.py
+++ b/sopel/modules/currency.py
@@ -7,7 +7,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
 import re

--- a/sopel/modules/dice.py
+++ b/sopel/modules/dice.py
@@ -7,7 +7,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import operator
 import random

--- a/sopel/modules/emoticons.py
+++ b/sopel/modules/emoticons.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from sopel.module import commands, example
 

--- a/sopel/modules/etymology.py
+++ b/sopel/modules/etymology.py
@@ -7,7 +7,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from re import sub
 

--- a/sopel/modules/find.py
+++ b/sopel/modules/find.py
@@ -11,13 +11,13 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import re
 
-from sopel.tools import Identifier, SopelMemory
 from sopel import module
 from sopel.formatting import bold
+from sopel.tools import Identifier, SopelMemory
 
 
 def setup(bot):

--- a/sopel/modules/find_updates.py
+++ b/sopel/modules/find_updates.py
@@ -9,7 +9,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import requests
 

--- a/sopel/modules/help.py
+++ b/sopel/modules/help.py
@@ -10,18 +10,18 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
-import re
 import collections
 import logging
+import re
 import socket
 import textwrap
 
 import requests
 
-from sopel.config.types import ChoiceAttribute, ValidatedAttribute, StaticSection
-from sopel.module import commands, rule, example, priority
+from sopel.config.types import ChoiceAttribute, StaticSection, ValidatedAttribute
+from sopel.module import commands, example, priority, rule
 from sopel.tools import SopelMemory
 
 

--- a/sopel/modules/instagram.py
+++ b/sopel/modules/instagram.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from datetime import datetime
 import logging

--- a/sopel/modules/invite.py
+++ b/sopel/modules/invite.py
@@ -7,7 +7,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from sopel import module, tools
 

--- a/sopel/modules/ip.py
+++ b/sopel/modules/ip.py
@@ -8,7 +8,7 @@ Licensed under the Eiffel Forum License 2.
 https://sopel.chat
 """
 
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
 import os

--- a/sopel/modules/isup.py
+++ b/sopel/modules/isup.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import requests
 

--- a/sopel/modules/lmgtfy.py
+++ b/sopel/modules/lmgtfy.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat/
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from sopel.module import commands, example
 from sopel.tools.web import quote

--- a/sopel/modules/meetbot.py
+++ b/sopel/modules/meetbot.py
@@ -13,8 +13,8 @@ import codecs
 import collections
 import os
 import re
-import time
 from string import punctuation, whitespace
+import time
 
 from sopel import formatting, module, tools
 from sopel.config.types import (FilenameAttribute, StaticSection,

--- a/sopel/modules/ping.py
+++ b/sopel/modules/ping.py
@@ -5,11 +5,11 @@ Copyright 2008 (?), Sean B. Palmer, inamidst.com
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import random
 
-from sopel.module import rule, priority, thread
+from sopel.module import priority, rule, thread
 
 
 @rule(r'(?i)(hi|hello|hey),? $nickname[ \t]*$')

--- a/sopel/modules/pronouns.py
+++ b/sopel/modules/pronouns.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from sopel.module import commands, example
 

--- a/sopel/modules/py.py
+++ b/sopel/modules/py.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from requests import get
 

--- a/sopel/modules/rand.py
+++ b/sopel/modules/rand.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import random
 import sys

--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -8,7 +8,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime as dt
 import re
@@ -20,7 +20,7 @@ import prawcore
 import requests
 
 from sopel.formatting import bold, color, colors
-from sopel.module import commands, example, require_chanmsg, rule, url, NOLIMIT, OP
+from sopel.module import commands, example, NOLIMIT, OP, require_chanmsg, rule, url
 from sopel.tools import time
 from sopel.tools.web import USER_AGENT
 

--- a/sopel/modules/reload.py
+++ b/sopel/modules/reload.py
@@ -6,13 +6,13 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
 import subprocess
 
-import sopel.module
 from sopel import plugins
+import sopel.module
 
 
 LOGGER = logging.getLogger(__name__)

--- a/sopel/modules/remind.py
+++ b/sopel/modules/remind.py
@@ -7,7 +7,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import collections
 from datetime import datetime
@@ -19,8 +19,8 @@ import time
 
 import pytz
 
-from sopel import tools, module
-from sopel.tools.time import get_timezone, format_time, validate_timezone
+from sopel import module, tools
+from sopel.tools.time import format_time, get_timezone, validate_timezone
 
 
 LOGGER = logging.getLogger(__name__)

--- a/sopel/modules/safety.py
+++ b/sopel/modules/safety.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 This module uses virustotal.com
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import logging
 import os.path
@@ -17,8 +17,8 @@ import time
 
 import requests
 
-from sopel.config.types import StaticSection, ValidatedAttribute, ListAttribute
-from sopel.formatting import color, bold
+from sopel.config.types import ListAttribute, StaticSection, ValidatedAttribute
+from sopel.formatting import bold, color
 from sopel.module import OP
 import sopel.tools
 

--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -7,7 +7,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import re
 

--- a/sopel/modules/seen.py
+++ b/sopel/modules/seen.py
@@ -8,12 +8,12 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime
 import time
 
-from sopel.module import commands, rule, priority, thread, unblockable
+from sopel.module import commands, priority, rule, thread, unblockable
 from sopel.tools import Identifier
 from sopel.tools.time import seconds_to_human
 

--- a/sopel/modules/tell.py
+++ b/sopel/modules/tell.py
@@ -7,19 +7,19 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
+from collections import defaultdict
 import io  # don't use `codecs` for loading the DB; it will split lines on some IRC formatting
 import logging
 import os
-import time
 import threading
-from collections import defaultdict
+import time
 
-from sopel.config.types import StaticSection, ValidatedAttribute
 from sopel import module
+from sopel.config.types import StaticSection, ValidatedAttribute
 from sopel.tools import Identifier
-from sopel.tools.time import get_timezone, format_time
+from sopel.tools.time import format_time, get_timezone
 
 
 LOGGER = logging.getLogger(__name__)

--- a/sopel/modules/tld.py
+++ b/sopel/modules/tld.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import re
 import sys

--- a/sopel/modules/translate.py
+++ b/sopel/modules/translate.py
@@ -7,7 +7,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import json
 import random
@@ -15,8 +15,8 @@ import sys
 
 import requests
 
-from sopel.module import rule, commands, priority, example, unblockable
-from sopel.tools import web, SopelMemory
+from sopel.module import commands, example, priority, rule, unblockable
+from sopel.tools import SopelMemory, web
 
 if sys.version_info.major >= 3:
     unicode = str

--- a/sopel/modules/unicode_info.py
+++ b/sopel/modules/unicode_info.py
@@ -7,7 +7,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
 import unicodedata

--- a/sopel/modules/units.py
+++ b/sopel/modules/units.py
@@ -7,7 +7,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import re
 

--- a/sopel/modules/uptime.py
+++ b/sopel/modules/uptime.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime
 

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -9,12 +9,12 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
+import ipaddress
 import re
 
 import dns.resolver
-import ipaddress
 import requests
 
 from sopel import __version__, module, tools

--- a/sopel/modules/version.py
+++ b/sopel/modules/version.py
@@ -7,7 +7,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from datetime import datetime
 from os import path

--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -6,14 +6,14 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import re
 
 from requests import get
 
 from sopel.config.types import StaticSection, ValidatedAttribute
-from sopel.module import NOLIMIT, commands, example, url
+from sopel.module import commands, example, NOLIMIT, url
 from sopel.tools.web import quote, unquote
 
 try:  # TODO: Remove fallback when dropping py2

--- a/sopel/modules/wiktionary.py
+++ b/sopel/modules/wiktionary.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import re
 

--- a/sopel/modules/xkcd.py
+++ b/sopel/modules/xkcd.py
@@ -8,15 +8,15 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import random
 import re
 
 import requests
 
-from sopel.modules.search import bing_search
 from sopel.module import commands, url
+from sopel.modules.search import bing_search
 
 
 ignored_sites = [

--- a/sopel/plugins/__init__.py
+++ b/sopel/plugins/__init__.py
@@ -28,7 +28,7 @@ exist for each type of plugin.
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import collections
 import imp

--- a/sopel/plugins/exceptions.py
+++ b/sopel/plugins/exceptions.py
@@ -3,7 +3,7 @@
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 
 class PluginError(Exception):

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -31,11 +31,11 @@ away from the rest of the application.
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
-import inspect
 import imp
 import importlib
+import inspect
 import itertools
 import os
 

--- a/sopel/test_tools.py
+++ b/sopel/test_tools.py
@@ -12,7 +12,7 @@
 # Copyright 2013, Ari Koivula, <ari@koivu.la>
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 # Licensed under the Eiffel Forum License 2.
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
 import re

--- a/sopel/tests/__init__.py
+++ b/sopel/tests/__init__.py
@@ -3,7 +3,7 @@
 
 .. versionadded:: 7.0
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 
 def rawlist(*args):

--- a/sopel/tests/factories.py
+++ b/sopel/tests/factories.py
@@ -3,12 +3,12 @@
 
 .. versionadded:: 7.0
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import re
 
 from sopel import bot, config, plugins, trigger
-from .mocks import MockIRCServer, MockUser, MockIRCBackend
+from .mocks import MockIRCBackend, MockIRCServer, MockUser
 
 
 class BotFactory(object):

--- a/sopel/tests/mocks.py
+++ b/sopel/tests/mocks.py
@@ -3,7 +3,7 @@
 
 .. versionadded:: 7.0
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 
 from sopel.irc.abstract_backends import AbstractIRCBackend

--- a/sopel/tests/pytest_plugin.py
+++ b/sopel/tests/pytest_plugin.py
@@ -3,11 +3,11 @@
 
 .. versionadded:: 7.0
 """
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 
-from .factories import BotFactory, ConfigFactory, TriggerFactory, IRCFactory, UserFactory
+from .factories import BotFactory, ConfigFactory, IRCFactory, TriggerFactory, UserFactory
 
 
 @pytest.fixture

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -12,9 +12,10 @@
 
 # https://sopel.chat
 
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import codecs
+from collections import defaultdict
 import functools
 import logging
 import os
@@ -22,7 +23,6 @@ import re
 import sys
 import threading
 import traceback
-from collections import defaultdict
 
 from sopel.tools._events import events  # NOQA
 

--- a/sopel/tools/_events.py
+++ b/sopel/tools/_events.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 
 class events(object):

--- a/sopel/tools/calculation.py
+++ b/sopel/tools/calculation.py
@@ -1,11 +1,11 @@
 # coding=utf-8
 """Tools to help safely do calculations from user input"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
-import time
+import ast
 import numbers
 import operator
-import ast
+import time
 
 __all__ = ['eval_equation']
 

--- a/sopel/tools/jobs.py
+++ b/sopel/tools/jobs.py
@@ -10,7 +10,7 @@
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime
 import logging

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -1,7 +1,8 @@
 # coding=utf-8
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import functools
+
 from sopel.tools import Identifier
 
 

--- a/sopel/tools/time.py
+++ b/sopel/tools/time.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Tools for getting and displaying the time."""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime
 

--- a/sopel/tools/web.py
+++ b/sopel/tools/web.py
@@ -17,7 +17,7 @@ applications, APIs, or websites in your plugins.
 # Copyright © 2019, dgw, technobabbl.es
 # Licensed under the Eiffel Forum License 2.
 
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import re
 import sys

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -1,10 +1,10 @@
 # coding=utf-8
 """Triggers are how Sopel tells callables about their runtime context."""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
+import datetime
 import re
 import sys
-import datetime
 
 from sopel import tools
 

--- a/sopel/web.py
+++ b/sopel/web.py
@@ -12,7 +12,7 @@ functions are available in a new package, ``sopel.tools.web``.
 # Copyright © 2019, dgw, technobabbl.es
 # Licensed under the Eiffel Forum License 2.
 
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
 

--- a/test/cli/test_cli_run.py
+++ b/test/cli/test_cli_run.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Tests for command handling"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import argparse
 from contextlib import contextmanager
@@ -13,7 +13,7 @@ from sopel.cli.run import (
     build_parser,
     get_configuration,
     get_pid_filename,
-    get_running_pid
+    get_running_pid,
 )
 
 

--- a/test/cli/test_cli_utils.py
+++ b/test/cli/test_cli_utils.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Tests for sopel.cli.utils"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import argparse
 from contextlib import contextmanager

--- a/test/irc/test_irc_abstract_backends.py
+++ b/test/irc/test_irc_abstract_backends.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Tests for core ``sopel.irc.backends``"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 
 from sopel.irc.abstract_backends import AbstractIRCBackend

--- a/test/irc/test_irc_isupport.py
+++ b/test/irc/test_irc_isupport.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Tests for core ``sopel.irc.isupport``"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 

--- a/test/modules/test_modules_isup.py
+++ b/test/modules/test_modules_isup.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Tests for Sopel's ``remind`` plugin"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 

--- a/test/modules/test_modules_remind.py
+++ b/test/modules/test_modules_remind.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Tests for Sopel's ``remind`` plugin"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from datetime import datetime
 import os

--- a/test/modules/test_modules_tell.py
+++ b/test/modules/test_modules_tell.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Tests for Sopel's ``tell`` plugin"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime
 import io

--- a/test/modules/test_modules_url.py
+++ b/test/modules/test_modules_url.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Tests for Sopel's ``url`` plugin"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 

--- a/test/plugins/test_plugins_handlers.py
+++ b/test/plugins/test_plugins_handlers.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Tests for the ``sopel.plugins.handlers`` module."""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
 import sys

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Tests for core ``sopel.bot`` module"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import re
 

--- a/test/test_commands.py
+++ b/test/test_commands.py
@@ -1,9 +1,10 @@
 # coding=utf-8
 """Tests for command handling"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import re
 
 import pytest
-import re
 
 from sopel.tools import get_command_regexp, get_nickname_command_regexp
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-from __future__ import unicode_literals, division, print_function, absolute_import
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import os
 import sys

--- a/test/test_coretasks.py
+++ b/test/test_coretasks.py
@@ -1,13 +1,13 @@
 # coding=utf-8
 """coretasks.py tests"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 
 from sopel import coretasks
-from sopel.module import VOICE, HALFOP, OP, ADMIN, OWNER
-from sopel.tools import Identifier
+from sopel.module import ADMIN, HALFOP, OP, OWNER, VOICE
 from sopel.tests import rawlist
+from sopel.tools import Identifier
 
 
 TMP_CONFIG = """

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -4,7 +4,7 @@
 TODO: Most of these tests assume functionality tested in other tests. This is
 enough to get everything working (and is better than nothing), but best
 practice would probably be not to do that."""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import json
 import os
@@ -13,7 +13,7 @@ import tempfile
 
 import pytest
 
-from sopel.db import ChannelValues, PluginValues, Nicknames, NickValues, SopelDB
+from sopel.db import ChannelValues, Nicknames, NickValues, PluginValues, SopelDB
 from sopel.tools import Identifier
 
 db_filename = tempfile.mkstemp()[1]

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -1,10 +1,10 @@
 # coding=utf-8
 """Tests for message formatting"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 
-from sopel.formatting import colors, color, hex_color, bold, italic, underline, strikethrough, monospace, reverse
+from sopel.formatting import bold, color, colors, hex_color, italic, monospace, reverse, strikethrough, underline
 
 
 def test_color():

--- a/test/test_irc.py
+++ b/test/test_irc.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Tests for core ``sopel.irc``"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Tests for the ``sopel.loader`` module."""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import inspect
 import re

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -1,11 +1,11 @@
 # coding=utf-8
 """Tests for message formatting"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 
-from sopel.trigger import PreTrigger, Trigger
 from sopel import module, tools
+from sopel.trigger import PreTrigger, Trigger
 
 
 TMP_CONFIG = """

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Test for the ``sopel.plugins`` module."""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
 

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Regression tests"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from sopel import coretasks, tools
 

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -1,9 +1,9 @@
 # coding=utf-8
 """Tests sopel.tools"""
-from __future__ import unicode_literals, absolute_import, print_function, division
-
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from datetime import timedelta
+
 from sopel import tools
 from sopel.tools.time import seconds_to_human
 

--- a/test/test_trigger.py
+++ b/test/test_trigger.py
@@ -1,13 +1,14 @@
 # coding=utf-8
 """Tests for message parsing"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
-import re
-import pytest
 import datetime
+import re
 
-from sopel.trigger import PreTrigger, Trigger
+import pytest
+
 from sopel.tools import Identifier
+from sopel.trigger import PreTrigger, Trigger
 
 
 TMP_CONFIG = """

--- a/test/tools/test_tools_jobs.py
+++ b/test/tools/test_tools_jobs.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Tests for Job Scheduler"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime
 import time

--- a/test/tools/test_tools_web.py
+++ b/test/tools/test_tools_web.py
@@ -1,6 +1,6 @@
 # coding=utf-8
 """Tests Sopel's web tools"""
-from __future__ import unicode_literals, absolute_import, print_function, division
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest
 


### PR DESCRIPTION
### Description
Adds flake8-import-order and fixes everything it complains about. See #1765

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches [Smoke tested - currently running shout test]
