### PR TITLE
tools: add `warning_in` arg to `@deprecated`; deprecate `get_input`

### DIFF
--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -163,12 +163,23 @@ def deprecated(
     return deprecated_func
 
 
+@deprecated('Shim for Python 2 cross-compatibility, no longer needed. '
+            'Use built-in `input()` instead.',
+            version='7.1',
+            warning_in='8.0',
+            removed_in='8.1')
 def get_input(prompt):
     """Get decoded input from the terminal (equivalent to Python 3's ``input``).
 
     :param str prompt: what to display as a prompt on the terminal
     :return: the user's input
     :rtype: str
+
+    .. deprecated:: 7.1
+
+        Use of this function will become a warning when Python 2 support is
+        dropped in Sopel 8.0. The function will be removed in Sopel 8.1.
+
     """
     if sys.version_info.major >= 3:
         return input(prompt)


### PR DESCRIPTION
### Description
* New `warning_in` parameter to `@deprecated` decorator to allow documenting & decorating a deprecated function all at once even if it shouldn't warn until some future version of Sopel
* `tools.get_input` will become unnecessary in Sopel 8.0 (it's a py2 compatibility shim), so it's now deprecated—but won't emit warnings until we actually do drop py2 in Sopel 8

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
Yeah, this is a messy diff. We probably should have just moved `@deprecated` to the top _last_ time there was an issue with using it to decorate something defined earlier in the same file, but didn't. Viewing this one commit-by-commit will help.