### PR TITLE
config: add is_secret attribute to use getpass hidden input

### DIFF
--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -9,6 +9,7 @@ from sopel.config.types import (
     FilenameAttribute,
     ListAttribute,
     NO_DEFAULT,
+    SecretAttribute,
     StaticSection,
     ValidatedAttribute,
 )
@@ -158,7 +159,7 @@ class CoreSection(StaticSection):
         value will override :attr:`server_auth_method`.
     """
 
-    auth_password = ValidatedAttribute('auth_password')
+    auth_password = SecretAttribute('auth_password')
     """The password to use to authenticate with the :attr:`auth_method`.
 
     See :ref:`Authentication`.
@@ -306,7 +307,7 @@ class CoreSection(StaticSection):
     Ignored when using SQLite.
     """
 
-    db_pass = ValidatedAttribute('db_pass')
+    db_pass = SecretAttribute('db_pass')
     """The password for Sopel's database.
 
     Ignored when using SQLite.
@@ -786,7 +787,7 @@ class CoreSection(StaticSection):
     .. versionadded:: 7.0
     """
 
-    nick_auth_password = ValidatedAttribute('nick_auth_password')
+    nick_auth_password = SecretAttribute('nick_auth_password')
     """The password to use to authenticate the bot's nick.
 
     .. seealso::
@@ -970,7 +971,7 @@ class CoreSection(StaticSection):
     .. versionadded:: 7.0
     """
 
-    server_auth_password = ValidatedAttribute('server_auth_password')
+    server_auth_password = SecretAttribute('server_auth_password')
     """The password to use to authenticate with the server.
 
     .. versionadded:: 7.0

--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -455,10 +455,6 @@ class ListAttribute(BaseValidated):
         return item
 
     def configure(self, prompt, default, parent, section_name):
-        """
-        With the ``prompt`` and ``default``, parse and return a value from
-        terminal.
-        """
         each_prompt = '?'
         if isinstance(prompt, tuple):
             each_prompt = prompt[1]
@@ -574,10 +570,6 @@ class FilenameAttribute(BaseValidated):
         instance._parser.set(instance._section_name, self.name, value)
 
     def configure(self, prompt, default, parent, section_name):
-        """
-        With the ``prompt`` and ``default``, parse and return a value from
-        terminal.
-        """
         if default is not NO_DEFAULT and default is not None:
             prompt = '{} [{}]'.format(prompt, default)
         value = get_input(prompt + ' ')


### PR DESCRIPTION
Fixes #819; closes #1571 

### Description

This PR doesn't try to auto-detect a password/secret attribute, it relies on plugin author to explicitly use a `SecretAttribute`, or to use the `is_secret` parameter. I don't know how it was done before Sopel 6, and the issue #819 doesn't tell either.

When `is_secret` is `True`, the `configure` mehtod uses `getpass.getpass` instead of `input`.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
