### PR TITLE
rules: add find and search rules

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -447,18 +447,20 @@ class Sopel(irc.AbstractBot):
 
         for callbl in callables:
             rules = getattr(callbl, 'rule', [])
+            find_rules = getattr(callbl, 'find_rules', [])
             commands = getattr(callbl, 'commands', [])
             nick_commands = getattr(callbl, 'nickname_commands', [])
             action_commands = getattr(callbl, 'action_commands', [])
+            is_rule = any([rules, find_rules])
             is_command = any([commands, nick_commands, action_commands])
 
             if rules:
                 rule = plugin_rules.Rule.from_callable(settings, callbl)
                 self._rules_manager.register(rule)
-            elif not is_command:
-                callbl.rule = [match_any]
-                self._rules_manager.register(
-                    plugin_rules.Rule.from_callable(self.settings, callbl))
+
+            if find_rules:
+                rule = plugin_rules.FindRule.from_callable(settings, callbl)
+                self._rules_manager.register(rule)
 
             if commands:
                 rule = plugin_rules.Command.from_callable(settings, callbl)
@@ -473,6 +475,11 @@ class Sopel(irc.AbstractBot):
                 rule = plugin_rules.ActionCommand.from_callable(
                     settings, callbl)
                 self._rules_manager.register_action_command(rule)
+
+            if not is_command and not is_rule:
+                callbl.rule = [match_any]
+                self._rules_manager.register(
+                    plugin_rules.Rule.from_callable(self.settings, callbl))
 
     def register_jobs(self, jobs):
         for func in jobs:

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -448,10 +448,11 @@ class Sopel(irc.AbstractBot):
         for callbl in callables:
             rules = getattr(callbl, 'rule', [])
             find_rules = getattr(callbl, 'find_rules', [])
+            search_rules = getattr(callbl, 'search_rules', [])
             commands = getattr(callbl, 'commands', [])
             nick_commands = getattr(callbl, 'nickname_commands', [])
             action_commands = getattr(callbl, 'action_commands', [])
-            is_rule = any([rules, find_rules])
+            is_rule = any([rules, find_rules, search_rules])
             is_command = any([commands, nick_commands, action_commands])
 
             if rules:
@@ -460,6 +461,10 @@ class Sopel(irc.AbstractBot):
 
             if find_rules:
                 rule = plugin_rules.FindRule.from_callable(settings, callbl)
+                self._rules_manager.register(rule)
+
+            if search_rules:
+                rule = plugin_rules.SearchRule.from_callable(settings, callbl)
                 self._rules_manager.register(rule)
 
             if commands:

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -93,6 +93,12 @@ def clean_callable(func, config):
             for rule in func.find_rules
         ]
 
+    if hasattr(func, 'search_rules'):
+        func.search_rules = [
+            compile_rule(nick, rule, alias_nicks)
+            for rule in func.search_rules
+        ]
+
     if any(hasattr(func, attr) for attr in ['commands', 'nickname_commands', 'action_commands']):
         if hasattr(func, 'example'):
             # If no examples are flagged as user-facing, just show the first one like Sopel<7.0 did
@@ -139,6 +145,7 @@ def is_limitable(obj):
     allowed_attrs = (
         'rule',
         'find_rules',
+        'search_rules',
         'event',
         'intents',
         'commands',
@@ -176,6 +183,7 @@ def is_triggerable(obj):
     allowed_attrs = (
         'rule',
         'find_rules',
+        'search_rules',
         'event',
         'intents',
         'commands',

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -82,7 +82,16 @@ def clean_callable(func, config):
     if hasattr(func, 'rule'):
         if isinstance(func.rule, basestring):
             func.rule = [func.rule]
-        func.rule = [compile_rule(nick, rule, alias_nicks) for rule in func.rule]
+        func.rule = [
+            compile_rule(nick, rule, alias_nicks)
+            for rule in func.rule
+        ]
+
+    if hasattr(func, 'find_rules'):
+        func.find_rules = [
+            compile_rule(nick, rule, alias_nicks)
+            for rule in func.find_rules
+        ]
 
     if any(hasattr(func, attr) for attr in ['commands', 'nickname_commands', 'action_commands']):
         if hasattr(func, 'example'):
@@ -129,6 +138,7 @@ def is_limitable(obj):
 
     allowed_attrs = (
         'rule',
+        'find_rules',
         'event',
         'intents',
         'commands',
@@ -165,6 +175,7 @@ def is_triggerable(obj):
 
     allowed_attrs = (
         'rule',
+        'find_rules',
         'event',
         'intents',
         'commands',

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -22,6 +22,7 @@ __all__ = [
     'echo',
     'event',
     'example',
+    'find',
     'intent',
     'interval',
     'nickname_commands',
@@ -178,8 +179,8 @@ def rule(*patterns):
 
     .. note::
 
-        A regex rule can match only once per line. A future version of Sopel
-        will (hopefully) remove this limitation.
+        A regex rule can match only once per line. Use the :func:`find`
+        decorator to match multiple times.
 
     .. note::
 
@@ -194,6 +195,56 @@ def rule(*patterns):
         for value in patterns:
             if value not in function.rule:
                 function.rule.append(value)
+        return function
+
+    return add_attribute
+
+
+def find(*patterns):
+    """Decorate a function to be called each time patterns is found in a line.
+
+    :param str patterns: one or more regular expression(s)
+
+    Each argument is a regular expression which will trigger the function::
+
+        @find('hello', 'here')
+            # will trigger once on "hello you"
+            # will trigger twice on "hello here"
+            # will trigger once on "I'm right here!"
+
+    This decorator can be used multiple times to add more rules::
+
+        @find('here')
+        @find('hello')
+            # will trigger once on "hello you"
+            # will trigger twice on "hello here"
+            # will trigger once on "I'm right here!"
+
+    If the Sopel instance is in a channel, or sent a ``PRIVMSG``, the function
+    will execute for each time in a string said matches the expression.
+
+    Inside the regular expression, some special directives can be used.
+    ``$nick`` will be replaced with the nick of the bot and ``,`` or ``:,`` and
+    ``$nickname`` will be replaced with the nick of the bot::
+
+        @find('$nickname')
+            # will trigger for each time the bot's nick is in a trigger
+
+    .. versionadded:: 7.1
+
+    .. note::
+
+        The regex rule will match for each non-overlapping matches, from left
+        to right, and the function will execute for each of these matches. To
+        match only once per line, use the :func:`rule` decorator instead.
+
+    """
+    def add_attribute(function):
+        if not hasattr(function, "find_rules"):
+            function.find_rules = []
+        for value in patterns:
+            if value not in function.find_rules:
+                function.find_rules.append(value)
         return function
 
     return add_attribute

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -193,7 +193,7 @@ def rule(*patterns):
         The regex rule will match only once per line, starting at the beginning
         of the line only.
 
-        To match for each time the expression is found, use the :func:`find`
+        To match for each time an expression is found, use the :func:`find`
         decorator instead. To match only once from anywhere in the line,
         use the :func:`search` decorator instead.
 
@@ -210,7 +210,7 @@ def rule(*patterns):
 
 
 def find(*patterns):
-    """Decorate a function to be called each time patterns is found in a line.
+    """Decorate a function to be called for each time a pattern is found in a line.
 
     :param str patterns: one or more regular expression(s)
 
@@ -230,8 +230,8 @@ def find(*patterns):
             # will trigger once on "I'm right here!"
 
     If the Sopel instance is in a channel, or sent a ``PRIVMSG``, the function
-    will execute for each time in a string said matches the expression. Each
-    match will also contains the position of the instance it found.
+    will execute for each time a received message matches an expression. Each
+    match will also contain the position of the instance it found.
 
     Inside the regular expression, some special directives can be used.
     ``$nick`` will be replaced with the nick of the bot and ``,`` or ``:``, and
@@ -244,7 +244,7 @@ def find(*patterns):
 
     .. note::
 
-        The regex rule will match for each non-overlapping matches, from left
+        The regex rule will match once for each non-overlapping match, from left
         to right, and the function will execute for each of these matches.
 
         To match only once from anywhere in the line, use the :func:`search`
@@ -264,7 +264,7 @@ def find(*patterns):
 
 
 def search(*patterns):
-    """Decorate a function to be called when a pattern is found in a line.
+    """Decorate a function to be called when a pattern matches anywhere in a line.
 
     :param str patterns: one or more regular expression(s)
 
@@ -286,7 +286,7 @@ def search(*patterns):
     If the Sopel instance is in a channel, or sent a PRIVMSG, where a part
     of a string matching this expression is said, the function will execute.
     Note that captured groups here will be retrievable through the
-    :class:`~sopel.trigger.Trigger` object later. The match will also contains
+    :class:`~sopel.trigger.Trigger` object later. The match will also contain
     the position of the first instance found.
 
     Inside the regular expression, some special directives can be used.
@@ -304,7 +304,7 @@ def search(*patterns):
         the left of the line, and the function will execute only once per
         regular expression.
 
-        To match for each time the expression is found, use the :func:`find`
+        To match for each time an expression is found, use the :func:`find`
         decorator instead. To match only once from the start of the line,
         use the :func:`rule` decorator instead.
 

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -1227,11 +1227,11 @@ class ActionCommand(NamedRuleMixin, Rule):
 class FindRule(Rule):
     """Anonymous find rule definition.
 
-    A find rule is like other anonymous rule with a twist: instead of maching
+    A find rule is like an anonymous rule with a twist: instead of matching
     only once per IRC line, a find rule will execute for each non-overlapping
     match for each of its regular expressions.
 
-    For example, to match for each word starting with the h letter in a line,
+    For example, to match for each word starting with the letter ``h`` in a line,
     you can use the pattern ``h\\w+``:
 
     .. code-block:: irc
@@ -1265,11 +1265,11 @@ class FindRule(Rule):
 class SearchRule(Rule):
     """Anonymous search rule definition.
 
-    An anonymous search rule (or simply "a search rule") is like anonymous
-    rules with a twist: it will execute exactly once per regular expression
-    that match any part of a line, not just from the start.
+    A search rule is like an anonymous rule with a twist: it will execute
+    exactly once per regular expression that matches anywhere in a line, not
+    just from the start.
 
-    For example, to search if any word starts with the ``h`` letter in a line,
+    For example, to search if any word starts with the letter ``h`` in a line,
     you can use the pattern ``h\\w+``:
 
     .. code-block:: irc

--- a/test/plugins/test_plugins_rules.py
+++ b/test/plugins/test_plugins_rules.py
@@ -2139,7 +2139,7 @@ def test_action_command_from_callable_regex_pattern(mockbot):
 
 
 # -----------------------------------------------------------------------------
-# test for :class:`sopel.plugins.rules.FindRule`
+# tests for :class:`sopel.plugins.rules.FindRule`
 
 def test_find_rule_str():
     regex = re.compile(r'.*')
@@ -2189,7 +2189,7 @@ def test_find_rule_from_callable(mockbot):
     loader.clean_callable(handler, mockbot.settings)
     handler.plugin_name = 'testplugin'
 
-    # create rule from a clean callable
+    # create rule from a cleaned callable
     rule = rules.FindRule.from_callable(mockbot.settings, handler)
     assert str(rule) == '<FindRule testplugin.handler (4)>'
 
@@ -2227,7 +2227,7 @@ def test_find_rule_from_callable(mockbot):
 
 
 # -----------------------------------------------------------------------------
-# test for :class:`sopel.plugins.rules.SearchRule`
+# tests for :class:`sopel.plugins.rules.SearchRule`
 
 def test_search_rule_str():
     regex = re.compile(r'.*')
@@ -2276,7 +2276,7 @@ def test_search_rule_from_callable(mockbot):
     loader.clean_callable(handler, mockbot.settings)
     handler.plugin_name = 'testplugin'
 
-    # create rule from a clean callable
+    # create rule from a cleaned callable
     rule = rules.SearchRule.from_callable(mockbot.settings, handler)
     assert str(rule) == '<SearchRule testplugin.handler (4)>'
 

--- a/test/plugins/test_plugins_rules.py
+++ b/test/plugins/test_plugins_rules.py
@@ -90,6 +90,28 @@ def test_manager_find(mockbot):
     assert result_match.group(0) == 'world', 'The second must match on "world"'
 
 
+def test_manager_search(mockbot):
+    regex = re.compile(r'\w+')
+    rule = rules.SearchRule([regex], plugin='testplugin', label='testrule')
+    manager = rules.Manager()
+    manager.register(rule)
+
+    assert manager.has_rule('testrule')
+    assert manager.has_rule('testrule', plugin='testplugin')
+    assert not manager.has_rule('testrule', plugin='not-plugin')
+
+    line = ':Foo!foo@example.com PRIVMSG #sopel :Hello, world'
+    pretrigger = trigger.PreTrigger(mockbot.nick, line)
+
+    items = manager.get_triggered_rules(mockbot, pretrigger)
+    assert len(items) == 1, 'Exactly one rule must match'
+
+    # first result
+    result_rule, result_match = items[0]
+    assert result_rule == rule
+    assert result_match.group(0) == 'Hello'
+
+
 def test_manager_command(mockbot):
     command = rules.Command('hello', prefix=r'\.', plugin='testplugin')
     manager = rules.Manager()
@@ -2202,3 +2224,90 @@ def test_find_rule_from_callable(mockbot):
 
     assert len(results) == 2, 'Exactly 2 rules must match'
     assert all(result.group(0) == 'hey' for result in results)
+
+
+# -----------------------------------------------------------------------------
+# test for :class:`sopel.plugins.rules.SearchRule`
+
+def test_search_rule_str():
+    regex = re.compile(r'.*')
+    rule = rules.SearchRule([regex], plugin='testplugin', label='testrule')
+
+    assert str(rule) == '<SearchRule testplugin.testrule (1)>'
+
+
+def test_search_rule_str_no_plugin():
+    regex = re.compile(r'.*')
+    rule = rules.SearchRule([regex], label='testrule')
+
+    assert str(rule) == '<SearchRule (no-plugin).testrule (1)>'
+
+
+def test_search_str_no_label():
+    regex = re.compile(r'.*')
+    rule = rules.SearchRule([regex], plugin='testplugin')
+
+    assert str(rule) == '<SearchRule testplugin.(generic) (1)>'
+
+
+def test_search_str_no_plugin_label():
+    regex = re.compile(r'.*')
+    rule = rules.SearchRule([regex])
+
+    assert str(rule) == '<SearchRule (no-plugin).(generic) (1)>'
+
+
+def test_search_rule_parse_pattern():
+    # playing with regex
+    regex = re.compile(r'\w+')
+
+    rule = rules.SearchRule([regex])
+    results = list(rule.parse('Hello, world!'))
+    assert len(results) == 1, 'Search rule on word must match only once'
+    assert results[0].group(0) == 'Hello'
+
+
+def test_search_rule_from_callable(mockbot):
+    # prepare callable
+    @module.search(r'hello', r'hi', r'hey', r'hello|hi')
+    def handler(wrapped, trigger):
+        wrapped.reply('Hi!')
+
+    loader.clean_callable(handler, mockbot.settings)
+    handler.plugin_name = 'testplugin'
+
+    # create rule from a clean callable
+    rule = rules.SearchRule.from_callable(mockbot.settings, handler)
+    assert str(rule) == '<SearchRule testplugin.handler (4)>'
+
+    # match on "Hello" twice
+    line = ':Foo!foo@example.com PRIVMSG #sopel :Hello, world'
+    pretrigger = trigger.PreTrigger(mockbot.nick, line)
+    results = list(rule.match(mockbot, pretrigger))
+
+    assert len(results) == 2, 'Exactly 2 rules must match'
+    assert all(result.group(0) == 'Hello' for result in results)
+
+    # match on "hi" twice
+    line = ':Foo!foo@example.com PRIVMSG #sopel :hi!'
+    pretrigger = trigger.PreTrigger(mockbot.nick, line)
+    results = list(rule.match(mockbot, pretrigger))
+
+    assert len(results) == 2, 'Exactly 2 rules must match'
+    assert all(result.group(0) == 'hi' for result in results)
+
+    # match on "hey" once
+    line = ':Foo!foo@example.com PRIVMSG #sopel :hey how are you doing?'
+    pretrigger = trigger.PreTrigger(mockbot.nick, line)
+    results = list(rule.match(mockbot, pretrigger))
+
+    assert len(results) == 1, 'Exactly 1 rule must match'
+    assert results[0].group(0) == 'hey'
+
+    # match on "hey" once even if not at the beginning of the line
+    line = ':Foo!foo@example.com PRIVMSG #sopel :I say hey, can you say hey?'
+    pretrigger = trigger.PreTrigger(mockbot.nick, line)
+    results = list(rule.match(mockbot, pretrigger))
+
+    assert len(results) == 1, 'The rule must match once from anywhere'
+    assert results[0].group(0) == 'hey'

--- a/test/plugins/test_plugins_rules.py
+++ b/test/plugins/test_plugins_rules.py
@@ -59,6 +59,37 @@ def test_manager_rule(mockbot):
     assert result_match.group(0) == 'Hello, world'
 
 
+def test_manager_find(mockbot):
+    regex = re.compile(r'\w+')
+    rule = rules.FindRule([regex], plugin='testplugin', label='testrule')
+    manager = rules.Manager()
+    manager.register(rule)
+
+    assert manager.has_rule('testrule')
+    assert manager.has_rule('testrule', plugin='testplugin')
+    assert not manager.has_rule('testrule', plugin='not-plugin')
+
+    line = ':Foo!foo@example.com PRIVMSG #sopel :Hello, world'
+    pretrigger = trigger.PreTrigger(mockbot.nick, line)
+
+    items = manager.get_triggered_rules(mockbot, pretrigger)
+    assert len(items) == 2, 'Exactly two rules must match'
+    assert len(items[0]) == 2, (
+        'First result must contain two items: (rule, match)')
+    assert len(items[1]) == 2, (
+        'Second result must contain two items: (rule, match)')
+
+    # first result
+    result_rule, result_match = items[0]
+    assert result_rule == rule
+    assert result_match.group(0) == 'Hello', 'The first must match on "Hello"'
+
+    # second result
+    result_rule, result_match = items[1]
+    assert result_rule == rule
+    assert result_match.group(0) == 'world', 'The second must match on "world"'
+
+
 def test_manager_command(mockbot):
     command = rules.Command('hello', prefix=r'\.', plugin='testplugin')
     manager = rules.Manager()
@@ -2083,3 +2114,91 @@ def test_action_command_from_callable_regex_pattern(mockbot):
     assert result.group(4) is None
     assert result.group(5) is None
     assert result.group(6) is None
+
+
+# -----------------------------------------------------------------------------
+# test for :class:`sopel.plugins.rules.FindRule`
+
+def test_find_rule_str():
+    regex = re.compile(r'.*')
+    rule = rules.FindRule([regex], plugin='testplugin', label='testrule')
+
+    assert str(rule) == '<FindRule testplugin.testrule (1)>'
+
+
+def test_find_rule_str_no_plugin():
+    regex = re.compile(r'.*')
+    rule = rules.FindRule([regex], label='testrule')
+
+    assert str(rule) == '<FindRule (no-plugin).testrule (1)>'
+
+
+def test_find_str_no_label():
+    regex = re.compile(r'.*')
+    rule = rules.FindRule([regex], plugin='testplugin')
+
+    assert str(rule) == '<FindRule testplugin.(generic) (1)>'
+
+
+def test_find_str_no_plugin_label():
+    regex = re.compile(r'.*')
+    rule = rules.FindRule([regex])
+
+    assert str(rule) == '<FindRule (no-plugin).(generic) (1)>'
+
+
+def test_find_rule_parse_pattern():
+    # playing with regex
+    regex = re.compile(r'\w+')
+
+    rule = rules.FindRule([regex])
+    results = list(rule.parse('Hello, world!'))
+    assert len(results) == 2, 'Find rule on word must match twice'
+    assert results[0].group(0) == 'Hello'
+    assert results[1].group(0) == 'world'
+
+
+def test_find_rule_from_callable(mockbot):
+    # prepare callable
+    @module.find(r'hello', r'hi', r'hey', r'hello|hi')
+    def handler(wrapped, trigger):
+        wrapped.reply('Hi!')
+
+    loader.clean_callable(handler, mockbot.settings)
+    handler.plugin_name = 'testplugin'
+
+    # create rule from a clean callable
+    rule = rules.FindRule.from_callable(mockbot.settings, handler)
+    assert str(rule) == '<FindRule testplugin.handler (4)>'
+
+    # match on "Hello" twice
+    line = ':Foo!foo@example.com PRIVMSG #sopel :Hello, world'
+    pretrigger = trigger.PreTrigger(mockbot.nick, line)
+    results = list(rule.match(mockbot, pretrigger))
+
+    assert len(results) == 2, 'Exactly 2 rules must match'
+    assert all(result.group(0) == 'Hello' for result in results)
+
+    # match on "hi" twice
+    line = ':Foo!foo@example.com PRIVMSG #sopel :hi!'
+    pretrigger = trigger.PreTrigger(mockbot.nick, line)
+    results = list(rule.match(mockbot, pretrigger))
+
+    assert len(results) == 2, 'Exactly 2 rules must match'
+    assert all(result.group(0) == 'hi' for result in results)
+
+    # match on "hey" twice
+    line = ':Foo!foo@example.com PRIVMSG #sopel :hey how are you doing?'
+    pretrigger = trigger.PreTrigger(mockbot.nick, line)
+    results = list(rule.match(mockbot, pretrigger))
+
+    assert len(results) == 1, 'Exactly 1 rule must match'
+    assert results[0].group(0) == 'hey'
+
+    # match on "hey" twice because it's twice in the line
+    line = ':Foo!foo@example.com PRIVMSG #sopel :I say hey, can you say hey?'
+    pretrigger = trigger.PreTrigger(mockbot.nick, line)
+    results = list(rule.match(mockbot, pretrigger))
+
+    assert len(results) == 2, 'Exactly 2 rules must match'
+    assert all(result.group(0) == 'hey' for result in results)

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -344,6 +344,10 @@ def test_register_callables(tmpconfig):
     def rule_find_hello(bot, trigger):
         pass
 
+    @module.search(r'(hi|hello|hey|sup)')
+    def rule_search_hello(bot, trigger):
+        pass
+
     @module.commands('do')
     @module.example('.do nothing')
     def command_do(bot, trigger):
@@ -386,6 +390,7 @@ def test_register_callables(tmpconfig):
     callables = [
         rule_hello,
         rule_find_hello,
+        rule_search_hello,
         command_do,
         command_main_sub,
         command_main_other,
@@ -409,9 +414,10 @@ def test_register_callables(tmpconfig):
     pretrigger = trigger.PreTrigger(sopel.nick, line)
 
     matches = sopel.rules.get_triggered_rules(sopel, pretrigger)
-    assert len(matches) == 2
+    assert len(matches) == 3
     assert matches[0][0].get_rule_label() == 'rule_hello'
     assert matches[1][0].get_rule_label() == 'rule_find_hello'
+    assert matches[2][0].get_rule_label() == 'rule_search_hello'
 
     # trigger command "do"
     line = ':Foo!foo@example.com PRIVMSG #sopel :.do'

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -340,6 +340,10 @@ def test_register_callables(tmpconfig):
     def rule_hello(bot, trigger):
         pass
 
+    @module.find(r'(hi|hello|hey|sup)')
+    def rule_find_hello(bot, trigger):
+        pass
+
     @module.commands('do')
     @module.example('.do nothing')
     def command_do(bot, trigger):
@@ -381,6 +385,7 @@ def test_register_callables(tmpconfig):
     # prepare callables to be registered
     callables = [
         rule_hello,
+        rule_find_hello,
         command_do,
         command_main_sub,
         command_main_other,
@@ -404,8 +409,9 @@ def test_register_callables(tmpconfig):
     pretrigger = trigger.PreTrigger(sopel.nick, line)
 
     matches = sopel.rules.get_triggered_rules(sopel, pretrigger)
-    assert len(matches) == 1
+    assert len(matches) == 2
     assert matches[0][0].get_rule_label() == 'rule_hello'
+    assert matches[1][0].get_rule_label() == 'rule_find_hello'
 
     # trigger command "do"
     line = ':Foo!foo@example.com PRIVMSG #sopel :.do'

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -202,6 +202,7 @@ def test_clean_callable_default(tmpconfig, func):
     assert not hasattr(func, 'global_rate')
     assert not hasattr(func, 'event')
     assert not hasattr(func, 'rule')
+    assert not hasattr(func, 'find_rules')
     assert not hasattr(func, 'commands')
     assert not hasattr(func, 'nickname_commands')
     assert not hasattr(func, 'action_commands')
@@ -371,6 +372,49 @@ def test_clean_callable_rule_nickname(tmpconfig, func):
     loader.clean_callable(func, tmpconfig)
     assert len(func.rule) == 1
     assert regex in func.rule
+
+
+def test_clean_callable_find_rules(tmpconfig, func):
+    setattr(func, 'find_rules', [r'abc'])
+    loader.clean_callable(func, tmpconfig)
+
+    assert hasattr(func, 'find_rules')
+    assert len(func.find_rules) == 1
+    assert not hasattr(func, 'rule')
+
+    # Test the regex is compiled properly
+    regex = func.find_rules[0]
+    assert regex.findall('abc')
+    assert regex.findall('abcd')
+    assert not regex.findall('adbc')
+
+    # Default values
+    assert hasattr(func, 'unblockable')
+    assert func.unblockable is False
+    assert hasattr(func, 'priority')
+    assert func.priority == 'medium'
+    assert hasattr(func, 'thread')
+    assert func.thread is True
+    assert hasattr(func, 'rate')
+    assert func.rate == 0
+    assert hasattr(func, 'channel_rate')
+    assert func.channel_rate == 0
+    assert hasattr(func, 'global_rate')
+    assert func.global_rate == 0
+
+    # idempotency
+    loader.clean_callable(func, tmpconfig)
+    assert hasattr(func, 'find_rules')
+    assert len(func.find_rules) == 1
+    assert regex in func.find_rules
+    assert not hasattr(func, 'rule')
+
+    assert func.unblockable is False
+    assert func.priority == 'medium'
+    assert func.thread is True
+    assert func.rate == 0
+    assert func.channel_rate == 0
+    assert func.global_rate == 0
 
 
 def test_clean_callable_nickname_command(tmpconfig, func):

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -203,6 +203,7 @@ def test_clean_callable_default(tmpconfig, func):
     assert not hasattr(func, 'event')
     assert not hasattr(func, 'rule')
     assert not hasattr(func, 'find_rules')
+    assert not hasattr(func, 'search_rules')
     assert not hasattr(func, 'commands')
     assert not hasattr(func, 'nickname_commands')
     assert not hasattr(func, 'action_commands')
@@ -407,6 +408,50 @@ def test_clean_callable_find_rules(tmpconfig, func):
     assert hasattr(func, 'find_rules')
     assert len(func.find_rules) == 1
     assert regex in func.find_rules
+    assert not hasattr(func, 'rule')
+
+    assert func.unblockable is False
+    assert func.priority == 'medium'
+    assert func.thread is True
+    assert func.rate == 0
+    assert func.channel_rate == 0
+    assert func.global_rate == 0
+
+
+def test_clean_callable_search_rules(tmpconfig, func):
+    setattr(func, 'search_rules', [r'abc'])
+    loader.clean_callable(func, tmpconfig)
+
+    assert hasattr(func, 'search_rules')
+    assert len(func.search_rules) == 1
+    assert not hasattr(func, 'rule')
+
+    # Test the regex is compiled properly
+    regex = func.search_rules[0]
+    assert regex.search('abc')
+    assert regex.search('xyzabc')
+    assert regex.search('abcd')
+    assert not regex.search('adbc')
+
+    # Default values
+    assert hasattr(func, 'unblockable')
+    assert func.unblockable is False
+    assert hasattr(func, 'priority')
+    assert func.priority == 'medium'
+    assert hasattr(func, 'thread')
+    assert func.thread is True
+    assert hasattr(func, 'rate')
+    assert func.rate == 0
+    assert hasattr(func, 'channel_rate')
+    assert func.channel_rate == 0
+    assert hasattr(func, 'global_rate')
+    assert func.global_rate == 0
+
+    # idempotency
+    loader.clean_callable(func, tmpconfig)
+    assert hasattr(func, 'search_rules')
+    assert len(func.search_rules) == 1
+    assert regex in func.search_rules
     assert not hasattr(func, 'rule')
 
     assert func.unblockable is False

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -123,6 +123,29 @@ def test_rule_multiple():
     assert mock.rule == [r'\w+', '.*', r'\d+']
 
 
+def test_find():
+    @module.find('.*')
+    def mock(bot, trigger, match):
+        return True
+    assert mock.find_rules == ['.*']
+
+
+def test_find_args():
+    @module.find('.*', r'\d+')
+    def mock(bot, trigger, match):
+        return True
+    assert mock.find_rules == ['.*', r'\d+']
+
+
+def test_find_multiple():
+    @module.find('.*', r'\d+')
+    @module.find('.*')
+    @module.find(r'\w+')
+    def mock(bot, trigger, match):
+        return True
+    assert mock.find_rules == [r'\w+', '.*', r'\d+']
+
+
 def test_thread():
     @module.thread(True)
     def mock(bot, trigger, match):

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -146,6 +146,29 @@ def test_find_multiple():
     assert mock.find_rules == [r'\w+', '.*', r'\d+']
 
 
+def test_search():
+    @module.search('.*')
+    def mock(bot, trigger, match):
+        return True
+    assert mock.search_rules == ['.*']
+
+
+def test_search_args():
+    @module.search('.*', r'\d+')
+    def mock(bot, trigger, match):
+        return True
+    assert mock.search_rules == ['.*', r'\d+']
+
+
+def test_search_multiple():
+    @module.search('.*', r'\d+')
+    @module.search('.*')
+    @module.search(r'\w+')
+    def mock(bot, trigger, match):
+        return True
+    assert mock.search_rules == [r'\w+', '.*', r'\d+']
+
+
 def test_thread():
     @module.thread(True)
     def mock(bot, trigger, match):


### PR DESCRIPTION
Fixes #1757 

Draft PR for now, until #1873 is at least approved.

### Description

Based on #1873 this PR adds two new rules:

- **Find rules**: an anonymous rule that executes its handler for every instance found in the line, allowing to execute a function multiple times for a single trigger object
- **Search rules**: an anonymous rule that works like the original rule, but matches from anywhere in the line, allowing to execute a function exactly once on any word or pattern contained within a line, not just from its beginning

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
