### PR TITLE
cli: fix SOPEL_CONFIG env var broken usage

### DIFF
--- a/test/cli/test_cli_run.py
+++ b/test/cli/test_cli_run.py
@@ -17,6 +17,14 @@ from sopel.cli.run import (
 )
 
 
+TMP_CONFIG = """
+[core]
+owner = testnick
+nick = TestBot
+enable = coretasks
+"""
+
+
 @contextmanager
 def cd(newdir):
     prevdir = os.getcwd()
@@ -366,41 +374,30 @@ def test_get_configuration(tmpdir):
         assert result.core.owner == 'TestName'
 
 
-def test_get_pid_filename_default():
+def test_get_pid_filename_default(configfactory):
     """Assert function returns the default filename from given ``pid_dir``"""
     pid_dir = '/pid'
-    parser = build_parser()
-    options = parser.parse_args(['legacy'])
+    settings = configfactory('default.cfg', TMP_CONFIG)
 
-    result = get_pid_filename(options, pid_dir)
+    result = get_pid_filename(settings, pid_dir)
     assert result == pid_dir + '/sopel.pid'
 
 
-def test_get_pid_filename_named():
+def test_get_pid_filename_named(configfactory):
     """Assert function returns a specific filename when config (with extension) is set"""
     pid_dir = '/pid'
-    parser = build_parser()
+    settings = configfactory('test.cfg', TMP_CONFIG)
 
-    # With extension
-    options = parser.parse_args(['legacy', '-c', 'test.cfg'])
-
-    result = get_pid_filename(options, pid_dir)
-    assert result == pid_dir + '/sopel-test.pid'
-
-    # Without extension
-    options = parser.parse_args(['legacy', '-c', 'test'])
-
-    result = get_pid_filename(options, pid_dir)
+    result = get_pid_filename(settings, pid_dir)
     assert result == pid_dir + '/sopel-test.pid'
 
 
-def test_get_pid_filename_ext_not_cfg():
+def test_get_pid_filename_ext_not_cfg(configfactory):
     """Assert function keeps the config file extension when it is not cfg"""
     pid_dir = '/pid'
-    parser = build_parser()
-    options = parser.parse_args(['legacy', '-c', 'test.ini'])
+    settings = configfactory('test.ini', TMP_CONFIG)
 
-    result = get_pid_filename(options, pid_dir)
+    result = get_pid_filename(settings, pid_dir)
     assert result == pid_dir + '/sopel-test.ini.pid'
 
 

--- a/test/cli/test_cli_utils.py
+++ b/test/cli/test_cli_utils.py
@@ -14,6 +14,9 @@ from sopel.cli.utils import (
     enumerate_configs,
     find_config,
     get_many_text,
+    green,
+    red,
+    yellow,
 )
 
 
@@ -39,6 +42,21 @@ def config_dir(tmpdir):
     return test_dir
 
 
+def test_green():
+    assert green('hello') == '\x1b[32mhello\x1b[0m'
+    assert green('hello', reset=False) == '\x1b[32mhello'
+
+
+def test_red():
+    assert red('hello') == '\x1b[31mhello\x1b[0m'
+    assert red('hello', reset=False) == '\x1b[31mhello'
+
+
+def test_yellow():
+    assert yellow('hello') == '\x1b[33mhello\x1b[0m'
+    assert yellow('hello', reset=False) == '\x1b[33mhello'
+
+
 def test_enumerate_configs(config_dir):
     """Assert function retrieves only .cfg files by default"""
     results = list(enumerate_configs(config_dir.strpath))
@@ -48,6 +66,11 @@ def test_enumerate_configs(config_dir):
     assert 'extra.ini' not in results
     assert 'README' not in results
     assert len(results) == 2
+
+
+def test_enumerate_configs_not_a_directory():
+    results = list(enumerate_configs('not_a_folder_that_exist'))
+    assert results == []
 
 
 def test_enumerate_configs_extension(config_dir):


### PR DESCRIPTION
### Description

The code around config loading for command lines didn't work properly: it ignored the `SOPEL_CONFIG` env var. So I fixed it, and added some tests too.

Its usage is now documented in the help message for the `-c/--config` option.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
