### PR TITLE
reddit: fix slash-info wrongly calling output funcs as `commanded`

### DIFF
--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -436,9 +436,9 @@ def reddit_slash_info(bot, trigger):
     searchtype = trigger.group('prefix').lower()
     match = trigger.group('id')
     if searchtype == "r":
-        return subreddit_info(bot, trigger, match, commanded=True)
+        return subreddit_info(bot, trigger, match, commanded=False)
     elif searchtype == "u":
-        return redditor_info(bot, trigger, match, commanded=True)
+        return redditor_info(bot, trigger, match, commanded=False)
 
 
 @commands('subreddit')


### PR DESCRIPTION
### Description
Tin. @kwaaak pointed out on IRC that inline reddit stuff generates a response even if the user/subreddit doesn't exist, when it would make more sense to fail silently. Looks like that was the intent, but the implementation was wrong.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
