### PR TITLE
irc: tweak backend interface

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -880,6 +880,7 @@ class Sopel(irc.AbstractBot):
 
     def _shutdown(self):
         """Internal bot shutdown method."""
+        LOGGER.info('Shutting down')
         # Stop Job Scheduler
         LOGGER.info('Stopping the Job Scheduler.')
         self.scheduler.stop()

--- a/sopel/irc/abstract_backends.py
+++ b/sopel/irc/abstract_backends.py
@@ -4,8 +4,6 @@
 # Licensed under the Eiffel Forum License 2.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import threading
-
 from .utils import safe
 
 
@@ -20,7 +18,20 @@ class AbstractIRCBackend(object):
     """
     def __init__(self, bot):
         self.bot = bot
-        self.writing_lock = threading.RLock()
+
+    def is_connected(self):
+        """Tell if the backend is connected or not.
+
+        :rtype: bool
+        """
+        raise NotImplementedError
+
+    def irc_send(self, data):
+        """Send an IRC line as raw ``data``.
+
+        :param bytes data: raw line to send
+        """
+        raise NotImplementedError
 
     def send_command(self, *args, **kwargs):
         """Send a command through the IRC connection.
@@ -43,8 +54,7 @@ class AbstractIRCBackend(object):
             callback on the bot instance with the raw message sent.
         """
         raw_command = self.prepare_command(*args, text=kwargs.get('text'))
-        with self.writing_lock:
-            self.send(raw_command.encode('utf-8'))
+        self.irc_send(raw_command.encode('utf-8'))
         self.bot.on_message_sent(raw_command)
 
     def prepare_command(self, *args, **kwargs):
@@ -158,7 +168,7 @@ class AbstractIRCBackend(object):
 
         This won't send anything if the backend isn't connected.
         """
-        if self.connected:  # TODO: refactor for a method instead of attribute
+        if self.is_connected():
             self.send_command('QUIT', text=reason)
 
     def send_kick(self, channel, nick, reason=None):

--- a/sopel/logger.py
+++ b/sopel/logger.py
@@ -21,7 +21,7 @@ class IrcLoggingHandler(logging.Handler):
     def __init__(self, bot, level):
         super(IrcLoggingHandler, self).__init__(level)
         self._bot = bot
-        self._channel = bot.config.core.logging_channel
+        self._channel = bot.settings.core.logging_channel
 
     def emit(self, record):
         """Emit a log ``record`` to the IRC channel.
@@ -29,6 +29,10 @@ class IrcLoggingHandler(logging.Handler):
         :param record: the log record to output
         :type record: :class:`logging.LogRecord`
         """
+        if not self._bot.backend.is_connected():
+            # Don't emit logs when the bot is not connected.
+            return
+
         try:
             msg = self.format(record)
             self._bot.say(msg, self._channel)

--- a/sopel/tests/mocks.py
+++ b/sopel/tests/mocks.py
@@ -19,8 +19,13 @@ class MockIRCBackend(AbstractIRCBackend):
         super(MockIRCBackend, self).__init__(*args, **kwargs)
         self.message_sent = []
         """List of raw messages sent by the bot."""
+        self.connected = False
+        """Convenient status flag."""
 
-    def send(self, data):
+    def is_connected(self):
+        return self.connected
+
+    def irc_send(self, data):
         """Store ``data`` into :attr:`message_sent`."""
         self.message_sent.append(data)
 

--- a/test/irc/test_irc_abstract_backends.py
+++ b/test/irc/test_irc_abstract_backends.py
@@ -212,7 +212,7 @@ def test_send_part_text():
 def test_send_quit():
     bot = BotCollector()
     backend = MockIRCBackend(bot)
-    backend.connected = True  # TODO: refactor without attribute
+    backend.connected = True
 
     backend.send_quit()
     expected = 'QUIT\r\n'
@@ -223,7 +223,7 @@ def test_send_quit():
 def test_send_quit_text():
     bot = BotCollector()
     backend = MockIRCBackend(bot)
-    backend.connected = True  # TODO: refactor without attribute
+    backend.connected = True
 
     backend.send_quit(reason='Bye freenode!')
     expected = 'QUIT :Bye freenode!\r\n'
@@ -234,7 +234,7 @@ def test_send_quit_text():
 def test_send_quit_disconnected():
     bot = BotCollector()
     backend = MockIRCBackend(bot)
-    backend.connected = False  # TODO: refactor without attribute
+    backend.connected = False
 
     backend.send_quit()
     backend.send_quit(reason='Bye freenode!')


### PR DESCRIPTION
### Description

We used `async_chat.connected` attribute directly in the code, which we shouldn't, so I replaced it with a new method, added to the abstract IRC backend interface.

Also, after further inspection, async_chat's `close` method can be used safely, so now we call it first, then we ask the bot to do whatever is needed with its `on_close` method. Since this method expect the connection to be closed already, it shouldn't be a problem.

The timeout scheduler doesn't need to be joined, since none of its jobs requires to wait that much. I also modified the bot's interface to have a new method (`irc_send`) which will ensure that 1) we don't have any conflict with the `async_chat.send` method, and 2) makes sure to be thread-safe - the abstract class doesn't need to care about that, it's not its job.

For the record, I've run this version of the bot, with these changes, for more than 36h, and I got 0 problem. I connected to Freenode using a secure connection (ssl on), with an authenticated account. So I feel pretty confident about this.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
