### PR TITLE
jobs: prevent parallel execution and plugin specific scheduler

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -46,6 +46,11 @@ sopel.tools.events
    :members:
    :undoc-members:
 
+sopel.tools.jobs
+----------------
+.. automodule:: sopel.tools.jobs
+   :members:
+
 sopel.formatting
 ----------------
 .. automodule:: sopel.formatting

--- a/docs/source/plugin.rst
+++ b/docs/source/plugin.rst
@@ -146,6 +146,12 @@ sopel.plugins.rules
       :members:
       :undoc-members:
 
+sopel.plugins.jobs
+------------------
+.. automodule:: sopel.plugins.jobs
+   :members:
+   :show-inheritance:
+
 sopel.loader
 ------------
 .. automodule:: sopel.loader

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -27,7 +27,7 @@ import time
 from sopel import loader, module
 from sopel.irc import isupport
 from sopel.irc.utils import CapReq, MyInfo
-from sopel.tools import events, Identifier, iteritems, jobs, target, web
+from sopel.tools import events, Identifier, iteritems, target, web
 
 
 if sys.version_info.major >= 3:
@@ -47,11 +47,14 @@ def setup(bot):
         wait_interval = max(bot.settings.core.throttle_wait, 1)
 
         @module.interval(wait_interval)
+        @module.label('throttle_join')
         def processing_job(bot):
             _join_event_processing(bot)
 
         loader.clean_callable(processing_job, bot.settings)
-        bot.scheduler.add_job(jobs.Job(wait_interval, processing_job))
+        processing_job.plugin_name = 'coretasks'
+
+        bot.register_jobs([processing_job])
 
 
 def shutdown(bot):

--- a/sopel/plugins/jobs.py
+++ b/sopel/plugins/jobs.py
@@ -1,0 +1,111 @@
+# coding=utf-8
+"""Sopel's plugin jobs management.
+
+.. versionadded:: 7.1
+
+.. important::
+
+    This is all fresh and new. Its usage and documentation is for Sopel core
+    development and advanced developers. It is subject to rapid changes
+    between versions without much (or any) warning.
+
+    Do **not** build your plugin based on what is here, you do **not** need to.
+
+"""
+# Copyright 2020, Florian Strzelecki <florian.strzelecki@gmail.com>
+#
+# Licensed under the Eiffel Forum License 2.
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import itertools
+import logging
+
+from sopel import tools
+from sopel.tools import jobs
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Scheduler(jobs.Scheduler):
+    """Plugins's Job Scheduler
+
+    :param manager: bot instance passed to jobs as argument
+    :type manager: :class:`sopel.bot.Sopel`
+
+    Scheduler that stores plugin jobs and behaves like its
+    :class:`parent class <sopel.tools.jobs.Scheduler>`.
+
+    .. versionadded:: 7.1
+
+    .. note::
+
+        This class is a specific implementation of the scheduler, made to store
+        jobs by their plugins and be used by the bot (its ``manager``).
+        It follows a similar interface as the
+        :class:`plugin rules manager <sopel.plugins.rules.Manager>`.
+
+    .. important::
+
+        This is an internal tool used by Sopel to manage its jobs. To register
+        a job, plugin authors should use :func:`sopel.module.interval`.
+
+    """
+    def __init__(self, manager):
+        super(Scheduler, self).__init__(manager)
+        self._jobs = tools.SopelMemoryWithDefault(list)
+
+    def register(self, job):
+        with self._mutex:
+            self._jobs[job.get_plugin_name()].append(job)
+        LOGGER.debug('Job registered: %s', str(job))
+
+    def unregister_plugin(self, plugin_name):
+        """Unregister all the jobs from a plugin.
+
+        :param str plugin_name: the name of the plugin to remove
+        :return: the number of jobs unregistered for this plugin
+        :rtype: int
+
+        All jobs of that plugin will be removed from the scheduler.
+
+        This method is thread safe. However, it won't cancel or stop any
+        currently running jobs.
+        """
+        unregistered_jobs = 0
+        with self._mutex:
+            jobs_count = len(self._jobs[plugin_name])
+            del self._jobs[plugin_name]
+            unregistered_jobs = unregistered_jobs + jobs_count
+
+        LOGGER.debug(
+            '[%s] Successfully unregistered %d jobs',
+            plugin_name,
+            unregistered_jobs)
+
+        return unregistered_jobs
+
+    def clear_jobs(self):
+        with self._mutex:
+            self._jobs = tools.SopelMemoryWithDefault(list)
+
+        LOGGER.debug('Successfully unregistered all jobs')
+
+    def remove_callable_job(self, callable):
+        plugin_name = getattr(callable, 'plugin_name', None)
+        if not self._jobs[plugin_name]:
+            return
+
+        with self._mutex:
+            self._jobs[plugin_name] = [
+                job for job in self._jobs[plugin_name]
+                if job._handler != callable
+            ]
+
+    def _get_ready_jobs(self, now):
+        with self._mutex:
+            jobs = [
+                job for job in itertools.chain(*self._jobs.values())
+                if job.is_ready_to_run(now)
+            ]
+
+        return jobs

--- a/test/tools/test_tools_jobs.py
+++ b/test/tools/test_tools_jobs.py
@@ -2,9 +2,11 @@
 """Tests for Job Scheduler"""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import datetime
 import time
 
+import pytest
+
+from sopel import loader, module
 from sopel.tools import jobs
 
 
@@ -16,9 +18,18 @@ enable = coretasks
 """
 
 
-def test_jobscheduler_stop(configfactory, botfactory):
-    mockbot = botfactory(configfactory('config.cfg', TMP_CONFIG))
-    scheduler = jobs.JobScheduler(mockbot)
+class WithJobMockException(Exception):
+    pass
+
+
+@pytest.fixture
+def mockconfig(configfactory):
+    return configfactory('config.cfg', TMP_CONFIG)
+
+
+def test_jobscheduler_stop(mockconfig, botfactory):
+    mockbot = botfactory(mockconfig)
+    scheduler = jobs.Scheduler(mockbot)
     assert not scheduler.stopping.is_set(), 'Stopping must not be set at init'
 
     scheduler.stop()
@@ -27,17 +38,222 @@ def test_jobscheduler_stop(configfactory, botfactory):
 
 def test_job_is_ready_to_run():
     now = time.time()
-    job = jobs.Job(5, None)
+    job = jobs.Job([5])
 
     assert job.is_ready_to_run(now + 20)
     assert not job.is_ready_to_run(now - 20)
 
 
-def test_job_string_representation():
-    timestamp = 523549800
-    job = jobs.Job(5, None)
-    job.next_time = timestamp
-    test_date = str(datetime.datetime.fromtimestamp(timestamp))
-    expected = '<Job(%s, 5s, None)>' % test_date
+def test_job_str():
+    job = jobs.Job([5])
+    expected = '<Job (unknown) [5s]>'
 
     assert str(job) == expected
+
+
+def test_job_str_intervals():
+    job = jobs.Job([5, 60, 30])
+    expected = '<Job (unknown) [5s, 30s, 60s]>'
+
+    assert str(job) == expected
+
+
+def test_job_str_handler():
+    def handler():
+        pass
+
+    job = jobs.Job([5], handler=handler)
+    expected = '<Job handler [5s]>'
+
+    assert str(job) == expected
+
+
+def test_job_str_handler_plugin():
+    def handler():
+        pass
+
+    job = jobs.Job([5], plugin='testplugin', handler=handler)
+    expected = '<Job testplugin.handler [5s]>'
+
+    assert str(job) == expected
+
+
+def test_job_str_label():
+    def handler():
+        pass
+
+    job = jobs.Job([5], label='testhandler', handler=handler)
+    expected = '<Job testhandler [5s]>'
+
+    assert str(job) == expected
+
+
+def test_job_str_label_plugin():
+    def handler():
+        pass
+
+    job = jobs.Job(
+        [5],
+        label='testhandler',
+        plugin='testplugin',
+        handler=handler,
+    )
+    expected = '<Job testplugin.testhandler [5s]>'
+
+    assert str(job) == expected
+
+
+def test_job_str_label_plugin_intervals():
+    def handler():
+        pass
+
+    job = jobs.Job(
+        [5, 3600, 60],
+        label='testhandler',
+        plugin='testplugin',
+        handler=handler,
+    )
+    expected = '<Job testplugin.testhandler [5s, 60s, 3600s]>'
+
+    assert str(job) == expected
+
+
+def test_job_next():
+    timestamp = 523549800
+    job = jobs.Job([5])
+    job.next_times[5] = timestamp
+
+    job.next(timestamp)
+    assert job.next_times == {
+        5: timestamp,
+    }
+
+    # assert idempotency
+    job.next(timestamp)
+    assert job.next_times == {
+        5: timestamp,
+    }
+
+    # now the "current time" is in the future compared to the last time
+    # so the next time should be last time + interval
+    job.next(timestamp + 1)
+    assert job.next_times == {
+        5: timestamp + 5,
+    }
+
+    # let's reset this
+    job.next_times[5] = timestamp
+
+    # now the "current time" is bigger than last time + interval
+    # so the next time will be the "current time"
+    job.next(timestamp + 6)
+    assert job.next_times == {
+        5: timestamp + 6,
+    }
+
+
+def test_job_next_many():
+    timestamp = 523549800
+    job = jobs.Job([5, 30])
+    job.next_times[5] = timestamp + 5
+    job.next_times[30] = timestamp + 30
+
+    # let's move 6s in the future, so past the 5s and before the 30s
+    job.next(timestamp + 6)
+
+    # the 5s interval => from timestamp + to timestamp + 2 * 5
+    # the 30s interval => untouched, still in the future
+    assert job.next_times == {
+        5: timestamp + 10,
+        30: timestamp + 30,
+    }
+
+    # assert idempotency
+    job.next(timestamp + 6)
+    assert job.next_times == {
+        5: timestamp + 10,
+        30: timestamp + 30,
+    }
+
+    # let's reset
+    job.next_times[5] = timestamp + 5
+    job.next_times[30] = timestamp + 30
+
+    # now, the next time is bigger than last + 5s,
+    # but still lower than last + 30s
+    job.next(timestamp + 15)
+    assert job.next_times == {
+        5: timestamp + 15,
+        30: timestamp + 30,
+    }
+
+    # let's reset again
+    job.next_times[5] = timestamp + 5
+    job.next_times[30] = timestamp + 30
+
+    # and now, this time is bigger than both 5s and 30s
+    job.next(timestamp + 35)
+    assert job.next_times == {
+        5: timestamp + 35,  # catching up
+        30: timestamp + 60,  # next iteration as intended
+    }
+
+
+def test_job_from_callable(mockconfig):
+    @module.interval(5)
+    @module.label('testjob')
+    def handler(manager):
+        """The job's docstring."""
+        return 'tested'
+
+    loader.clean_callable(handler, mockconfig)
+    handler.plugin_name = 'testplugin'
+
+    job = jobs.Job.from_callable(mockconfig, handler)
+
+    assert len(job.next_times.items()) == 1
+    assert 5 in job.next_times
+    assert job.is_threaded()
+    assert job.intervals == set([5])
+    assert job.execute(None) == 'tested'
+    assert job.get_job_label() == 'testjob'
+    assert job.get_plugin_name() == 'testplugin'
+    assert job.get_doc() == "The job's docstring."
+    assert str(job) == '<Job testplugin.testjob [5s]>'
+
+
+def test_job_with():
+    job = jobs.Job([5])
+    # play with time: move 1s back in the future
+    last_time = job.next_times[5] = time.time() - 1
+
+    assert last_time is not None
+
+    with job:
+        assert job.is_running.is_set()
+        assert job.next_times[5] == last_time
+
+    # now the job is not running anymore, and its next time is last_time + 5s
+    assert not job.is_running.is_set()
+    assert job.next_times[5] == last_time + 5
+
+
+def test_job_with_exception():
+    job = jobs.Job([5])
+    # play with time: move 1s back in the future
+    last_time = job.next_times[5] = time.time() - 1
+
+    assert last_time is not None
+
+    with pytest.raises(WithJobMockException):
+        # the "with job" must not prevent the exception from being raised up
+        with job:
+            assert job.is_running.is_set()
+            assert job.next_times[5] == last_time
+            # fake an exception while the job is running
+            raise WithJobMockException
+
+    # now the job is not running anymore, and its next time is last_time + 5s
+    # even though an exception was raised!
+    assert not job.is_running.is_set()
+    assert job.next_times[5] == last_time + 5


### PR DESCRIPTION
Closes #1144 

### Description

Initially, it was only about preventing parallel execution of jobs, but then I realized I needed way more than that:

* changed the job object to be registered only once for any set of intervals,
* changed the job object to have similar meta-data than plugin's rules
* added a new scheduler, that can be used in a plugin-specific context (similar to the plugin's rules manager)

Also, I realized that the "catch up" mechanism makes no sense: either the job can be run in time, or it can't, but it won't try to run it more than once because it's late. I can see why it was like that before, but there are several problems with how it was implemented:

* the scheduler is not reliable: it ticks at best every second, at worst every now and then
* a job isn't aware of the catch up mechanism: is it late? is it on time? it can't know, so it can't adapt itself

In that regard, it's best not to over-engineer the solution, and to just take the most optimistic and safe approach: execute only once at a time, then see if it should execute again or a bit later, given the configured intervals.

And here we are, with a lot of changes for something that seem easy at first. The good news is that it was necessary anyway to work on a better documentation spec for Sopel: in the future, we'll be able to list not only rules and commands, but also jobs! But that will be for a future PR.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
