### PR TITLE
reddit: use new `find` rule type to get all slash-refs in line

### DIFF
--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -20,7 +20,7 @@ import prawcore
 import requests
 
 from sopel.formatting import bold, color, colors
-from sopel.module import commands, example, NOLIMIT, OP, require_chanmsg, rule, url
+from sopel.module import commands, example, find, NOLIMIT, OP, require_chanmsg, url
 from sopel.tools import time
 from sopel.tools.web import USER_AGENT
 
@@ -431,7 +431,7 @@ def get_channel_spoiler_free(bot, trigger):
         bot.say('%s is flagged as spoilers-allowed' % channel)
 
 
-@rule(r'.*(?<!\S)/?(?P<prefix>r|u)/(?P<id>[a-zA-Z0-9-_]+)\b.*')
+@find(r'(?<!\S)/?(?P<prefix>r|u)/(?P<id>[a-zA-Z0-9-_]+)\b')
 def reddit_slash_info(bot, trigger):
     searchtype = trigger.group('prefix').lower()
     match = trigger.group('id')


### PR DESCRIPTION
### Description
We're no longer restricted to matching only one `u/` or `r/` reference per line thanks to #1881.

Closes no issue, because I knew I'd remember without one. 😝

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
