### PR TITLE
bot: signal handler now checks if the bot is connected

### DIFF
--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -60,14 +60,6 @@ def run(settings, pid_file, daemon=False):
         tools.stderr(
             'Could not open CA certificates file. SSL will not work properly!')
 
-    def signal_handler(sig, frame):
-        if sig == signal.SIGUSR1 or sig == signal.SIGTERM or sig == signal.SIGINT:
-            LOGGER.warning('Got quit signal, shutting down.')
-            p.quit('Closing')
-        elif sig == signal.SIGUSR2 or sig == signal.SIGILL:
-            LOGGER.warning('Got restart signal, shutting down and restarting.')
-            p.restart('Restarting')
-
     # Define empty variable `p` for bot
     p = None
     while True:
@@ -75,18 +67,10 @@ def run(settings, pid_file, daemon=False):
             break
         try:
             p = bot.Sopel(settings, daemon=daemon)
-            if hasattr(signal, 'SIGUSR1'):
-                signal.signal(signal.SIGUSR1, signal_handler)
-            if hasattr(signal, 'SIGTERM'):
-                signal.signal(signal.SIGTERM, signal_handler)
-            if hasattr(signal, 'SIGINT'):
-                signal.signal(signal.SIGINT, signal_handler)
-            if hasattr(signal, 'SIGUSR2'):
-                signal.signal(signal.SIGUSR2, signal_handler)
-            if hasattr(signal, 'SIGILL'):
-                signal.signal(signal.SIGILL, signal_handler)
             p.setup()
+            p.set_signal_handlers()
         except KeyboardInterrupt:
+            tools.stderr('Bot setup interrupted')
             break
         except Exception:
             # In that case, there is nothing we can do.

--- a/sopel/irc/backends.py
+++ b/sopel/irc/backends.py
@@ -101,7 +101,7 @@ class AsynchatBackend(AbstractIRCBackend, asynchat.async_chat):
 
         :param bytes data: raw line to send
 
-        This uses :meth:`asynchat.async_chat.send` method to send ``data``
+        This uses :meth:`asyncore.dispatcher.send` method to send ``data``
         directly. This method is thread-safe.
         """
         with self.writing_lock:


### PR DESCRIPTION
Closes #1705 

### Description

(based on #1890)

I moved the signal handler to `sopel.bot.Sopel`, and made sure that it sends QUIT message only if the bot is connected. When the bot is not connected, it raises `KeyboardInterrupt` instead, which is properly handled (hopefully).

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
