### PR TITLE
rules, emoticons: action commands & commands working together at last

### DIFF
--- a/sopel/module.py
+++ b/sopel/module.py
@@ -538,7 +538,6 @@ def action_commands(*command_list):
 
     """
     def add_attribute(function):
-        function.intents = ['ACTION']
         if not hasattr(function, 'action_commands'):
             function.action_commands = []
         for cmd in command_list:

--- a/sopel/modules/emoticons.py
+++ b/sopel/modules/emoticons.py
@@ -8,104 +8,108 @@ https://sopel.chat
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from sopel.module import commands, example
+from sopel import module
 
 
-@commands('shrug')
-@example('.shrug', r'¯\_(ツ)_/¯')
+@module.commands('shrug')
+@module.action_commands('shrugs')
+@module.example('.shrug', r'¯\_(ツ)_/¯')
 def shrug(bot, trigger):
     bot.say('¯\\_(ツ)_/¯')
 
 
-@commands('happy')
-@example('.happy', 'ᕕ( ᐛ )ᕗ')
+@module.commands('happy')
+@module.example('.happy', 'ᕕ( ᐛ )ᕗ')
 def happy(bot, trigger):
     bot.say('ᕕ( ᐛ )ᕗ')
 
 
-@commands('tableflip', 'tflip')
-@example('.tableflip', '(╯°□°）╯︵ ┻━┻')
-@example('.tflip', '(╯°□°）╯︵ ┻━┻')
+@module.commands('tableflip', 'tflip')
+@module.action_commands('flips table', 'flips a table', 'flips the table')
+@module.example('.tableflip', '(╯°□°）╯︵ ┻━┻')
+@module.example('.tflip', '(╯°□°）╯︵ ┻━┻')
 def tableflip(bot, trigger):
     bot.say('(╯°□°）╯︵ ┻━┻')
 
 
-@commands('unflip')
-@example('.unflip', '┬┬ ﻿ノ( ゜-゜ノ)')
+@module.commands('unflip')
+@module.action_commands('unflips table', 'unflips the table')
+@module.example('.unflip', '┬┬ ﻿ノ( ゜-゜ノ)')
 def unflip(bot, trigger):
     bot.say('┬┬ ﻿ノ( ゜-゜ノ)')
 
 
-@commands('lenny')
-@example('.lenny', '( ͡° ͜ʖ ͡°)')
+@module.commands('lenny')
+@module.example('.lenny', '( ͡° ͜ʖ ͡°)')
 def lenny(bot, trigger):
     bot.say('( ͡° ͜ʖ ͡°)')
 
 
-@commands('rage', 'anger')
-@example('.rage', 'щ(ಠ益ಠщ)')
-@example('.anger', 'щ(ಠ益ಠщ)')
+@module.commands('rage', 'anger')
+@module.example('.rage', 'щ(ಠ益ಠщ)')
+@module.example('.anger', 'щ(ಠ益ಠщ)')
 def anger(bot, trigger):
     bot.say('щ(ಠ益ಠщ)')
 
 
-@commands('cry')
-@example('.cry', '( p′︵‵。)')
+@module.commands('cry')
+@module.action_commands('cries')
+@module.example('.cry', '( p′︵‵。)')
 def cry(bot, trigger):
     bot.say('( p′︵‵。)')
 
 
-@commands('love')
-@example('.love', '(●♡∀♡)')
+@module.commands('love')
+@module.example('.love', '(●♡∀♡)')
 def love(bot, trigger):
     bot.say('(●♡∀♡)')
 
 
-@commands('success', 'winner')
-@example('.success', '٩( ᐛ )و')
-@example('.winner', '٩( ᐛ )و')
+@module.commands('success', 'winner')
+@module.example('.success', '٩( ᐛ )و')
+@module.example('.winner', '٩( ᐛ )و')
 def success(bot, trigger):
     bot.say('٩( ᐛ )و')
 
 
-@commands('confused', 'wat')
-@example('.confused', '(●__●)???')
-@example('.wat', '(●__●)???')
+@module.commands('confused', 'wat')
+@module.example('.confused', '(●__●)???')
+@module.example('.wat', '(●__●)???')
 def wat(bot, trigger):
     bot.say('(●__●)???')
 
 
-@commands('crazy')
-@example('.crazy', '⊙_ʘ')
+@module.commands('crazy')
+@module.example('.crazy', '⊙_ʘ')
 def crazy(bot, trigger):
     bot.say('⊙_ʘ')
 
 
-@commands('hungry')
-@example('.hungry', 'ლ(´ڡ`ლ)')
+@module.commands('hungry')
+@module.example('.hungry', 'ლ(´ڡ`ლ)')
 def hungry(bot, trigger):
     bot.say('ლ(´ڡ`ლ)')
 
 
-@commands('surprised')
-@example('.surprised', '(((( ;°Д°))))')
+@module.commands('surprised')
+@module.example('.surprised', '(((( ;°Д°))))')
 def surprised(bot, trigger):
     bot.say('(((( ;°Д°))))')
 
 
-@commands('sick')
-@example('.sick', '(-﹏-。)')
+@module.commands('sick')
+@module.example('.sick', '(-﹏-。)')
 def sick(bot, trigger):
     bot.say('(-﹏-。)')
 
 
-@commands('afraid')
-@example('.afraid', '(　〇□〇）')
+@module.commands('afraid')
+@module.example('.afraid', '(　〇□〇）')
 def afraid(bot, trigger):
     bot.say('(　〇□〇）')
 
 
-@commands('worried')
-@example('.worried', '(　ﾟдﾟ)')
+@module.commands('worried')
+@module.example('.worried', '(　ﾟдﾟ)')
 def worried(bot, trigger):
     bot.say('(　ﾟдﾟ)')

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -236,6 +236,7 @@ def test_commands():
     def mock(bot, trigger, match):
         return True
     assert mock.commands == ['sopel']
+    assert not hasattr(mock, 'rule')
 
 
 def test_commands_args():
@@ -243,6 +244,7 @@ def test_commands_args():
     def mock(bot, trigger, match):
         return True
     assert mock.commands == ['sopel', 'bot']
+    assert not hasattr(mock, 'rule')
 
 
 def test_commands_multiple():
@@ -252,6 +254,7 @@ def test_commands_multiple():
     def mock(bot, trigger, match):
         return True
     assert mock.commands == ['robot', 'bot', 'sopel']
+    assert not hasattr(mock, 'rule')
 
 
 def test_nickname_commands():
@@ -259,6 +262,7 @@ def test_nickname_commands():
     def mock(bot, trigger, match):
         return True
     assert mock.nickname_commands == ['sopel']
+    assert not hasattr(mock, 'rule')
 
 
 def test_nickname_commands_args():
@@ -266,6 +270,7 @@ def test_nickname_commands_args():
     def mock(bot, trigger, match):
         return True
     assert mock.nickname_commands == ['sopel', 'bot']
+    assert not hasattr(mock, 'rule')
 
 
 def test_nickname_commands_multiple():
@@ -275,6 +280,7 @@ def test_nickname_commands_multiple():
     def mock(bot, trigger, match):
         return True
     assert mock.nickname_commands == ['robot', 'bot', 'sopel']
+    assert not hasattr(mock, 'rule')
 
 
 def test_action_commands():
@@ -282,7 +288,8 @@ def test_action_commands():
     def mock(bot, trigger, match):
         return True
     assert mock.action_commands == ['sopel']
-    assert mock.intents == ['ACTION']
+    assert not hasattr(mock, 'intents')
+    assert not hasattr(mock, 'rule')
 
 
 def test_action_commands_args():
@@ -290,7 +297,8 @@ def test_action_commands_args():
     def mock(bot, trigger, match):
         return True
     assert mock.action_commands == ['sopel', 'bot']
-    assert mock.intents == ['ACTION']
+    assert not hasattr(mock, 'intents')
+    assert not hasattr(mock, 'rule')
 
 
 def test_action_commands_multiple():
@@ -300,7 +308,22 @@ def test_action_commands_multiple():
     def mock(bot, trigger, match):
         return True
     assert mock.action_commands == ['robot', 'bot', 'sopel']
-    assert mock.intents == ['ACTION']
+    assert not hasattr(mock, 'intents')
+    assert not hasattr(mock, 'rule')
+
+
+def test_all_commands():
+    @module.commands('sopel')
+    @module.action_commands('me_sopel')
+    @module.nickname_commands('name_sopel')
+    def mock(bot, trigger, match):
+        return True
+
+    assert mock.commands == ['sopel']
+    assert mock.action_commands == ['me_sopel']
+    assert mock.nickname_commands == ['name_sopel']
+    assert not hasattr(mock, 'intents')
+    assert not hasattr(mock, 'rule')
 
 
 def test_label():


### PR DESCRIPTION
### Description

All I wanted was to do `/me flips table` and have the bot to reply to me with the best emote ever.

However, I forgot just one little detail in my last PR about rules & commands, which is to not set the `intents` attribute in `action_commands`. Everything else was done and ready to work as intended, it was just this dumb line I forgot.

Oh well, what one can do about it?

```
/me flips table
(╯°□°）╯︵ ┻━┻
```

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
