### PR TITLE
url: add auto-title config option & debug logging

### DIFF
--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -51,6 +51,9 @@ MAX_BYTES = 655360 * 2
 
 
 class UrlSection(StaticSection):
+    enable_auto_title = ValidatedAttribute(
+        'enable_auto_title', bool, default=True)
+    """Enable auto-title (enabled by default)"""
     # TODO some validation rules maybe?
     exclude = ListAttribute('exclude')
     """A list of regular expressions to match URLs for which the title should not be shown."""
@@ -71,6 +74,7 @@ def configure(config):
     """
     | name | example | purpose |
     | ---- | ------- | ------- |
+    | enable_auto_title | yes | Enable auto-title. |
     | exclude | https?://git\\\\.io/.* | A list of regular expressions for URLs for which the title should not be shown. |
     | exclusion\\_char | ! | A character (or string) which, when immediately preceding a URL, will stop the URL's title from being shown. |
     | shorten\\_url\\_length | 72 | If greater than 0, the title fetcher will include a TinyURL version of links longer than this many characters. |
@@ -78,6 +82,10 @@ def configure(config):
     | enable\\_dns\\_resolution | False | Enable DNS resolution for all domains to validate if there are RFC1918 resolutions. |
     """
     config.define_section('url', UrlSection)
+    config.url.configure_setting(
+        'enable_auto_title',
+        'Enable auto-title?'
+    )
     config.url.configure_setting(
         'exclude',
         'Enter regular expressions for each URL you would like to exclude.'
@@ -181,6 +189,11 @@ def title_auto(bot, trigger):
     where the URL redirects to and show the title for that (or call a function
     from another module to give more information).
     """
+    # Enabled or disabled by feature flag
+    if not bot.settings.url.enable_auto_title:
+        return
+
+    # Avoid fetching links from the "title" command
     if re.match(bot.config.core.prefix + 'title', trigger):
         return
 


### PR DESCRIPTION
### Description

Now with `url.enable_auto_title` it is possible to deactivate the auto-title feature from the `url` plugin. It is activated by default, so no breaking change.

I used this occasion to add some debug & error logs, because bot owner are not the only ones to get quality of life improvement.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
