### PR TITLE
emoticons: add smirk command + action command

### DIFF
--- a/sopel/modules/emoticons.py
+++ b/sopel/modules/emoticons.py
@@ -24,6 +24,13 @@ def happy(bot, trigger):
     bot.say('ᕕ( ᐛ )ᕗ')
 
 
+@module.commands('smirk')
+@module.action_commands('smirks')
+@module.example('.smirk', '(¬‿¬)')
+def smirk(bot, trigger):
+    bot.say('(¬‿¬)')
+
+
 @module.commands('tableflip', 'tflip')
 @module.action_commands('flips table', 'flips a table', 'flips the table')
 @module.example('.tableflip', '(╯°□°）╯︵ ┻━┻')


### PR DESCRIPTION
### Description
Tin. Adds `(¬‿¬)` as a "smirk" emote.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
