### PR TITLE
cli: support `SOPEL_CONFIG_DIR` envvar to override `--config-dir` default

### DIFF
--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -291,9 +291,14 @@ def add_common_arguments(parser):
         """))
     parser.add_argument(
         '--config-dir',
-        default=config.DEFAULT_HOMEDIR,
+        default=os.environ.get('SOPEL_CONFIG_DIR') or config.DEFAULT_HOMEDIR,
         dest='configdir',
-        help='Look for configuration files in this directory.')
+        help=inspect.cleandoc("""
+            Look for configuration files in this directory.
+            By default, Sopel will search in ``~/.sopel``.
+            When the ``SOPEL_CONFIG_DIR`` environment variable is set and not
+            empty, it is used as the default value.
+        """))
 
 
 def load_settings(options):


### PR DESCRIPTION
### Description
Really, it's just the one thing described in the PR title.

In hindsight, adding `SOPEL_CONFIG` and `SOPEL_<SECTION>_<OPTION>` support without also adding this seems kinda silly.

Draft for now because the tests haven't been updated yet. Hopefully I'll have a chance to talk to @Exirel on IRC tomorrow (my time; he's +7 hours from me), but there's also a review request in case he has any quick suggestions that don't need to wait for a synchronous chat opportunity. 😉

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches