### PR TITLE
plugins.handlers: thEy'Re CaLleD pLuGInS tHoUGh

### DIFF
--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -96,7 +96,7 @@ class AbstractPluginHandler(object):
         :return: A human readable label for display purpose
         :rtype: str
 
-        This method should, at least, return ``module_name + S + "module"``.
+        This method should, at least, return ``module_name + S + "plugin"``.
         """
         raise NotImplementedError
 
@@ -234,7 +234,7 @@ class PyModulePlugin(AbstractPluginHandler):
         self._module = None
 
     def get_label(self):
-        default_label = '%s module' % self.name
+        default_label = '%s plugin' % self.name
         module_doc = getattr(self._module, '__doc__', None)
 
         if not self.is_loaded() or not module_doc:

--- a/test/plugins/test_plugins_handlers.py
+++ b/test/plugins/test_plugins_handlers.py
@@ -12,7 +12,7 @@ from sopel.plugins import handlers
 
 
 MOCK_MODULE_CONTENT = """# coding=utf-8
-\"\"\"module label
+\"\"\"plugin label
 \"\"\"
 """
 
@@ -36,7 +36,7 @@ def test_get_label_pymodule():
     assert 'source' in meta
 
     assert meta['name'] == 'coretasks'
-    assert meta['label'] == 'coretasks module', 'Expecting default label'
+    assert meta['label'] == 'coretasks plugin', 'Expecting default label'
     assert meta['type'] == handlers.PyModulePlugin.PLUGIN_TYPE
     assert meta['source'] == 'sopel.coretasks'
 
@@ -46,7 +46,7 @@ def test_get_label_pyfile(plugin_tmpfile):
     meta = plugin.get_meta_description()
 
     assert meta['name'] == 'file_mod'
-    assert meta['label'] == 'file_mod module', 'Expecting default label'
+    assert meta['label'] == 'file_mod plugin', 'Expecting default label'
     assert meta['type'] == handlers.PyFilePlugin.PLUGIN_TYPE
     assert meta['source'] == plugin_tmpfile.strpath
 
@@ -57,7 +57,7 @@ def test_get_label_pyfile_loaded(plugin_tmpfile):
     meta = plugin.get_meta_description()
 
     assert meta['name'] == 'file_mod'
-    assert meta['label'] == 'module label'
+    assert meta['label'] == 'plugin label'
     assert meta['type'] == handlers.PyFilePlugin.PLUGIN_TYPE
     assert meta['source'] == plugin_tmpfile.strpath
 
@@ -79,6 +79,6 @@ def test_get_label_entrypoint(plugin_tmpfile):
 
     meta = plugin.get_meta_description()
     assert meta['name'] == 'test_plugin'
-    assert meta['label'] == 'module label'
+    assert meta['label'] == 'plugin label'
     assert meta['type'] == handlers.EntryPointPlugin.PLUGIN_TYPE
     assert meta['source'] == 'test_plugin = file_mod'


### PR DESCRIPTION
### Description
This soothes my perfectionism.

Specifically requesting Exi's review because he wrote this module, and did so relatively recently, so he's the best person to tell me if I overlooked another thing that needs tweaking for this.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches