### PR TITLE
plugin: example raises AssertionError when regex does not match

### DIFF
--- a/sopel/test_tools.py
+++ b/sopel/test_tools.py
@@ -222,8 +222,13 @@ def get_example_test(tested_func, msg, results, privmsg, admin,
             # output content
             for expected, output in zip(results, outputs):
                 if use_regexp:
+                    message = (
+                        "Output does not match the regex:\n"
+                        "Pattern: %s\n"
+                        "Output: %s"
+                    ) % (expected, output)
                     if not re.match(expected, output):
-                        assert expected == output
+                        raise AssertionError(message)
                 else:
                     assert expected == output
 


### PR DESCRIPTION
### Description

The decorator `example` generates a test function when used with pytest and an expected output. When a regex is used for said test, a fake `assert expected == output` was used to mark the test as failed. It is not adapted because a) if the assert pass, it means the test should not use a regex in the first place and b) it creates a confusing test output. So now, it raises an `AssertionError` with a proper error message, which is well understood by any test runner - after all, `assert` is a way to raise the exact same error.

Note: I use `plugin: ...` in the commit message because it's related to the `sopel.plugin.example` decorator, so it makes more sense to me.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
