### PR TITLE
coretasks: replace module.label by plugin.label

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -24,7 +24,7 @@ import re
 import sys
 import time
 
-from sopel import loader, module
+from sopel import loader, module, plugin
 from sopel.irc import isupport
 from sopel.irc.utils import CapReq, MyInfo
 from sopel.tools import events, Identifier, iteritems, target, web
@@ -47,7 +47,7 @@ def setup(bot):
         wait_interval = max(bot.settings.core.throttle_wait, 1)
 
         @module.interval(wait_interval)
-        @module.label('throttle_join')
+        @plugin.label('throttle_join')
         def processing_job(bot):
             _join_event_processing(bot)
 


### PR DESCRIPTION
### Description

This is a hotfix, this code should have been modified by #1898 and not merged with this error. My bad.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
