### PR TITLE
build: fix/upgrade `geoip2` requirements where possible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,11 @@ xmltodict<0.12.0; python_version == '3.3'
 xmltodict==0.12; python_version != '3.3'
 pytz
 praw>=4.0.0,<6.0.0
-geoip2<3.0.0
+geoip2<3.0; python_version <= '3.5' and python_version != '2.7'
+geoip2>=3.0,<4.0; python_version == '2.7'
+geoip2>=4.0,<5.0; python_version >= '3.6'
+# transitive dependency of geoip2; v2 dropped py2.7 & py3 < 3.6
+maxminddb<2.0; python_version < '3.6'
 ipaddress<2.0; python_version < '3.3'
 requests>=2.0.0,<3.0.0
 urllib3<1.23; python_version == '3.3'

--- a/sopel/modules/ip.py
+++ b/sopel/modules/ip.py
@@ -115,7 +115,7 @@ def _find_geoip_db(bot):
 
 @commands('iplookup', 'ip')
 @example('.ip 8.8.8.8',
-         r'\[IP\/Host Lookup\] Hostname: \S*dns\S*\.google\S* \| Location: United States \| ISP: AS15169 \S+',
+         r'\[IP\/Host Lookup\] Hostname: \S*dns\S*\.google\S*( \| .+?: .+?)+ \| ISP: AS15169 \S+',
          re=True,
          ignore='Downloading GeoIP database, please wait...',
          online=True)

--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -99,7 +99,7 @@ def duck_api(query):
 # the last example (in source line order) is what .help displays
 @example(
     '.duck sopel.chat irc bot',
-    r'https?:\/\/(sopel\.chat\/?|github\.com\/sopel-irc\/sopel)',
+    r'https?:\/\/.*sopel.*',
     re=True,
     online=True)
 def duck(bot, trigger):


### PR DESCRIPTION
Split `geoip2` requirement into ranges based on Python release.

Capped `maxminddb` version on old Pythons now that v2.0 dropped them.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
I'm planning to cut a 7.0.5 release with this unless any @sopel-irc/rockstars strenuously object. We're still too far off from finishing 7.1 to wait for that release. This is going to cause issues with new installs of 7.0.4.