### PR TITLE
instagram: fix for being blocked

### DIFF
--- a/sopel/modules/instagram.py
+++ b/sopel/modules/instagram.py
@@ -39,11 +39,24 @@ def instaparse(bot, trigger, match):
     try:
         bot.say(parse_insta_json(json))
     except ParseError:
-        LOGGER.exception(
-            "Unable to find Instagram's payload for URL %s", instagram_url)
-        bot.say(
-            "Unable to parse this Instagram URL. "
-            "It's probably a temporary error; try again in a bit.")
+        try:
+            json = get_oembed_json(instagram_url)
+            bot.say(parse_oembed_json(json))
+        except ParseError:
+            LOGGER.exception(
+                "Unable to find Instagram's payload for URL %s", instagram_url)
+            bot.say(
+                "Unable to parse this Instagram URL. "
+                "It's probably a temporary error; try again in a bit.")
+        else:
+            LOGGER.info(
+                "Used fallback to oEmbed metadata; "
+                "Sopel's IP may be blocked by Instagram.")
+
+
+def get_oembed_json(url):
+    response = get("https://api.instagram.com/oembed/?url={}".format(url))
+    return response.json()
 
 
 def get_insta_json(url):
@@ -139,3 +152,12 @@ def parse_insta_json(json):
 
     # Build the message
     return ' | '.join(parts)
+
+
+def parse_oembed_json(json):
+    if not json:
+        raise ParseError("No valid JSON returned")
+    return "[insta] Post by {} | {}".format(
+        json['author_name'],
+        json['title']
+    )


### PR DESCRIPTION
### Description
This fixes Sopel parsing instagram links when blocked using the traditional method.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
