### PR TITLE
admin: reply on save

### DIFF
--- a/sopel/modules/admin.py
+++ b/sopel/modules/admin.py
@@ -407,3 +407,4 @@ def unset_config(bot, trigger):
 def save_config(bot, trigger):
     """Save state of Sopel's config object to the configuration file."""
     bot.config.save()
+    bot.reply('Configuration file saved.')


### PR DESCRIPTION
### Description
This replies to the owner/admin with a message when `.save`ing the configuration file. Pretty simple.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
