### PR TITLE
reddit: handle new gallery view by showing submission info

### DIFF
--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -46,6 +46,7 @@ user_url = r'%s/u(?:ser)?/([\w-]+)' % domain
 comment_url = r'%s/r/\S+?/comments/\S+?/\S+?/([\w-]+)' % domain
 image_url = r'https?://i\.redd\.it/\S+'
 video_url = r'https?://v\.redd\.it/([\w-]+)'
+gallery_url = r'https?://(?:www\.)?reddit\.com/gallery/([\w-]+)'
 
 
 def setup(bot):
@@ -127,6 +128,12 @@ def video_info(bot, trigger, match):
 def rpost_info(bot, trigger, match):
     match = match or trigger
     return say_post_info(bot, trigger, match.group(1))
+
+
+@url(gallery_url)
+def rgallery_info(bot, trigger, match):
+    match = match or trigger
+    return say_post_info(bot, trigger, match.group(1), False)
 
 
 def say_post_info(bot, trigger, id_, show_link=True, show_comments_link=False):


### PR DESCRIPTION
### Description
Might or might not be useful to try and fetch all the image URLs from the gallery instead, but initially let's just show the title & subreddit. A quick look at the raw data Reddit provides in the API payload for a gallery submission yielded pretty useless URLs (`preview.redd.it`, with resizing & format conversion embedded).

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
