### PR TITLE
ip: fix case sensitivity of querying by nickname

### DIFF
--- a/sopel/modules/ip.py
+++ b/sopel/modules/ip.py
@@ -131,7 +131,7 @@ def ip(bot, trigger):
         query = trigger.group(2).strip()
     else:
         # Need to get the host for the username
-        username = trigger.group(2).strip()
+        username = trigger.group(2).strip().lower()
         user_in_botdb = bot.users.get(username)
         if user_in_botdb is not None:
             query = user_in_botdb.host


### PR DESCRIPTION
### Description
Fixes problem with .ip not working when uppercase letters in queried nick. 
The DB stores users in lowercase, so it does not get a match otherwise.

Ex. when quering user "GLaDER"(hiding successful query output because privacy) 

Found in 7.0.4, running in docker.
Currently not linked to any issue.  

<erikpi> | .ip GLaDER
<sopel> | I'm not aware of this user.
<erikpi> | .ip glader
<sopel> | [IP/Host Lookup] Hostname: XXXX \| Location: XXX\| Region: XXXX \| City: XXXX \| ISP: XXXXX


### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
