### PR TITLE
trigger: add a plain attribute to PreTrigger and Trigger

### DIFF
--- a/sopel/formatting.py
+++ b/sopel/formatting.py
@@ -95,10 +95,10 @@ CONTROL_NON_PRINTING = [
     # '\x1d', CONTROL_ITALIC
     # '\x1e', CONTROL_STRIKETHROUGH
     # '\x1f', CONTROL_UNDERLINE
+    '\x7f',
 ]
 
 # Regex to detect Control Pattern
-
 COLOR_PATTERN = re.escape(CONTROL_COLOR) + r'((\d{1,2},\d{2})|\d{2})?'
 HEX_COLOR_PATTERN = '%s(%s)?' % (
     re.escape(CONTROL_HEX_COLOR),

--- a/sopel/formatting.py
+++ b/sopel/formatting.py
@@ -65,9 +65,9 @@ CONTROL_REVERSE = '\x16'
 CONTROL_NON_PRINTING = [
     '\x00',
     '\x01',
-    # '\x02', CONTROL_BOLD
-    # '\x03', CONTROL_COLOR
-    # '\x04', CONTROL_HEX_COLOR
+    '\x02',  # CONTROL_BOLD
+    '\x03',  # CONTROL_COLOR
+    '\x04',  # CONTROL_HEX_COLOR
     '\x05',
     '\x06',
     '\x07',
@@ -78,23 +78,23 @@ CONTROL_NON_PRINTING = [
     '\x0c',
     '\x0d',
     '\x0e',
-    # '\x0f', CONTROL_NORMAL
+    '\x0f',  # CONTROL_NORMAL
     '\x10',
-    # '\x11', CONTROL_MONOSPACE
+    '\x11',  # CONTROL_MONOSPACE
     '\x12',
     '\x13',
     '\x14',
     '\x15',
-    # '\x16', CONTROL_REVERSE
+    '\x16',  # CONTROL_REVERSE
     '\x17',
     '\x18',
     '\x19',
     '\x1a',
     '\x1b',
     '\x1c',
-    # '\x1d', CONTROL_ITALIC
-    # '\x1e', CONTROL_STRIKETHROUGH
-    # '\x1f', CONTROL_UNDERLINE
+    '\x1d',  # CONTROL_ITALIC
+    '\x1e',  # CONTROL_STRIKETHROUGH
+    '\x1f',  # CONTROL_UNDERLINE
     '\x7f',
 ]
 
@@ -109,18 +109,9 @@ HEX_COLOR_PATTERN = '%s(%s)?' % (
 )
 
 PLAIN_PATTERN = '|'.join([
-    # strip color code
     '(' + COLOR_PATTERN + ')',
     '(' + HEX_COLOR_PATTERN + ')',
-    # strip other known codes
-    '(' + re.escape(CONTROL_BOLD) + ')',
-    '(' + re.escape(CONTROL_ITALIC) + ')',
-    '(' + re.escape(CONTROL_UNDERLINE) + ')',
-    '(' + re.escape(CONTROL_STRIKETHROUGH) + ')',
-    '(' + re.escape(CONTROL_MONOSPACE) + ')',
-    '(' + re.escape(CONTROL_REVERSE) + ')',
-    '(' + re.escape(CONTROL_NORMAL) + ')',
-] + [re.escape(code) for code in CONTROL_NON_PRINTING])
+])
 PLAIN_REGEX = re.compile(PLAIN_PATTERN)
 
 
@@ -318,4 +309,6 @@ def plain(text):
     :param str text: text with potential IRC formatting control code(s)
     :rtype: str
     """
-    return PLAIN_REGEX.sub('', text)
+    if '\x03' in text or '\x04' in text:
+        text = PLAIN_REGEX.sub('', text)
+    return ''.join(c for c in text if ord(c) >= 0x20 and c != '\x7F')

--- a/sopel/formatting.py
+++ b/sopel/formatting.py
@@ -62,6 +62,41 @@ CONTROL_MONOSPACE = '\x11'
 CONTROL_REVERSE = '\x16'
 """The control code to start or end reverse-color formatting."""
 
+CONTROL_NON_PRINTING = [
+    '\x00',
+    '\x01',
+    # '\x02', CONTROL_BOLD
+    # '\x03', CONTROL_COLOR
+    # '\x04', CONTROL_HEX_COLOR
+    '\x05',
+    '\x06',
+    '\x07',
+    '\x08',
+    '\x09',
+    '\x0a',
+    '\x0b',
+    '\x0c',
+    '\x0d',
+    '\x0e',
+    # '\x0f', CONTROL_NORMAL
+    '\x10',
+    # '\x11', CONTROL_MONOSPACE
+    '\x12',
+    '\x13',
+    '\x14',
+    '\x15',
+    # '\x16', CONTROL_REVERSE
+    '\x17',
+    '\x18',
+    '\x19',
+    '\x1a',
+    '\x1b',
+    '\x1c',
+    # '\x1d', CONTROL_ITALIC
+    # '\x1e', CONTROL_STRIKETHROUGH
+    # '\x1f', CONTROL_UNDERLINE
+]
+
 # Regex to detect Control Pattern
 
 COLOR_PATTERN = re.escape(CONTROL_COLOR) + r'((\d{1,2},\d{2})|\d{2})?'
@@ -77,6 +112,7 @@ PLAIN_PATTERN = '|'.join([
     # strip color code
     '(' + COLOR_PATTERN + ')',
     '(' + HEX_COLOR_PATTERN + ')',
+    # strip other known codes
     '(' + re.escape(CONTROL_BOLD) + ')',
     '(' + re.escape(CONTROL_ITALIC) + ')',
     '(' + re.escape(CONTROL_UNDERLINE) + ')',
@@ -84,7 +120,7 @@ PLAIN_PATTERN = '|'.join([
     '(' + re.escape(CONTROL_MONOSPACE) + ')',
     '(' + re.escape(CONTROL_REVERSE) + ')',
     '(' + re.escape(CONTROL_NORMAL) + ')',
-])
+] + [re.escape(code) for code in CONTROL_NON_PRINTING])
 PLAIN_REGEX = re.compile(PLAIN_PATTERN)
 
 

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -6,7 +6,7 @@ import datetime
 import re
 import sys
 
-from sopel import tools
+from sopel import formatting, tools
 from sopel.tools import web
 
 
@@ -90,6 +90,10 @@ class PreTrigger(object):
         This is for ``PRIVMSG`` and ``NOTICE`` messages only. For other
         messages, this will be an empty ``tuple``.
 
+    .. py:attribute:: plain
+
+        The last argument of the IRC command with control codes stripped.
+
     .. py:attribute:: time
 
         The time when the message was received.
@@ -109,6 +113,7 @@ class PreTrigger(object):
         line = line.strip('\r\n')
         self.line = line
         self.urls = tuple()
+        self.plain = ''
 
         # Break off IRCv3 message tags, if present
         self.tags = {}
@@ -189,6 +194,10 @@ class PreTrigger(object):
         if self.event == 'JOIN' and len(self.args) == 3:
             # Account is the second arg `...JOIN #Sopel account :realname`
             self.tags['account'] = self.args[1]
+
+        # get plain text message
+        if self.args:
+            self.plain = formatting.plain(self.args[-1])
 
 
 class Trigger(unicode):
@@ -337,6 +346,13 @@ class Trigger(unicode):
 
     URLs are listed only for ``PRIVMSG`` or a ``NOTICE``, otherwise this is
     an empty tuple.
+    """
+    plain = property(lambda self: self._pretrigger.plain)
+    """The text without formatting control codes.
+
+    :type: str
+
+    This is the text of the trigger object without formatting control codes.
     """
     tags = property(lambda self: self._pretrigger.tags)
     """A map of the IRCv3 message tags on the message.

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -4,7 +4,19 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import pytest
 
-from sopel.formatting import bold, color, colors, hex_color, italic, monospace, reverse, strikethrough, underline
+from sopel.formatting import (
+    bold,
+    color,
+    colors,
+    CONTROL_NORMAL,
+    hex_color,
+    italic,
+    monospace,
+    plain,
+    reverse,
+    strikethrough,
+    underline,
+)
 
 
 def test_color():
@@ -54,3 +66,55 @@ def test_monospace():
 def test_reverse():
     text = 'Hello World'
     assert reverse(text) == '\x16' + text + '\x16'
+
+
+def test_plain_color():
+    text = 'some text'
+    assert plain(color(text, colors.PINK)) == text
+    assert plain(color(text, colors.PINK, colors.TEAL)) == text
+
+
+def test_plain_hex_color():
+    text = 'some text'
+    assert plain(hex_color(text, 'ff0098')) == text
+    assert plain(hex_color(text, 'ff0098', '00b571')) == text
+
+
+def test_plain_bold():
+    text = 'some text'
+    assert plain(bold(text)) == text
+
+
+def test_plain_italic():
+    text = 'some text'
+    assert plain(italic(text)) == text
+
+
+def test_plain_underline():
+    text = 'some text'
+    assert plain(underline(text)) == text
+
+
+def test_plain_strikethrough():
+    text = 'some text'
+    assert plain(strikethrough(text)) == text
+
+
+def test_plain_monospace():
+    text = 'some text'
+    assert plain(monospace(text)) == text
+
+
+def test_plain_reverse():
+    text = 'some text'
+    assert plain(reverse(text)) == text
+
+
+def test_plain_reset():
+    text = 'some%s text' % CONTROL_NORMAL
+    assert plain(text) == 'some text'
+
+
+def test_plain_unknown():
+    text = 'some \x99text'
+    assert plain(text) == text, 'An unknown control code must not be stripped'

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -8,6 +8,7 @@ from sopel.formatting import (
     bold,
     color,
     colors,
+    CONTROL_NON_PRINTING,
     CONTROL_NORMAL,
     hex_color,
     italic,
@@ -112,6 +113,12 @@ def test_plain_reverse():
 
 def test_plain_reset():
     text = 'some%s text' % CONTROL_NORMAL
+    assert plain(text) == 'some text'
+
+
+@pytest.mark.parametrize('code', CONTROL_NON_PRINTING)
+def test_plain_non_printing(code):
+    text = 'some%s text' % code
     assert plain(text) == 'some text'
 
 

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -74,11 +74,21 @@ def test_plain_color():
     assert plain(color(text, colors.PINK)) == text
     assert plain(color(text, colors.PINK, colors.TEAL)) == text
 
+    tpl = 'b %s a'
+    expected = tpl % text
+    assert plain(tpl % color(text, colors.PINK)) == expected
+    assert plain(tpl % color(text, colors.PINK, colors.TEAL)) == expected
+
 
 def test_plain_hex_color():
     text = 'some text'
     assert plain(hex_color(text, 'ff0098')) == text
     assert plain(hex_color(text, 'ff0098', '00b571')) == text
+
+    tpl = 'b %s a'
+    expected = tpl % text
+    assert plain(tpl % hex_color(text, 'ff0098')) == expected
+    assert plain(tpl % hex_color(text, 'ff0098', '00b571')) == expected
 
 
 def test_plain_bold():
@@ -125,3 +135,8 @@ def test_plain_non_printing(code):
 def test_plain_unknown():
     text = 'some \x99text'
     assert plain(text) == text, 'An unknown control code must not be stripped'
+
+
+def test_plain_emoji():
+    text = 'some emoji 💪 in here'
+    assert plain(text) == text

--- a/test/test_trigger.py
+++ b/test/test_trigger.py
@@ -41,6 +41,7 @@ def test_basic_pretrigger(nick):
     assert pretrigger.line == line
     assert pretrigger.args == ['#Sopel', 'Hello, world']
     assert pretrigger.text == 'Hello, world'
+    assert pretrigger.plain == 'Hello, world'
     assert pretrigger.event == 'PRIVMSG'
     assert pretrigger.nick == Identifier('Foo')
     assert pretrigger.user == 'foo'
@@ -56,6 +57,7 @@ def test_pm_pretrigger(nick):
     assert pretrigger.line == line
     assert pretrigger.args == ['Sopel', 'Hello, world']
     assert pretrigger.text == 'Hello, world'
+    assert pretrigger.plain == 'Hello, world'
     assert pretrigger.event == 'PRIVMSG'
     assert pretrigger.nick == Identifier('Foo')
     assert pretrigger.user == 'foo'
@@ -71,6 +73,7 @@ def test_quit_pretrigger(nick):
     assert pretrigger.line == line
     assert pretrigger.args == ['quit message text']
     assert pretrigger.text == 'quit message text'
+    assert pretrigger.plain == 'quit message text'
     assert pretrigger.event == 'QUIT'
     assert pretrigger.nick == Identifier('Foo')
     assert pretrigger.user == 'foo'
@@ -86,6 +89,7 @@ def test_join_pretrigger(nick):
     assert pretrigger.line == line
     assert pretrigger.args == ['#Sopel']
     assert pretrigger.text == '#Sopel'
+    assert pretrigger.plain == '#Sopel'
     assert pretrigger.event == 'JOIN'
     assert pretrigger.nick == Identifier('Foo')
     assert pretrigger.user == 'foo'
@@ -103,6 +107,7 @@ def test_tags_pretrigger(nick):
     assert pretrigger.line == line
     assert pretrigger.args == ['#Sopel', 'Hello, world']
     assert pretrigger.text == 'Hello, world'
+    assert pretrigger.plain == 'Hello, world'
     assert pretrigger.event == 'PRIVMSG'
     assert pretrigger.nick == Identifier('Foo')
     assert pretrigger.user == 'foo'
@@ -118,6 +123,7 @@ def test_intents_pretrigger(nick):
     assert pretrigger.line == line
     assert pretrigger.args == ['#Sopel', 'Hello, world']
     assert pretrigger.text == 'Hello, world'
+    assert pretrigger.plain == 'Hello, world'
     assert pretrigger.event == 'PRIVMSG'
     assert pretrigger.nick == Identifier('Foo')
     assert pretrigger.user == 'foo'
@@ -133,6 +139,7 @@ def test_unusual_pretrigger(nick):
     assert pretrigger.line == line
     assert pretrigger.args == []
     assert pretrigger.text == 'PING'
+    assert pretrigger.plain == ''
     assert pretrigger.event == 'PING'
 
 
@@ -144,6 +151,7 @@ def test_ctcp_intent_pretrigger(nick):
     assert pretrigger.line == line
     assert pretrigger.args == ['Sopel', '']
     assert pretrigger.text == '\x01VERSION\x01'
+    assert pretrigger.plain == ''
     assert pretrigger.event == 'PRIVMSG'
     assert pretrigger.nick == Identifier('Foo')
     assert pretrigger.user == 'foo'
@@ -159,11 +167,28 @@ def test_ctcp_data_pretrigger(nick):
     assert pretrigger.line == line
     assert pretrigger.args == ['Sopel', '1123321']
     assert pretrigger.text == '\x01PING 1123321\x01'
+    assert pretrigger.plain == '1123321'
     assert pretrigger.event == 'PRIVMSG'
     assert pretrigger.nick == Identifier('Foo')
     assert pretrigger.user == 'foo'
     assert pretrigger.host == 'example.com'
     assert pretrigger.sender == Identifier('Foo')
+
+
+def test_ctcp_action_pretrigger(nick):
+    line = ':Foo!foo@example.com PRIVMSG #Sopel :\x01ACTION Hello, world\x01'
+    pretrigger = PreTrigger(nick, line)
+    assert pretrigger.tags == {'intent': 'ACTION'}
+    assert pretrigger.hostmask == 'Foo!foo@example.com'
+    assert pretrigger.line == line
+    assert pretrigger.args == ['#Sopel', 'Hello, world']
+    assert pretrigger.text == '\x01ACTION Hello, world\x01'
+    assert pretrigger.plain == 'Hello, world'
+    assert pretrigger.event == 'PRIVMSG'
+    assert pretrigger.nick == Identifier('Foo')
+    assert pretrigger.user == 'foo'
+    assert pretrigger.host == 'example.com'
+    assert pretrigger.sender == '#Sopel'
 
 
 def test_ircv3_extended_join_pretrigger(nick):
@@ -174,6 +199,7 @@ def test_ircv3_extended_join_pretrigger(nick):
     assert pretrigger.line == line
     assert pretrigger.args == ['#Sopel', 'bar', 'Real Name']
     assert pretrigger.text == 'Real Name'
+    assert pretrigger.plain == 'Real Name'
     assert pretrigger.event == 'JOIN'
     assert pretrigger.nick == Identifier('Foo')
     assert pretrigger.user == 'foo'
@@ -202,6 +228,7 @@ def test_ircv3_extended_join_trigger(nick, configfactory):
     assert trigger.group == fakematch.group
     assert trigger.groups == fakematch.groups
     assert trigger.args == ['#Sopel', 'bar', 'Real Name']
+    assert trigger.plain == 'Real Name'
     assert trigger.account == 'bar'
     assert trigger.tags == {'account': 'bar'}
     assert trigger.owner is True
@@ -229,6 +256,7 @@ def test_ircv3_intents_trigger(nick, configfactory):
     assert trigger.groups == fakematch.groups
     assert trigger.groupdict == fakematch.groupdict
     assert trigger.args == ['#Sopel', 'Hello, world']
+    assert trigger.plain == 'Hello, world'
     assert trigger.tags == {'intent': 'ACTION'}
     assert trigger.account is None
     assert trigger.admin is True


### PR DESCRIPTION
### Description

- `sopel.formatting.plain` to strip known control codes from a text
- `sopel.trigger.PreTrigger.plain` is `args`'s last item without its control code
- `sopel.trigger.Trigger.plain` exposes `sopel.trigger.PreTrigger.plain`
- Closes #1768

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
