### PR TITLE
build: cap `update-checker` version on older Pythons without f-strings

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ xmltodict<0.12.0; python_version == '3.3'
 xmltodict==0.12; python_version != '3.3'
 pytz
 praw>=4.0.0,<6.0.0
+# transitive dependency of praw; v0.18 introduced f-string syntax
+update-checker<0.18; python_version < '3.6'
 geoip2<3.0; python_version <= '3.5' and python_version != '2.7'
 geoip2>=3.0,<4.0; python_version == '2.7'
 geoip2>=4.0,<5.0; python_version >= '3.6'


### PR DESCRIPTION
### Description
Fixes CI builds on Python <3.6 and may or may not help with new installs on the same (depending on pip version in use).

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

N.B.: I'm letting Travis test all the Python versions so I don't have to install them locally.