### PR TITLE
tools.compile_rule: better whitespace handling for `$nick` placeholder

### DIFF
--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -214,9 +214,11 @@ def compile_rule(nick, pattern, alias_nicks):
         nick = re.escape(nick)
 
     pattern = pattern.replace('$nickname', nick)
-    pattern = pattern.replace('$nick', r'{}[,:]\s+'.format(nick))
+    pattern = pattern.replace('$nick ', r'{}[,:]\s*'.format(nick))  # @rule('$nick hi')
+    pattern = pattern.replace('$nick', r'{}[,:]\s+'.format(nick))  # @rule('$nickhi')
     flags = re.IGNORECASE
     if '\n' in pattern:
+        # See https://docs.python.org/3/library/re.html#re.VERBOSE
         flags |= re.VERBOSE
     return re.compile(pattern, flags)
 


### PR DESCRIPTION
### Description
If the placeholder is followed by a space, replace it with a pattern that will consume extra whitespace but doesn't require any.

If the placeholder is NOT followed by a space, use the original pattern that requires at least one space to match.

Meant to resolve #1885.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
