### PR TITLE
docs: the plugin chapter

### DIFF
--- a/docs/source/bot.rst
+++ b/docs/source/bot.rst
@@ -1,9 +1,11 @@
+=====================
 The bot and its state
 =====================
 
 .. autoclass:: sopel.bot.Sopel
-    :members:
-    :inherited-members:
+   :members:
+   :inherited-members:
+   :show-inheritance:
 
 .. autoclass:: sopel.bot.SopelWrapper
-    :members:
+   :members:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -21,8 +21,9 @@ Documentation
 -------------
 
 .. toctree::
-    :titlesonly:
+    :maxdepth: 2
 
     run
+    plugin
     package
     tests

--- a/docs/source/package.rst
+++ b/docs/source/package.rst
@@ -5,7 +5,6 @@ Sopel Package API
 .. toctree::
     :titlesonly:
 
-    plugin
     bot
     trigger
     config

--- a/docs/source/plugin.rst
+++ b/docs/source/plugin.rst
@@ -1,6 +1,6 @@
-=====================
-Plugin for Developers
-=====================
+===========================
+Plugins: Developer Overview
+===========================
 
 .. toctree::
    :titlesonly:
@@ -16,31 +16,113 @@ Plugin glossary
 .. glossary::
    :sorted:
 
-   Sopel Plugin
-      A Sopel plugin is a plugin made for Sopel. It contains rule handlers
-      and can have a ``setup`` and a ``shutdown`` functions. It is of one
-      of the possible plugin types, preferably :term:`Single file plugin`, or
-      :term:`Entry point plugin`. The other two types are :term:`Folder plugin`
-      and :term:`Namespace package plugin`.
+   Sopel plugin
+      A Sopel plugin is a plugin made for Sopel. It contains
+      :term:`rules <Rule>`, it has a setup/shutdown cycle, and it can extend
+      the bot's configuration with its own
+      :class:`section <sopel.config.types.StaticSection>`.
+
+      It is of one of the possible plugin types, preferably
+      a :term:`Single file plugin`, or an :term:`Entry point plugin`. The other
+      two types are :term:`Folder plugin` and :term:`Namespace package plugin`.
+
+   Rule
+      A rule defines how to match a specific message from the IRC server,
+      usually with a regular expression. It also defines how to react to these
+      messages. For that it can execute a :term:`callable <Plugin callable>`.
+
+   Rule system
+      The rule system is how Sopel manages and handles :term:`rules <Rule>`.
+
+   Generic rule
+      A generic rule matches any message using a regular expression. It doesn't
+      use any specific format, unlike a :term:`Named rule`. It can match the
+      whole message (:term:`Match rule`), or any part of it
+      (:term:`Search rule`), or it may trigger for every match in the message
+      (:term:`Find rule`).
+
+   Match rule
+      A match rule is a :term:`Generic rule` that triggers when the regex
+      matches the whole message.
+
+   Search rule
+      A search rule is a :term:`Generic rule` that triggers when the regex
+      matches any part of the message.
+
+   Find rule
+      A find rule is a :term:`Generic rule` that triggers for every time the
+      regex matches a part of the message.
+
+   Named rule
+      A named rule is a rule that uses a regular expression with a specific
+      format: with a name, and usually with a prefix, or a set of specific
+      conditions. See :term:`Command`, :term:`Action command`, and
+      :term:`Nick command`. A named rule always matches the message from its
+      start, and it accepts any number of arguments::
+
+         [nick] <prefix><name> [<arg1> <arg2> <...> <argN>]
+
+      A named rule can have aliases, i.e. alternative names used to trigger
+      the rule.
+
+   Command
+      A command is a :term:`Named rule` that reacts to a :term:`Command prefix`
+      and a name.
+
+   Action command
+      An action command is a :term:`Named rule` that reacts to a name in a
+      message sent with the ``ACTION`` intent/CTCP.
+
+   Nick command
+      A nick command (or nickname command) is a :term:`Named rule` that reacts
+      to a name prefixed by the bot's nickname in a message.
+
+   Command prefix
+      The command prefix is a regular expression joined to a :term:`Command`'s
+      name as its prefix. It is defined by configuration using
+      :attr:`core.prefix <sopel.config.core_section.CoreSection.prefix>`.
+
+   URL callback
+      A URL callback is a rule that triggers for every URL in a message.
+
+   Rate limiting
+      How often a :term:`rule <Rule>` can be triggered on a per-user basis, in
+      a channel, or across the IRC network.
+
+   Plugin callable
+      A plugin callable is a Python callable, that handles a specific message
+      from the IRC server matching a :term:`Rule`. See also the
+      :doc:`plugin/anatomy` chapter for the plugin callable signature.
+
+   Plugin job
+      A plugin job is a Python callable, that executes periodically on a
+      schedule. See also the :doc:`plugin/anatomy` chapter for the plugin
+      job signature.
 
    Single file plugin
-      A :term:`Sopel Plugin` composed of a single Python file. Can be loaded by
+      A :term:`Sopel plugin` composed of a single Python file. Can be loaded by
       Sopel even when it's not available from ``sys.path``.
 
    Folder plugin
       A plugin composed of a directory that contains a ``__init__.py`` file.
-      It is not considered as a proper Python package unless it's parent
-      directory is in ``sys.path``. As it can create confusion, they are not
+      It is not considered as a proper Python package unless its parent
+      directory is in ``sys.path``. As they can create problems, they are not
       recommended, and either :term:`Single file plugin` or
       :term:`Entry point plugin` should be used instead.
 
    Namespace package plugin
       A plugin that is a Python namespace package, i.e. a package within a
       specific namespace (``sopel_modules.<name>``, where ``sopel_modules`` is
-      the namespace, and ``<name>`` is the Plugin's name). This is the old way
+      the namespace, and ``<name>`` is the plugin's name). This is the old way
       to distribute plugins and is not recommended; :term:`Entry point plugin`
       should be used instead.
 
    Entry point plugin
       A plugin that is an installed Python package and exposed through the
-      ``sopel.plugins`` Python setup entry point named.
+      ``sopel.plugins`` setuptools entry point.
+
+   Sopelunking
+      Action performed by a :term:`Sopelunker`.
+
+   Sopelunker
+      A person who does :term:`Sopelunking`.

--- a/docs/source/plugin.rst
+++ b/docs/source/plugin.rst
@@ -93,12 +93,13 @@ Plugin glossary
    Plugin callable
       A plugin callable is a Python callable, that handles a specific message
       from the IRC server matching a :term:`Rule`. See also the
-      :doc:`plugin/anatomy` chapter for the plugin callable signature.
+      :ref:`Plugin Anatomy: callables <plugin-anatomy-callables>` section for
+      the plugin callable signature.
 
    Plugin job
       A plugin job is a Python callable, that executes periodically on a
-      schedule. See also the :doc:`plugin/anatomy` chapter for the plugin
-      job signature.
+      schedule. See also the :ref:`Plugin Anatomy: jobs <plugin-anatomy-jobs>`
+      section for the plugin job signature.
 
    Single file plugin
       A :term:`Sopel plugin` composed of a single Python file. Can be loaded by

--- a/docs/source/plugin.rst
+++ b/docs/source/plugin.rst
@@ -1,189 +1,46 @@
-================
-Plugin structure
-================
+=====================
+Plugin for Developers
+=====================
 
-.. contents::
-   :local:
-   :depth: 1
+.. toctree::
+   :titlesonly:
 
-Anatomy of a plugin
-===================
+   plugin/what
+   plugin/anatomy
+   plugin/decorators
+   plugin/internals
 
-A Sopel plugin consists of a Python module containing one or more
-``callable``\s. It may optionally also contain ``configure``, ``setup``, and
-``shutdown`` hooks.
+Plugin glossary
+===============
 
-Sopel plugins conventionally have all-lowercase names, usually one word.
-However, sometimes multiple words are needed for clarity or disambiguation;
-``snake_case`` is normally used for these.
+.. glossary::
+   :sorted:
 
-.. note::
+   Sopel Plugin
+      A Sopel plugin is a plugin made for Sopel. It contains rule handlers
+      and can have a ``setup`` and a ``shutdown`` functions. It is of one
+      of the possible plugin types, preferably :term:`Single file plugin`, or
+      :term:`Entry point plugin`. The other two types are :term:`Folder plugin`
+      and :term:`Namespace package plugin`.
 
-    How Sopel determines a plugin's name depends on what kind of plugin it is:
+   Single file plugin
+      A :term:`Sopel Plugin` composed of a single Python file. Can be loaded by
+      Sopel even when it's not available from ``sys.path``.
 
-    Single file
-      The file's basename (e.g. ``plugin`` in ``plugin.py``)
+   Folder plugin
+      A plugin composed of a directory that contains a ``__init__.py`` file.
+      It is not considered as a proper Python package unless it's parent
+      directory is in ``sys.path``. As it can create confusion, they are not
+      recommended, and either :term:`Single file plugin` or
+      :term:`Entry point plugin` should be used instead.
 
-    Folder
-      The folder name (e.g. ``plugin`` in ``~/.sopel/plugins/plugin/__init__.py``)
+   Namespace package plugin
+      A plugin that is a Python namespace package, i.e. a package within a
+      specific namespace (``sopel_modules.<name>``, where ``sopel_modules`` is
+      the namespace, and ``<name>`` is the Plugin's name). This is the old way
+      to distribute plugins and is not recommended; :term:`Entry point plugin`
+      should be used instead.
 
-    Namespace package
-      The submodule name (e.g. ``plugin`` in ``sopel_modules.plugin``)
-
-    Entry point
-      The entry point name (e.g. ``plugin`` in ``plugin = my_plugin.module.path``)
-
-.. py:function:: callable(bot, trigger)
-
-    :param bot: the bot's instance
-    :type bot: :class:`sopel.bot.SopelWrapper`
-    :param trigger: the object that triggered the call
-    :type trigger: :class:`sopel.trigger.Trigger`
-
-    A callable is any function which takes as its arguments a
-    :class:`sopel.bot.SopelWrapper` object and a :class:`sopel.trigger.Trigger`
-    object, and is wrapped with appropriate decorators from
-    :mod:`sopel.plugin`. The ``bot`` provides the ability to send messages to
-    the network and check the state of the bot. The ``trigger`` provides
-    information about the line which triggered this function to be called.
-
-    The return value of these function is ignored, unless it is
-    :const:`sopel.plugin.NOLIMIT`, in which case rate limiting will not be
-    applied for that call.
-
-    Note that the name can, and should, be anything - it doesn't need to be
-    called "callable"::
-
-        from sopel import plugin
-
-        @plugin.command('hello')
-        def say_hello(bot, trigger):
-            """Reply hello to you."""
-            bot.reply('Hello!')
-
-
-.. py:function:: setup(bot)
-
-    :param bot: the bot's instance
-    :type bot: :class:`sopel.bot.Sopel`
-
-    This is an optional function of a plugin, which will be called while the
-    plugin is being loaded. The purpose of this function is to perform whatever
-    actions are needed to allow a plugin to function properly (e.g, ensuring
-    that the appropriate configuration variables exist and are set). Note that
-    this normally occurs prior to connection to the server, so the behavior of
-    the messaging functions on the :class:`sopel.bot.Sopel` object it's passed
-    is undefined.
-
-    Throwing an exception from this function (such as a
-    :exc:`sopel.config.ConfigurationError`) will prevent any callables in the
-    plugin from being registered, and provide an error message to the user.
-    This is useful when requiring the presence of configuration values or
-    making other environmental requirements.
-
-    The bot will not continue loading plugins or connecting during the
-    execution of this function. As such, an infinite loop (such as an
-    unthreaded polling loop) will cause the bot to hang.
-
-.. py:function:: shutdown(bot)
-
-    :param bot: the bot's instance
-    :type bot: :class:`sopel.bot.Sopel`
-
-    This is an optional function of a plugin, which will be called while the
-    bot is quitting. Note that this normally occurs after closing connection
-    to the server, so the behavior of the messaging functions on the
-    :class:`sopel.bot.Sopel` object it's passed is undefined. The purpose of
-    this function is to perform whatever actions are needed to allow a plugin
-    to properly clean up (e.g, ensuring that any temporary cache files are
-    deleted).
-
-    The bot will not continue notifying other plugins or continue quitting
-    during the execution of this function. As such, an infinite loop (such as
-    an unthreaded polling loop) will cause the bot to hang.
-
-    .. versionadded:: 4.1
-
-.. py:function:: configure(config)
-
-    :param bot: the bot's configuration object
-    :type bot: :class:`sopel.config.Config`
-
-    This is an optional function of a plugin, which will be called during the
-    user's setup of the bot. It's intended purpose is to use the methods of the
-    passed :class:`sopel.config.Config` object in order to create the
-    configuration variables it needs to function properly.
-
-    .. versionadded:: 3.0
-
-
-Callable decorators
-===================
-
-.. automodule:: sopel.plugin
-   :members:
-
-About ``sopel.module``
-----------------------
-
-Before Sopel 7.1, ``sopel.module`` was the preferred and only way to decorate
-callables for plugins. However, since the term ``module`` can be confusing
-(mostly because it already has a special meaning in Python), it has been
-replaced by ``plugin`` in most cases related to add-ons for Sopel.
-
-.. automodule:: sopel.module
-   :members:
-
-
-Internal machinery
-==================
-
-.. important::
-
-   This section contains modules and classes used by Sopel internally. They are
-   subject to rapid changes between versions. They are documented here for
-   completeness, and for the aid of Sopel’s core development.
-
-.. contents::
-   :local:
-
-
-sopel.plugins
--------------
-.. automodule:: sopel.plugins
-   :members:
-
-sopel.plugins.handlers
-----------------------
-.. automodule:: sopel.plugins.handlers
-   :members:
-
-sopel.plugins.exceptions
-------------------------
-.. automodule:: sopel.plugins.exceptions
-   :members:
-
-sopel.plugins.rules
--------------------
-.. automodule:: sopel.plugins.rules
-   :members:
-   :show-inheritance:
-
-   .. autoclass:: AbstractRule
-      :members:
-      :undoc-members:
-
-   .. autoclass:: NamedRuleMixin
-      :members:
-      :undoc-members:
-
-sopel.plugins.jobs
-------------------
-.. automodule:: sopel.plugins.jobs
-   :members:
-   :show-inheritance:
-
-sopel.loader
-------------
-.. automodule:: sopel.loader
-   :members:
+   Entry point plugin
+      A plugin that is an installed Python package and exposed through the
+      ``sopel.plugins`` Python setup entry point named.

--- a/docs/source/plugin.rst
+++ b/docs/source/plugin.rst
@@ -70,6 +70,11 @@ Plugin glossary
       A command is a :term:`Named rule` that reacts to a :term:`Command prefix`
       and a name.
 
+   Command prefix
+      The command prefix is a regular expression joined to a :term:`Command`'s
+      name as its prefix. It is defined by configuration using
+      :attr:`core.prefix <sopel.config.core_section.CoreSection.prefix>`.
+
    Action command
       An action command is a :term:`Named rule` that reacts to a name in a
       message sent with the ``ACTION`` intent/CTCP.
@@ -77,11 +82,6 @@ Plugin glossary
    Nick command
       A nick command (or nickname command) is a :term:`Named rule` that reacts
       to a name prefixed by the bot's nickname in a message.
-
-   Command prefix
-      The command prefix is a regular expression joined to a :term:`Command`'s
-      name as its prefix. It is defined by configuration using
-      :attr:`core.prefix <sopel.config.core_section.CoreSection.prefix>`.
 
    URL callback
       A URL callback is a rule that triggers for every URL in a message.

--- a/docs/source/plugin.rst
+++ b/docs/source/plugin.rst
@@ -7,6 +7,7 @@ Plugins: Developer Overview
 
    plugin/what
    plugin/anatomy
+   plugin/bot
    plugin/decorators
    plugin/internals
 

--- a/docs/source/plugin/anatomy.rst
+++ b/docs/source/plugin/anatomy.rst
@@ -19,9 +19,9 @@ uses a :term:`Rule system`: plugins define rules, Sopel loads them and triggers
 them when a message matches.
 
 Sopel identifies a callable as a rule when it has been decorated with any of
-these :mod:`sopel.plugin`'s decorators:
+these decorators from :mod:`sopel.plugin`:
 
-* :term:`Generic rule`:: :func:`~sopel.plugin.rule`,
+* :term:`Generic rule`: :func:`~sopel.plugin.rule`,
   :func:`~sopel.plugin.find`, and :func:`~sopel.plugin.search`
 * :term:`Named rule`: :func:`~sopel.plugin.commands`, 
   :func:`~sopel.plugin.action_commands`, and
@@ -35,7 +35,7 @@ decorators are used alone:
 * event based rule: :func:`~sopel.plugin.event`
 * intent/CTCP based rule: :func:`~sopel.plugin.intent`
 
-In that case, it will use a match-all regex (`r'.*'`)::
+In that case, it will use a match-all regex (``r'.*'``)::
 
    from sopel import plugin
 
@@ -66,6 +66,8 @@ better to limit who can trigger them. There are decorators for that:
 
 * :func:`sopel.plugin.require_account`: requires services/NickServ
   authentication; works only if the server implements modern IRC authentication
+  (see also :attr:`Trigger.account <sopel.trigger.Trigger.account>` and
+  the `account-tag`__ specification for more information)
 * :func:`sopel.plugin.require_privilege`: requires a specific level of
   privileges in the channel; works only for channel messages, not private
   messages, and you probably want to use it with
@@ -73,6 +75,8 @@ better to limit who can trigger them. There are decorators for that:
 * :func:`sopel.plugin.require_admin`: only the bot's owner and its admins can
   trigger the rule
 * :func:`sopel.plugin.require_owner`: only the bot's owner can trigger the rule
+
+.. __: https://ircv3.net/specs/extensions/account-tag-3.2
 
 Rate limiting
 -------------
@@ -97,6 +101,9 @@ Example::
    @plugin.rate(user=2)
    def you_said_ah(bot, trigger):
       bot.reply('Ha AH!')
+
+A rule with rate-limiting can return :const:`sopel.plugin.NOLIMIT` to let the
+user try again after a failed command, e.g. if a required argument is missing.
 
 Rule labels
 -----------
@@ -144,13 +151,13 @@ the same interface:
 
 A callable must accept two positional arguments: a
 :class:`bot <sopel.bot.SopelWrapper>` object, and a
-:class:`trigger <sopel.trigger.Trigger>` object. Both are objects tied to the
+:class:`trigger <sopel.trigger.Trigger>` object. Both are tied to the specific
 message that matches the rule.
 
 The ``bot`` provides the ability to send messages to the network (to say
 something or to send a specific command such as ``JOIN``), and to check the
 state of the bot such as its settings, memory, or database. It is a context
-aware wrapper around the :class:`~sopel.bot.Sopel` instance.
+aware wrapper around the running :class:`~sopel.bot.Sopel` instance.
 
 The ``trigger`` provides information about the line which triggered the rule
 and this callable to be executed.
@@ -178,8 +185,9 @@ Plugin jobs
 ===========
 
 Another feature available to plugins is the ability to define
-:term:`jobs <Plugin job>`. It is a Python callable decorated with
-:func:`sopel.plugin.interval` and that executes every period of time.
+:term:`jobs <Plugin job>`. A job is a Python callable decorated with
+:func:`sopel.plugin.interval`, which executes the callable
+periodically on a schedule.
 
 A job follows this interface:
 
@@ -227,7 +235,7 @@ The ``setup`` function must follow this interface:
 
 This function is optional. If it exists, it will be called while the plugin is
 being loaded. The purpose of this function is to perform whatever actions are
-needed to allow a plugin to function properly (e.g, ensuring that the
+needed to allow a plugin to do its work properly (e.g, ensuring that the
 appropriate configuration variables exist and are set). Note that this normally
 occurs prior to connection to the server, so the behavior of the messaging
 functions on the :class:`sopel.bot.Sopel` object it's passed is undefined and
@@ -263,8 +271,8 @@ to the server, so the behavior of the messaging functions on the
 likely to fail.
 
 The purpose of this function is to perform whatever actions are needed to allow
-a plugin to properly clean up (e.g. ensuring that any temporary cache files are
-deleted).
+a plugin to properly clean up after itself (e.g. ensuring that any temporary
+cache files are deleted).
 
 The bot will not continue notifying other plugins or continue quitting during
 the execution of this function. As such, an infinite loop (such as an
@@ -284,7 +292,7 @@ and may require. Then, it should add this section to the bot's settings::
 
    class FooSection(types.StaticSection):
        bar = types.ListAttribute('bar')
-       fizz = ValidatedAttribute('fizz', bool, default=False)
+       fizz = types.ValidatedAttribute('fizz', bool, default=False)
 
    def setup(bot):
       bot.settings.define_section('foo', FooSection)
@@ -321,7 +329,7 @@ The ``configure`` function must follow this interface:
 
 Its intended purpose is to use the methods of the passed
 :class:`sopel.config.Config` object in order to create the configuration
-variables it needs to function properly.
+variables it needs to work properly.
 
 .. versionadded:: 3.0
 

--- a/docs/source/plugin/anatomy.rst
+++ b/docs/source/plugin/anatomy.rst
@@ -1,0 +1,90 @@
+===================
+Anatomy of a plugin
+===================
+
+A Sopel plugin consists of a Python module containing one or more
+``callable``\s. It may optionally also contain ``configure``, ``setup``, and
+``shutdown`` hooks.
+
+.. py:function:: callable(bot, trigger)
+
+    :param bot: the bot's instance
+    :type bot: :class:`sopel.bot.SopelWrapper`
+    :param trigger: the object that triggered the call
+    :type trigger: :class:`sopel.trigger.Trigger`
+
+    A callable is any function which takes as its arguments a
+    :class:`sopel.bot.SopelWrapper` object and a :class:`sopel.trigger.Trigger`
+    object, and is wrapped with appropriate decorators from
+    :mod:`sopel.plugin`. The ``bot`` provides the ability to send messages to
+    the network and check the state of the bot. The ``trigger`` provides
+    information about the line which triggered this function to be called.
+
+    The return value of these function is ignored, unless it is
+    :const:`sopel.plugin.NOLIMIT`, in which case rate limiting will not be
+    applied for that call.
+
+    Note that the name can, and should, be anything - it doesn't need to be
+    called "callable"::
+
+        from sopel import plugin
+
+        @plugin.commands('hello')
+        def say_hello(bot, trigger):
+            """Reply hello to you."""
+            bot.reply('Hello!')
+
+
+.. py:function:: setup(bot)
+
+    :param bot: the bot's instance
+    :type bot: :class:`sopel.bot.Sopel`
+
+    This is an optional function of a plugin, which will be called while the
+    plugin is being loaded. The purpose of this function is to perform whatever
+    actions are needed to allow a plugin to function properly (e.g, ensuring
+    that the appropriate configuration variables exist and are set). Note that
+    this normally occurs prior to connection to the server, so the behavior of
+    the messaging functions on the :class:`sopel.bot.Sopel` object it's passed
+    is undefined.
+
+    Throwing an exception from this function (such as a
+    :exc:`sopel.config.ConfigurationError`) will prevent any callables in the
+    plugin from being registered, and provide an error message to the user.
+    This is useful when requiring the presence of configuration values or
+    making other environmental requirements.
+
+    The bot will not continue loading plugins or connecting during the
+    execution of this function. As such, an infinite loop (such as an
+    unthreaded polling loop) will cause the bot to hang.
+
+.. py:function:: shutdown(bot)
+
+    :param bot: the bot's instance
+    :type bot: :class:`sopel.bot.Sopel`
+
+    This is an optional function of a plugin, which will be called while the
+    bot is quitting. Note that this normally occurs after closing connection
+    to the server, so the behavior of the messaging functions on the
+    :class:`sopel.bot.Sopel` object it's passed is undefined. The purpose of
+    this function is to perform whatever actions are needed to allow a plugin
+    to properly clean up (e.g, ensuring that any temporary cache files are
+    deleted).
+
+    The bot will not continue notifying other plugins or continue quitting
+    during the execution of this function. As such, an infinite loop (such as
+    an unthreaded polling loop) will cause the bot to hang.
+
+    .. versionadded:: 4.1
+
+.. py:function:: configure(config)
+
+    :param bot: the bot's configuration object
+    :type bot: :class:`sopel.config.Config`
+
+    This is an optional function of a plugin, which will be called during the
+    user's setup of the bot. It's intended purpose is to use the methods of the
+    passed :class:`sopel.config.Config` object in order to create the
+    configuration variables it needs to function properly.
+
+    .. versionadded:: 3.0

--- a/docs/source/plugin/anatomy.rst
+++ b/docs/source/plugin/anatomy.rst
@@ -23,9 +23,9 @@ these decorators from :mod:`sopel.plugin`:
 
 * :term:`Generic rule`: :func:`~sopel.plugin.rule`,
   :func:`~sopel.plugin.find`, and :func:`~sopel.plugin.search`
-* :term:`Named rule`: :func:`~sopel.plugin.commands`, 
-  :func:`~sopel.plugin.action_commands`, and
-  :func:`~sopel.plugin.nickname_commands`
+* :term:`Named rule`: :func:`~sopel.plugin.command`,
+  :func:`~sopel.plugin.action_command`, and
+  :func:`~sopel.plugin.nickname_command`
 * :term:`URL callback`: :func:`~sopel.plugin.url` and
   :func:`~sopel.plugin.url_lazy`
 
@@ -175,7 +175,7 @@ The return value of a callable is ignored unless it is
 
       from sopel import plugin
 
-      @plugin.commands('hello')
+      @plugin.command('hello')
       def say_hello(bot, trigger):
          """Reply hello to you."""
          bot.reply('Hello!')

--- a/docs/source/plugin/anatomy.rst
+++ b/docs/source/plugin/anatomy.rst
@@ -1,3 +1,5 @@
+.. _plugin-anatomy:
+
 ===================
 Anatomy of a plugin
 ===================
@@ -11,12 +13,14 @@ A Sopel plugin consists of a Python module containing one or more
    :depth: 2
 
 
+.. _plugin-anatomy-rules:
+
 Defining rules
 ==============
 
 The main goal of a Sopel plugin is to react to IRC messages. For that, Sopel
-uses a :term:`Rule system`: plugins define rules, Sopel loads them and triggers
-them when a message matches.
+uses a :term:`Rule system`: plugins define rules, which Sopel loads, and then
+Sopel triggers any matching rules for each message it receives.
 
 Sopel identifies a callable as a rule when it has been decorated with any of
 these decorators from :mod:`sopel.plugin`:
@@ -40,10 +44,10 @@ In that case, it will use a match-all regex (``r'.*'``)::
    from sopel import plugin
 
    @plugin.event('JOIN')
-   def on_join_2(bot, trigger):
+   def on_join(bot, trigger):
       pass
 
-   # this is equivalent to this:
+   # the above is equivalent to this:
    @plugin.rule(r'.*')
    @plugin.event('JOIN')
    def on_join(bot, trigger):
@@ -135,6 +139,8 @@ The rule in question is defined by the ``hello`` plugin like so::
       bot.reply('Ha AH!')
 
 
+.. _plugin-anatomy-callables:
+
 Plugin callables
 ================
 
@@ -181,6 +187,8 @@ The return value of a callable is ignored unless it is
          bot.reply('Hello!')
 
 
+.. _plugin-anatomy-jobs:
+
 Plugin jobs
 ===========
 
@@ -214,6 +222,9 @@ A job follows this interface:
    A job may execute while the ``bot`` is **not** connected, and it must not
    assume any network access.
 
+
+
+.. _plugin-anatomy-setup-shutdown:
 
 Plugin setup & shutdown
 =======================
@@ -280,6 +291,8 @@ unthreaded polling loop) will cause the bot to hang.
 
 .. versionadded:: 4.1
 
+
+.. _plugin-anatomy-config:
 
 Plugin configuration
 ====================

--- a/docs/source/plugin/anatomy.rst
+++ b/docs/source/plugin/anatomy.rst
@@ -6,85 +6,342 @@ A Sopel plugin consists of a Python module containing one or more
 ``callable``\s. It may optionally also contain ``configure``, ``setup``, and
 ``shutdown`` hooks.
 
-.. py:function:: callable(bot, trigger)
+.. contents::
+   :local:
+   :depth: 2
 
-    :param bot: the bot's instance
-    :type bot: :class:`sopel.bot.SopelWrapper`
-    :param trigger: the object that triggered the call
-    :type trigger: :class:`sopel.trigger.Trigger`
 
-    A callable is any function which takes as its arguments a
-    :class:`sopel.bot.SopelWrapper` object and a :class:`sopel.trigger.Trigger`
-    object, and is wrapped with appropriate decorators from
-    :mod:`sopel.plugin`. The ``bot`` provides the ability to send messages to
-    the network and check the state of the bot. The ``trigger`` provides
-    information about the line which triggered this function to be called.
+Defining rules
+==============
 
-    The return value of these function is ignored, unless it is
-    :const:`sopel.plugin.NOLIMIT`, in which case rate limiting will not be
-    applied for that call.
+The main goal of a Sopel plugin is to react to IRC messages. For that, Sopel
+uses a :term:`Rule system`: plugins define rules, Sopel loads them and triggers
+them when a message matches.
 
-    Note that the name can, and should, be anything - it doesn't need to be
-    called "callable"::
+Sopel identifies a callable as a rule when it has been decorated with any of
+these :mod:`sopel.plugin`'s decorators:
 
-        from sopel import plugin
+* :term:`Generic rule`:: :func:`~sopel.plugin.rule`,
+  :func:`~sopel.plugin.find`, and :func:`~sopel.plugin.search`
+* :term:`Named rule`: :func:`~sopel.plugin.commands`, 
+  :func:`~sopel.plugin.action_commands`, and
+  :func:`~sopel.plugin.nickname_commands`
+* :term:`URL callback`: :func:`~sopel.plugin.url` and
+  :func:`~sopel.plugin.url_lazy`
 
-        @plugin.commands('hello')
-        def say_hello(bot, trigger):
-            """Reply hello to you."""
-            bot.reply('Hello!')
+Additionally, Sopel identifies a callable as a generic rule when these
+decorators are used alone:
 
+* event based rule: :func:`~sopel.plugin.event`
+* intent/CTCP based rule: :func:`~sopel.plugin.intent`
+
+In that case, it will use a match-all regex (`r'.*'`)::
+
+   from sopel import plugin
+
+   @plugin.event('JOIN')
+   def on_join_2(bot, trigger):
+      pass
+
+   # this is equivalent to this:
+   @plugin.rule(r'.*')
+   @plugin.event('JOIN')
+   def on_join(bot, trigger):
+      pass
+
+Channel vs. private messages
+----------------------------
+
+By default, :term:`rules <Rule>` can be triggered from a channel or a private
+message. It is possible to limit that to either one of these options:
+
+* channel only: :func:`sopel.plugin.require_chanmsg`
+* private message only: :func:`sopel.plugin.require_privmsg`
+
+Access right requirements
+-------------------------
+
+By default anyone can trigger a :term:`rule <Rule>`, and for some it might be
+better to limit who can trigger them. There are decorators for that:
+
+* :func:`sopel.plugin.require_account`: requires services/NickServ
+  authentication; works only if the server implements modern IRC authentication
+* :func:`sopel.plugin.require_privilege`: requires a specific level of
+  privileges in the channel; works only for channel messages, not private
+  messages, and you probably want to use it with
+  :func:`~sopel.plugin.require_chanmsg`
+* :func:`sopel.plugin.require_admin`: only the bot's owner and its admins can
+  trigger the rule
+* :func:`sopel.plugin.require_owner`: only the bot's owner can trigger the rule
+
+Rate limiting
+-------------
+
+All :term:`rules <Rule>` can have rate limiting with the
+:func:`sopel.plugin.rate` decorator. Rate limiting means how often a rule can
+be triggered. This is different from the flood protection logic, which is how
+often Sopel can send messages to the network. By default, a rule doesn't have
+any rate limiting.
+
+There are three types of rate limiting:
+
+* per-user: how often a rule triggers for each user
+* per-channel: how often a rule triggers for a given channel
+* globally: how often a rule triggers accross the whole network
+
+Example::
+
+   from sopel import plugin
+
+   @plugin.rule(r'Ah[!?.]?')
+   @plugin.rate(user=2)
+   def you_said_ah(bot, trigger):
+      bot.reply('Ha AH!')
+
+Rule labels
+-----------
+
+A rule has a label: it will be used for logging, documentation, and internal
+manipulation. There are two cases to consider:
+
+* :term:`Generic rules <Generic rule>` and :term:`URL callbacks <URL callback>`
+  use their :term:`callable <Plugin callable>`'s name by default (i.e. the
+  function's ``__name__``). This can be overridden with the
+  :func:`sopel.plugin.label` decorator.
+* A :term:`Named rule` is already named (by definition), so it uses its name
+  directly as rule label. This can't be overridden by a decorator.
+
+This label is particulary useful for bot owners who want to disable a rule in
+a specific channel. In the following example, the ``say_hello`` rule from the
+``hello`` plugin is disabled in the ``#rude`` channel:
+
+.. code-block:: ini
+
+   [#rude]
+   disable_commands = {'hello': ['say_hello']}
+
+The rule in question is defined by the ``hello`` plugin like so::
+
+   @plugin.rule(r'hello!?', r'hi!?', r'hey!?')
+   @plugin.label('say_hello')
+   def handler_hello(bot, trigger):
+      bot.reply('Ha AH!')
+
+
+Plugin callables
+================
+
+When a message from the IRC server matches a :term:`Rule`, Sopel will execute
+its attached :term:`callable <Plugin callable>`. All plugin callables follow
+the same interface:
+
+.. py:function:: plugin_callable(bot, trigger)
+
+   :param bot: wrapped bot instance
+   :type bot: :class:`sopel.bot.SopelWrapper`
+   :param trigger: the object that triggered the call
+   :type trigger: :class:`sopel.trigger.Trigger`
+
+A callable must accept two positional arguments: a
+:class:`bot <sopel.bot.SopelWrapper>` object, and a
+:class:`trigger <sopel.trigger.Trigger>` object. Both are objects tied to the
+message that matches the rule.
+
+The ``bot`` provides the ability to send messages to the network (to say
+something or to send a specific command such as ``JOIN``), and to check the
+state of the bot such as its settings, memory, or database. It is a context
+aware wrapper around the :class:`~sopel.bot.Sopel` instance.
+
+The ``trigger`` provides information about the line which triggered the rule
+and this callable to be executed.
+
+The return value of a callable is ignored unless it is
+:const:`sopel.plugin.NOLIMIT`, in which case
+:term:`rate limiting <Rate limiting>` will not be applied for that call.
+(See :func:`sopel.plugin.rate`.)
+
+.. note::
+
+   Note that the name can, and should, be anything, and it doesn't have to be
+   called ``plugin_callable``. At least, it should not be called ``callable``,
+   since that is a :func:`Python built-in function <callable>`::
+
+      from sopel import plugin
+
+      @plugin.commands('hello')
+      def say_hello(bot, trigger):
+         """Reply hello to you."""
+         bot.reply('Hello!')
+
+
+Plugin jobs
+===========
+
+Another feature available to plugins is the ability to define
+:term:`jobs <Plugin job>`. It is a Python callable decorated with
+:func:`sopel.plugin.interval` and that executes every period of time.
+
+A job follows this interface:
+
+.. py:function:: plugin_job(bot)
+
+   :param bot: the bot instance
+   :type bot: :class:`sopel.bot.Sopel`
+
+.. note::
+
+   Note that the name can be anything, and it doesn't have to be called
+   ``plugin_job``::
+
+      from sopel import plugin
+
+      @plugin.interval(5)
+      def spam_every_5s(bot):
+          if "#here" in bot.channels:
+              bot.say("It has been five seconds!", "#here")
+
+
+.. important::
+
+   A job may execute while the ``bot`` is **not** connected, and it must not
+   assume any network access.
+
+
+Plugin setup & shutdown
+=======================
+
+When loading and unloading plugins, a plugin can perform setup and shutdown
+actions. For that purpose, a plugin can define optional functions named
+``setup`` and ``shutdown``. There can be one and only one function with each
+name for a plugin.
+
+Setup
+-----
+
+The ``setup`` function must follow this interface:
 
 .. py:function:: setup(bot)
 
-    :param bot: the bot's instance
-    :type bot: :class:`sopel.bot.Sopel`
+   :param bot: the bot instance
+   :type bot: :class:`sopel.bot.Sopel`
 
-    This is an optional function of a plugin, which will be called while the
-    plugin is being loaded. The purpose of this function is to perform whatever
-    actions are needed to allow a plugin to function properly (e.g, ensuring
-    that the appropriate configuration variables exist and are set). Note that
-    this normally occurs prior to connection to the server, so the behavior of
-    the messaging functions on the :class:`sopel.bot.Sopel` object it's passed
-    is undefined.
+This function is optional. If it exists, it will be called while the plugin is
+being loaded. The purpose of this function is to perform whatever actions are
+needed to allow a plugin to function properly (e.g, ensuring that the
+appropriate configuration variables exist and are set). Note that this normally
+occurs prior to connection to the server, so the behavior of the messaging
+functions on the :class:`sopel.bot.Sopel` object it's passed is undefined and
+they are likely to fail.
 
-    Throwing an exception from this function (such as a
-    :exc:`sopel.config.ConfigurationError`) will prevent any callables in the
-    plugin from being registered, and provide an error message to the user.
-    This is useful when requiring the presence of configuration values or
-    making other environmental requirements.
+Throwing an exception from this function will stop Sopel from loading the
+plugin, and none of its :term:`rules <Rule>` or :term:`jobs <Plugin job>` will
+be registered. The exception will be caught, an error message logged, and Sopel
+will try to load the next plugin.
 
-    The bot will not continue loading plugins or connecting during the
-    execution of this function. As such, an infinite loop (such as an
-    unthreaded polling loop) will cause the bot to hang.
+This is useful when requiring the presence of configuration values (by raising
+a :exc:`~sopel.config.ConfigurationError` error) or making other environmental
+requirements (dependencies, file/folder access rights, and so on).
+
+The bot will not continue loading plugins or connecting during the execution of
+this function. As such, an infinite loop (such as an unthreaded polling loop)
+will cause the bot to hang.
+
+Shutdown
+--------
+
+The ``shutdown`` function must follow this interface:
 
 .. py:function:: shutdown(bot)
 
-    :param bot: the bot's instance
-    :type bot: :class:`sopel.bot.Sopel`
+   :param bot: the bot instance
+   :type bot: :class:`sopel.bot.Sopel`
 
-    This is an optional function of a plugin, which will be called while the
-    bot is quitting. Note that this normally occurs after closing connection
-    to the server, so the behavior of the messaging functions on the
-    :class:`sopel.bot.Sopel` object it's passed is undefined. The purpose of
-    this function is to perform whatever actions are needed to allow a plugin
-    to properly clean up (e.g, ensuring that any temporary cache files are
-    deleted).
+This function is optional. If it exists, it will be called while the bot
+is shutting down. Note that this normally occurs after closing connection
+to the server, so the behavior of the messaging functions on the
+:class:`bot <sopel.bot.Sopel>` object it's passed is undefined and they are
+likely to fail.
 
-    The bot will not continue notifying other plugins or continue quitting
-    during the execution of this function. As such, an infinite loop (such as
-    an unthreaded polling loop) will cause the bot to hang.
+The purpose of this function is to perform whatever actions are needed to allow
+a plugin to properly clean up (e.g. ensuring that any temporary cache files are
+deleted).
 
-    .. versionadded:: 4.1
+The bot will not continue notifying other plugins or continue quitting during
+the execution of this function. As such, an infinite loop (such as an
+unthreaded polling loop) will cause the bot to hang.
 
-.. py:function:: configure(config)
+.. versionadded:: 4.1
 
-    :param bot: the bot's configuration object
-    :type bot: :class:`sopel.config.Config`
 
-    This is an optional function of a plugin, which will be called during the
-    user's setup of the bot. It's intended purpose is to use the methods of the
-    passed :class:`sopel.config.Config` object in order to create the
-    configuration variables it needs to function properly.
+Plugin configuration
+====================
 
-    .. versionadded:: 3.0
+A plugin can define and use a configuration section. By subclassing
+:class:`sopel.config.types.StaticSection`, it can define the options it uses
+and may require. Then, it should add this section to the bot's settings::
+
+   from sopel.config import types
+
+   class FooSection(types.StaticSection):
+       bar = types.ListAttribute('bar')
+       fizz = ValidatedAttribute('fizz', bool, default=False)
+
+   def setup(bot):
+      bot.settings.define_section('foo', FooSection)
+
+This will allow the bot to properly load this part of the configuration file:
+
+.. code-block:: ini
+
+   [foo]
+   bar =
+      spam
+      eggs
+      bacon
+   fizz = yes
+
+.. seealso::
+
+   The :meth:`~sopel.config.Config.define_section` method to define a new
+   section so the bot can parse it properly.
+
+Configuration wizard
+--------------------
+
+When the owner sets up the bot, Sopel provides a configuration wizard. When a
+plugin defines a ``configure`` function, the user will be asked if they want
+to configure said plugin, and if yes, this function will execute.
+
+The ``configure`` function must follow this interface:
+
+.. py:function:: configure(settings)
+
+   :param settings: the bot's configuration object
+   :type settings: :class:`sopel.config.Config`
+
+Its intended purpose is to use the methods of the passed
+:class:`sopel.config.Config` object in order to create the configuration
+variables it needs to function properly.
+
+.. versionadded:: 3.0
+
+Example::
+
+   def configure(config):
+      config.define_section('foo', FooSection)
+      config.foo.configure_setting('bar', 'What do you want?')
+      config.foo.configure_setting('fizz', 'Do you fizz?')
+
+.. note::
+
+   The ``configure`` function is called only from the command line, and
+   network access must not be assumed.
+
+   This process doesn't call the bot's ``setup`` or ``shutdown`` functions, so
+   this function **must** define the configuration section it wants to use.
+
+.. seealso::
+
+   The :meth:`~sopel.config.Config.define_section` method to define a new
+   section, and the :meth:`~sopel.config.types.StaticSection.configure_setting`
+   method to prompt the user to set an option.

--- a/docs/source/plugin/bot.rst
+++ b/docs/source/plugin/bot.rst
@@ -41,7 +41,7 @@ rule is triggered, you can use the bot's settings::
 
 .. note::
 
-    The ``say`` methods sends a ``PRIVMSG`` command to the IRC server. To send
+    The ``say`` method sends a ``PRIVMSG`` command to the IRC server. To send
     a ``NOTICE`` command instead, you need to use the
     :meth:`~sopel.bot.SopelWrapper.notice` method instead.
 
@@ -59,7 +59,7 @@ shortcut for that::
 
     bot.reply('ping!')
 
-As for the ``say`` method seen above, the :meth:`~sopel.bot.SopelWrapper.reply`
+As with the ``say`` method seen above, the :meth:`~sopel.bot.SopelWrapper.reply`
 method can send your message to another destination::
 
     bot.reply('ping!', '#another-channel')
@@ -75,7 +75,7 @@ bot's owner.
 .. note::
 
     By default the ``reply`` method sends its message using a ``PRIVMSG``
-    command. You can set ``notice=True`` as argument to make it uses a
+    command. You can set ``notice=True`` as argument to make it use a
     ``NOTICE`` command instead::
 
         bot.reply('ping!', notice=True)
@@ -84,16 +84,16 @@ bot's owner.
 Make it act
 ===========
 
-Beside talking, the bot can also **act**:
+Besides talking, the bot can also **act**:
 
 * to :meth:`~sopel.bot.Sopel.join` a channel,
 * or to :meth:`~sopel.bot.Sopel.part` from it,
 * and even to :meth:`~sopel.bot.Sopel.quit` the server,
 
-Oh, and let's not forget about ``/me something something``, which can be done
-with the :meth:`~sopel.bot.SopelWrapper.action` method::
+Oh, and let's not forget about ``/me does something``, which can be done with
+the :meth:`~sopel.bot.SopelWrapper.action` method::
 
-    bot.action('something something')
+    bot.action('does something')
 
 
 Channels & users
@@ -108,7 +108,7 @@ the bot is in::
         # do something with the name and the channel
 
 With the ``trigger`` object, you can also access the channel object directly
-(granted the message comes from a channel, which you should check first)::
+(assuming the message comes from a channel, which you should check first)::
 
     channel = bot.channels[trigger.sender]
 
@@ -120,13 +120,13 @@ which provides the following information:
 * its :attr:`~sopel.tools.target.Channel.users`
 * and its users' :attr:`~sopel.tools.target.Channel.privileges`
 
-Using ``trigger.nick``, you can get the nick's profile and privileges in a
+Using ``trigger.nick``, you can get the nick's privileges and profile in a
 channel like this::
 
     user_privileges = channel.privileges[trigger.nick]
-    user = channels.users[trigger.nick]
+    user = channel.users[trigger.nick]
 
-Then you can check if the user is voiced (mode +v) or not::
+Then, for example, you can check if the user is voiced (mode +v) or not::
 
     from sopel import plugin
 

--- a/docs/source/plugin/bot.rst
+++ b/docs/source/plugin/bot.rst
@@ -1,0 +1,139 @@
+=====================
+Interact with the bot
+=====================
+
+Once a :term:`Rule` has been triggered, it's time to do whatever the plugin is
+supposed to do. Thanks to the ``bot`` parameter, you can make the bot talk:
+say something in a channel, reply to someone, send a notice, or join a channel.
+
+.. contents::
+   :local:
+   :depth: 2
+
+
+Make it talk
+============
+
+The most basic way to make the bot talk is to use its
+:meth:`~sopel.bot.SopelWrapper.say` method. The wrapper knows the origin of
+the trigger (a channel or a private message), and it will use this origin as
+the default destination for your message::
+
+    # will send that to trigger.sender
+    bot.say('The bot is now talking!')
+
+If you want to send the message to another destination, you can pass it as the
+second argument::
+
+    bot.say('The bot is now talking!, '#private-channel')
+
+Instead of a string, you can use a instance of :class:`sopel.tools.Identifier`.
+
+If you want to reply to a user in a private message, you can use the trigger's
+:attr:`~sopel.trigger.Trigger.nick` attribute as destination::
+
+    bot.say('I reply in private message', trigger.nick)
+
+And if you want to send a private message to the bot's owner every time your
+rule is triggered, you can use the bot's settings::
+
+    bot.say('Hi owner!', bot.settings.core.owner)
+
+.. note::
+
+    The ``say`` methods sends a ``PRIVMSG`` command to the IRC server. To send
+    a ``NOTICE`` command instead, you need to use the
+    :meth:`~sopel.bot.SopelWrapper.notice` method instead.
+
+
+Make it reply
+=============
+
+Now maybe you want to make sure the user gets notified by the bot's message.
+For that, you could use ``trigger.nick`` this way::
+
+    bot.say('%s: ping!' % trigger.nick)
+
+It'll work fine and it's a common usage. So common indeed that Sopel provides a
+shortcut for that::
+
+    bot.reply('ping!')
+
+As for the ``say`` method seen above, the :meth:`~sopel.bot.SopelWrapper.reply`
+method can send your message to another destination::
+
+    bot.reply('ping!', '#another-channel')
+
+Also, if you want to reply to **someone else**, you can do that too by using
+the ``reply_to`` parameter::
+
+    bot.reply('ping!', reply_to=bot.settings.core.owner)
+
+In that example, we send a message on the same channel, with a highlight to the
+bot's owner.
+
+.. note::
+
+    By default the ``reply`` method sends its message using a ``PRIVMSG``
+    command. You can set ``notice=True`` as argument to make it uses a
+    ``NOTICE`` command instead::
+
+        bot.reply('ping!', notice=True)
+
+
+Make it act
+===========
+
+Beside talking, the bot can also **act**:
+
+* to :meth:`~sopel.bot.Sopel.join` a channel,
+* or to :meth:`~sopel.bot.Sopel.part` from it,
+* and even to :meth:`~sopel.bot.Sopel.quit` the server,
+
+Oh, and let's not forget about ``/me something something``, which can be done
+with the :meth:`~sopel.bot.SopelWrapper.action` method::
+
+    bot.action('something something')
+
+
+Channels & users
+================
+
+Knowing how to talk is good for a bot, but you may be wondering what the bot
+knows about the channels and their users. For that, you can use the bot's
+:attr:`~sopel.bot.Sopel.channels` attribute. For example, to list all channels
+the bot is in::
+
+    for name, channel in bot.channels.items():
+        # do something with the name and the channel
+
+With the ``trigger`` object, you can also access the channel object directly
+(granted the message comes from a channel, which you should check first)::
+
+    channel = bot.channels[trigger.sender]
+
+The ``channel`` object is an instance of :class:`sopel.tools.target.Channel`,
+which provides the following information:
+
+* its :attr:`~sopel.tools.target.Channel.name`
+* its :attr:`~sopel.tools.target.Channel.topic`
+* its :attr:`~sopel.tools.target.Channel.users`
+* and its users' :attr:`~sopel.tools.target.Channel.privileges`
+
+Using ``trigger.nick``, you can get the nick's profile and privileges in a
+channel like this::
+
+    user_privileges = channel.privileges[trigger.nick]
+    user = channels.users[trigger.nick]
+
+Then you can check if the user is voiced (mode +v) or not::
+
+    from sopel import plugin
+
+    if user_privileges & plugin.VOICED:
+        # user is voiced
+    elif user_privileges >= plugin.VOICED:
+        # not voiced, but higher privileges
+        # like plugin.HALFOP or plugin.OP
+    else:
+        # no privilege

--- a/docs/source/plugin/bot.rst
+++ b/docs/source/plugin/bot.rst
@@ -25,9 +25,9 @@ the default destination for your message::
 If you want to send the message to another destination, you can pass it as the
 second argument::
 
-    bot.say('The bot is now talking!, '#private-channel')
+    bot.say('The bot is now talking!', '#private-channel')
 
-Instead of a string, you can use a instance of :class:`sopel.tools.Identifier`.
+Instead of a string, you can use an instance of :class:`sopel.tools.Identifier`.
 
 If you want to reply to a user in a private message, you can use the trigger's
 :attr:`~sopel.trigger.Trigger.nick` attribute as destination::
@@ -132,7 +132,7 @@ Then, for example, you can check if the user is voiced (mode +v) or not::
 
     if user_privileges & plugin.VOICED:
         # user is voiced
-    elif user_privileges >= plugin.VOICED:
+    elif user_privileges > plugin.VOICED:
         # not voiced, but higher privileges
         # like plugin.HALFOP or plugin.OP
     else:

--- a/docs/source/plugin/decorators.rst
+++ b/docs/source/plugin/decorators.rst
@@ -1,0 +1,21 @@
+===================
+Callable decorators
+===================
+
+sopel.plugin
+============
+
+.. automodule:: sopel.plugin
+   :members:
+
+
+About ``sopel.module``
+======================
+
+Before Sopel 7.1, ``sopel.module`` was the preferred and only way to decorate
+callables for plugins. However, since the term ``module`` can be confusing
+(mostly because it already has a special meaning in Python), it has been
+replaced by ``plugin`` in most cases related to add-ons for Sopel.
+
+.. automodule:: sopel.module
+   :members:

--- a/docs/source/plugin/internals.rst
+++ b/docs/source/plugin/internals.rst
@@ -1,0 +1,59 @@
+==================
+Internal machinery
+==================
+
+.. important::
+
+   This section contains modules and classes used by Sopel internally. They are
+   subject to rapid changes between versions. They are documented here for
+   completeness, and for the aid of Sopel’s core development.
+
+.. contents::
+   :local:
+
+
+sopel.plugins
+=============
+
+.. automodule:: sopel.plugins
+   :members:
+
+sopel.plugins.handlers
+======================
+
+.. automodule:: sopel.plugins.handlers
+   :members:
+
+sopel.plugins.exceptions
+========================
+
+.. automodule:: sopel.plugins.exceptions
+   :members:
+
+sopel.plugins.rules
+===================
+
+.. automodule:: sopel.plugins.rules
+   :members:
+   :show-inheritance:
+
+   .. autoclass:: AbstractRule
+      :members:
+      :undoc-members:
+
+   .. autoclass:: NamedRuleMixin
+      :members:
+      :undoc-members:
+
+sopel.plugins.jobs
+==================
+
+.. automodule:: sopel.plugins.jobs
+   :members:
+   :show-inheritance:
+
+sopel.loader
+============
+
+.. automodule:: sopel.loader
+   :members:

--- a/docs/source/plugin/internals.rst
+++ b/docs/source/plugin/internals.rst
@@ -12,10 +12,22 @@ Internal machinery
    :local:
 
 
+sopel.loader
+============
+
+.. automodule:: sopel.loader
+   :members:
+
 sopel.plugins
 =============
 
 .. automodule:: sopel.plugins
+   :members:
+
+sopel.plugins.exceptions
+========================
+
+.. automodule:: sopel.plugins.exceptions
    :members:
 
 sopel.plugins.handlers
@@ -24,11 +36,12 @@ sopel.plugins.handlers
 .. automodule:: sopel.plugins.handlers
    :members:
 
-sopel.plugins.exceptions
-========================
+sopel.plugins.jobs
+==================
 
-.. automodule:: sopel.plugins.exceptions
+.. automodule:: sopel.plugins.jobs
    :members:
+   :show-inheritance:
 
 sopel.plugins.rules
 ===================
@@ -44,16 +57,3 @@ sopel.plugins.rules
    .. autoclass:: NamedRuleMixin
       :members:
       :undoc-members:
-
-sopel.plugins.jobs
-==================
-
-.. automodule:: sopel.plugins.jobs
-   :members:
-   :show-inheritance:
-
-sopel.loader
-============
-
-.. automodule:: sopel.loader
-   :members:

--- a/docs/source/plugin/what.rst
+++ b/docs/source/plugin/what.rst
@@ -27,22 +27,35 @@ A **Single file** plugin is the most basic form a Sopel plugin can take. It is
 composed of a single file available to Sopel from its plugins directory (or
 from one of its
 :attr:`extra directories <sopel.config.core_section.CoreSection.extra>`). You
-should write a single file plugin when:
+can write a single file plugin when:
 
 * everything is in a single file
-* you don't have any dependencies other than Sopel and Python's built-in library,
-  or your plugin is a "one-off" for your use only (not intended to be shared)
+* if possible, dependencies should be limited to Sopel and Python's built-in
+  library, or your plugin is a "one-off" for your use only (not intended to be
+  shared)
 
 This type of plugin is easy to install: copy its file into the right location,
 and Sopel will load it on startup.
+
+.. note::
+
+   You can still use a single file plugin with extra dependencies: bot owners
+   will have to install them themselves, so you should probably document them,
+   and possibly list them in a ``requirements.txt`` file to be used with
+   ``pip install -r`` if you want to simplify the installation process.
 
 Folder
 ------
 
 A **Folder** plugin is a folder that contains a ``__init__.py`` file. It is
 available to Sopel the same way a :ref:`Single file` plugin is, and shares the
-same limitation: Everything that is not available in this ``__init__.py`` file
-won't be visible to Sopel.
+same limitation:
+
+* everything that is not available in this ``__init__.py`` file won't be
+  visible to Sopel
+* if possible, dependencies should be limited to Sopel and Python's built-in
+  library, or your plugin is a "one-off" for your use only (not intended to be
+  shared)
 
 By default, Sopel's plugin directories are **not** available in ``sys.path``,
 so it is not possible to do ``from my_plugin_dir import some_module`` without
@@ -51,6 +64,12 @@ a specific configuration from the bot's owner.
 When a plugin author wants to split code into different files, and/or share it
 between multiple plugins, the best option is to use an :ref:`Entry point`
 plugin instead.
+
+.. note::
+
+   As per the single file plugin, you can still use a folder plugin  with extra
+   dependencies, and you can follow the same advices about ``requirements.txt``
+   and ``pip``.
 
 Namespace package
 -----------------

--- a/docs/source/plugin/what.rst
+++ b/docs/source/plugin/what.rst
@@ -30,17 +30,17 @@ from one of its
 can write a single file plugin when:
 
 * everything is in a single file
-* if possible, dependencies should be limited to Sopel and Python's built-in
-  library, or your plugin is a "one-off" for your use only (not intended to be
-  shared)
+* either:
+   * dependencies are limited to Sopel and Python's built-in library; or
+   * your plugin is a "one-off" for your use only (not intended to be shared)
 
 This type of plugin is easy to install: copy its file into the right location,
 and Sopel will load it on startup.
 
 .. note::
 
-   You can still use a single file plugin with extra dependencies: bot owners
-   will have to install them themselves, so you should probably document them,
+   You *can* still use extra dependencies with a single file plugin. Bot owners
+   will have to install them manually, so you should probably document them,
    and possibly list them in a ``requirements.txt`` file to be used with
    ``pip install -r`` if you want to simplify the installation process.
 
@@ -49,13 +49,14 @@ Folder
 
 A **Folder** plugin is a folder that contains a ``__init__.py`` file. It is
 available to Sopel the same way a :ref:`Single file` plugin is, and shares the
-same limitation:
+same warnings/advice:
 
 * everything that is not available in this ``__init__.py`` file won't be
   visible to Sopel
-* if possible, dependencies should be limited to Sopel and Python's built-in
-  library, or your plugin is a "one-off" for your use only (not intended to be
-  shared)
+* either:
+   * dependencies should be limited to Sopel and Python's built-in library,
+     for ease of installation; or
+   * the plugin is a "one-off", not intended to be shared
 
 By default, Sopel's plugin directories are **not** available in ``sys.path``,
 so it is not possible to do ``from my_plugin_dir import some_module`` without
@@ -67,9 +68,8 @@ plugin instead.
 
 .. note::
 
-   As per the single file plugin, you can still use a folder plugin  with extra
-   dependencies, and you can follow the same advices about ``requirements.txt``
-   and ``pip``.
+   Just like single file plugins, you *can* use extra dependencies with folder
+   plugins; the same advice about ``requirements.txt`` and ``pip`` applies.
 
 Namespace package
 -----------------
@@ -123,8 +123,8 @@ entry point plugin, which is great to bundle multiple plugins at once.
 
 .. seealso::
 
-   The PyPA specification explains in its `Entry points specification`_ what
-   entry points are and how to use them.
+   The Python Packaging Authority explains how entry points work and how to
+   use them in its `Entry points specification`_.
 
 .. __: `Entry points specification`_
 

--- a/docs/source/plugin/what.rst
+++ b/docs/source/plugin/what.rst
@@ -4,9 +4,9 @@ What is a Plugin?
 
 Before writing your first plugin, you may want to know what is a plugin, how is
 it made, and what are the best solutions for your need. In this chapter we'll
-cover what is a Plugin, what you can do with them, and some vocabulary.
+cover what is a plugin, what you can do with them, and some vocabulary.
 
-You may want to skip ahead to :doc:`anatomy` if you already know what a Plugin
+You may want to skip ahead to :doc:`anatomy` if you already know what a plugin
 is and what types of plugin there are.
 
 .. contents::
@@ -24,7 +24,7 @@ Single file
 -----------
 
 A **Single file** plugin is the most basic form a Sopel plugin can take. It is
-composed of a single file available to Sopel from its plugin's directory (or
+composed of a single file available to Sopel from its plugins directory (or
 from one of its
 :attr:`extra directories <sopel.config.core_section.CoreSection.extra>`). You
 should write a single file plugin when:
@@ -40,15 +40,15 @@ Folder
 ------
 
 A **Folder** plugin is a folder that contains a ``__init__.py`` file. It is
-available to Sopel the same way a :ref:`Single file` plugin is, and share the
-same limitation. Everything that is not available in this ``__init__.py`` file
+available to Sopel the same way a :ref:`Single file` plugin is, and shares the
+same limitation: Everything that is not available in this ``__init__.py`` file
 won't be visible to Sopel.
 
 By default, Sopel's plugin directories are **not** available in ``sys.path``,
 so it is not possible to do ``from my_plugin_dir import some_module`` without
 a specific configuration from the bot's owner.
 
-When a Plugin author wants to split code into different files, and/or share it
+When a plugin author wants to split code into different files, and/or share it
 between multiple plugins, the best option is to use an :ref:`Entry point`
 plugin instead.
 
@@ -56,20 +56,22 @@ Namespace package
 -----------------
 
 A **Namespace package** plugin is a Python :term:`namespace package`, using
-the namespace ``sopel_modules``. It must installed in the Python's environement
+the namespace ``sopel_modules``. It must be installed in the Python environment
 to be used by Sopel, and can require Python dependencies.
 
 Given a ``sopel_modules.plugin`` plugin, Sopel will load everything that is
-available from ``sopel_modules/plugin/__init__.py`` file.
+available from the ``sopel_modules/plugin/__init__.py`` file.
 
 It is the initial version of Sopel's packaged plugins: it can be packaged and
 uploaded to `PyPI`_ then installed using ``pip install``.
 
-When a Plugin author wants to distribute a Sopel plugin, the best option is to
+When a plugin author wants to distribute a Sopel plugin, the best option is to
 use an :ref:`Entry point` plugin instead.
 
 Entry point
 -----------
+
+.. versionadded:: 7.0.0
 
 An **Entry point** plugin is a Python module or package distributed via a
 ``setup.py`` script, and it is available to Sopel via Sopel's ``sopel.plugins``
@@ -90,12 +92,12 @@ You should write an entry point plugin when:
 
 * you want to distribute your plugin on `PyPI`_
 * you want to split the code in multiple files
-* you have dependencies other than Sopel and the Python's built-in library
+* you have dependencies beyond Sopel and Python's standard library
 * you want a modern and reliable way to package your Sopel plugin
 * you want to distribute more than one Sopel plugin per distributed package
 
-An entry point plugin is the best way to package and distribute clean and easy
-to update Sopel plugin.
+An entry point plugin is the best way to package and distribute a Sopel plugin
+or collection of plugins in a clean and easy-to-update manner.
 
 Note that a single Python distributed package can expose more than one Sopel
 entry point plugin, which is great to bundle multiple plugins at once.
@@ -108,8 +110,8 @@ entry point plugin, which is great to bundle multiple plugins at once.
 .. __: `Entry points specification`_
 
 
-Plugin's Name
-=============
+Naming plugins
+==============
 
 Sopel plugins conventionally have all-lowercase names, usually one word.
 However, sometimes multiple words are needed for clarity or disambiguation;

--- a/docs/source/plugin/what.rst
+++ b/docs/source/plugin/what.rst
@@ -3,7 +3,7 @@ What is a Plugin?
 =================
 
 Before writing your first plugin, you may want to know what is a plugin, how is
-it made, and what are the best solutions for your need. In this chapter we'll
+it made, and what are the best solutions for your needs. In this chapter we'll
 cover what is a plugin, what you can do with them, and some vocabulary.
 
 You may want to skip ahead to :doc:`anatomy` if you already know what a plugin
@@ -30,11 +30,11 @@ from one of its
 should write a single file plugin when:
 
 * everything is in a single file
-* you don't have any dependencies other than Sopel and the Python's built-in
-  library
+* you don't have any dependencies other than Sopel and Python's built-in library,
+  or your plugin is a "one-off" for your use only (not intended to be shared)
 
-This type of plugin is easy to install and share: copy its file into the right
-location, and Sopel will load it on startup.
+This type of plugin is easy to install: copy its file into the right location,
+and Sopel will load it on startup.
 
 Folder
 ------
@@ -71,7 +71,7 @@ use an :ref:`Entry point` plugin instead.
 Entry point
 -----------
 
-.. versionadded:: 7.0.0
+.. versionadded:: 7.0
 
 An **Entry point** plugin is a Python module or package distributed via a
 ``setup.py`` script, and it is available to Sopel via Sopel's ``sopel.plugins``
@@ -96,8 +96,8 @@ You should write an entry point plugin when:
 * you want a modern and reliable way to package your Sopel plugin
 * you want to distribute more than one Sopel plugin per distributed package
 
-An entry point plugin is the best way to package and distribute a Sopel plugin
-or collection of plugins in a clean and easy-to-update manner.
+An entry point plugin is the best, most flexible way to package and distribute
+a Sopel plugin (or collection of plugins) in a clean, easy-to-update manner.
 
 Note that a single Python distributed package can expose more than one Sopel
 entry point plugin, which is great to bundle multiple plugins at once.

--- a/docs/source/plugin/what.rst
+++ b/docs/source/plugin/what.rst
@@ -1,0 +1,133 @@
+=================
+What is a Plugin?
+=================
+
+Before writing your first plugin, you may want to know what is a plugin, how is
+it made, and what are the best solutions for your need. In this chapter we'll
+cover what is a Plugin, what you can do with them, and some vocabulary.
+
+You may want to skip ahead to :doc:`anatomy` if you already know what a Plugin
+is and what types of plugin there are.
+
+.. contents::
+    :local:
+    :depth: 2
+
+Plugin Types
+============
+
+There are four types of plugins: :term:`Single file plugin`,
+:term:`Folder plugin`, :term:`Namespace package plugin`, and
+:term:`Entry point plugin`.
+
+Single file
+-----------
+
+A **Single file** plugin is the most basic form a Sopel plugin can take. It is
+composed of a single file available to Sopel from its plugin's directory (or
+from one of its
+:attr:`extra directories <sopel.config.core_section.CoreSection.extra>`). You
+should write a single file plugin when:
+
+* everything is in a single file
+* you don't have any dependencies other than Sopel and the Python's built-in
+  library
+
+This type of plugin is easy to install and share: copy its file into the right
+location, and Sopel will load it on startup.
+
+Folder
+------
+
+A **Folder** plugin is a folder that contains a ``__init__.py`` file. It is
+available to Sopel the same way a :ref:`Single file` plugin is, and share the
+same limitation. Everything that is not available in this ``__init__.py`` file
+won't be visible to Sopel.
+
+By default, Sopel's plugin directories are **not** available in ``sys.path``,
+so it is not possible to do ``from my_plugin_dir import some_module`` without
+a specific configuration from the bot's owner.
+
+When a Plugin author wants to split code into different files, and/or share it
+between multiple plugins, the best option is to use an :ref:`Entry point`
+plugin instead.
+
+Namespace package
+-----------------
+
+A **Namespace package** plugin is a Python :term:`namespace package`, using
+the namespace ``sopel_modules``. It must installed in the Python's environement
+to be used by Sopel, and can require Python dependencies.
+
+Given a ``sopel_modules.plugin`` plugin, Sopel will load everything that is
+available from ``sopel_modules/plugin/__init__.py`` file.
+
+It is the initial version of Sopel's packaged plugins: it can be packaged and
+uploaded to `PyPI`_ then installed using ``pip install``.
+
+When a Plugin author wants to distribute a Sopel plugin, the best option is to
+use an :ref:`Entry point` plugin instead.
+
+Entry point
+-----------
+
+An **Entry point** plugin is a Python module or package distributed via a
+``setup.py`` script, and it is available to Sopel via Sopel's ``sopel.plugins``
+`setup entry point`__.
+
+Given this definition of an entry point from a ``setup.cfg`` file::
+
+   [options.entry_points]
+   sopel.plugins =
+       my_plugin = package_name.my_plugin_file
+
+Sopel will load everything available from the ``package_name.my_plugin_file``
+Python module under the plugin name ``my_plugin``. It means that you can have
+any package name and any module name as long as it is a valid Python module
+and as long as you properly define the entry point.
+
+You should write an entry point plugin when:
+
+* you want to distribute your plugin on `PyPI`_
+* you want to split the code in multiple files
+* you have dependencies other than Sopel and the Python's built-in library
+* you want a modern and reliable way to package your Sopel plugin
+* you want to distribute more than one Sopel plugin per distributed package
+
+An entry point plugin is the best way to package and distribute clean and easy
+to update Sopel plugin.
+
+Note that a single Python distributed package can expose more than one Sopel
+entry point plugin, which is great to bundle multiple plugins at once.
+
+.. seealso::
+
+   The PyPA specification explains in its `Entry points specification`_ what
+   entry points are and how to use them.
+
+.. __: `Entry points specification`_
+
+
+Plugin's Name
+=============
+
+Sopel plugins conventionally have all-lowercase names, usually one word.
+However, sometimes multiple words are needed for clarity or disambiguation;
+``snake_case`` is normally used for these.
+
+How Sopel determines a plugin's name depends on what kind of plugin it is:
+
+Single file
+   The file's basename (e.g. ``plugin`` in ``plugin.py``)
+
+Folder
+   The folder name (e.g. ``plugin`` in ``~/.sopel/plugins/plugin/__init__.py``)
+
+Namespace package
+   The submodule name (e.g. ``plugin`` in ``sopel_modules.plugin``)
+
+Entry point
+   The entry point name (e.g. ``plugin`` in ``plugin = my_plugin.module.path``)
+
+.. _PyPI: https://pypi.org/
+.. _Entry points specification: https://packaging.python.org/specifications/entry-points/

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -512,16 +512,6 @@ def action_command(*command_list):
 
     .. versionadded:: 7.0
 
-    .. important::
-
-        This decorator will prevent the other command types from working on
-        the same callable. Normally only one command type is used per
-        function, but if you need to trigger the same command with e.g. both
-        action and nickname commands, use a main function called from
-        decorated wrappers.
-
-        Hopefully, a future version of Sopel will remove this limitation.
-
     .. note::
 
         You can use a regular expression for the command name(s), but this is


### PR DESCRIPTION
### Description

I moved the content of `source/plugin.rst` to `source/plugin/*.rst` files and then worked around that structure:

* a glossary
* what is a plugin (explain what it is, plugin types, and plugin name)
* anatomy of a plugin (plugin callables, jobs, setup & shutdown, and about plugin configuration)
* interact with the bot (how to use `bot` to talk, join channels, and stuffs)
* `sopel.plugin` (plugin decorators, already explained in anatomy of a plugin)
* `sopel.plugins` (internals, no need to touch that)

I took the same approach I used for the core configuration: one part is a thorough explanation of the topic and the other part is the good old `autodoc`. I really like it!

I think it's possible to do even more, and that should be done later, either by me or someone else, in this version or a future one. The most important here is that I think it's a good structure to work with.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
