### PR TITLE
plugin: rename plural decorators to be consistent

### DIFF
--- a/docs/source/plugin.rst
+++ b/docs/source/plugin.rst
@@ -56,7 +56,7 @@ However, sometimes multiple words are needed for clarity or disambiguation;
 
         from sopel import plugin
 
-        @plugin.commands('hello')
+        @plugin.command('hello')
         def say_hello(bot, trigger):
             """Reply hello to you."""
             bot.reply('Hello!')

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -140,7 +140,7 @@ class CoreSection(StaticSection):
             Liam
 
     This would then allow both "William: Hi!" and "Bill: Hi!" to work with
-    :func:`~sopel.plugin.nickname_commands`.
+    :func:`~sopel.plugin.nickname_command`.
     """
 
     auth_method = ChoiceAttribute('auth_method', choices=[

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -13,15 +13,15 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 # Therefore, don't add anything to this import list. Ever.
 from sopel.plugin import (  # noqa
     ADMIN,
-    action_commands,
-    commands,
+    action_command as action_commands,
+    command as commands,
     echo,
     event,
     example,
     HALFOP,
     intent,
     interval,
-    nickname_commands,
+    nickname_command as nickname_commands,
     NOLIMIT,
     OP,
     OPER,

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -370,17 +370,17 @@ def command(*command_list):
 
     Example::
 
-        @commands("hello")
+        @command("hello")
             # If the command prefix is "\\.", this would trigger on lines
             # starting with ".hello".
 
-        @commands('j', 'join')
+        @command('j', 'join')
             # If the command prefix is "\\.", this would trigger on lines
             # starting with either ".j" or ".join".
 
     You can use a space in the command name to implement subcommands::
 
-        @commands('main sub1', 'main sub2')
+        @command('main sub1', 'main sub2')
             # For ".main sub1", trigger.group(1) will return "main sub1"
             # For ".main sub2", trigger.group(1) will return "main sub2"
 
@@ -389,7 +389,7 @@ def command(*command_list):
     So for instance, to have ``.main`` and ``.main sub`` working properly, you
     need to declare them like this::
 
-        @commands('main sub', 'main')
+        @command('main sub', 'main')
             # This command will react properly to ".main sub" and ".main"
 
     Then, you can check ``trigger.group(1)`` to know if it was used as
@@ -399,10 +399,10 @@ def command(*command_list):
 
     Another option is to declare command with subcommands only, like this::
 
-        @commands('main sub1)
+        @command('main sub1)
             # this command will be triggered on .main sub1
 
-        @commands('main sub2')
+        @command('main sub2')
             # this other command will be triggered on .main sub2
 
     In that case, ``.main`` won't trigger anything, and you won't have to
@@ -414,11 +414,11 @@ def command(*command_list):
         are invoked in the reverse order of appearance::
 
             # These two decorators...
-            @commands('hi')
-            @commands('hello')
+            @command('hi')
+            @command('hello')
 
             # ...are equivalent to this single decorator
-            @commands('hello', 'hi')
+            @command('hello', 'hi')
 
         See also the `Function Definitions`__ chapter from the Python
         documentation for more information about functions and decorators.
@@ -462,7 +462,7 @@ def nickname_command(*command_list):
 
     Example::
 
-        @nickname_commands("hello!")
+        @nickname_command("hello!")
             # Would trigger on "$nickname: hello!", "$nickname,   hello!",
             # "$nickname hello!", "$nickname hello! parameter1" and
             # "$nickname hello! p1 p2 p3 p4 p5 p6 p7 p8 p9".
@@ -507,7 +507,7 @@ def action_command(*command_list):
 
     Example::
 
-        @action_commands("hello!")
+        @action_command("hello!")
             # Would trigger on "/me hello!"
 
     .. versionadded:: 7.0

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -17,8 +17,8 @@ __all__ = [
     # constants
     'NOLIMIT', 'VOICE', 'HALFOP', 'OP', 'ADMIN', 'OWNER', 'OPER',
     # decorators
-    'action_commands',
-    'commands',
+    'action_command',
+    'command',
     'echo',
     'event',
     'example',
@@ -26,7 +26,7 @@ __all__ = [
     'intent',
     'interval',
     'label',
-    'nickname_commands',
+    'nickname_command',
     'output_prefix',
     'priority',
     'rate',
@@ -358,7 +358,7 @@ def echo(function=None):
     return add_attribute
 
 
-def commands(*command_list):
+def command(*command_list):
     """Decorate a function to set one or more commands that should trigger it.
 
     :param str command_list: one or more command name(s) to match
@@ -450,7 +450,7 @@ def commands(*command_list):
     return add_attribute
 
 
-def nickname_commands(*command_list):
+def nickname_command(*command_list):
     """Decorate a function to trigger on lines starting with "$nickname: command".
 
     :param str command_list: one or more command name(s) to match
@@ -495,7 +495,7 @@ def nickname_commands(*command_list):
     return add_attribute
 
 
-def action_commands(*command_list):
+def action_command(*command_list):
     """Decorate a function to trigger on CTCP ACTION lines.
 
     :param str command_list: one or more command name(s) to match

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -298,8 +298,8 @@ class Trigger(unicode):
     .. seealso::
 
        For more information on predefined numbered match groups in commands,
-       see :func:`.plugin.commands`, :func:`.plugin.action_commands`, and
-       :func:`.plugin.nickname_commands`.
+       see :func:`.plugin.command`, :func:`.plugin.action_command`, and
+       :func:`.plugin.nickname_command`.
 
        Also see Python's :meth:`re.Match.group` documentation for details
        about this method's behavior.


### PR DESCRIPTION
### Description
* `plugin.action_commands` is now `plugin.action_command`
* `plugin.commands` is now `plugin.command`
* `plugin.nickname_commands` is now `plugin.nickname_command`

The legacy imports in `sopel.module` have the old names preserved by using the `as` keyword.

Should be the last thing we need to do for #1619 (except make sure to call out the renames when writing the changelog for 7.1). I did a manual find-and-replace in all files to rename all Sphinx references to these decorators, but the small number of changes it turned up made me suspicious and I'd love a second set of eyes to double-check those. Yes, even though I also went through and reviewed all ~600 matches of "commands" in the source code & doc files.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches