### PR TITLE
irc, config: config options for flood penalty on longer messages

### DIFF
--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -526,6 +526,57 @@ class CoreSection(StaticSection):
     .. versionadded:: 7.0
     """
 
+    flood_max_wait = ValidatedAttribute('flood_max_wait', float, default=2)
+    """How much time to wait at most when flood protection kicks in.
+
+    :default: ``2``
+
+    This is equivalent to the default value:
+
+    .. code-block:: ini
+
+        flood_max_wait = 2
+
+    .. seealso::
+
+        The :ref:`Flood Prevention` chapter to learn what each flood-related
+        setting does.
+
+    .. versionadded:: 7.1
+    """
+
+    flood_penalty_ratio = ValidatedAttribute('flood_penalty_ratio',
+                                             float,
+                                             default=1.4)
+    """Ratio of the message length used to compute the added wait penalty.
+
+    :default: ``1.4``
+
+    Messages longer than :attr:`flood_text_length` will get an added
+    wait penalty (in seconds) that will be computed like this::
+
+        overflow = max(0, (len(text) - flood_text_length))
+        rate = flood_text_length * flood_penalty_ratio
+        penalty = overflow / rate
+
+    .. note::
+
+        If the penalty ratio is 0, this penalty will be disabled.
+
+    This is equivalent to the default value:
+
+    .. code-block:: ini
+
+        flood_penalty_ratio = 1.4
+
+    .. seealso::
+
+        The :ref:`Flood Prevention` chapter to learn what each flood-related
+        setting does.
+
+    .. versionadded:: 7.1
+    """
+
     flood_refill_rate = ValidatedAttribute('flood_refill_rate', int, default=1)
     """How quickly burst mode recovers, in messages per second.
 
@@ -543,6 +594,28 @@ class CoreSection(StaticSection):
         setting does.
 
     .. versionadded:: 7.0
+    """
+
+    flood_text_length = ValidatedAttribute('flood_text_length', int, default=50)
+    """Length of text at which an extra wait penalty is added.
+
+    :default: ``50``
+
+    Messages longer than this (in bytes) get an added wait penalty if the
+    flood protection limit is reached.
+
+    This is equivalent to the default value:
+
+    .. code-block:: ini
+
+        flood_text_length = 50
+
+    .. seealso::
+
+        The :ref:`Flood Prevention` chapter to learn what each flood-related
+        setting does.
+
+    .. versionadded:: 7.1
     """
 
     help_prefix = ValidatedAttribute('help_prefix',


### PR DESCRIPTION
### Description

It was asked by someone on IRC so I added some config options to control extra wait penalty on longer messages, and one thing led to another I also added a setting to control the maximum wait time because why not.

I've to say that @dgw was right again, but maybe even more "on the nose" than ever before:

```
07:22:51 <+dgw> It's some arcane magic from AT LEAST a decade ago.
         https://github.com/sopel-irc/sopel/blame/d610029b3933c2ddd6751a7523dd12a30cf4ae8b/irc.py#L139
07:23:24 <+dgw> actually 11
         https://github.com/sopel-irc/sopel/blame/c79635a1627813028d48b2cd0a5e226cd116bae5/irc.py#L135
07:23:28 <+dgw> "Initial commit"
07:23:33 <+dgw> can't get older than that
[...]
07:25:19 <+dgw> also, like half the code in Sopel makes me go hmm
```

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
