### PR TITLE
core: change/recover in-use nick; fix obsolete USER command syntax

### DIFF
--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -46,7 +46,6 @@ except ImportError:
     has_ssl = False
 
 from sopel import tools
-from sopel.tools import events
 from sopel.trigger import PreTrigger
 from .backends import AsynchatBackend, SSLAsynchatBackend
 from .isupport import ISupport
@@ -294,6 +293,15 @@ class AbstractBot(object):
 
         self.last_error_timestamp = datetime.now()
         self.error_count = self.error_count + 1
+
+    def change_current_nick(self, new_nick):
+        """Change the current nick without configuration modification.
+
+        :param str new_nick: new nick to be used by the bot
+        """
+        self._nick = tools.Identifier(new_nick)
+        LOGGER.debug('Sending nick "%s"', self.nick)
+        self.backend.send_nick(self.nick)
 
     def on_close(self):
         """Call shutdown methods."""

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -45,8 +45,7 @@ except ImportError:
     # no SSL support
     has_ssl = False
 
-from sopel import tools
-from sopel.trigger import PreTrigger
+from sopel import tools, trigger
 from .backends import AsynchatBackend, SSLAsynchatBackend
 from .isupport import ISupport
 from .utils import CapReq, safe
@@ -212,7 +211,7 @@ class AbstractBot(object):
         """
         self.last_raw_line = message
 
-        pretrigger = PreTrigger(
+        pretrigger = trigger.PreTrigger(
             self.nick,
             message,
             url_schemes=self.settings.core.auto_url_schemes,
@@ -257,7 +256,7 @@ class AbstractBot(object):
                 except KeyError:
                     pass  # we tried, and that's good enough
 
-            pretrigger = PreTrigger(
+            pretrigger = trigger.PreTrigger(
                 self.nick,
                 ":{0}!{1}@{2} {3}".format(self.nick, self.user, host, raw),
                 url_schemes=self.settings.core.auto_url_schemes,
@@ -265,12 +264,7 @@ class AbstractBot(object):
             self.dispatch(pretrigger)
 
     def on_error(self):
-        """Handle any uncaptured error in the bot itself.
-
-        This method is an override of :meth:`asyncore.dispatcher.handle_error`,
-        the :class:`asynchat.async_chat` being a subclass of
-        :class:`asyncore.dispatcher`.
-        """
+        """Handle any uncaptured error in the bot itself."""
         LOGGER.error('Fatal error in core, please review exceptions log.')
 
         err_log = logging.getLogger('sopel.exceptions')

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -203,7 +203,7 @@ class AbstractBot(object):
         LOGGER.debug('Sending nick "%s"', self.nick)
         self.backend.send_nick(self.nick)
         LOGGER.debug('Sending user "%s" (name: "%s")', self.user, self.name)
-        self.backend.send_user(self.user, '+iw', self.nick, self.name)
+        self.backend.send_user(self.user, '0', '*', self.name)
 
     def on_message(self, message):
         """Handle an incoming IRC message.

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -225,13 +225,7 @@ class AbstractBot(object):
             self.backend.send_pong(pretrigger.args[-1])
         elif pretrigger.event == 'ERROR':
             LOGGER.error("ERROR received from server: %s", pretrigger.args[-1])
-            if self.hasquit:
-                # TODO: refactor direct interface with asynchat
-                self.backend.close_when_done()
-        elif pretrigger.event == events.ERR_NICKNAMEINUSE:
-            LOGGER.error('Nickname already in use!')
-            # TODO: refactor direct interface with asynchat
-            self.backend.handle_close()
+            self.backend.on_irc_error(pretrigger)
 
         self.dispatch(pretrigger)
 

--- a/sopel/irc/abstract_backends.py
+++ b/sopel/irc/abstract_backends.py
@@ -26,6 +26,17 @@ class AbstractIRCBackend(object):
         """
         raise NotImplementedError
 
+    def on_irc_error(self, pretrigger):
+        """Action to perform when the server sends an error event.
+
+        :param pretrigger: PreTrigger object with the error event
+        :type pretrigger: :class:`sopel.trigger.PreTrigger`
+
+        On IRC error, if ``bot.hasquit`` is set, the backend should close the
+        connection so the bot can quit or reconnect as required.
+        """
+        raise NotImplementedError
+
     def irc_send(self, data):
         """Send an IRC line as raw ``data``.
 

--- a/sopel/irc/backends.py
+++ b/sopel/irc/backends.py
@@ -99,6 +99,10 @@ class AsynchatBackend(AbstractIRCBackend, asynchat.async_chat):
     def is_connected(self):
         return self.connected
 
+    def on_irc_error(self, pretrigger):
+        if self.bot.hasquit:
+            self.close_when_done()
+
     def irc_send(self, data):
         """Send an IRC line as raw ``data`` to the socket connection.
 

--- a/sopel/irc/backends.py
+++ b/sopel/irc/backends.py
@@ -165,7 +165,12 @@ class AsynchatBackend(AbstractIRCBackend, asynchat.async_chat):
         self.bot.on_close()
 
     def handle_error(self):
-        """Called when an exception is raised and not otherwise handled."""
+        """Called when an exception is raised and not otherwise handled.
+
+        This method is an override of :meth:`asyncore.dispatcher.handle_error`,
+        the :class:`asynchat.async_chat` being a subclass of
+        :class:`asyncore.dispatcher`.
+        """
         LOGGER.info('Connection error...')
         self.bot.on_error()
 

--- a/test/test_irc.py
+++ b/test/test_irc.py
@@ -34,7 +34,7 @@ def test_on_connect(bot):
     assert bot.backend.message_sent == rawlist(
         'CAP LS 302',
         'NICK Sopel',
-        'USER sopel +iw Sopel :Sopel (https://sopel.chat)'
+        'USER sopel 0 * :Sopel (https://sopel.chat)'
     )
 
 
@@ -47,7 +47,7 @@ def test_on_connect_auth_password(bot):
         'CAP LS 302',
         'PASS auth_secret',
         'NICK Sopel',
-        'USER sopel +iw Sopel :Sopel (https://sopel.chat)'
+        'USER sopel 0 * :Sopel (https://sopel.chat)'
     )
 
 
@@ -60,7 +60,7 @@ def test_on_connect_server_auth_password(bot):
         'CAP LS 302',
         'PASS server_secret',
         'NICK Sopel',
-        'USER sopel +iw Sopel :Sopel (https://sopel.chat)'
+        'USER sopel 0 * :Sopel (https://sopel.chat)'
     )
 
 
@@ -75,7 +75,7 @@ def test_on_connect_auth_password_override_server_auth(bot):
         'CAP LS 302',
         'PASS auth_secret',
         'NICK Sopel',
-        'USER sopel +iw Sopel :Sopel (https://sopel.chat)'
+        'USER sopel 0 * :Sopel (https://sopel.chat)'
     )
 
 


### PR DESCRIPTION
### Description

Basic implementation to fix #300 (no configuration, no alternative, nothing):

1. on connection, if we receive a "nick already used" event, we change the current nick, adding an extra ` _` to its end
2. on auth with a nickserv account, if `bot.nick` is not `bot.settings.core.nick`, we try to use `NickServ GHOST`
3. when `bot.settings.core.nick` QUIT, we try to get back to that nick

Maybe this should be optional, maybe we could have a list of nick aliases to use for that purpose. But I wanted to show what is possible with the current state of the code. It tested it by using a copy of a config file, and checking that the second instance ghost the first one and get its nick back.

From another user point of view, here are the logs:

```
15:25:05 → Exibot joined (~Exibot@hostmask)
15:27:33 → Exibot_ joined (~Exibot@hostmask)
15:27:33 ⇐ Exibot quit (~Exibot@hostmask) Disconnected by services
15:27:34 Exibot_ → Exibot
```

After some discussions, I also fixed an improper use of the `USER` command, and made some minor code-style changes.

I'll do an Exirel and say: everything else is good for another PR!

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
