### PR TITLE
docs: add space before attribute lists

### DIFF
--- a/docs/source/_static/custom.css
+++ b/docs/source/_static/custom.css
@@ -1,0 +1,3 @@
+.section dl.py:not(:first-of-type) {
+    margin-top: 1.5em;
+}


### PR DESCRIPTION
### Description
Main motivation: Class/Module members/attributes were too close together in production docs. Finally got motivated to fix it.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
Might want to amend the commit/PR title if that spacing is the only tweak. Thinking I might find a few more before this is actually ready to go, but who knows? I might not.