### PR TITLE
loader, plugin: load decorated callables only

### DIFF
--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -234,8 +234,11 @@ def clean_module(module, config):
     urls = []
     for obj in itervalues(vars(module)):
         if callable(obj):
+            is_sopel_callable = getattr(obj, '_sopel_callable', False) is True
             if getattr(obj, '__name__', None) == 'shutdown':
                 shutdowns.append(obj)
+            elif not is_sopel_callable:
+                continue
             elif is_triggerable(obj):
                 clean_callable(obj, config)
                 callables.append(obj)

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -147,6 +147,7 @@ def interval(*intervals):
 
     """
     def add_attribute(function):
+        function._sopel_callable = True
         if not hasattr(function, "interval"):
             function.interval = []
         for arg in intervals:
@@ -201,6 +202,7 @@ def rule(*patterns):
 
     """
     def add_attribute(function):
+        function._sopel_callable = True
         if not hasattr(function, "rule"):
             function.rule = []
         for value in patterns:
@@ -255,6 +257,7 @@ def find(*patterns):
 
     """
     def add_attribute(function):
+        function._sopel_callable = True
         if not hasattr(function, "find_rules"):
             function.find_rules = []
         for value in patterns:
@@ -312,6 +315,7 @@ def search(*patterns):
 
     """
     def add_attribute(function):
+        function._sopel_callable = True
         if not hasattr(function, "search_rules"):
             function.search_rules = []
         for value in patterns:
@@ -441,6 +445,7 @@ def command(*command_list):
 
     """
     def add_attribute(function):
+        function._sopel_callable = True
         if not hasattr(function, "commands"):
             function.commands = []
         for command in command_list:
@@ -486,6 +491,7 @@ def nickname_command(*command_list):
 
     """
     def add_attribute(function):
+        function._sopel_callable = True
         if not hasattr(function, 'nickname_commands'):
             function.nickname_commands = []
         for cmd in command_list:
@@ -540,6 +546,7 @@ def action_command(*command_list):
 
     """
     def add_attribute(function):
+        function._sopel_callable = True
         if not hasattr(function, 'action_commands'):
             function.action_commands = []
         for cmd in command_list:
@@ -608,6 +615,7 @@ def event(*event_list):
 
     """
     def add_attribute(function):
+        function._sopel_callable = True
         if not hasattr(function, "event"):
             function.event = []
         for name in event_list:
@@ -632,6 +640,7 @@ def intent(*intent_list):
 
     """
     def add_attribute(function):
+        function._sopel_callable = True
         if not hasattr(function, "intents"):
             function.intents = []
         for name in intent_list:
@@ -945,6 +954,7 @@ def url(*url_rules):
 
     """
     def actual_decorator(function):
+        function._sopel_callable = True
         if not hasattr(function, 'url_regex'):
             function.url_regex = []
         for url_rule in url_rules:
@@ -995,6 +1005,7 @@ def url_lazy(*loaders):
 
     """
     def decorator(function):
+        function._sopel_callable = True
         if not hasattr(function, 'url_lazy_loaders'):
             function.url_lazy_loaders = []
         function.url_lazy_loaders.extend(loaders)

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -63,6 +63,25 @@ def shutdown():
 def ignored():
     pass
 
+
+@sopel.module.rate(10)
+def ignored_rate():
+    pass
+
+
+class Ignored:
+    def __init__(self):
+        self.rule = [r'.*']
+
+    def __call__(self, bot, trigger):
+        pass
+
+ignored_obj = Ignored()
+
+def ignored_trickster():
+    pass
+
+ignored_trickster._sopel_callable = True
 """
 
 
@@ -185,6 +204,23 @@ def test_clean_module(testplugin, tmpconfig):
     assert test_mod.ignored not in jobs
     assert test_mod.ignored not in shutdowns
     assert test_mod.ignored not in urls
+    # @rate doesn't create a callable and is ignored
+    assert test_mod.ignored_rate not in callables
+    assert test_mod.ignored_rate not in jobs
+    assert test_mod.ignored_rate not in shutdowns
+    assert test_mod.ignored_rate not in urls
+    # object with a triggerable attribute are ignored by default
+    assert loader.is_triggerable(test_mod.ignored_obj)
+    assert test_mod.ignored_obj not in callables
+    assert test_mod.ignored_obj not in jobs
+    assert test_mod.ignored_obj not in shutdowns
+    assert test_mod.ignored_obj not in urls
+    # trickster function is ignored: it's still not a proper plugin callable
+    assert not loader.is_triggerable(test_mod.ignored_trickster)
+    assert test_mod.ignored_trickster not in callables
+    assert test_mod.ignored_trickster not in jobs
+    assert test_mod.ignored_trickster not in shutdowns
+    assert test_mod.ignored_trickster not in urls
 
 
 def test_clean_module_idempotency(testplugin, tmpconfig):


### PR DESCRIPTION
### Description

Fix #859 and that's it.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
