### PR TITLE
tools: new `SopelIdentifierMemory` class

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -91,7 +91,7 @@ class Sopel(irc.AbstractBot):
             Use :attr:`channels` instead. Will be removed in Sopel 8.
         """
 
-        self.channels = tools.SopelMemory()  # name to chan obj
+        self.channels = tools.SopelIdentifierMemory()
         """A map of the channels that Sopel is in.
 
         The keys are :class:`sopel.tools.Identifier`\\s of the channel names,
@@ -99,7 +99,7 @@ class Sopel(irc.AbstractBot):
         the users in the channel and their permissions.
         """
 
-        self.users = tools.SopelMemory()  # name to user obj
+        self.users = tools.SopelIdentifierMemory()
         """A map of the users that Sopel is aware of.
 
         The keys are :class:`sopel.tools.Identifier`\\s of the nicknames, and

--- a/sopel/modules/find.py
+++ b/sopel/modules/find.py
@@ -19,12 +19,12 @@ import re
 
 from sopel import plugin
 from sopel.formatting import bold
-from sopel.tools import Identifier, SopelMemory
+from sopel.tools import Identifier, SopelIdentifierMemory
 
 
 def setup(bot):
     if 'find_lines' not in bot.memory:
-        bot.memory['find_lines'] = SopelMemory()
+        bot.memory['find_lines'] = SopelIdentifierMemory()
 
 
 def shutdown(bot):
@@ -43,7 +43,7 @@ def collectlines(bot, trigger):
     """Create a temporary log of what people say"""
     # Add a log for the channel and nick, if there isn't already one
     if trigger.sender not in bot.memory['find_lines']:
-        bot.memory['find_lines'][trigger.sender] = SopelMemory()
+        bot.memory['find_lines'][trigger.sender] = SopelIdentifierMemory()
     if trigger.nick not in bot.memory['find_lines'][trigger.sender]:
         bot.memory['find_lines'][trigger.sender][trigger.nick] = deque(maxlen=10)
 

--- a/sopel/modules/translate.py
+++ b/sopel/modules/translate.py
@@ -26,7 +26,7 @@ PLUGIN_OUTPUT_PREFIX = '[translate] '
 
 def setup(bot):
     if 'mangle_lines' not in bot.memory:
-        bot.memory['mangle_lines'] = tools.SopelMemory()
+        bot.memory['mangle_lines'] = tools.SopelIdentifierMemory()
 
 
 def shutdown(bot):
@@ -212,7 +212,7 @@ def mangle(bot, trigger):
     random.shuffle(lang_list)
     if trigger.group(2) is None:
         try:
-            phrase = (bot.memory['mangle_lines'][trigger.sender.lower()], '')
+            phrase = (bot.memory['mangle_lines'][trigger.sender], '')
         except KeyError:
             bot.reply("What do you want me to mangle?")
             return
@@ -248,7 +248,7 @@ def mangle(bot, trigger):
 @plugin.priority('low')
 @plugin.unblockable
 def collect_mangle_lines(bot, trigger):
-    bot.memory['mangle_lines'][trigger.sender.lower()] = "%s said '%s'" % (
+    bot.memory['mangle_lines'][trigger.sender] = "%s said '%s'" % (
         trigger.nick,
         trigger.group(0).strip(),
     )

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -134,7 +134,7 @@ def setup(bot):
 
     # Ensure last_seen_url is in memory
     if 'last_seen_url' not in bot.memory:
-        bot.memory['last_seen_url'] = tools.SopelMemory()
+        bot.memory['last_seen_url'] = tools.SopelIdentifierMemory()
 
     # Initialize shortened_urls as a dict if it doesn't exist.
     if 'shortened_urls' not in bot.memory:

--- a/sopel/test_tools.py
+++ b/sopel/test_tools.py
@@ -70,10 +70,10 @@ class MockSopel(object):
         self.user = "sopel"
 
         channel = sopel.tools.Identifier("#Sopel")
-        self.channels = sopel.tools.SopelMemory()
+        self.channels = sopel.tools.SopelIdentifierMemory()
         self.channels[channel] = sopel.tools.target.Channel(channel)
 
-        self.users = sopel.tools.SopelMemory()
+        self.users = sopel.tools.SopelIdentifierMemory()
         self.privileges = sopel.tools.SopelMemory()
 
         self.memory = sopel.tools.SopelMemory()

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -751,6 +751,46 @@ class SopelMemoryWithDefault(defaultdict):
         return self.__contains__(key)
 
 
+class SopelIdentifierMemory(SopelMemory):
+    """Special Sopel memory that stores ``Identifier`` as key.
+
+    This is a convenient subclass of :class:`SopelMemory` that always casts its
+    keys as instances of :class:`Identifier`::
+
+        >>> from sopel import tools
+        >>> memory = tools.SopelIdentifierMemory()
+        >>> memory['Exirel'] = 'king'
+        >>> list(memory.items())
+        [(Identifier('Exirel'), 'king')]
+        >>> tools.Identifier('exirel') in memory
+        True
+        >>> 'exirel' in memory
+        True
+
+    As seen in the example above, it is possible to perform various operations
+    with both ``Identifier`` and :class:`str` objects, taking advantage of the
+    case-insensitive behavior of ``Identifier``.
+
+    .. note::
+
+        Internally, it will try to do ``key = tools.Identifier(key)``, which
+        will raise an exception if it cannot instantiate the key properly::
+
+            >>> memory[1] = 'error'
+            AttributeError: 'int' object has no attribute 'lower'
+
+    .. versionadded:: 7.1
+    """
+    def __getitem__(self, key):
+        return super(SopelIdentifierMemory, self).__getitem__(Identifier(key))
+
+    def __contains__(self, key):
+        return super(SopelIdentifierMemory, self).__contains__(Identifier(key))
+
+    def __setitem__(self, key, value):
+        super(SopelIdentifierMemory, self).__setitem__(Identifier(key), value)
+
+
 @deprecated(version='7.0', removed_in='8.0')
 def get_raising_file_and_line(tb=None):
     """Get the file and line number where an exception happened.

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -218,3 +218,37 @@ def test_chain_loaders(configfactory):
     results = loader(settings)
 
     assert results == [re_numeric, re_text]
+
+
+def test_sopel_identifier_memory_str():
+    user = tools.Identifier('Exirel')
+    memory = tools.SopelIdentifierMemory()
+    test_value = 'king'
+
+    memory['Exirel'] = test_value
+    assert user in memory
+    assert 'Exirel' in memory
+    assert 'exirel' in memory
+    assert 'exi' not in memory
+    assert '#channel' not in memory
+
+    assert memory[user] == test_value
+    assert memory['Exirel'] == test_value
+    assert memory['exirel'] == test_value
+
+
+def test_sopel_identifier_memory_id():
+    user = tools.Identifier('Exirel')
+    memory = tools.SopelIdentifierMemory()
+    test_value = 'king'
+
+    memory[user] = test_value
+    assert user in memory
+    assert 'Exirel' in memory
+    assert 'exirel' in memory
+    assert 'exi' not in memory
+    assert '#channel' not in memory
+
+    assert memory[user] == test_value
+    assert memory['Exirel'] == test_value
+    assert memory['exirel'] == test_value


### PR DESCRIPTION
### Description

In an attempt to fix #1341, I decided to create a new class that specifically deals with `tools.Identifier` as its keys: nothing more, nothing less, just `Identifier`.

My idea is that we *want* `SopelMemory` to consider `"nick"` and `Identifier("nick")` as two separated keys, and what we need is a specific **type** of memory, one that is specifically designed to store and retrieve values from `Identifier` key. So that's what I did here.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
