### PR TITLE
tld: comprehensive rewrite

### DIFF
--- a/sopel/modules/tld.py
+++ b/sopel/modules/tld.py
@@ -2,12 +2,16 @@
 """
 tld.py - Sopel TLD Plugin
 Copyright 2009-10, Michael Yanovich, yanovich.net
+Copyright 2020, dgw, technobabbl.es
 Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from datetime import datetime
+from encodings import idna
+import logging
 import re
 import sys
 
@@ -20,8 +24,70 @@ if sys.version_info.major >= 3:
     unicode = str
 
 
-uri = 'https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains'
+LOGGER = logging.getLogger(__name__)
+
+
+DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
+IANA_LIST_URI = 'https://data.iana.org/TLD/tlds-alpha-by-domain.txt'
+WIKI_PAGE_URI = 'https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains'
 r_tag = re.compile(r'<(?!!)[^>]+>')
+
+
+def setup(bot):
+    bot.memory['tld_list_cache'] = bot.db.get_plugin_value(
+        'tld', 'tld_list_cache', [])
+    bot.memory['tld_list_cache_updated'] = bot.db.get_plugin_value(
+        'tld', 'tld_list_cache_updated', '2000-01-01 00:00:00')
+    bot.memory['tld_list_cache_updated'] = datetime.strptime(
+        bot.memory['tld_list_cache_updated'], DATE_FORMAT)
+
+
+
+def shutdown(bot):
+    if bot.memory['tld_list_cache']:
+        bot.db.set_plugin_value(
+            'tld', 'tld_list_cache', bot.memory['tld_list_cache'])
+        bot.db.set_plugin_value(
+            'tld', 'tld_list_cache_updated',
+            bot.memory['tld_list_cache_updated'].strftime(DATE_FORMAT))
+
+    for key in ['tld_list_cache', 'tld_list_cache_updated']:
+        try:
+            del bot.memory[key]
+        except KeyError:
+            pass
+
+
+@plugin.interval(60 * 60)
+def update_tld_list(bot):
+    now = datetime.now()
+    then = bot.memory['tld_list_cache_updated']
+    since = now - then
+    if since.days < 7:
+        LOGGER.debug(
+            "Skipping TLD list cache update; the cached list is only %d days old.",
+            since.days,
+        )
+        return
+
+    try:
+        tld_list = requests.get(IANA_LIST_URI).text
+    except requests.exceptions.RequestException:
+        # Probably a transient error; log it and continue life
+        LOGGER.warning(
+            "Error fetching IANA TLD list; will try again later.",
+            exc_info=True)
+        return
+
+    tld_list = [
+        line.lower()
+        for line in tld_list.splitlines()
+        if not line.startswith('#')
+    ]
+
+    bot.memory['tld_list_cache'] = tld_list
+    bot.memory['tld_list_cache_updated'] = now
+    LOGGER.debug("Updated TLD list cache.")
 
 
 @plugin.command('tld')
@@ -29,13 +95,28 @@ r_tag = re.compile(r'<(?!!)[^>]+>')
 @plugin.output_prefix('[tld] ')
 def gettld(bot, trigger):
     """Show information about the given Top Level Domain."""
-    page = requests.get(uri).text
     tld = trigger.group(2)
     if not tld:
         bot.reply("You must provide a top-level domain to search.")
         return  # Stop if no tld argument is provided
     if tld[0] == '.':
         tld = tld[1:]
+
+    if not bot.memory['tld_list_cache']:
+        update_tld_list(bot)
+    tld_list = bot.memory['tld_list_cache']
+
+    if not any([
+        name in tld_list
+        for name
+        in [tld.lower(), idna.ToASCII(tld).decode('utf-8')]
+    ]):
+        bot.reply(
+            "The top-level domain '{}' is not in IANA's list of valid TLDs."
+            .format(tld))
+        return
+
+    page = requests.get(WIKI_PAGE_URI).text
     search = r'(?i)<td><a href="\S+" title="\S+">\.{0}</a></td>\n(<td><a href=".*</a></td>\n)?<td>([A-Za-z0-9].*?)</td>\n<td>(.*)</td>\n<td[^>]*>(.*?)</td>\n<td[^>]*>(.*?)</td>\n'
     search = search.format(tld)
     re_country = re.compile(search)
@@ -74,7 +155,7 @@ def gettld(bot, trigger):
                 dict_val["notes"] = dict_val["notes"][:400] + "..."
             reply = "%s (%s, %s). IDN: %s, DNSSEC: %s, SLD: %s" % (dict_val["country"], dict_val["expl"], dict_val["notes"], dict_val["idn"], dict_val["dnssec"], dict_val["sld"])
         else:
-            reply = "No matches found for TLD: {0}".format(unicode(tld))
+            reply = "The top-level domain '{}' exists, but no details about it could be found.".format(tld)
     # Final touches + output
     reply = web.decode(reply)
     bot.say(reply)

--- a/sopel/modules/tld.py
+++ b/sopel/modules/tld.py
@@ -17,11 +17,13 @@ import sys
 
 import requests
 
-from sopel import plugin
-from sopel.tools import web
+from sopel import plugin, tools
 
 if sys.version_info.major >= 3:
     unicode = str
+    from html.parser import HTMLParser
+else:
+    from HTMLParser import HTMLParser
 
 
 LOGGER = logging.getLogger(__name__)
@@ -30,7 +32,8 @@ LOGGER = logging.getLogger(__name__)
 DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
 IANA_LIST_URI = 'https://data.iana.org/TLD/tlds-alpha-by-domain.txt'
 WIKI_PAGE_URI = 'https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains'
-r_tag = re.compile(r'<(?!!)[^>]+>')
+r_tld = re.compile(r'^\.(\S+)')
+r_idn = re.compile(r'^(xn--[A-Za-z0-9]+)')
 
 
 def setup(bot):
@@ -38,9 +41,16 @@ def setup(bot):
         'tld', 'tld_list_cache', [])
     bot.memory['tld_list_cache_updated'] = bot.db.get_plugin_value(
         'tld', 'tld_list_cache_updated', '2000-01-01 00:00:00')
+    bot.memory['tld_data_cache'] = bot.db.get_plugin_value(
+        'tld', 'tld_data_cache', {})
+    bot.memory['tld_data_cache_updated'] = bot.db.get_plugin_value(
+        'tld', 'tld_data_cache_updated', '2000-01-01 00:00:00')
+
+    # restore datetime objects from string format
     bot.memory['tld_list_cache_updated'] = datetime.strptime(
         bot.memory['tld_list_cache_updated'], DATE_FORMAT)
-
+    bot.memory['tld_data_cache_updated'] = datetime.strptime(
+        bot.memory['tld_data_cache_updated'], DATE_FORMAT)
 
 
 def shutdown(bot):
@@ -50,44 +60,174 @@ def shutdown(bot):
         bot.db.set_plugin_value(
             'tld', 'tld_list_cache_updated',
             bot.memory['tld_list_cache_updated'].strftime(DATE_FORMAT))
+    if bot.memory['tld_data_cache']:
+        bot.db.set_plugin_value(
+            'tld', 'tld_data_cache', bot.memory['tld_data_cache'])
+        bot.db.set_plugin_value(
+            'tld', 'tld_data_cache_updated',
+            bot.memory['tld_data_cache_updated'].strftime(DATE_FORMAT))
 
-    for key in ['tld_list_cache', 'tld_list_cache_updated']:
+    for key in [
+        'tld_list_cache',
+        'tld_list_cache_updated',
+        'tld_data_cache',
+        'tld_data_cache_updated',
+    ]:
         try:
             del bot.memory[key]
         except KeyError:
             pass
 
 
-@plugin.interval(60 * 60)
-def update_tld_list(bot):
+class WikipediaTLDListParser(HTMLParser):
+    def __init__(self):
+        HTMLParser.__init__(self)
+        self.in_cell = False
+        self.skipping = True
+        self.current_row = []
+        self.current_cell = ''
+        self.rows = []
+        self.tables = []
+
+    def handle_starttag(self, tag, attrs):
+        if tag == 'td' or tag == 'th':
+            self.in_cell = True
+        elif tag == 'sup':
+            # ignore superscripts; they're almost exclusively footnotes
+            self.skipping = True
+        elif tag == 'table':
+            for name, value in attrs:
+                if name == 'class' and 'wikitable' in value:
+                    self.skipping = False
+
+    def handle_endtag(self, tag):
+        if tag == 'td' or tag == 'th':
+            self.in_cell = False
+            if not self.skipping:
+                self.current_row.append(self.current_cell)
+            self.current_cell = ''
+        elif tag == 'tr':
+            if not self.skipping:
+                self.rows.append(tuple([cell.strip() for cell in self.current_row]))
+            self.current_row = []
+        elif tag == 'table':
+            if not self.skipping:
+                self.tables.append(self.rows)
+            self.rows = []
+            self.skipping = True
+            self.in_cell = False
+        elif tag == 'sup' and self.in_cell:
+            self.skipping = False
+
+    def handle_data(self, data):
+        if self.in_cell and not self.skipping:
+            self.current_cell += data
+
+
+def process_parser_result(parser):
+    tables = parser.tables
+    tld_list = {}
+
+    for table in tables:
+        headings = table[0]
+        for row in table[1:]:
+            key = None
+            idn_key = None
+            for cell in row:
+                tld = r_tld.match(cell)
+                if tld:
+                    key = tld.group(1).lower()
+                idn = r_idn.match(cell)
+                if idn:
+                    idn_key = idn.group(1).lower()
+            if not any([key, idn_key]):
+                LOGGER.warning(
+                    "Skipping row %s; could not find string to use as lookup key.",
+                    str(row),
+                )
+                continue
+
+            # Some cleanup happens directly in the dict comprehension here.
+            # Empty values (actually falsy, but only empty strings are possible)
+            # and values consisting only of a dash (indicating the absence of
+            # information or restrictions) get left out of the final data.
+            # When the data is presented later, these empty fields are just
+            # clutter taking up limited space in the IRC line.
+            zipped = {
+                field: value
+                for field, value
+                in dict(zip(headings, row)).items()
+                if value and value != '—'
+            }
+            if key:
+                tld_list[key] = zipped
+            if idn_key:
+                tld_list[idn_key] = zipped
+
+    return tld_list
+
+
+def _update_tld_data(bot, which):
+    if which == 'list':
+        then = bot.memory['tld_list_cache_updated']
+    elif which == 'data':
+        then = bot.memory['tld_data_cache_updated']
+    else:
+        LOGGER.error("Asked to update unknown cache type '%s'.", which)
+        return
+
     now = datetime.now()
-    then = bot.memory['tld_list_cache_updated']
     since = now - then
     if since.days < 7:
         LOGGER.debug(
-            "Skipping TLD list cache update; the cached list is only %d days old.",
+            "Skipping TLD %s cache update; the cache is only %d days old.",
+            which,
             since.days,
         )
         return
 
-    try:
-        tld_list = requests.get(IANA_LIST_URI).text
-    except requests.exceptions.RequestException:
-        # Probably a transient error; log it and continue life
-        LOGGER.warning(
-            "Error fetching IANA TLD list; will try again later.",
-            exc_info=True)
-        return
+    if which == 'list':
+        try:
+            tld_list = requests.get(IANA_LIST_URI).text
+        except requests.exceptions.RequestException:
+            # Probably a transient error; log it and continue life
+            LOGGER.warning(
+                "Error fetching IANA TLD list; will try again later.",
+                exc_info=True)
+            return
 
-    tld_list = [
-        line.lower()
-        for line in tld_list.splitlines()
-        if not line.startswith('#')
-    ]
+        tld_list = [
+            line.lower()
+            for line in tld_list.splitlines()
+            if not line.startswith('#')
+        ]
 
-    bot.memory['tld_list_cache'] = tld_list
-    bot.memory['tld_list_cache_updated'] = now
-    LOGGER.debug("Updated TLD list cache.")
+        bot.memory['tld_list_cache'] = tld_list
+        bot.memory['tld_list_cache_updated'] = now
+    elif which == 'data':
+        try:
+            tld_data = requests.get(WIKI_PAGE_URI).text
+        except requests.exceptions.RequestException:
+            # Log error and continue life; it'll be fine
+            LOGGER.warning(
+                "Error fetching TLD data from Wikipedia; will try again later.",
+                exc_info=True)
+            return
+
+        parser = WikipediaTLDListParser()
+        parser.feed(tld_data)
+        tld_data = process_parser_result(parser)
+
+        bot.memory['tld_data_cache'] = tld_data
+        bot.memory['tld_data_cache_updated'] = now
+
+    LOGGER.debug("Updated TLD %s cache.", which)
+
+
+@plugin.interval(60 * 60)
+def update_caches(bot):
+    _update_tld_data(bot, 'list')
+    _update_tld_data(bot, 'data')
 
 
 @plugin.command('tld')
@@ -99,63 +239,54 @@ def gettld(bot, trigger):
     if not tld:
         bot.reply("You must provide a top-level domain to search.")
         return  # Stop if no tld argument is provided
-    if tld[0] == '.':
-        tld = tld[1:]
+    tld = tld.strip('.').lower()
 
     if not bot.memory['tld_list_cache']:
-        update_tld_list(bot)
+        _update_tld_data(bot, 'list')
     tld_list = bot.memory['tld_list_cache']
 
     if not any([
         name in tld_list
         for name
-        in [tld.lower(), idna.ToASCII(tld).decode('utf-8')]
+        in [tld, idna.ToASCII(tld).decode('utf-8')]
     ]):
         bot.reply(
             "The top-level domain '{}' is not in IANA's list of valid TLDs."
             .format(tld))
         return
 
-    page = requests.get(WIKI_PAGE_URI).text
-    search = r'(?i)<td><a href="\S+" title="\S+">\.{0}</a></td>\n(<td><a href=".*</a></td>\n)?<td>([A-Za-z0-9].*?)</td>\n<td>(.*)</td>\n<td[^>]*>(.*?)</td>\n<td[^>]*>(.*?)</td>\n'
-    search = search.format(tld)
-    re_country = re.compile(search)
-    matches = re_country.findall(page)
-    if not matches:
-        search = r'(?i)<td><a href="\S+" title="(\S+)">\.{0}</a></td>\n<td><a href=".*">(.*)</a></td>\n<td>([A-Za-z0-9].*?)</td>\n<td[^>]*>(.*?)</td>\n<td[^>]*>(.*?)</td>\n'
-        search = search.format(tld)
-        re_country = re.compile(search)
-        matches = re_country.findall(page)
-    if matches:
-        matches = list(matches[0])
-        i = 0
-        while i < len(matches):
-            matches[i] = r_tag.sub("", matches[i])
-            i += 1
-        desc = matches[2]
-        if len(desc) > 400:
-            desc = desc[:400] + "..."
-        reply = "%s -- %s. IDN: %s, DNSSEC: %s" % (
-            matches[1], desc, matches[3], matches[4]
+    if not bot.memory['tld_data_cache']:
+        _update_tld_data(bot, 'data')
+    tld_data = bot.memory['tld_data_cache']
+
+    record = tld_data.get(tld, None)
+    if not record:
+        bot.say(
+            "The top-level domain '{}' exists, "
+            "but no details about it could be found."
+            .format(tld)
         )
-    else:
-        search = r'<td><a href="\S+" title="\S+">.{0}</a></td>\n<td><span class="flagicon"><img.*?\">(.*?)</a></td>\n<td[^>]*>(.*?)</td>\n<td[^>]*>(.*?)</td>\n<td[^>]*>(.*?)</td>\n<td[^>]*>(.*?)</td>\n<td[^>]*>(.*?)</td>\n'
-        search = search.format(unicode(tld))
-        re_country = re.compile(search)
-        matches = re_country.findall(page)
-        if matches:
-            matches = matches[0]
-            dict_val = dict()
-            dict_val["country"], dict_val["expl"], dict_val["notes"], dict_val["idn"], dict_val["dnssec"], dict_val["sld"] = matches
-            for key in dict_val:
-                if dict_val[key] == "&#160;":
-                    dict_val[key] = "N/A"
-                dict_val[key] = r_tag.sub('', dict_val[key])
-            if len(dict_val["notes"]) > 400:
-                dict_val["notes"] = dict_val["notes"][:400] + "..."
-            reply = "%s (%s, %s). IDN: %s, DNSSEC: %s, SLD: %s" % (dict_val["country"], dict_val["expl"], dict_val["notes"], dict_val["idn"], dict_val["dnssec"], dict_val["sld"])
-        else:
-            reply = "The top-level domain '{}' exists, but no details about it could be found.".format(tld)
-    # Final touches + output
-    reply = web.decode(reply)
-    bot.say(reply)
+        return
+
+    # Build the order in which to output available data fields
+    fields = list(record.keys())
+    # This trick moves matching keys to the end of the list
+    fields.sort(key=lambda s: s.startswith('Notes') or s.startswith('Comments'))
+    # This column depends on HTML formatting to make sense; skip it for now
+    try:
+        fields.remove('Explanation')
+    except ValueError:
+        pass
+
+    items = []
+    for field in fields:
+        value = record[field]
+        if value:
+            items.append('{}: {}'.format(field, value))
+
+    message = ' | '.join(items)
+    usable, excess = tools.get_sendable_message(message)
+    if excess:
+        message = usable + ' […]'
+
+    bot.say(message)


### PR DESCRIPTION
### Description
In short, this fixes Sopel being unable to find known-valid TLDs. But it also makes things _better_ than before. No more ugly, unmaintainable regex!

* Pulls from IANA for verifying that a TLD is recognized
* If a TLD is not in the IANA list, it stops and says so
* If the given TLD exists in the IANA list, return at least a confirmation of existence
* If the TLD exists in the Wikipedia article we've been using for years, also include more details from there
* Wikipedia table data is now transformed into an in-memory dictionary using `HTMLParser`

Both the IANA and Wikipedia data sources are cached locally, persisted/restored to/from the bot's database on shutdown/startup, and periodically updated by a plugin job (minimum age 7 days).

I think about the only thing I didn't do was add example-tests. But I haven't decided _against_ doing so. I've just not gotten to it.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### See also
This might be sufficient to consider #1648 as "done". I've been unable to find any viable alternative data source that actually provides the information contained in Wikipedia's tables—even the basics like whether a TLD allows second-level registrations or supports DNSSEC/IDN/etc.