### PR TITLE
isup: fix error-series HTTP status codes; get away from assuming TLD

### DIFF
--- a/sopel/modules/isup.py
+++ b/sopel/modules/isup.py
@@ -57,7 +57,9 @@ def handle_isup(bot, trigger, secure=True):
     """
     try:
         site = get_site_url(trigger.group(2))
-        response = requests.head(site, verify=secure).headers
+        response = requests.head(site, verify=secure)
+        response.raise_for_status()
+        response = response.headers
     except ValueError as error:
         bot.reply(str(error))
     except requests.exceptions.SSLError:

--- a/sopel/modules/isup.py
+++ b/sopel/modules/isup.py
@@ -27,7 +27,7 @@ def get_site_url(site):
     or a :exc:`ValueError` is raised.
 
     If the ``site`` does not have a scheme, ``http`` is used. If it doesn't
-    have a TLD, ``.com`` is used.
+    have a TLD, a :exc:`ValueError` is raised.
     """
     site = site.strip() if site else ''
     if not site:
@@ -41,7 +41,9 @@ def get_site_url(site):
         site = 'http://' + site
 
     if '.' not in site:
-        site += ".com"
+        # TODO: Make this more robust against e.g.
+        # .isup lanpeer/path/to/some/IoT.service
+        raise ValueError('I need a fully qualified domain name (with a dot).')
 
     return site
 

--- a/sopel/modules/isup.py
+++ b/sopel/modules/isup.py
@@ -33,7 +33,7 @@ def get_site_url(site):
     if not site:
         raise ValueError('What site do you want to check?')
 
-    if site[:7] != 'http://' and site[:8] != 'https://':
+    if not site.startswith(('http://', 'https://')):
         if '://' in site:
             protocol = site.split('://')[0] + '://'
             raise ValueError('Try it again without the %s' % protocol)

--- a/sopel/modules/isup.py
+++ b/sopel/modules/isup.py
@@ -40,10 +40,11 @@ def get_site_url(site):
 
         site = 'http://' + site
 
-    if '.' not in site:
-        # TODO: Make this more robust against e.g.
-        # .isup lanpeer/path/to/some/IoT.service
+    domain = site.split('/')[2].split(':')[0]
+    if '.' not in domain:
         raise ValueError('I need a fully qualified domain name (with a dot).')
+    if domain.endswith(('.local', '.example', '.test', '.invalid', '.localhost')):
+        raise ValueError("I can't check LAN-local or invalid domains.")
 
     return site
 

--- a/test/modules/test_modules_isup.py
+++ b/test/modules/test_modules_isup.py
@@ -8,8 +8,6 @@ from sopel.modules import isup
 
 
 VALID_SITE_URLS = (
-    # no TLD, no scheme
-    ('example', 'http://example.com'),
     # no scheme
     ('www.example.com', 'http://www.example.com'),
     # with scheme
@@ -37,6 +35,7 @@ INVALID_SITE_URLS = (
     '      ',  # empty once stripped
     'steam://browsemedia',  # invalid protocol
     '://',  # invalid protocol (that's a weird one)
+    'example',  # no TLD, no scheme
 )
 
 

--- a/test/modules/test_modules_isup.py
+++ b/test/modules/test_modules_isup.py
@@ -36,6 +36,10 @@ INVALID_SITE_URLS = (
     'steam://browsemedia',  # invalid protocol
     '://',  # invalid protocol (that's a weird one)
     'example',  # no TLD, no scheme
+    'something.local',  # LAN-local address
+    'something.local:8080',  # LAN-local address with explicit port
+    'lanmachine/path/to/iot.device',  # unqualified name with dot in path
+    'lanmachine:8080/path/to/iot.device',  # unqualified name with explicit port & dot in path
 )
 
 


### PR DESCRIPTION
### Description
Unbelievably, `isup` has been sometimes (often?) returning "looks fine" for sites that send back error status codes, e.g. HTTP 4xx, 5xx. Those should be considered "down".

I also threw in a couple other little tweaks, the important one being that a bare name like `google` will no longer assume `google.com` as the input. (There's one last TODO left for myself before this PR is actually _ready_ for review, about properly handling full URLs that contain a `.` but refer to a LAN name.)

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
