### PR TITLE
coretasks: assume + only if core.modes does not start with + or -

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -153,7 +153,11 @@ def startup(bot, trigger):
     auth_after_register(bot)
 
     modes = bot.config.core.modes
-    bot.write(('MODE', '%s +%s' % (bot.nick, modes)))
+    if modes:
+        if not modes.startswith(('+', '-')):
+            # Assume "+" by default.
+            modes = '+' + modes
+        bot.write(('MODE', bot.nick, modes))
 
     bot.memory['retry_join'] = dict()
 


### PR DESCRIPTION
### Description

Fix #1917 and nothing more.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
