### PR TITLE
coretasks, admin: minor style fix for bot.write

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -101,9 +101,9 @@ def auth_after_register(bot):
     if auth_method == 'nickserv':
         bot.say('IDENTIFY %s' % auth_password, auth_target or 'NickServ')
     elif auth_method == 'authserv':
-        bot.write(('AUTHSERV auth', auth_username + ' ' + auth_password))
+        bot.write(('AUTHSERV', 'auth', auth_username, auth_password))
     elif auth_method == 'Q':
-        bot.write(('AUTH', auth_username + ' ' + auth_password))
+        bot.write(('AUTH', auth_username, auth_password))
     elif auth_method == 'userserv':
         bot.say("LOGIN %s %s" % (auth_username, auth_password),
                 auth_target or 'UserServ')

--- a/sopel/modules/admin.py
+++ b/sopel/modules/admin.py
@@ -250,7 +250,7 @@ def hold_ground(bot, trigger):
 def mode(bot, trigger):
     """Set a user mode on Sopel. Can only be done in privmsg by an admin."""
     mode = trigger.group(3)
-    bot.write(('MODE', bot.nick + ' ' + mode))
+    bot.write(('MODE', bot.nick, mode))
 
 
 def parse_section_option_value(config, trigger):


### PR DESCRIPTION
### Description

No one asked for this, but I did it anyway: `bot.write` accepts a list (any iterable) of arguments as its first parameter and will automatically join them with a space.

It means that this:

    bot.write(('COMMAND arg %s' % param,))

Can be written as:

    bot.write(('COMMAND', 'arg', param))

Which I prefer and is better in every way. So I checked the code and fixed them whenever possible.

I didn't modify one `bot.write` in `coretasks` because it's already fixed in #1941 and I don't want to create unnecessary merge conflict.

_This PR is very "hashtag first world problem" and "hashtag totally not a maniac"._

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
