### PR TITLE
bot: prevent sys.exit when loading plugin to crash the bot

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -300,6 +300,10 @@ class Sopel(irc.AbstractBot):
             except Exception as e:
                 load_error = load_error + 1
                 LOGGER.exception('Error loading %s: %s', name, e)
+            except SystemExit:
+                load_error = load_error + 1
+                LOGGER.exception(
+                    'Error loading %s (plugin tried to exit)', name)
             else:
                 try:
                     if plugin.has_setup():


### PR DESCRIPTION
### Description

Fix #1830

Check for `SystemExit` while loading plugins, and prevent the bot to crash.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
