### PR TITLE
tools: make `time` and `web` always accessible by importing `tools`

### DIFF
--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -27,7 +27,9 @@ import traceback
 from pkg_resources import parse_version
 
 from sopel import __version__
-from sopel.tools._events import events  # NOQA
+
+from ._events import events  # NOQA
+from . import time, web  # NOQA
 
 if sys.version_info.major >= 3:
     raw_input = input


### PR DESCRIPTION
### Description
It's really silly that anyone who wants to use the `time` submodule has to do `import sopel.tools.time` even if they've already done `from sopel import tools`. This makes that unnecessary.

The intention here is to make `from sopel import tools` the only import needed to use the `tools`, `tools.events`, `tools.time`, and `tools.web` modules, without any extra nonsense.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches