### PR TITLE
isup: more specific errors

### DIFF
--- a/sopel/modules/isup.py
+++ b/sopel/modules/isup.py
@@ -62,7 +62,6 @@ def handle_isup(bot, trigger, secure=True):
         site = get_site_url(trigger.group(2))
         response = requests.head(site, verify=secure, timeout=(10.0, 5.0))
         response.raise_for_status()
-        response = response.headers
     except ValueError as error:
         bot.reply(str(error))
     except requests.exceptions.SSLError:
@@ -85,11 +84,9 @@ def handle_isup(bot, trigger, secure=True):
         bot.say(
             '{} looks down to me (connection error).'
             .format(site))
-    else:
-        if response:
-            bot.say(site + ' looks fine to me.')
-        else:  # TODO: Is it even possible to get here any more?
-            bot.say(site + ' looks down to me.')
+
+    # If no exception happened, the request succeeded.
+    bot.say(site + ' looks fine to me.')
 
 
 @plugin.command('isupinsecure')

--- a/test/modules/test_modules_isup.py
+++ b/test/modules/test_modules_isup.py
@@ -31,6 +31,7 @@ def test_get_site_url(site, expected):
 
 
 INVALID_SITE_URLS = (
+    None,  # missing
     '',  # empty
     '      ',  # empty once stripped
     'steam://browsemedia',  # invalid protocol


### PR DESCRIPTION
### Description
Follow-up to #1940, wherein @Exirel requested more specific error messages than just "seems down".

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches