### PR TITLE
version: tweak docstring for clarification

### DIFF
--- a/sopel/modules/version.py
+++ b/sopel/modules/version.py
@@ -36,7 +36,11 @@ def git_info():
 @plugin.command('version')
 @plugin.output_prefix('[version] ')
 def version(bot, trigger):
-    """Display the latest commit version, if Sopel is running in a git repo."""
+    """Display the installed version of Sopel.
+
+    Includes the version of Python Sopel is installed on.
+    Includes the commit hash if Sopel is installed from source.
+    """
     parts = [
         'Sopel v%s' % release,
         'Python: %s' % platform.python_version()


### PR DESCRIPTION
### Description
Tweak the docstring of the `.version` command so it is more accurate and informative

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
