### PR TITLE
find_updates: restore unstable release handling

### DIFF
--- a/sopel/__init__.py
+++ b/sopel/__init__.py
@@ -47,7 +47,7 @@ __version__ = pkg_resources.get_distribution('sopel').version
 
 
 def _version_info(version=__version__):
-    regex = re.compile(r'(\d+)\.(\d+)\.(\d+)(?:(a|b|rc)(\d+))?.*')
+    regex = re.compile(r'(\d+)\.(\d+)\.(\d+)(?:[\-\.]?(a|b|rc)(\d+))?.*')
     version_groups = regex.match(version).groups()
     major, minor, micro = (int(piece) for piece in version_groups[0:3])
     level = version_groups[3]

--- a/sopel/modules/find_updates.py
+++ b/sopel/modules/find_updates.py
@@ -24,9 +24,13 @@ from sopel import (
 
 wait_time = 24 * 60 * 60  # check once per day
 version_url = 'https://sopel.chat/latest.json'
-message = (
-    'A new Sopel version, {}, is available. I am running {}. Please update '
+stable_message = (
+    'A new Sopel version, {}, is available; I am running {}. Please update '
     'me. Full release notes at {}'
+)
+unstable_message = (
+    'A new pre-release version, {}, is available; I am running {}. Please '
+    'update me.{}'
 )
 
 
@@ -81,13 +85,15 @@ def check_version(bot):
     if version.releaselevel == 'final':
         latest = info['version']
         notes = info['release_notes']
+        message = stable_message
     else:
         latest = info['unstable']
         notes = info.get('unstable_notes', '')
         if notes:
-            notes = 'Full release notes at ' + notes
+            notes = ' Full release notes at ' + notes
+        message = unstable_message
     latest_version = _version_info(latest)
-    msg = message.format(latest, current_version, notes)
 
     if version < latest_version:
+        msg = message.format(latest, current_version, notes)
         bot.say('[update] ' + msg, bot.config.core.owner)

--- a/sopel/modules/find_updates.py
+++ b/sopel/modules/find_updates.py
@@ -23,7 +23,6 @@ from sopel import (
 
 
 wait_time = 24 * 60 * 60  # check once per day
-startup_check_run = False
 version_url = 'https://sopel.chat/latest.json'
 message = (
     'A new Sopel version, {}, is available. I am running {}. Please update '
@@ -33,9 +32,8 @@ message = (
 
 @plugin.event(tools.events.RPL_LUSERCLIENT)
 def startup_version_check(bot, trigger):
-    global startup_check_run
-    if not startup_check_run:
-        startup_check_run = True
+    if not bot.memory.get('update_startup_check_run', False):
+        bot.memory['update_startup_check_run'] = True
         check_version(bot)
 
 


### PR DESCRIPTION
### Description
#1937 cleaned up some unused stuff that should not have been unused. Regardless of how we got here, it's time to put that stuff back in working order.

Coming soon: a companion PR in the website repo to actually generate the right JSON values for this.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [ ] I have tested the functionality of the things this change touches

### Notes
Yes, I meant to leave that last checkbox unchecked. I need to implement the website piece, or at least mock up what the JSON will look like and test on a local dev server. That sounds like a weekend project. 😅