### PR TITLE
bot, irc: in `bot.say()`, fill IRC line if possible & add optional truncation indicator

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,9 @@ import-order-style = google
 ignore =
     # Line length limit. Acceptable (for now).
     E501,
+    # Newline before binary operator. Sometimes this is more readable, e.g. in
+    # long arithmetic expressions.
+    W503,
     # Newline after binary operator. Ignored by default (which we want to keep)
     W504,
     # These are forbidding certain __future__ imports. The future-import plugin

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -1118,7 +1118,7 @@ class SopelWrapper(object):
     def __setattr__(self, attr, value):
         return setattr(self._bot, attr, value)
 
-    def say(self, message, destination=None, max_messages=1):
+    def say(self, message, destination=None, max_messages=1, trailing=''):
         """Override ``Sopel.say`` to use trigger source by default.
 
         :param str message: message to say
@@ -1136,7 +1136,7 @@ class SopelWrapper(object):
         """
         if destination is None:
             destination = self._trigger.sender
-        self._bot.say(self._out_pfx + message, destination, max_messages)
+        self._bot.say(self._out_pfx + message, destination, max_messages, trailing)
 
     def action(self, message, destination=None):
         """Override ``Sopel.action`` to use trigger source by default.

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -592,7 +592,7 @@ class AbstractBot(object):
                 - 1  # space between prefix & command
                 - 7  # PRIVMSG command
                 - 1  # space before recipient
-                - len(recipient)  # target channel/nick
+                - len(recipient.encode('utf-8'))  # target channel/nick (can contain Unicode)
                 - 2  # space after recipient, colon before text
                 - 2  # trailing CRLF
             )

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -533,13 +533,16 @@ class AbstractBot(object):
         else:
             self.say(text, dest)
 
-    def say(self, text, recipient, max_messages=1):
+    def say(self, text, recipient, max_messages=1, trailing=''):
         """Send a PRIVMSG to a user or channel.
 
         :param str text: the text to send
         :param str recipient: the message recipient
         :param int max_messages: split ``text`` into at most this many messages
                                  if it is too long to fit in one (optional)
+        :param str trailing: text to append if ``text`` is too long to fit in
+                             a single message, or into the last message if
+                             ``max_messages`` is greater than 1 (optional)
 
         By default, this will attempt to send the entire ``text`` in one
         message. If the text is too long for the server, it may be truncated.
@@ -553,14 +556,21 @@ class AbstractBot(object):
         If the ``text`` is too long to fit into the specified number of
         messages using the above splitting, the final message will contain the
         entire remainder, which may be truncated by the server.
+
+        The ``trailing`` parameter allows gracefully terminating a ``text``
+        that is too long to fit in the specified number of messages. The final
+        message (or only message, if ``max_messages`` is left at the default
+        value of 1) will be truncated slightly to fit the ``trailing`` string.
+        Note that the ``trailing`` parameter must include leading whitespace
+        if you desire any between it and the truncated text.
         """
         excess = ''
         if not isinstance(text, unicode):
             # Make sure we are dealing with a Unicode string
             text = text.decode('utf-8')
 
-        if max_messages > 1:
-            # Manage multi-line only when needed
+        if max_messages > 1 or trailing:
+            # Handle message splitting/truncation only if needed
             try:
                 hostmask_length = len(self.hostmask)
             except KeyError:
@@ -587,6 +597,12 @@ class AbstractBot(object):
                 - 2  # trailing CRLF
             )
             text, excess = tools.get_sendable_message(text, safe_length)
+
+        if max_messages == 1 and excess and trailing:
+            # only append `trailing` if this is the last message AND it's still too long
+            safe_length -= len(trailing.encode('utf-8'))
+            text, excess = tools.get_sendable_message(text, safe_length)
+            text += trailing
 
         flood_max_wait = self.settings.core.flood_max_wait
         flood_burst_lines = self.settings.core.flood_burst_lines
@@ -661,7 +677,7 @@ class AbstractBot(object):
             recipient_stack['messages'].append((time.time(), safe(text)))
             recipient_stack['messages'] = recipient_stack['messages'][-10:]
 
-        # Now that we've sent the first part, we need to send the rest. Doing
-        # this recursively seems simpler than iteratively.
-        if excess:
-            self.say(excess, recipient, max_messages - 1)
+        # Now that we've sent the first part, we need to send the rest if
+        # requested. Doing so recursively seems simpler than iteratively.
+        if max_messages > 1 and excess:
+            self.say(excess, recipient, max_messages - 1, trailing)

--- a/test/test_irc.py
+++ b/test/test_irc.py
@@ -241,7 +241,9 @@ def test_say_long_extra(bot):
 
 def test_say_long_extra_multi_message(bot):
     """Test a long message that doesn't fit, with split allowed."""
-    text = 'a' * 400
+    prefix_length = 1 + len(bot.nick) + 1 + 1 + len(bot.user) + 1 + 63 + 1
+    # ':', nick, '!', '~', ident/username, '@', maximum hostname length, <0x20>
+    text = 'a' * (512 - prefix_length - len('PRIVMSG #sopel :\r\n'))
     bot.say(text + 'b', '#sopel', max_messages=2)
 
     assert bot.backend.message_sent == rawlist(

--- a/test/test_irc.py
+++ b/test/test_irc.py
@@ -255,6 +255,18 @@ def test_say_long_extra_multi_message(bot):
     )
 
 
+def test_say_long_extra_multi_message_multibyte_recipient(bot):
+    """Test a split-allowed message sent to recipient with multi-byte char."""
+    text = 'a' * (
+        512 - prefix_length(bot) - len('PRIVMSG #sopel² :\r\n'.encode('utf-8')))
+    bot.say(text + 'b', '#sopel²', max_messages=2)
+
+    assert bot.backend.message_sent == rawlist(
+        'PRIVMSG #sopel² :%s' % text,  # the 'b' is split from message
+        'PRIVMSG #sopel² :b',
+    )
+
+
 def test_say_long_trailing_fit(bot):
     """Test optional truncation indicator with message that fits in one line."""
     text = 'a' * (512 - prefix_length(bot) - len('PRIVMSG #sopel :\r\n') - 3)


### PR DESCRIPTION
### Description
By way of killing (or at least gravely wounding) two birds with one stone, this is my valiant attempt to resolve #1328, and also close #1322—which was left open pending a change like this to make use of the stored hostmask when sending messages. (I say "attempt" mostly because certain @sopel-irc/rockstars might disagree with subtle code style decisions I made; the new logic itself is almost fully covered by new or updated unit tests.)

`bot.say()` now has the ability to calculate a `safe_length` for messages, and use that instead of the arbitrary default value of 400 from `tools.get_sendable_message()`. There is also a new optional parameter, `trailing`, which replicates a common pattern I've seen in my own and other plugins to append some arbitrary "continuation string" to a message that was too long. (Alternative parameter name suggestions welcome; that's just the best I could think up.)

For plugin authors, use of the new `trailing` parameter replaces manually calling `tools.get_sendable_message()` with some arbitrary length value that "should be" short enough to avoid truncation by the server, and leaves truncating the message to Sopel—which knows its own nick, ident, and hopefully hostmask. If Sopel's hostmask is not known, a worst-case maximum length is used instead (thanks to @deathbybandaid for https://github.com/sopel-irc/sopel/issues/1322#issuecomment-565865343, which got me 90% of the way there). The worst-case maximum tries to be as comprehensive as possible, taking advantage of the `USERLEN` token in `ISUPPORT` if sent by the server, RFC maximum lengths for the hostname and ident, and Sopel's configured ident & nickname values.\*

This also _kind of_ addresses part of #1559, regarding calculating the penalty based on only the truncated message body, in the case where `(max_messages > 1) or trailing` would evaluate to `True` during execution of `bot.say()`.

The new truncation behavior is explicitly _not_ enabled for the most basic usage of `bot.say()` yet, as noted in the commit log. We are limiting the potential impact of this behavior change in 7.x to existing plugins that already expressed some concern for over-length messages via use of `max_messages`, and new/updated plugins that opt-in to the new `trailing` behavior.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Next steps
Future PRs may:
- enable the `safe_length` for _all_ calls to `bot.say()`
- move this logic so it can be used for `bot.action()`, `bot.notice()`, and possibly even other commands that take text arguments such as KICK/TOPIC
  - I readily admit, I was focused on getting this working for the most common messaging function used by plugin authors; making it more generic was left for future-me (or whoever else decides to do it first)
- add the optional `max_messages` and/or `trailing` parameters to other messaging functions (e.g. `bot.notice()` or `bot.reply()`; only `trailing` would make sense for `bot.action()`, IMO)
- ??? (ideas always welcome)

### Notes
\* — I have considered using the `NICKLEN` token from `ISUPPORT` (if available) and the RFC maximum nickname length, too. But in the nickname's case, it seems more likely to _cause_ problems on servers that support longer-than-RFC nicks but don't send `NICKLEN`.