### PR TITLE
Path setting and doc tweaks; meetbot enforcement change

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -67,6 +67,13 @@ other value will be considered as "false".
 When a config option is a choice, it means you can provide only one of the
 values defined as valid for this option, or Sopel will complain about it.
 
+.. note::
+
+   The INI file structure Sopel uses does **not** require quoting of values,
+   except for specific cases such as the escaped list value shown above.
+   Quoting a value unnecessarily can lead to unexpected behavior such as an
+   absolute pathname being interpreted as relative to Sopel's home directory.
+
 .. __: https://docs.python.org/3/library/configparser.html#supported-ini-file-structure
 
 
@@ -190,7 +197,7 @@ you need to set :attr:`~CoreSection.use_ssl` to true::
     [core]
     use_ssl = yes
     verify_ssl = yes
-    ca_certs = path/to/sopel/ca_certs.pem
+    ca_certs = /path/to/sopel/ca_certs.pem
 
 In that case:
 
@@ -400,7 +407,7 @@ and the required credentials:
     (``UserServ`` by default)
 
 Multi-stage
--------------
+-----------
 
 In some cases, an IRC bot needs to use both server-based and
 nick-based authentication.
@@ -588,6 +595,7 @@ Example of configuration for logging::
     logging_level = INFO
     logging_format = [%(asctime)s] %(levelname)s - %(message)s
     logging_datefmt = %Y-%m-%d %H:%M:%S
+    logdir = /path/to/logs
 
 .. versionadded:: 7.0
 
@@ -631,7 +639,10 @@ Raw Logs
 --------
 
 It is possible to store raw logs of what Sopel receives and sends by setting
-the flag :attr:`~CoreSection.log_raw` to true.
+the flag :attr:`~CoreSection.log_raw` to true::
+
+    [core]
+    log_raw = on
 
 In that case, IRC messages received and sent are stored into a file named
 ``<base>.raw.log``, located in the log directory.

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -234,6 +234,9 @@ class CoreSection(StaticSection):
 
     If not specified, Sopel will try to find the certificate trust store
     itself from a set of known locations.
+
+    If the given value is not an absolute path, it will be interpreted relative
+    to the directory containing the config file with which Sopel was started.
     """
 
     channels = ListAttribute('channels')
@@ -685,6 +688,8 @@ class CoreSection(StaticSection):
     log_raw = ValidatedAttribute('log_raw', bool, default=False)
     """Whether a log of raw lines as sent and received should be kept.
 
+    :default: ``no``
+
     To enable this logging:
 
     .. code-block:: ini
@@ -699,6 +704,11 @@ class CoreSection(StaticSection):
 
     logdir = FilenameAttribute('logdir', directory=True, default='logs')
     """Directory in which to place logs.
+
+    :default: ``logs``
+
+    If the given value is not an absolute path, it will be interpreted relative
+    to the directory containing the config file with which Sopel was started.
 
     .. seealso::
 

--- a/sopel/modules/ip.py
+++ b/sopel/modules/ip.py
@@ -39,7 +39,11 @@ LOGGER = logging.getLogger(__name__)
 
 class GeoipSection(types.StaticSection):
     GeoIP_db_path = types.FilenameAttribute('GeoIP_db_path', directory=True)
-    """Path of the directory containing the GeoIP database files."""
+    """Path of the directory containing the GeoIP database files.
+
+    If the given value is not an absolute path, it will be interpreted relative
+    to the directory containing the config file with which Sopel was started.
+    """
 
 
 def configure(config):

--- a/sopel/modules/meetbot.py
+++ b/sopel/modules/meetbot.py
@@ -29,6 +29,7 @@ class MeetbotSection(types.StaticSection):
 
     meeting_log_path = types.FilenameAttribute(
         "meeting_log_path",
+        relative=False,
         directory=True,
         default="~/www/meetings")
     """Path to meeting logs storage directory.


### PR DESCRIPTION
### Description
Inspired by that raw-logs-not-working problem someone brought to our IRC the other day, which turned out to be due to quotes in the config file, I decided to make some documentation adjustments.

I might have also tried to earn a few bonus points by making `meetbot` enforce its own documented restriction on the meeting log path, which it said should be absolute but which it then allowed to be relative anyway.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches