### PR TITLE
admin: add .chanlist command to show what channels Sopel is in

### DIFF
--- a/sopel/modules/admin.py
+++ b/sopel/modules/admin.py
@@ -154,6 +154,19 @@ def temporary_part(bot, trigger):
 
 
 @plugin.require_privmsg
+@plugin.require_admin
+@plugin.command('chanlist', 'channels')
+@plugin.priority('low')
+def channel_list(bot, trigger):
+    """Show channels Sopel is in."""
+    channels = ', '.join(sorted(bot.channels.keys()))
+
+    # conservative assumption about how much room we have in the line to make
+    # sure `max_messages` won't actually truncate anything
+    bot.say(channels, max_messages=1 + len(channels) // 400)
+
+
+@plugin.require_privmsg
 @plugin.require_owner
 @plugin.command('restart')
 @plugin.priority('low')


### PR DESCRIPTION
### Description
Tin.

This was requested on our IRC channel. Instead of just telling the user how to write their own command to do it, I realized that such a feature probably *does* belong in the admin plugin that ships with Sopel.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - Note: I'm relying on tests and other code I've patched recently to prove that `max_messages` works as intended