### PR TITLE
core: use CHANTYPES for `Identifier.is_nick()` if advertised

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -24,7 +24,7 @@ import re
 import sys
 import time
 
-from sopel import loader, module, plugin
+from sopel import loader, module, plugin, tools
 from sopel.config import ConfigurationError
 from sopel.irc import isupport
 from sopel.irc.utils import CapReq, MyInfo
@@ -168,7 +168,6 @@ def startup(bot, trigger):
     251 RPL_LUSERCLIENT is a mandatory message that is sent after client
     connects to the server in rfc1459. RFC2812 does not require it and all
     networks might not send it. We support both.
-
     """
     if bot.connection_registered:
         return
@@ -243,6 +242,11 @@ def handle_isupport(bot, trigger):
             LOGGER.warning('Unable to parse ISUPPORT parameter: %r', arg)
 
     bot._isupport = bot._isupport.apply(**parameters)
+
+    # If CHANTYPES is advertised, substitute it for the default RFC set used
+    # when checking `Identifier.is_nick()`.
+    if hasattr(bot.isupport, 'CHANTYPES'):
+        tools._update_channel_prefixes(bot.isupport.CHANTYPES)
 
 
 @module.priority('high')

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -409,6 +409,29 @@ class Ddict(dict):
         return dict.__getitem__(self, key)
 
 
+def _update_channel_prefixes(seq):
+    """Override the default set of channel prefixes.
+
+    :param seq: the current server's supported channel prefixes
+    :type seq: any iterable sequence type
+
+    It's useful to do this way because it leaves the well-entrenched
+    :class:`Identifier` type alone and we don't need to worry about deprecating
+    or changing any existing API functionality.
+
+    .. versionadded:: 7.1
+    """
+    global _channel_prefixes
+
+    try:
+        t = tuple(seq)
+    except TypeError:
+        # non-iterable won't work, but don't automatically fix it
+        raise
+
+    _channel_prefixes = t
+
+
 class Identifier(unicode):
     """A `unicode` subclass which acts appropriately for IRC identifiers.
 


### PR DESCRIPTION
### Description
Very simple: If the server's ISUPPORT info includes CHANTYPES, update the list of prefixes in `tools`. Does so through a private helper function to prevent breaking anything in case a bad value gets through.

Admittedly, this approach is a bit overengineered, and maybe also runs the update in a suboptimal location. This is why we have code review. x) **Edit:** Leave it to @Exirel, who says he'll have better ideas Soon™.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - Well it's just replacing one tuple with another, so…