### PR TITLE
Audit docs (mostly) for incorrect use of the term "module"

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -1,7 +1,7 @@
 # coding=utf-8
 """Tasks that allow the bot to run, but aren't user-facing functionality
 
-This is written as a module to make it easier to extend to support more
+This is written as a plugin to make it easier to extend to support more
 responses to standard IRC codes without having to shove them all into the
 dispatch function in bot.py and making it easier to maintain.
 """
@@ -37,7 +37,7 @@ if sys.version_info.major >= 3:
 LOGGER = logging.getLogger(__name__)
 
 batched_caps = {}
-who_reqs = {}  # Keeps track of reqs coming from this module, rather than others
+who_reqs = {}  # Keeps track of reqs coming from this plugin, rather than others
 
 
 def setup(bot):

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -334,11 +334,11 @@ class AbstractBot(object):
         logger = logging.getLogger('sopel.raw')
         logger.info('\t'.join([prefix, line.strip()]))
 
-    def cap_req(self, module_name, capability, arg=None, failure_callback=None,
+    def cap_req(self, plugin_name, capability, arg=None, failure_callback=None,
                 success_callback=None):
         """Tell Sopel to request a capability when it starts.
 
-        :param str module_name: the module requesting the capability
+        :param str plugin_name: the plugin requesting the capability
         :param str capability: the capability requested, optionally prefixed
                                with ``-`` or ``=``
         :param str arg: arguments for the capability request
@@ -352,16 +352,16 @@ class AbstractBot(object):
         By prefixing the capability with ``-``, it will be ensured that the
         capability is not enabled. Similarly, by prefixing the capability with
         ``=``, it will be ensured that the capability is enabled. Requiring and
-        disabling is "first come, first served"; if one module requires a
+        disabling is "first come, first served"; if one plugin requires a
         capability, and another prohibits it, this function will raise an
-        exception in whichever module loads second. An exception will also be
-        raised if the module is being loaded after the bot has already started,
+        exception in whichever plugin loads second. An exception will also be
+        raised if the plugin is being loaded after the bot has already started,
         and the request would change the set of enabled capabilities.
 
-        If the capability is not prefixed, and no other module prohibits it, it
+        If the capability is not prefixed, and no other plugin prohibits it, it
         will be requested. Otherwise, it will not be requested. Since
         capability requests that are not mandatory may be rejected by the
-        server, as well as by other modules, a module which makes such a
+        server, as well as by other plugins, a plugin which makes such a
         request should account for that possibility.
 
         The actual capability request to the server is handled after the
@@ -377,7 +377,7 @@ class AbstractBot(object):
         capability negotiation, or later.
 
         If ``arg`` is given, and does not exactly match what the server
-        provides or what other modules have requested for that capability, it is
+        provides or what other plugins have requested for that capability, it is
         considered a conflict.
         """
         # TODO raise better exceptions
@@ -394,7 +394,7 @@ class AbstractBot(object):
                                 'connection has been completed.')
             if any((ent.prefix != '-' for ent in entry)):
                 raise Exception('Capability conflict')
-            entry.append(CapReq(prefix, module_name, failure_callback, arg,
+            entry.append(CapReq(prefix, plugin_name, failure_callback, arg,
                                 success_callback))
             self._cap_reqs[cap] = entry
         else:
@@ -409,7 +409,7 @@ class AbstractBot(object):
             # rejected it.
             if any((ent.prefix == '-' for ent in entry)) and prefix == '=':
                 raise Exception('Capability conflict')
-            entry.append(CapReq(prefix, module_name, failure_callback, arg,
+            entry.append(CapReq(prefix, plugin_name, failure_callback, arg,
                                 success_callback))
             self._cap_reqs[cap] = entry
 

--- a/sopel/irc/utils.py
+++ b/sopel/irc/utils.py
@@ -49,8 +49,9 @@ def safe(string):
 class CapReq(object):
     """Represents a pending CAP REQ request.
 
-    :param str prefix: either ``=`` (must be enabled)
-                       or ``-`` (must **not** be enabled)
+    :param str prefix: either ``=`` (must be enabled),
+                       ``-`` (must **not** be enabled),
+                       or empty string (desired but optional)
     :param str module: the requesting package/module name
     :param failure: function to call if this capability request fails
     :type failure: :term:`function`

--- a/sopel/irc/utils.py
+++ b/sopel/irc/utils.py
@@ -9,6 +9,8 @@ import sys
 
 from dns import rdtypes, resolver
 
+from sopel.tools import deprecated
+
 if sys.version_info.major >= 3:
     unicode = str
 
@@ -52,7 +54,7 @@ class CapReq(object):
     :param str prefix: either ``=`` (must be enabled),
                        ``-`` (must **not** be enabled),
                        or empty string (desired but optional)
-    :param str module: the requesting package/module name
+    :param str plugin: the requesting plugin's name
     :param failure: function to call if this capability request fails
     :type failure: :term:`function`
     :param str arg: optional capability value; the request will fail if
@@ -68,15 +70,24 @@ class CapReq(object):
         For more information on how capability requests work, see the
         documentation for :meth:`sopel.irc.AbstractBot.cap_req`.
     """
-    def __init__(self, prefix, module, failure=None, arg=None, success=None):
+    def __init__(self, prefix, plugin, failure=None, arg=None, success=None):
         def nop(bot, cap):
             pass
         # TODO at some point, reorder those args to be sane
         self.prefix = prefix
-        self.module = module
+        self.plugin = plugin
         self.arg = arg
         self.failure = failure or nop
         self.success = success or nop
+
+    @property
+    @deprecated(
+        reason='use the `plugin` property instead',
+        version='7.1',
+        removed_in='8.0',
+    )
+    def module(self):
+        return self.plugin
 
 
 class MyInfo(collections.namedtuple('MyInfo', MYINFO_ARGS)):

--- a/sopel/logger.py
+++ b/sopel/logger.py
@@ -156,6 +156,12 @@ def setup_logging(settings):
     dictConfig(logging_config)
 
 
+@tools.deprecated(
+    reason='use sopel.tools.get_logger instead',
+    version='7.0',
+    warning_in='8.0',
+    removed_in='9.0',
+)
 def get_logger(name=None):
     """Return a logger for a module, if the name is given.
 

--- a/sopel/plugins/__init__.py
+++ b/sopel/plugins/__init__.py
@@ -3,9 +3,9 @@
 
 .. versionadded:: 7.0
 
-Sopel uses plugins (also called "modules") and uses what are called
-Plugin Handlers as an interface between the bot and its plugins. This interface
-is defined by the :class:`~.handlers.AbstractPluginHandler` abstract class.
+Sopel uses what are called Plugin Handlers as an interface between the bot and
+its plugins (formerly called "modules"). This interface is defined by the
+:class:`~.handlers.AbstractPluginHandler` abstract class.
 
 Plugins that can be used by Sopel are provided by :func:`~.get_usable_plugins`
 in an :class:`ordered dict<collections.OrderedDict>`. This dict contains one

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -339,7 +339,7 @@ class PyFilePlugin(PyModulePlugin):
 
     def _load(self):
         # The current implementation uses `imp.load_module` to perform the
-        # load action, which also reload the module. However, `imp` is
+        # load action, which also reloads the module. However, `imp` is
         # deprecated in Python 3, so that might need to be changed when the
         # support for Python 2 is dropped.
         #
@@ -422,7 +422,7 @@ class EntryPointPlugin(PyModulePlugin):
 
     In this example, the plugin ``custom`` is loaded from an entry point.
     Unlike the :class:`~.PyModulePlugin`, the name is not derived from the
-    actual python module, but from its entry point's name.
+    actual Python module, but from its entry point's name.
 
     .. seealso::
 


### PR DESCRIPTION
### Description
This is the final step for 7.1 in #1738. Making these commits was literally just me going through about 1,400 find-in-files results for the string "module". Fortunately I was able to skip a lot with negative regex lookarounds (e.g. decorators, object attributes).

I mixed in a few little tweaks to other stuff, because without them it would have been a _very_ small PR indeed.

In summary:

* coretasks: audit for outdated uses of "module" vs. "plugin" (6fa4bb1)
* irc: audit for outdated use of "module" vs. "plugin" (650e672)
  * Some of this actually changes an argument name, something we might not want to do right now (and in fact the "module" moniker goes all the way down into the `CapReq` type from `irc.utils`).
  * More importantly, it seems that nothing actually *uses* the `cap_req()` function provided here. Something to address in a future patch, perhaps.
* irc.utils: fix docs for `CapReq` param `prefix` (f8ed9e5)
  * The empty string is also allowed; it means "request this if no other CapReq forbids it".
  * Here I did _not_ change the parameter name `module` or anything else, yet. I'm still not entirely sure how this and `cap_req()` fit together, and we'll probably end up dropping most or all of the above commit.
* logger: decorate `get_logger()` with deprecation info (e02a286)
  * I think this was deprecated before we added that `warning_in` parameter for `tools.deprecated()` in #1872, but now we won't have to remember to decorate this function later.
* plugins: audit docs for outdated use of "module" vs. "plugin" (d5854f8)
* plugins.handlers: small fixes (all uses of "module" are correct) (850a178)
* irc.utils: rename "module" param & attribute to "plugin" (33b094ba)
  * Kept `CapReq.module` as a `@tools.deprecated` `@property`. Looks like nothing was accessing it, but let's still keep it around until 8.0 just in case.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - Note: There are minimal code changes (none if the single code-touching commit to `irc` is rejected)

### Notes
Yes, I'm aware that I threw some unrelated stuff in here, not that long after admonishing @Exirel for doing the same in #1944. I don't regret it. That stuff needs fixing, too. 😜