### PR TITLE
plugin: keep old-school plugin devs happy w/plural command decorators

### DIFF
--- a/sopel/module.py
+++ b/sopel/module.py
@@ -13,15 +13,15 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 # Therefore, don't add anything to this import list. Ever.
 from sopel.plugin import (  # noqa
     ADMIN,
-    action_command as action_commands,
-    command as commands,
+    action_commands,
+    commands,
     echo,
     event,
     example,
     HALFOP,
     intent,
     interval,
-    nickname_command as nickname_commands,
+    nickname_commands,
     NOLIMIT,
     OP,
     OPER,

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -18,7 +18,9 @@ __all__ = [
     'NOLIMIT', 'VOICE', 'HALFOP', 'OP', 'ADMIN', 'OWNER', 'OPER',
     # decorators
     'action_command',
+    'action_commands',
     'command',
+    'commands',
     'echo',
     'event',
     'example',
@@ -27,6 +29,7 @@ __all__ = [
     'interval',
     'label',
     'nickname_command',
+    'nickname_commands',
     'output_prefix',
     'priority',
     'rate',
@@ -455,6 +458,10 @@ def command(*command_list):
     return add_attribute
 
 
+commands = command
+"""Alias to :func:`command`."""
+
+
 def nickname_command(*command_list):
     """Decorate a function to trigger on lines starting with "$nickname: command".
 
@@ -501,6 +508,10 @@ def nickname_command(*command_list):
     return add_attribute
 
 
+nickname_commands = nickname_command
+"""Alias to :func:`nickname_command`."""
+
+
 def action_command(*command_list):
     """Decorate a function to trigger on CTCP ACTION lines.
 
@@ -544,6 +555,10 @@ def action_command(*command_list):
                 function.action_commands.append(cmd)
         return function
     return add_attribute
+
+
+action_commands = action_command
+"""Alias to :func:`action_command`."""
 
 
 def label(value):


### PR DESCRIPTION
### Description
Enough people expressed dismay that our upcoming migration to `sopel.plugin` (from `sopel.module`) would get rid of the plural `commands` decorator family. So we can have both, and plugin devs may choose depending on how they decorate stuff.

```py
@plugin.command('justone')
def one_name(bot, trigger):
    pass

@plugin.commands('multiple', 'names')
def two_names(bot, trigger):
    pass
```

I gave the aliases very short docstrings that just link back to the main entry, so Sphinx wouldn't duplicate the whole shebang.
Locally built preview:

![image](https://user-images.githubusercontent.com/164140/96647511-683b4600-12f3-11eb-9167-c665c125bc86.png)

@Exirel, is adding tests for the aliases worthwhile? I don't feel like bothering. 😝

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches