### PR TITLE
tld: small tweak to parser's handling of superscript

### DIFF
--- a/sopel/modules/tld.py
+++ b/sopel/modules/tld.py
@@ -93,7 +93,7 @@ class WikipediaTLDListParser(HTMLParser):
     def handle_starttag(self, tag, attrs):
         if tag == 'td' or tag == 'th':
             self.in_cell = True
-        elif tag == 'sup':
+        elif tag == 'sup' and self.in_cell:
             # ignore superscripts; they're almost exclusively footnotes
             self.skipping = True
         elif tag == 'table':


### PR DESCRIPTION
### Description
Without this, some TLDs like `.бел` won't be included in the data table.

Originally added while chasing a different (Heisen)bug (#1945), but unlike that bug, this one was reproducible across multiple parses of the wiki page.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches