### PR TITLE
cli, setup: hard-code Python 2 EOL message

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import sys
-import time
 
 try:
     from setuptools import setup, __version__ as setuptools_version
@@ -42,12 +41,9 @@ if sys.version_info < (2, 7) or (
     raise ImportError('Sopel requires Python 2.7+ or 3.3+.')
 # Py2 EOL: https://www.python.org/dev/peps/pep-0373/#maintenance-releases
 if sys.version_info.major == 2:
-    now = time.time()
-    state = "has reached end of life"
-    if now >= 1588291200:  # 2020-05-01 00:00:00 UTC
-        state += " and will receive no further updates"
     print(
-        "Warning: Python 2 %s. Sopel 8.0 will drop support for it." % state,
+        'Warning: Python 2.x has reached end of life and will receive '
+        'no further updates. Sopel 8.0 will drop support for it.',
         file=sys.stderr,
     )
 

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -30,11 +30,9 @@ if sys.version_info < (2, 7) or (
     tools.stderr('Error: Sopel requires Python 2.7+ or 3.3+.')
     sys.exit(1)
 if sys.version_info.major == 2:
-    now = time.time()
-    state = 'has reached end of life'
-    if now >= 1588291200:  # 2020-05-01 00:00:00 UTC
-        state += ' and will receive no further updates'
-    tools.stderr('Warning: Python 2.x %s. Sopel 8.0 will drop support for it.' % state)
+    tools.stderr(
+        'Warning: Python 2.x has reached end of life and will receive '
+        'no further updates. Sopel 8.0 will drop support for it.')
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
### Description
Updates to Python 2.x stopped months ago. Any future release is certain to be installed and run after support stopped, therefore there's no need for wasting CPU cycles on date comparisons.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches