### PR TITLE
tld: Use Wiki API

### DIFF
--- a/sopel/modules/tld.py
+++ b/sopel/modules/tld.py
@@ -31,7 +31,7 @@ LOGGER = logging.getLogger(__name__)
 
 DATE_FORMAT = '%Y-%m-%d %H:%M:%S'
 IANA_LIST_URI = 'https://data.iana.org/TLD/tlds-alpha-by-domain.txt'
-WIKI_PAGE_URI = 'https://en.wikipedia.org/wiki/List_of_Internet_top-level_domains'
+WIKI_PAGE_NAME = 'List_of_Internet_top-level_domains'
 r_tld = re.compile(r'^\.(\S+)')
 r_idn = re.compile(r'^(xn--[A-Za-z0-9]+)')
 
@@ -234,8 +234,21 @@ def _update_tld_data(bot, which):
         bot.memory['tld_list_cache_updated'] = now
     elif which == 'data':
         try:
-            tld_data = requests.get(WIKI_PAGE_URI).text
-        except requests.exceptions.RequestException:
+            # https://www.mediawiki.org/wiki/Special:MyLanguage/API:Get_the_contents_of_a_page
+            tld_response = requests.get(
+                "https://en.wikipedia.org/w/api.php",
+                params={
+                    "action": "parse",
+                    "format": "json",
+                    "prop": "text",
+                    "utf8": 1,
+                    "formatversion": 2,
+                    "page": WIKI_PAGE_NAME,
+                },
+            ).json()
+            tld_data = tld_response["parse"]["text"]
+        # py <3.5 needs ValueError instead of more specific json.decoder.JSONDecodeError
+        except (requests.exceptions.RequestException, ValueError, KeyError):
             # Log error and continue life; it'll be fine
             LOGGER.warning(
                 "Error fetching TLD data from Wikipedia; will try again later.",


### PR DESCRIPTION
### Description
Use the Wikipedia API to fetch only [article content](https://en.wikipedia.org/wiki/Special:ApiSandbox#action=parse&format=json&page=List_of_Internet_top-level_domains&prop=text&utf8=1&formatversion=2) instead of scraping the *entire* page.
I'd like to use a better parser, but we probably don't want to add dependencies to the larger sopel repo just for this.
`make qa` currently fails in the same way it does on `master`.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
