### PR TITLE
ci: test on Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
       python: 3.7
     - name: "Python 3.8 on Bionic"
       python: 3.8
+    - name: "Python 3.9 on Bionic"
+      python: 3.9
 git:
   submodules: false
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,8 @@ cache:
   directories:
     - $HOME/.cache/pip
 install:
-  - pip install --upgrade "setuptools<=39.2.0"  # last version to support Python 3.3
+  # setuptools should be left alone once we drop Python 3.3 support
+  - pip install --upgrade "setuptools<=39.2.0; python_version < '3.9'"
   - pip install --upgrade -r requirements.txt -r dev-requirements.txt
   - python setup.py develop
 script:


### PR DESCRIPTION
It took a few weeks for Travis CI to add Python 3.9 stable to the available versions, but it finally arrived.

This CI configuration has been [validated](https://travis-ci.org/github/sopel-irc/sopel/builds/739190149) on a test branch.

Letting this jump the usual merge order might make sense, after which it should be possible for me to just "kick" older PRs through Travis' web UI and make them rerun with the added job. Could be annoying if they continue under-allocating build workers to the .org platform, but migrating onto .com is currently a last-resort thing due to the migration function _still_ being labeled "Beta" (some things like build logs do _not_ transfer).