### PR TITLE
config: warn if unexpected settings exist

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -254,7 +254,7 @@ class Sopel(irc.AbstractBot):
         """
         self.setup_logging()
         self.setup_plugins()
-        self._scheduler.start()
+        self.post_setup()
 
     def setup_logging(self):
         """Set up logging based on config options."""
@@ -321,6 +321,34 @@ class Sopel(irc.AbstractBot):
                 load_disabled)
         else:
             LOGGER.warning("Warning: Couldn't load any plugins")
+
+    # post setup
+
+    def post_setup(self):
+        """Perform post-setup actions.
+
+        This method handles everything that should happen after all the plugins
+        are loaded, and before the bot can connect to the IRC server.
+
+        At the moment, this method checks for undefined configuration options,
+        and starts the job scheduler.
+
+        .. versionadded:: 7.1
+        """
+        settings = self.settings
+        for section_name, section in settings.get_defined_sections():
+            for option_name in settings.parser.options(section_name):
+                if not hasattr(section, option_name):
+                    LOGGER.warning(
+                        'Config option `%s.%s` is not defined by its section '
+                        'and may not be recognized by Sopel.',
+                        section_name,
+                        option_name,
+                    )
+
+        self._scheduler.start()
+
+    # plugins management
 
     def reload_plugin(self, name):
         """Reload a plugin.
@@ -447,6 +475,8 @@ class Sopel(irc.AbstractBot):
             raise plugins.exceptions.PluginNotRegistered(name)
 
         return self._plugins[name].get_meta_description()
+
+    # callable management
 
     @deprecated(
         reason="Replaced by specific `unregister_*` methods.",
@@ -604,6 +634,8 @@ class Sopel(irc.AbstractBot):
             Use :meth:`say` instead. Will be removed in Sopel 8.
         """
         self.say(text, recipient, max_messages)
+
+    # message dispatch
 
     def call_rule(self, rule, sopel, trigger):
         # rate limiting
@@ -852,6 +884,8 @@ class Sopel(irc.AbstractBot):
             self._running_triggers = [
                 t for t in running_triggers if t.is_alive()]
 
+    # event handlers
+
     def on_scheduler_error(self, scheduler, exc):
         """Called when the Job Scheduler fails.
 
@@ -964,6 +998,8 @@ class Sopel(irc.AbstractBot):
 
         # Avoid calling shutdown methods if we already have.
         self.shutdown_methods = []
+
+    # URL callbacks management
 
     def register_url_callback(self, pattern, callback):
         """Register a ``callback`` for URLs matching the regex ``pattern``.

--- a/sopel/config/__init__.py
+++ b/sopel/config/__init__.py
@@ -159,6 +159,30 @@ class Config(object):
         else:
             return os.path.dirname(self.filename)
 
+    def get_defined_sections(self):
+        """Retrieve all defined static sections of this configuration.
+
+        :return: all instances of :class:`~sopel.config.types.StaticSection`
+                 defined for this configuration file
+        :rtype: list
+
+        When a plugin defines a section (using :meth:`define_section`), it
+        associates a :class:`~sopel.config.types.StaticSection` for the section.
+        This method allows to retrieve these instances of ``StaticSection``,
+        and only these.
+
+        .. versionadded:: 7.1
+        """
+        sections = (
+            (name, getattr(self, name))
+            for name in self.parser.sections()
+        )
+        return [
+            (name, section)
+            for name, section in sections
+            if isinstance(section, types.StaticSection)
+        ]
+
     def save(self):
         """Write all changes to the config file.
 

--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -66,20 +66,23 @@ class StaticSection(object):
         self._parent = config
         self._parser = config.parser
         self._section_name = section_name
+
         for value in dir(self):
+            if value in ('_parent', '_parser', '_section_name'):
+                # ignore internal attributes
+                continue
+
             try:
                 getattr(self, value)
             except ValueError as e:
                 raise ValueError(
-                    'Invalid value for {}.{}: {}'.format(section_name, value,
-                                                         str(e))
-                )
+                    'Invalid value for {}.{}: {}'.format(
+                        section_name, value, str(e)))
             except AttributeError:
                 if validate:
                     raise ValueError(
-                        'Missing required value for {}.{}'.format(section_name,
-                                                                  value)
-                    )
+                        'Missing required value for {}.{}'.format(
+                            section_name, value))
 
     def configure_setting(self, name, prompt, default=NO_DEFAULT):
         """Return a validated value for this attribute from the terminal.

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -36,6 +36,9 @@ channels =
     "#startquote
     &endquote"
     "&quoted"
+
+[somesection]
+is_defined = no
 """  # noqa (trailing whitespaces are intended)
 
 TEST_CHANNELS = [
@@ -343,3 +346,21 @@ def test_save_modified_config(multi_fakeconfig):
         '&endquote"',
         '"&quoted"',  # doesn't start with a # so it isn't escaped
     ]
+
+
+def test_get_defined_sections(multi_fakeconfig):
+    assert multi_fakeconfig.parser.has_section('core')
+    assert multi_fakeconfig.parser.has_section('fake')
+    assert multi_fakeconfig.parser.has_section('spam')
+    assert multi_fakeconfig.parser.has_section('somesection')
+
+    results = multi_fakeconfig.get_defined_sections()
+
+    assert len(results) == 3, 'There should be 3 defined sections'
+
+    items = dict(results)
+    assert 'core' in items, 'core must be always defined'
+    assert 'fake' in items
+    assert 'spam' in items
+    assert 'somesection' not in items, (
+        'somesection was not defined and should not appear as such')


### PR DESCRIPTION
### Description

Fix #1570

To implement this, I added new methods and changed the bot's `setup()` method:

* `sopel.config.Config.get_defined_sections()` retrieves all defined sections, so it's easier to know which sections of the config file are defined in order to check them for unexpected settings
* `sopel.bot.Sopel.setup()` now calls a new method called `post_setup()`, to start the scheduler and perform post-setup checks

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
