### PR TITLE
plugin: replace intent by ctcp

### DIFF
--- a/docs/source/plugin.rst
+++ b/docs/source/plugin.rst
@@ -77,7 +77,7 @@ Plugin glossary
 
    Action command
       An action command is a :term:`Named rule` that reacts to a name in a
-      message sent with the ``ACTION`` intent/CTCP.
+      message sent with the ``ACTION`` CTCP command.
 
    Nick command
       A nick command (or nickname command) is a :term:`Named rule` that reacts

--- a/docs/source/plugin/anatomy.rst
+++ b/docs/source/plugin/anatomy.rst
@@ -37,7 +37,7 @@ Additionally, Sopel identifies a callable as a generic rule when these
 decorators are used alone:
 
 * event based rule: :func:`~sopel.plugin.event`
-* intent/CTCP based rule: :func:`~sopel.plugin.intent`
+* CTCP based rule: :func:`~sopel.plugin.ctcp`
 
 In that case, it will use a match-all regex (``r'.*'``)::
 

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -19,7 +19,7 @@ from sopel.plugin import (  # noqa
     event,
     example,
     HALFOP,
-    intent,
+    ctcp as _future_ctcp,
     interval,
     nickname_commands,
     NOLIMIT,
@@ -41,3 +41,21 @@ from sopel.plugin import (  # noqa
     url,
     VOICE,
 )
+
+
+def intent(*intent_list):
+    """Decorate a callable to trigger on intent messages.
+
+    :param str intent_list: one or more intent(s) on which to trigger (really,
+                            the only useful value is ``ACTION``)
+
+    .. versionadded:: 5.2.0
+
+    .. deprecated:: 7.1
+
+    .. important::
+
+        This will be removed in Sopel 9, as the IRCv3 intent specification is
+        long dead. You can use :func:`@ctcp <sopel.plugin.ctcp>` instead.
+    """
+    return _future_ctcp(*intent_list)

--- a/sopel/modules/seen.py
+++ b/sopel/modules/seen.py
@@ -70,4 +70,4 @@ def note(bot, trigger):
     bot.db.set_nick_value(nick, 'seen_timestamp', time.time())
     bot.db.set_nick_value(nick, 'seen_channel', trigger.sender)
     bot.db.set_nick_value(nick, 'seen_message', trigger)
-    bot.db.set_nick_value(nick, 'seen_action', 'intent' in trigger.tags)
+    bot.db.set_nick_value(nick, 'seen_action', trigger.ctcp is not None)

--- a/sopel/modules/version.py
+++ b/sopel/modules/version.py
@@ -52,21 +52,21 @@ def version(bot, trigger):
     bot.say(' | '.join(parts))
 
 
-@plugin.intent('VERSION')
+@plugin.ctcp('VERSION')
 @plugin.rate(20)
 def ctcp_version(bot, trigger):
     bot.write(('NOTICE', trigger.nick),
               '\x01VERSION Sopel IRC Bot version %s\x01' % release)
 
 
-@plugin.intent('SOURCE')
+@plugin.ctcp('SOURCE')
 @plugin.rate(20)
 def ctcp_source(bot, trigger):
     bot.write(('NOTICE', trigger.nick),
               '\x01SOURCE https://github.com/sopel-irc/sopel\x01')
 
 
-@plugin.intent('PING')
+@plugin.ctcp('PING')
 @plugin.rate(10)
 def ctcp_ping(bot, trigger):
     text = trigger.group()
@@ -76,7 +76,7 @@ def ctcp_ping(bot, trigger):
               '\x01PING {0}\x01'.format(text))
 
 
-@plugin.intent('TIME')
+@plugin.ctcp('TIME')
 @plugin.rate(20)
 def ctcp_time(bot, trigger):
     dt = datetime.datetime.now()

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -286,6 +286,22 @@ class Trigger(unicode):
     ``PRIVMSG``. Other event types like ``NOTICE``, ``NICK``, ``TOPIC``,
     ``KICK``, etc. must be requested using :func:`.plugin.event`.
     """
+    ctcp = property(lambda self: self.tags.get('intent', None))
+    """The CTCP command (if any).
+
+    :type: str
+
+    Common CTCP commands are ``ACTION``, ``VERSION``, and ``TIME``. Other
+    commands include ``USERINFO``, ``PING``, and various ``DCC`` operations.
+
+    .. versionadded:: 7.1
+
+    .. important::
+
+        Use this attribute instead of the ``intent`` tag in :attr:`tags`.
+        Message intents never made it past the IRCv3 draft stage, and Sopel will
+        drop support for them in a future release.
+    """
     match = property(lambda self: self._match)
     """The :ref:`Match object <match-objects>` for the triggering line.
 

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -99,3 +99,24 @@ def test_url_lazy_multiple():
 
     assert mock.url_lazy_loaders == [loader_1, loader_2]
     assert not hasattr(mock, 'url_regex')
+
+
+def test_ctcp():
+    @plugin.ctcp('ACTION')
+    def mock(bot, trigger, match):
+        return True
+    assert mock.intents == ['ACTION']
+
+
+def test_ctcp_empty():
+    @plugin.ctcp()
+    def mock(bot, trigger, match):
+        return True
+    assert mock.intents == ['ACTION']
+
+
+def test_ctcp_direct():
+    @plugin.ctcp
+    def mock(bot, trigger, match):
+        return True
+    assert mock.intents == ['ACTION']

--- a/test/test_trigger.py
+++ b/test/test_trigger.py
@@ -191,6 +191,35 @@ def test_ctcp_action_pretrigger(nick):
     assert pretrigger.sender == '#Sopel'
 
 
+def test_ctcp_action_trigger(nick, configfactory):
+    line = ':Foo!bar@example.com PRIVMSG #Sopel :\x01ACTION Hello, world\x01'
+    pretrigger = PreTrigger(nick, line)
+
+    config = configfactory('default.cfg', TMP_CONFIG)
+    fakematch = re.match('.*', line)
+
+    trigger = Trigger(config, pretrigger, fakematch)
+    assert trigger.sender == '#Sopel'
+    assert trigger.raw == line
+    assert trigger.is_privmsg is False
+    assert trigger.hostmask == 'Foo!bar@example.com'
+    assert trigger.user == 'bar'
+    assert trigger.nick == Identifier('Foo')
+    assert trigger.host == 'example.com'
+    assert trigger.event == 'PRIVMSG'
+    assert trigger.match == fakematch
+    assert trigger.group == fakematch.group
+    assert trigger.groups == fakematch.groups
+    assert trigger.groupdict == fakematch.groupdict
+    assert trigger.args == ['#Sopel', 'Hello, world']
+    assert trigger.plain == 'Hello, world'
+    assert trigger.tags == {'intent': 'ACTION'}
+    assert trigger.ctcp == 'ACTION'
+    assert trigger.account is None
+    assert trigger.admin is True
+    assert trigger.owner is True
+
+
 def test_ircv3_extended_join_pretrigger(nick):
     line = ':Foo!foo@example.com JOIN #Sopel bar :Real Name'
     pretrigger = PreTrigger(nick, line)
@@ -231,6 +260,7 @@ def test_ircv3_extended_join_trigger(nick, configfactory):
     assert trigger.plain == 'Real Name'
     assert trigger.account == 'bar'
     assert trigger.tags == {'account': 'bar'}
+    assert trigger.ctcp is None
     assert trigger.owner is True
     assert trigger.admin is True
 
@@ -258,6 +288,7 @@ def test_ircv3_intents_trigger(nick, configfactory):
     assert trigger.args == ['#Sopel', 'Hello, world']
     assert trigger.plain == 'Hello, world'
     assert trigger.tags == {'intent': 'ACTION'}
+    assert trigger.ctcp == 'ACTION'
     assert trigger.account is None
     assert trigger.admin is True
     assert trigger.owner is True


### PR DESCRIPTION
### Description

This is part of #1683: it replaces `sopel.module.intent` by `sopel.plugin.ctcp`. This does not change how "intents" are managed internally by Sopel, which should be done later, possibly in Sopel 8 or maybe Sopel 9.

Also, because CTCP is mostly used for ``ACTION``, this is now the default: you can use `ctcp`, `ctcp()`, or `ctcp('ACTION')` to achieve the same result.

I updated the doc and tests accordingly.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
