### PR TITLE
core: fix invalid usage of r-string for SASL auth token

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -835,7 +835,7 @@ def auth_proceed(bot, trigger):
     else:
         return
     sasl_username = sasl_username or bot.nick
-    sasl_token = r'\0'.join((sasl_username, sasl_username, sasl_password))
+    sasl_token = '\x00'.join((sasl_username, sasl_username, sasl_password))
     send_authenticate(bot, sasl_token)
 
 


### PR DESCRIPTION
### Description

Fix #1974 

@dgw if this can be merged in priority, as this bug prevent from using SASL in dev (I don't use SASL so I didn't notice).

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
