### PR TITLE
core, test: make SASL PLAIN token generation testable (and test it)

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -835,8 +835,12 @@ def auth_proceed(bot, trigger):
     else:
         return
     sasl_username = sasl_username or bot.nick
-    sasl_token = '\x00'.join((sasl_username, sasl_username, sasl_password))
+    sasl_token = _make_sasl_plain_token(sasl_username, sasl_password)
     send_authenticate(bot, sasl_token)
+
+
+def _make_sasl_plain_token(account, password):
+    return '\x00'.join((account, account, password))
 
 
 @module.event(events.RPL_SASLSUCCESS)

--- a/test/test_coretasks.py
+++ b/test/test_coretasks.py
@@ -247,3 +247,10 @@ def test_handle_rpl_myinfo(mockbot):
     assert mockbot.myinfo.client == 'TestName'
     assert mockbot.myinfo.servername == 'irc.example.net'
     assert mockbot.myinfo.version == 'example-1.2.3'
+
+
+def test_sasl_plain_token_generation():
+    """Make sure SASL PLAIN tokens match the expected format."""
+    assert (
+        coretasks._make_sasl_plain_token('sopel', 'sasliscool') ==
+        'sopel\x00sopel\x00sasliscool')


### PR DESCRIPTION
### Description
This is a follow-up to #1974 & #1976, which should prevent a similar regression from being introduced in the future.

Considered putting the new utility function in `sopel.tools`, but figured it's not useful to anything outside `coretasks`.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches