### PR TITLE
quality: Docstring cleanup for pydocstyle prep

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,9 +3,12 @@ coveralls>=2.0; python_version >= '3.5'
 flake8<3.6.0; python_version == '3.3'
 flake8>=3.7.0,<3.8.0; python_version != '3.3'
 flake8-coding
+flake8-docstrings
 flake8-future-import<0.4.6
 flake8-import-order; python_version > '3.3'
 flake8-import-order<=1.18.1; python_version <= '3.3'
+# required by flake8-docstrings, 3+ drop py2
+pydocstyle<3.0
 pytest<3.3; python_version == '3.3'
 pytest>=4.6,<4.7; python_version != '3.3'
 pytest-vcr==1.0.2; python_version != '3.3'

--- a/pytest_run.py
+++ b/pytest_run.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 # coding=utf-8
-"""This is a script for running pytest from the command line.
+"""A script for running pytest from the command line.
 
 This script exists so that the project directory gets added to sys.path, which
 prevents us from accidentally testing the globally installed sopel version.

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,10 +59,20 @@ ignore =
     # support for Python older than 3.5)
     FI15,
     # Ignore "annotations" future import, since it's not available before 3.7
-    FI18
+    FI18,
+    # Ignore missing docstrings we don't care about (magic method, __init__)
+    D105, D107,
+    # Ignore missing docstrings for now, TODO
+    #  public module, public class, public method, public function, public package
+    D100, D101, D102, D103, D104,
+    # Ignore some that the module config convention breaks for now, TODO
+    D205, D212, D400, D415,
+    # Docstring style and option choices
+    D203, D213, D407, D413
 exclude =
     docs/*,
     env/*,
     contrib/*,
     conftest.py
 accept-encodings = utf-8
+docstring-convention = all

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -1096,6 +1096,7 @@ class SopelWrapper(object):
     to the sender (either a channel or in a private message) and even to
     :meth:`reply to someone<reply>` in a channel.
     """
+
     def __init__(self, sopel, trigger, output_prefix=''):
         if not output_prefix:
             # Just in case someone passes in False, None, etc.
@@ -1200,7 +1201,7 @@ class SopelWrapper(object):
         self._bot.reply(message, destination, reply_to, notice)
 
     def kick(self, nick, channel=None, message=None):
-        """Override ``Sopel.kick`` to kick in a channel
+        """Override ``Sopel.kick`` to kick in a channel.
 
         :param str nick: nick to kick out of the ``channel``
         :param str channel: optional channel to kick ``nick`` from

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -131,7 +131,7 @@ class Sopel(irc.AbstractBot):
 
     @property
     def command_groups(self):
-        """A mapping of plugin names to lists of their commands.
+        """Map of plugin names to lists of their commands.
 
         .. versionchanged:: 7.1
             This attribute is now generated on the fly from the registered list
@@ -156,7 +156,7 @@ class Sopel(irc.AbstractBot):
 
     @property
     def doc(self):
-        """A dictionary of command names to their documentation.
+        """Map of command names to their documentation.
 
         Each command is mapped to its docstring and any available examples, if
         declared in the plugin's code.
@@ -188,7 +188,7 @@ class Sopel(irc.AbstractBot):
 
     @property
     def hostmask(self):
-        """The current hostmask for the bot :class:`sopel.tools.target.User`.
+        """Get current hostmask for the bot :class:`sopel.tools.target.User`.
 
         :return: the bot's current hostmask
         :rtype: str
@@ -823,7 +823,7 @@ class Sopel(irc.AbstractBot):
 
     @property
     def running_triggers(self):
-        """Current active threads for triggers.
+        """Get current active threads for triggers.
 
         :return: the running thread(s) currently processing trigger(s)
         :rtype: :term:`iterable`
@@ -853,7 +853,7 @@ class Sopel(irc.AbstractBot):
                 t for t in running_triggers if t.is_alive()]
 
     def on_scheduler_error(self, scheduler, exc):
-        """Called when the Job Scheduler fails.
+        """Handle failed Job Scheduler.
 
         :param scheduler: the job scheduler that errored
         :type scheduler: :class:`sopel.plugins.jobs.Scheduler`
@@ -866,7 +866,7 @@ class Sopel(irc.AbstractBot):
         self.error(exception=exc)
 
     def on_job_error(self, scheduler, job, exc):
-        """Called when a job from the Job Scheduler fails.
+        """Handle failed job from the Job Scheduler.
 
         :param scheduler: the job scheduler responsible for the errored ``job``
         :type scheduler: :class:`sopel.plugins.jobs.Scheduler`
@@ -881,9 +881,9 @@ class Sopel(irc.AbstractBot):
         self.error(exception=exc)
 
     def error(self, trigger=None, exception=None):
-        """Called internally when a plugin causes an error.
+        r"""Handle uncaught plugin errors.
 
-        :param trigger: the ``Trigger``\\ing line (if available)
+        :param trigger: the ``Trigger``\ing line (if available)
         :type trigger: :class:`sopel.trigger.Trigger`
         :param Exception exception: the exception raised by the error (if
                                     available)
@@ -933,7 +933,7 @@ class Sopel(irc.AbstractBot):
         return False
 
     def _shutdown(self):
-        """Internal bot shutdown method."""
+        """Shut down the bot."""
         LOGGER.info('Shutting down')
         # Stop Job Scheduler
         LOGGER.info('Stopping the Job Scheduler.')

--- a/sopel/cli/config.py
+++ b/sopel/cli/config.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Sopel Config Command Line Interface (CLI): ``sopel-config``"""
+"""Sopel Config Command Line Interface (CLI): ``sopel-config``."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import argparse

--- a/sopel/cli/plugins.py
+++ b/sopel/cli/plugins.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Sopel Plugins Command Line Interface (CLI): ``sopel-plugins``"""
+"""Sopel Plugins Command Line Interface (CLI): ``sopel-plugins``."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import argparse

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python2.7
 # coding=utf-8
-"""
-Sopel - An IRC Bot
+"""Sopel - An IRC Bot.
+
 Copyright 2008, Sean B. Palmer, inamidst.com
 Copyright © 2012-2014, Elad Alfassa <elad@fedoraproject.org>
 Licensed under the Eiffel Forum License 2.

--- a/sopel/config/__init__.py
+++ b/sopel/config/__init__.py
@@ -148,7 +148,7 @@ class Config(object):
 
     @property
     def homedir(self):
-        """The config file's home directory.
+        """Home directory for config file.
 
         If the :attr:`core.homedir <.core_section.CoreSection.homedir>` setting
         is available, that value is used. Otherwise, the default ``homedir`` is

--- a/sopel/config/__init__.py
+++ b/sopel/config/__init__.py
@@ -80,6 +80,7 @@ class ConfigurationError(Exception):
 
     :param str value: a description of the error that has occurred
     """
+
     def __init__(self, value):
         self.value = value
 
@@ -92,6 +93,7 @@ class ConfigurationNotFound(ConfigurationError):
 
     :param str filename: file path that could not be found
     """
+
     def __init__(self, filename):
         super(ConfigurationNotFound, self).__init__(None)
         self.filename = filename
@@ -118,6 +120,7 @@ class Config(object):
     Sopel to run. All other sections must be defined later, by the code that
     needs them, using :meth:`define_section`.
     """
+
     def __init__(self, filename, validate=True):
         self.filename = filename
         """The config object's associated file."""
@@ -215,11 +218,11 @@ class Config(object):
             return False
 
     def define_section(self, name, cls_, validate=True):
-        """Define the available settings in a section.
+        r"""Define the available settings in a section.
 
         :param str name: name of the new section
-        :param cls\\_: :term:`class` defining the settings within the section
-        :type cls\\_: subclass of :class:`~.types.StaticSection`
+        :param cls\_: :term:`class` defining the settings within the section
+        :type cls\_: subclass of :class:`~.types.StaticSection`
         :param bool validate: whether to validate the section's values
                               (optional; defaults to ``True``)
         :raise ValueError: if the section ``name`` has been defined already with
@@ -260,16 +263,17 @@ class Config(object):
         setattr(self, name, cls_(self, name, validate=validate))
 
     class ConfigSection(object):
-        """Represents a section of the config file.
+        r"""Represents a section of the config file.
 
         :param str name: name of this section
         :param items: key-value pairs
-        :type items: :term:`iterable` of two-item :class:`tuple`\\s
+        :type items: :term:`iterable` of two-item :class:`tuple`\s
         :param parent: this section's containing object
         :type parent: :class:`Config`
 
         Contains all keys in the section as attributes.
         """
+
         def __init__(self, name, items, parent):
             object.__setattr__(self, '_name', name)
             object.__setattr__(self, '_parent', parent)

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -637,7 +637,7 @@ class CoreSection(StaticSection):
 
     @property
     def homedir(self):
-        """The directory in which various files are stored at runtime.
+        """Directory where Sopel's data is stored.
 
         By default, this is the same directory as the config file. It cannot be
         changed at runtime.

--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -60,6 +60,7 @@ class StaticSection(object):
         Python will work just fine.
 
     """
+
     def __init__(self, config, section_name, validate=True):
         if not config.parser.has_section(section_name):
             config.parser.add_section(section_name)
@@ -149,6 +150,7 @@ class BaseValidated(object):
             settings>` using environment variables
 
     """
+
     def __init__(self, name, default=None, is_secret=False):
         self.name = name
         """Name of the attribute."""
@@ -209,7 +211,8 @@ class BaseValidated(object):
     def parse(self, value, *args, **kwargs):
         """Take a string from the file, and return the appropriate object.
 
-        Must be implemented in subclasses."""
+        Must be implemented in subclasses.
+        """
         raise NotImplementedError("Parse method must be implemented in subclass")
 
     def __get__(self, instance, owner=None):
@@ -288,6 +291,7 @@ class ValidatedAttribute(BaseValidated):
     :param bool is_secret: ``True`` when the attribute should be considered
                            a secret, like a password (default to ``False``)
     """
+
     def __init__(self,
                  name,
                  parse=None,
@@ -332,6 +336,7 @@ class SecretAttribute(ValidatedAttribute):
     This attribute is always considered to be secret/sensitive data, but
     otherwise behaves like other any option.
     """
+
     def __init__(self, name, parse=None, serialize=None, default=None):
         super(SecretAttribute, self).__init__(
             name,
@@ -403,6 +408,7 @@ class ListAttribute(BaseValidated):
         The comma delimiter fallback does not support commas within items in
         the list.
     """
+
     DELIMITER = ','
     QUOTE_REGEX = re.compile(r'^"(?P<value>#.*)"$')
     """Regex pattern to match value that requires quotation marks.
@@ -536,6 +542,7 @@ class ChoiceAttribute(BaseValidated):
                     :const:`sopel.config.types.NO_DEFAULT` (optional)
     :type default: str
     """
+
     def __init__(self, name, choices, default=None):
         super(ChoiceAttribute, self).__init__(name, default=default)
         self.choices = choices
@@ -583,6 +590,7 @@ class FilenameAttribute(BaseValidated):
                     :const:`sopel.config.types.NO_DEFAULT` (optional)
     :type default: str
     """
+
     def __init__(self, name, relative=True, directory=False, default=None):
         super(FilenameAttribute, self).__init__(name, default=default)
         self.relative = relative

--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -618,7 +618,7 @@ class FilenameAttribute(BaseValidated):
         return self.parse(result)
 
     def _serialize(self, value, settings, section):
-        """Used to validate ``value`` when it is changed at runtime.
+        """Validate ``value`` when it is changed at runtime.
 
         :param settings: the config object which contains this attribute
         :type settings: :class:`~sopel.config.Config`

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Tasks that allow the bot to run, but aren't user-facing functionality
+"""Tasks that allow the bot to run, but aren't user-facing functionality.
 
 This is written as a module to make it easier to extend to support more
 responses to standard IRC codes without having to shove them all into the
@@ -84,7 +84,7 @@ def _join_event_processing(bot):
 
 
 def auth_after_register(bot):
-    """Do NickServ/AuthServ auth"""
+    """Do NickServ/AuthServ auth."""
     if bot.config.core.auth_method:
         auth_method = bot.config.core.auth_method
         auth_username = bot.config.core.auth_username
@@ -900,8 +900,8 @@ def _get_sasl_pass_and_mech(bot):
 @module.unblockable
 @module.require_admin
 def blocks(bot, trigger):
-    """
-    Manage Sopel's blocking features.\
+    """Manage Sopel's blocking features.
+
     See [ignore system documentation]({% link _usage/ignoring-people.md %}).
     """
     STRINGS = {
@@ -1088,7 +1088,7 @@ def track_topic(bot, trigger):
 
 @module.rule(r'(?u).*(.+://\S+).*')
 def handle_url_callbacks(bot, trigger):
-    """Dispatch callbacks on URLs
+    """Dispatch callbacks on URLs.
 
     For each URL found in the trigger, trigger the URL callback registered by
     the ``@url`` decorator.

--- a/sopel/db.py
+++ b/sopel/db.py
@@ -47,12 +47,14 @@ MYSQL_TABLE_ARGS = {'mysql_engine': 'InnoDB',
 
 class NickIDs(BASE):
     """Nick IDs table SQLAlchemy class."""
+
     __tablename__ = 'nick_ids'
     nick_id = Column(Integer, primary_key=True)
 
 
 class Nicknames(BASE):
     """Nicknames table SQLAlchemy class."""
+
     __tablename__ = 'nicknames'
     __table_args__ = MYSQL_TABLE_ARGS
     nick_id = Column(Integer, ForeignKey('nick_ids.nick_id'), primary_key=True)
@@ -62,6 +64,7 @@ class Nicknames(BASE):
 
 class NickValues(BASE):
     """Nick values table SQLAlchemy class."""
+
     __tablename__ = 'nick_values'
     __table_args__ = MYSQL_TABLE_ARGS
     nick_id = Column(Integer, ForeignKey('nick_ids.nick_id'), primary_key=True)
@@ -71,6 +74,7 @@ class NickValues(BASE):
 
 class ChannelValues(BASE):
     """Channel values table SQLAlchemy class."""
+
     __tablename__ = 'channel_values'
     __table_args__ = MYSQL_TABLE_ARGS
     channel = Column(String(255), primary_key=True)
@@ -80,6 +84,7 @@ class ChannelValues(BASE):
 
 class PluginValues(BASE):
     """Plugin values table SQLAlchemy class."""
+
     __tablename__ = 'plugin_values'
     __table_args__ = MYSQL_TABLE_ARGS
     plugin = Column(String(255), primary_key=True)
@@ -862,7 +867,7 @@ class SopelDB(object):
             return self.get_channel_value(name, key, default)
 
     def get_preferred_value(self, names, key):
-        """Get a value for the first name which has it set.
+        r"""Get a value for the first name which has it set.
 
         :param list names: a list of channel names and/or nicknames
         :param str key: the name by which the desired value was saved
@@ -878,7 +883,7 @@ class SopelDB(object):
         .. note::
 
             This is the only ``get_*_value()`` method that does not support
-            passing a ``default``. Try to avoid using it on ``key``\\s which
+            passing a ``default``. Try to avoid using it on ``key``\s which
             might have ``None`` as a valid value, to avoid ambiguous logic.
 
         """

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -108,7 +108,7 @@ class AbstractBot(object):
 
     @property
     def config(self):
-        """The :class:`sopel.config.Config` for the current Sopel instance."""
+        """Get the :class:`sopel.config.Config` for the current Sopel instance."""
         # TODO: Deprecate config, replaced by settings
         return self.settings
 

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -60,6 +60,7 @@ LOGGER = logging.getLogger(__name__)
 
 class AbstractBot(object):
     """Abstract definition of Sopel's interface."""
+
     def __init__(self, settings):
         # private properties: access as read-only properties
         self._nick = tools.Identifier(settings.core.nick)
@@ -414,7 +415,7 @@ class AbstractBot(object):
             self._cap_reqs[cap] = entry
 
     def write(self, args, text=None):
-        """Send a command to the server.
+        r"""Send a command to the server.
 
         :param args: an iterable of strings, which will be joined by spaces
         :type args: :term:`iterable`
@@ -431,7 +432,7 @@ class AbstractBot(object):
         and ``sopel.write(('PRIVMSG', ':Hello, world!'))`` will send
         ``PRIVMSG :Hello, world!`` to the server.
 
-        Newlines and carriage returns (``'\\n'`` and ``'\\r'``) are removed
+        Newlines and carriage returns (``'\n'`` and ``'\r'``) are removed
         before sending. Additionally, if the message (after joining) is longer
         than than 510 characters, any remaining characters will not be sent.
 

--- a/sopel/irc/abstract_backends.py
+++ b/sopel/irc/abstract_backends.py
@@ -28,7 +28,7 @@ class AbstractIRCBackend(object):
         raise NotImplementedError
 
     def on_irc_error(self, pretrigger):
-        """Action to perform when the server sends an error event.
+        """Perform action when the server sends an error event.
 
         :param pretrigger: PreTrigger object with the error event
         :type pretrigger: :class:`sopel.trigger.PreTrigger`

--- a/sopel/irc/abstract_backends.py
+++ b/sopel/irc/abstract_backends.py
@@ -16,6 +16,7 @@ class AbstractIRCBackend(object):
     Some methods of this class **MUST** be overridden by a subclass, or the
     backend implementation will not function correctly.
     """
+
     def __init__(self, bot):
         self.bot = bot
 

--- a/sopel/irc/backends.py
+++ b/sopel/irc/backends.py
@@ -129,7 +129,7 @@ class AsynchatBackend(AbstractIRCBackend, asynchat.async_chat):
             LOGGER.debug('Timeout Job registered: %s', str(job))
 
     def initiate_connect(self, host, port, source_address):
-        """Initiate IRC connection.
+        """Set up the IRC connection.
 
         :param str host: IRC server hostname
         :param int port: IRC server port
@@ -152,13 +152,13 @@ class AsynchatBackend(AbstractIRCBackend, asynchat.async_chat):
             self.handle_close()
 
     def handle_connect(self):
-        """Called when the active opener's socket actually makes a connection."""
+        """Handle active opener's new accepted connection."""
         LOGGER.info('Connection accepted by the server...')
         self.timeout_scheduler.start()
         self.bot.on_connect()
 
     def handle_close(self):
-        """Called when the socket is closed."""
+        """Handle closed socket."""
         LOGGER.debug('Stopping timeout watchdog')
         self.timeout_scheduler.stop()
         LOGGER.info('Closing connection')
@@ -166,7 +166,7 @@ class AsynchatBackend(AbstractIRCBackend, asynchat.async_chat):
         self.bot.on_close()
 
     def handle_error(self):
-        """Called when an exception is raised and not otherwise handled.
+        """Handle unhandled exceptions.
 
         This method is an override of :meth:`asyncore.dispatcher.handle_error`,
         the :class:`asynchat.async_chat` being a subclass of
@@ -211,12 +211,12 @@ class AsynchatBackend(AbstractIRCBackend, asynchat.async_chat):
         self.bot.on_message(line)
 
     def on_scheduler_error(self, scheduler, exc):
-        """Called when the Job Scheduler fails."""
+        """Handle Job Scheduler failures."""
         LOGGER.exception('Error with the timeout scheduler: %s', exc)
         self.handle_close()
 
     def on_job_error(self, scheduler, job, exc):
-        """Called when a job from the Job Scheduler fails."""
+        """Handle failures of a job from the Job Scheduler."""
         LOGGER.exception('Error with the timeout scheduler: %s', exc)
         self.handle_close()
 

--- a/sopel/irc/backends.py
+++ b/sopel/irc/backends.py
@@ -72,6 +72,7 @@ class AsynchatBackend(AbstractIRCBackend, asynchat.async_chat):
     :param int server_timeout: connection timeout in seconds
     :param int ping_timeout: ping timeout in seconds
     """
+
     def __init__(self, bot, server_timeout=None, ping_timeout=None, **kwargs):
         AbstractIRCBackend.__init__(self, bot)
         asynchat.async_chat.__init__(self)
@@ -230,6 +231,7 @@ class SSLAsynchatBackend(AsynchatBackend):
     :param str ca_certs: filesystem path to a CA Certs file containing trusted
                          root certificates
     """
+
     def __init__(self, bot, verify_ssl=True, ca_certs=None, **kwargs):
         AsynchatBackend.__init__(self, bot, **kwargs)
         self.verify_ssl = verify_ssl

--- a/sopel/irc/isupport.py
+++ b/sopel/irc/isupport.py
@@ -172,6 +172,7 @@ class ISupport(object):
 
     .. __: https://modern.ircdocs.horse/#rplisupport-parameters
     """
+
     def __init__(self, **kwargs):
         self.__isupport = dict(
             (key.upper(), value)

--- a/sopel/irc/utils.py
+++ b/sopel/irc/utils.py
@@ -67,6 +67,7 @@ class CapReq(object):
         For more information on how capability requests work, see the
         documentation for :meth:`sopel.irc.AbstractBot.cap_req`.
     """
+
     def __init__(self, prefix, module, failure=None, arg=None, success=None):
         def nop(bot, cap):
             pass

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -13,7 +13,7 @@ if sys.version_info.major >= 3:
 
 
 def trim_docstring(doc):
-    """Get the docstring as a series of lines that can be sent"""
+    """Get the docstring as a series of lines that can be sent."""
     if not doc:
         return []
     lines = doc.expandtabs().splitlines()
@@ -34,7 +34,7 @@ def trim_docstring(doc):
 
 
 def clean_callable(func, config):
-    """Clean the callable. (compile regexes, fix docs, set defaults)
+    """Clean the callable. (compile regexes, fix docs, set defaults).
 
     :param func: the callable to clean
     :type func: callable

--- a/sopel/logger.py
+++ b/sopel/logger.py
@@ -18,6 +18,7 @@ class IrcLoggingHandler(logging.Handler):
 
     Implementation of a :class:`logging.Handler`.
     """
+
     def __init__(self, bot, level):
         super(IrcLoggingHandler, self).__init__(level)
         self._bot = bot
@@ -52,6 +53,7 @@ class ChannelOutputFormatter(logging.Formatter):
 
     Implementation of a :class:`logging.Formatter`.
     """
+
     def __init__(self, fmt='[%(filename)s] %(message)s', datefmt=None):
         super(ChannelOutputFormatter, self).__init__(fmt=fmt, datefmt=datefmt)
 

--- a/sopel/modules/admin.py
+++ b/sopel/modules/admin.py
@@ -185,9 +185,9 @@ def quit(bot, trigger):
 @plugin.priority('low')
 @plugin.example('.say #YourPants Does anyone else smell neurotoxin?')
 def say(bot, trigger):
-    """
-    Send a message to a given channel or nick. Can only be done in privmsg by
-    an admin.
+    """Send a message to a given channel or nick.
+
+    Can only be done in privmsg by an admin.
     """
     if trigger.group(2) is None:
         return
@@ -205,9 +205,9 @@ def say(bot, trigger):
 @plugin.command('me')
 @plugin.priority('low')
 def me(bot, trigger):
-    """
-    Send an ACTION (/me) to a given channel or nick. Can only be done in
-    privmsg by an admin.
+    """Send an ACTION (/me) to a given channel or nick.
+
+    Can only be done in privmsg by an admin.
     """
     if trigger.group(2) is None:
         return

--- a/sopel/modules/admin.py
+++ b/sopel/modules/admin.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-admin.py - Sopel Admin Plugin
+"""admin.py - Sopel Admin Plugin.
+
 Copyright 2010-2011, Sean B. Palmer (inamidst.com) and Michael Yanovich
 (yanovich.net)
 Copyright © 2012, Elad Alfassa, <elad@fedoraproject.org>
@@ -25,11 +25,11 @@ class AdminSection(types.StaticSection):
 
 
 def configure(config):
-    """
+    r"""
     | name | example | purpose |
     | ---- | ------- | ------- |
-    | hold\\_ground | False | Auto-rejoin the channel after being kicked. |
-    | auto\\_accept\\_invite | True | Auto-join channels when invited. |
+    | hold\_ground | False | Auto-rejoin the channel after being kicked. |
+    | auto\_accept\_invite | True | Auto-join channels when invited. |
     """
     config.define_section('admin', AdminSection)
     config.admin.configure_setting('hold_ground',

--- a/sopel/modules/admin.py
+++ b/sopel/modules/admin.py
@@ -232,9 +232,7 @@ def invite_join(bot, trigger):
 @plugin.event('KICK')
 @plugin.priority('low')
 def hold_ground(bot, trigger):
-    """
-    This function monitors all kicks across all channels Sopel is in. If it
-    detects that it is the one kicked it'll automatically join that channel.
+    """Monitor KICK messages to rejoin if kicked.
 
     WARNING: This may not be needed and could cause problems if Sopel becomes
     annoying. Please use this with caution.

--- a/sopel/modules/adminchannel.py
+++ b/sopel/modules/adminchannel.py
@@ -32,9 +32,9 @@ def default_mask(trigger):
 @plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV)
 @plugin.command('op')
 def op(bot, trigger):
-    """
-    Command to op users in a room. If no nick is given,
-    Sopel will op the nick who sent the command
+    """Op users in a room.
+
+    If no nick is given, Sopel will op the nick who sent the command.
     """
     if bot.channels[trigger.sender].privileges[bot.nick] < plugin.OP:
         bot.reply(ERROR_MESSAGE_NOT_OP)
@@ -50,9 +50,9 @@ def op(bot, trigger):
 @plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV)
 @plugin.command('deop')
 def deop(bot, trigger):
-    """
-    Command to deop users in a room. If no nick is given,
-    Sopel will deop the nick who sent the command
+    """Deop users in a room.
+
+    If no nick is given, Sopel will deop the nick who sent the command.
     """
     if bot.channels[trigger.sender].privileges[bot.nick] < plugin.OP:
         bot.reply(ERROR_MESSAGE_NOT_OP)
@@ -68,9 +68,9 @@ def deop(bot, trigger):
 @plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV)
 @plugin.command('voice')
 def voice(bot, trigger):
-    """
-    Command to voice users in a room. If no nick is given,
-    Sopel will voice the nick who sent the command
+    """Voice users in a room.
+
+    If no nick is given, Sopel will voice the nick who sent the command.
     """
     if bot.channels[trigger.sender].privileges[bot.nick] < plugin.HALFOP:
         bot.reply(ERROR_MESSAGE_NOT_OP)
@@ -86,9 +86,9 @@ def voice(bot, trigger):
 @plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV)
 @plugin.command('devoice')
 def devoice(bot, trigger):
-    """
-    Command to devoice users in a room. If no nick is given,
-    Sopel will devoice the nick who sent the command
+    """Devoice users in a room.
+
+    If no nick is given, Sopel will devoice the nick who sent the command
     """
     if bot.channels[trigger.sender].privileges[bot.nick] < plugin.HALFOP:
         bot.reply(ERROR_MESSAGE_NOT_OP)

--- a/sopel/modules/adminchannel.py
+++ b/sopel/modules/adminchannel.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-adminchannel.py - Sopel Channel Admin Plugin
+"""adminchannel.py - Sopel Channel Admin Plugin.
+
 Copyright 2010-2011, Michael Yanovich, Alek Rollyson, and Elsie Powell
 Copyright © 2012, Elad Alfassa <elad@fedoraproject.org>
 Licensed under the Eiffel Forum License 2.
@@ -158,7 +158,7 @@ def configureHostMask(mask):
 @plugin.command('ban')
 @plugin.priority('high')
 def ban(bot, trigger):
-    """Ban a user from the channel
+    """Ban a user from the channel.
 
     The bot must be a channel operator for this command to work.
     """
@@ -187,7 +187,7 @@ def ban(bot, trigger):
 @plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV)
 @plugin.command('unban')
 def unban(bot, trigger):
-    """Unban a user from the channel
+    """Unban a user from the channel.
 
     The bot must be a channel operator for this command to work.
     """
@@ -216,7 +216,7 @@ def unban(bot, trigger):
 @plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV)
 @plugin.command('quiet')
 def quiet(bot, trigger):
-    """Quiet a user
+    """Quiet a user.
 
     The bot must be a channel operator for this command to work.
     """
@@ -245,7 +245,7 @@ def quiet(bot, trigger):
 @plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV)
 @plugin.command('unquiet')
 def unquiet(bot, trigger):
-    """Unquiet a user
+    """Unquiet a user.
 
     The bot must be a channel operator for this command to work.
     """
@@ -276,7 +276,7 @@ def unquiet(bot, trigger):
 @plugin.example('.kickban [#chan] user1 user!*@* get out of here')
 @plugin.priority('high')
 def kickban(bot, trigger):
-    """Kick and ban a user from the channel
+    """Kick and ban a user from the channel.
 
     The bot must be a channel operator for this command to work.
     """
@@ -311,7 +311,7 @@ def kickban(bot, trigger):
 @plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV)
 @plugin.command('topic')
 def topic(bot, trigger):
-    """Change the channel topic
+    """Change the channel topic.
 
     The bot must be a channel operator for this command to work.
     """
@@ -347,7 +347,7 @@ def topic(bot, trigger):
 @plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV)
 @plugin.command('tmask')
 def set_mask(bot, trigger):
-    """Set the topic mask to use for the current channel
+    """Set the topic mask to use for the current channel.
 
     Within the topic mask, {} is used to allow substituting in chunks of text.
 

--- a/sopel/modules/announce.py
+++ b/sopel/modules/announce.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-announce.py - Sopel Announcement Plugin
+"""announce.py - Sopel Announcement Plugin.
+
 Sends announcements to all channels the bot has joined.
 Copyright © 2013, Elad Alfassa, <elad@fedoraproject.org>
 Licensed under the Eiffel Forum License 2.

--- a/sopel/modules/bugzilla.py
+++ b/sopel/modules/bugzilla.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-bugzilla.py - Sopel Bugzilla Plugin
+"""bugzilla.py - Sopel Bugzilla Plugin.
+
 Copyright 2013-2015, Embolalia, embolalia.com
 Licensed under the Eiffel Forum License 2.
 

--- a/sopel/modules/calc.py
+++ b/sopel/modules/calc.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-calc.py - Sopel Calculator Plugin
+"""calc.py - Sopel Calculator Plugin.
+
 Copyright 2008, Sean B. Palmer, inamidst.com
 Licensed under the Eiffel Forum License 2.
 

--- a/sopel/modules/choose.py
+++ b/sopel/modules/choose.py
@@ -30,7 +30,7 @@ from sopel import plugin
 @plugin.example(".choose a | b | c", user_help=True)
 @plugin.example(".choose a, b, c", user_help=True)
 def choose(bot, trigger):
-    """Makes a difficult choice easy."""
+    """Make a difficult choice easy."""
     if not trigger.group(2):
         bot.reply("I'd choose an option, but you didn't give me any.")
         return

--- a/sopel/modules/choose.py
+++ b/sopel/modules/choose.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-choose.py - Sopel Choice Plugin
+"""choose.py - Sopel Choice Plugin.
+
 Copyright 2010-2013, Dimitri "Tyrope" Molenaars, TyRope.nl
 Copyright 2013, Ari Koivula, <ari@koivu.la>
 Copyright 2018, Florian Strzelecki, <florian.strzelecki@gmail.com>

--- a/sopel/modules/clock.py
+++ b/sopel/modules/clock.py
@@ -165,7 +165,7 @@ def update_user(bot, trigger):
 @plugin.example('.gettz', user_help=True)
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def get_user_tz(bot, trigger):
-    """Gets a user's preferred time zone.
+    """Get a user's preferred time zone.
 
     It will show yours if no user specified.
     """
@@ -185,7 +185,7 @@ def get_user_tz(bot, trigger):
 @plugin.command('settimeformat', 'settf')
 @plugin.example('.settf %Y-%m-%dT%T%z')
 def update_user_format(bot, trigger):
-    """Sets your preferred format for time.
+    """Set your preferred format for time.
 
     Uses the standard strftime format. You can use <http://strftime.net> or
     your favorite search engine to learn more.
@@ -222,7 +222,7 @@ def update_user_format(bot, trigger):
 @plugin.example('.gettf', user_help=True)
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def get_user_format(bot, trigger):
-    """Gets a user's preferred time format.
+    """Get a user's preferred time format.
 
     It will show yours if no user specified.
     """
@@ -274,7 +274,7 @@ def update_channel(bot, trigger):
 @plugin.example('.getctz', user_help=True)
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def get_channel_tz(bot, trigger):
-    """Gets the channel's preferred timezone.
+    """Get the channel's preferred timezone.
 
     It returns the current channel's if no channel name is given.
     """
@@ -297,7 +297,7 @@ def get_channel_tz(bot, trigger):
 @plugin.require_privilege(plugin.OP)
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def update_channel_format(bot, trigger):
-    """Sets your preferred format for time.
+    """Set your preferred format for time.
 
     Uses the standard strftime format. You can use <http://strftime.net> or
     your favorite search engine to learn more.
@@ -338,7 +338,7 @@ def update_channel_format(bot, trigger):
 @plugin.example('.getctf', user_help=True)
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def get_channel_format(bot, trigger):
-    """Gets the channel's preferred time format
+    """Get the channel's preferred time format.
 
     It returns the current channel's if no channel name is given.
     """

--- a/sopel/modules/clock.py
+++ b/sopel/modules/clock.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""clock.py - Sopel Clock Plugin
+"""clock.py - Sopel Clock Plugin.
 
 Copyright 2008-9, Sean B. Palmer, inamidst.com
 Copyright 2012, Elsie Powell, embolalia.com

--- a/sopel/modules/countdown.py
+++ b/sopel/modules/countdown.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-countdown.py - Sopel Countdown Plugin
+"""countdown.py - Sopel Countdown Plugin.
+
 Copyright 2011, Michael Yanovich, yanovich.net
 Licensed under the Eiffel Forum License 2.
 

--- a/sopel/modules/countdown.py
+++ b/sopel/modules/countdown.py
@@ -17,7 +17,7 @@ from sopel import plugin
 @plugin.example('.countdown 2078 09 14')
 @plugin.output_prefix('[countdown] ')
 def generic_countdown(bot, trigger):
-    """Displays a countdown to a given date."""
+    """Display a countdown to a given date."""
     text = trigger.group(2)
     if not text:
         bot.reply("Please use correct format: {}countdown 2012 12 21"

--- a/sopel/modules/currency.py
+++ b/sopel/modules/currency.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-currency.py - Sopel Currency Conversion Plugin
+"""currency.py - Sopel Currency Conversion Plugin.
+
 Copyright 2013, Elsie Powell, embolalia.com
 Copyright 2019, Mikkel Jeppesen
 Licensed under the Eiffel Forum License 2.
@@ -47,11 +47,11 @@ class CurrencySection(types.StaticSection):
 
 
 def configure(config):
-    """
+    r"""
     | name | example | purpose |
     | ---- | ------- | ------- |
-    | auto\\_convert | False | Whether to convert currencies without an explicit command |
-    | fixer\\_io\\_key | 0123456789abcdef0123456789abcdef | Optional API key for Fixer.io (increases currency support) |
+    | auto\_convert | False | Whether to convert currencies without an explicit command |
+    | fixer\_io\_key | 0123456789abcdef0123456789abcdef | Optional API key for Fixer.io (increases currency support) |
     """
     config.define_section('currency', CurrencySection, validate=False)
     config.currency.configure_setting('fixer_io_key', 'Optional API key for Fixer.io (leave blank to use exchangeratesapi.io):')
@@ -86,7 +86,7 @@ def build_reply(amount, base, target, out_string):
 
 
 def exchange(bot, match):
-    """Show the exchange rate between two currencies"""
+    """Show the exchange rate between two currencies."""
     if not match:
         bot.reply(UNRECOGNIZED_INPUT)
         return

--- a/sopel/modules/currency.py
+++ b/sopel/modules/currency.py
@@ -63,13 +63,15 @@ def setup(bot):
 
 
 class FixerError(Exception):
-    """A Fixer.io API Error Exception"""
+    """Fixer.io API Error Exception."""
+
     def __init__(self, status):
         super(FixerError, self).__init__("FixerError: {}".format(status))
 
 
 class UnsupportedCurrencyError(Exception):
-    """A currency is currently not supported by the API"""
+    """Currency is currently not supported by the API."""
+
     def __init__(self, currency):
         super(UnsupportedCurrencyError, self).__init__(currency)
 

--- a/sopel/modules/dice.py
+++ b/sopel/modules/dice.py
@@ -113,7 +113,7 @@ class DicePouch:
         return result
 
     def get_number_of_faces(self):
-        """Returns sum of different faces for dropped and not dropped dice
+        """Return sum of different faces for dropped and not dropped dice.
 
         This can be used to estimate, whether the result can be shown in
         compressed form in a reasonable amount of space.
@@ -179,7 +179,7 @@ def _roll_dice(bot, dice_expression):
 @plugin.example(".roll 1d6", user_help=True)
 @plugin.output_prefix('[dice] ')
 def roll(bot, trigger):
-    """Rolls dice and reports the result.
+    """Roll dice and reports the result.
 
     The dice roll follows this format: XdY[vZ][+N][#COMMENT]
 

--- a/sopel/modules/dice.py
+++ b/sopel/modules/dice.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-dice.py - Sopel Dice Plugin
+"""dice.py - Sopel Dice Plugin.
+
 Copyright 2010-2013, Dimitri "Tyrope" Molenaars, TyRope.nl
 Copyright 2013, Ari Koivula, <ari@koivu.la>
 Licensed under the Eiffel Forum License 2.
@@ -50,7 +50,6 @@ class DicePouch:
         Args:
             n: the number of dice to drop.
         """
-
         sorted_x = sorted(self.dice.items(), key=operator.itemgetter(0))
 
         for i, count in sorted_x:

--- a/sopel/modules/emoticons.py
+++ b/sopel/modules/emoticons.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-emoticons.py - Sopel Emoticons Plugin
+"""emoticons.py - Sopel Emoticons Plugin.
+
 Copyright 2018, brasstax
 Licensed under the Eiffel Forum License 2
 

--- a/sopel/modules/find.py
+++ b/sopel/modules/find.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-find.py - Sopel Spelling Correction Plugin
+"""find.py - Sopel Spelling Correction Plugin.
+
 This plugin will fix spelling errors if someone corrects them
 using the sed notation (s///) commonly found in vi/vim.
 
@@ -40,7 +40,7 @@ def shutdown(bot):
 @plugin.require_chanmsg
 @plugin.unblockable
 def collectlines(bot, trigger):
-    """Create a temporary log of what people say"""
+    """Create a temporary log of what people say."""
     # Add a log for the channel and nick, if there isn't already one
     if trigger.sender not in bot.memory['find_lines']:
         bot.memory['find_lines'][trigger.sender] = SopelIdentifierMemory()

--- a/sopel/modules/find_updates.py
+++ b/sopel/modules/find_updates.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-find_updates.py - Sopel Update Check Plugin
+"""find_updates.py - Sopel Update Check Plugin.
+
 This is separated from version.py, so that it can be easily overridden by
 distribution packagers, and they can check their repositories rather than the
 Sopel website.

--- a/sopel/modules/help.py
+++ b/sopel/modules/help.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-help.py - Sopel Help Plugin
+"""help.py - Sopel Help Plugin.
+
 Copyright 2008, Sean B. Palmer, inamidst.com
 Copyright © 2013, Elad Alfassa, <elad@fedoraproject.org>
 Copyright © 2018, Adam Erdman, pandorah.org
@@ -41,6 +41,7 @@ TRACKED_SETTINGS = {
 
 class PostingException(Exception):
     """Custom exception type for errors posting help to the chosen pastebin."""
+
     pass
 
 
@@ -174,6 +175,7 @@ REPLY_METHODS = [
 
 class HelpSection(types.StaticSection):
     """Configuration section for this plugin."""
+
     output = types.ChoiceAttribute('output',
                                    list(PASTEBIN_PROVIDERS),
                                    default='clbin')
@@ -189,12 +191,12 @@ class HelpSection(types.StaticSection):
 
 
 def configure(config):
-    """
+    r"""
     | name | example | purpose |
     | ---- | ------- | ------- |
     | output | clbin | The pastebin provider to use for help output |
-    | reply\\_method | channel | How/where help output should be sent |
-    | show\\_server\\_host | True | Whether to show the IRC server's hostname/IP at the top of command listings |
+    | reply\_method | channel | How/where help output should be sent |
+    | show\_server\_host | True | Whether to show the IRC server's hostname/IP at the top of command listings |
     """
     config.define_section('help', HelpSection)
     provider_list = ', '.join(PASTEBIN_PROVIDERS)

--- a/sopel/modules/help.py
+++ b/sopel/modules/help.py
@@ -251,7 +251,7 @@ def is_cache_valid(bot):
 @plugin.command('help', 'commands')
 @plugin.priority('low')
 def help(bot, trigger):
-    """Shows a command's documentation, and an example if available. With no arguments, lists all commands."""
+    """Show a command's documentation, and an example if available. With no arguments, lists all commands."""
     if bot.config.help.reply_method == 'query':
         def respond(text):
             bot.say(text, trigger.nick)
@@ -325,7 +325,7 @@ def help(bot, trigger):
 
 
 def create_list(bot, msg):
-    """Creates & uploads the command list.
+    """Create and upload the command list.
 
     Returns the URL from the chosen pastebin provider.
     """

--- a/sopel/modules/instagram.py
+++ b/sopel/modules/instagram.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-instagram.py - Sopel Instagram Plugin
+"""instagram.py - Sopel Instagram Plugin.
+
 Copyright 2018, Sopel contributors
 Licensed under the Eiffel Forum License 2.
 

--- a/sopel/modules/invite.py
+++ b/sopel/modules/invite.py
@@ -16,7 +16,7 @@ MIN_PRIV = plugin.HALFOP
 
 
 def invite_handler(bot, sender, user, channel):
-    """Common control logic for invite commands received from anywhere."""
+    """Check common requirements for invite commands."""
     sender = tools.Identifier(sender)
     user = tools.Identifier(user)
     channel = tools.Identifier(channel)
@@ -60,10 +60,7 @@ def invite_handler(bot, sender, user, channel):
 @plugin.example('.invite jenny', user_help=True)
 @plugin.example('.invite converge #sopel', user_help=True)
 def invite(bot, trigger):
-    """
-    Invite the given user to the current channel, or (with optional
-    second argument) another channel that Sopel is in.
-    """
+    """Invite the given user to the current or given channel."""
     if not trigger.group(3):
         return bot.reply("Whom should I invite?")
     user = trigger.group(3)

--- a/sopel/modules/invite.py
+++ b/sopel/modules/invite.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-invite.py - Sopel Invite Plugin
+"""invite.py - Sopel Invite Plugin.
+
 Copyright © 2016, João Vanzuita, https://github.com/converge
 Copyright © 2019, dgw, https://github.com/dgw
 Licensed under the Eiffel Forum License 2.

--- a/sopel/modules/ip.py
+++ b/sopel/modules/ip.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-ip.py - Sopel GeoIP Lookup Plugin
+"""ip.py - Sopel GeoIP Lookup Plugin.
+
 Copyright 2011, Dimitri Molenaars, TyRope.nl,
 Copyright © 2013, Elad Alfassa <elad@fedoraproject.org>
 Licensed under the Eiffel Forum License 2.
@@ -43,10 +43,10 @@ class GeoipSection(types.StaticSection):
 
 
 def configure(config):
-    """
+    r"""
     | name | example | purpose |
     | ---- | ------- | ------- |
-    | GeoIP\\_db\\_path | /home/sopel/GeoIP/ | Path to the GeoIP database files |
+    | GeoIP\_db\_path | /home/sopel/GeoIP/ | Path to the GeoIP database files |
     """
     config.define_section('ip', GeoipSection)
     config.ip.configure_setting('GeoIP_db_path',
@@ -58,7 +58,7 @@ def setup(bot):
 
 
 def _decompress(source, target, delete_after_decompression=True):
-    """Decompress just the database from the archive"""
+    """Decompress just the database from the archive."""
     # https://stackoverflow.com/a/16452962
     tar = tarfile.open(source)
     for member in tar.getmembers():
@@ -70,7 +70,7 @@ def _decompress(source, target, delete_after_decompression=True):
 
 
 def _find_geoip_db(bot):
-    """Find the GeoIP database"""
+    """Find the GeoIP database."""
     config = bot.config
     if config.ip.GeoIP_db_path:
         cities_db = os.path.join(config.ip.GeoIP_db_path, 'GeoLite2-City.mmdb')
@@ -122,7 +122,7 @@ def _find_geoip_db(bot):
     online=True)
 @plugin.output_prefix('[IP/Host Lookup] ')
 def ip(bot, trigger):
-    """IP Lookup tool"""
+    """IP Lookup tool."""
     # Check if there is input at all
     if not trigger.group(2):
         bot.reply("No search term.")

--- a/sopel/modules/isup.py
+++ b/sopel/modules/isup.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-isup.py - Sopel Website Status Check Plugin
+"""isup.py - Sopel Website Status Check Plugin.
+
 Copyright 2011, Elsie Powell http://embolalia.com
 Licensed under the Eiffel Forum License 2.
 
@@ -17,7 +17,7 @@ PLUGIN_OUTPUT_PREFIX = '[isup] '
 
 
 def get_site_url(site):
-    """Get a ``site`` URL
+    """Get a ``site`` URL.
 
     :param str site: the site to get URL for
     :return: a valid site URL
@@ -50,7 +50,7 @@ def get_site_url(site):
 
 
 def handle_isup(bot, trigger, secure=True):
-    """Handle the ``bot`` command from ``trigger``
+    """Handle the ``bot`` command from ``trigger``.
 
     :param bot: Sopel instance
     :type bot: :class:`sopel.bot.SopelWrapper`

--- a/sopel/modules/lmgtfy.py
+++ b/sopel/modules/lmgtfy.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-lmgtfy.py - Sopel Let Me Google That For You Plugin
+"""lmgtfy.py - Sopel Let Me Google That For You Plugin.
+
 Copyright 2013, Dimitri Molenaars http://tyrope.nl/
 Licensed under the Eiffel Forum License 2.
 

--- a/sopel/modules/meetbot.py
+++ b/sopel/modules/meetbot.py
@@ -504,8 +504,9 @@ def log_meeting(bot, trigger):
 @plugin.command("comment")
 @plugin.require_privmsg()
 def take_comment(bot, trigger):
-    """
-    Log a comment, to be shown with other comments when a chair uses .comments.
+    """Log a comment.
+
+    Comments will be shown with others when a chair uses .comments.
     Intended to allow commentary from those outside the primary group of people
     in the meeting.
 

--- a/sopel/modules/meetbot.py
+++ b/sopel/modules/meetbot.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-meetbot.py - Sopel Meeting Logger Plugin
+"""meetbot.py - Sopel Meeting Logger Plugin.
+
 This plugin is an attempt to implement some of the functionality of Debian's meetbot
 Copyright © 2012, Elad Alfassa, <elad@fedoraproject.org>
 Licensed under the Eiffel Forum License 2.
@@ -25,7 +25,7 @@ UNTITLED_MEETING = "Untitled meeting"
 
 
 class MeetbotSection(types.StaticSection):
-    """Configuration file section definition"""
+    """Configuration file section definition."""
 
     meeting_log_path = types.FilenameAttribute(
         "meeting_log_path",
@@ -43,11 +43,11 @@ class MeetbotSection(types.StaticSection):
 
 
 def configure(config):
-    """
+    r"""
     | name | example | purpose |
     | ---- | ------- | ------- |
-    | meeting\\_log\\_path | /home/sopel/www/meetings | Path to meeting logs storage directory (should be an absolute path, accessible on a webserver) |
-    | meeting\\_log\\_baseurl | http://example.com/~sopel/meetings | Base URL for the meeting logs directory |
+    | meeting\_log\_path | /home/sopel/www/meetings | Path to meeting logs storage directory (should be an absolute path, accessible on a webserver) |
+    | meeting\_log\_baseurl | http://example.com/~sopel/meetings | Base URL for the meeting logs directory |
     """
     config.define_section("meetbot", MeetbotSection)
     config.meetbot.configure_setting(
@@ -192,8 +192,8 @@ def is_chair(nick, channel):
 @plugin.example(".startmeeting Meeting Title", user_help=True)
 @plugin.require_chanmsg("Meetings can only be started in channels")
 def startmeeting(bot, trigger):
-    """
-    Start a meeting.\
+    """Start a meeting.
+
     See [meetbot plugin usage]({% link _usage/meetbot-plugin.md %})
     """
     if is_meeting_running(trigger.sender):
@@ -253,8 +253,8 @@ def startmeeting(bot, trigger):
 @plugin.command("subject")
 @plugin.example(".subject roll call")
 def meetingsubject(bot, trigger):
-    """
-    Change the meeting subject.\
+    """Change the meeting subject.
+
     See [meetbot plugin usage]({% link _usage/meetbot-plugin.md %})
     """
     if not is_meeting_running(trigger.sender):
@@ -284,8 +284,8 @@ def meetingsubject(bot, trigger):
 @plugin.command("endmeeting")
 @plugin.example(".endmeeting")
 def endmeeting(bot, trigger):
-    """
-    End a meeting.\
+    """End a meeting.
+
     See [meetbot plugin usage]({% link _usage/meetbot-plugin.md %})
     """
     if not is_meeting_running(trigger.sender):
@@ -317,8 +317,8 @@ def endmeeting(bot, trigger):
 @plugin.command("chairs")
 @plugin.example(".chairs Tyrope Jason elad")
 def chairs(bot, trigger):
-    """
-    Set the meeting chairs.\
+    """Set the meeting chairs.
+
     See [meetbot plugin usage]({% link _usage/meetbot-plugin.md %})
     """
     if not is_meeting_running(trigger.sender):
@@ -349,8 +349,8 @@ def chairs(bot, trigger):
 @plugin.command("action")
 @plugin.example(".action elad will develop a meetbot")
 def meetingaction(bot, trigger):
-    """
-    Log an action in the meeting log.\
+    """Log an action in the meeting log.
+
     See [meetbot plugin usage]({% link _usage/meetbot-plugin.md %})
     """
     if not is_meeting_running(trigger.sender):
@@ -387,8 +387,8 @@ def listactions(bot, trigger):
 @plugin.command("agreed")
 @plugin.example(".agreed Bowties are cool")
 def meetingagreed(bot, trigger):
-    """
-    Log an agreement in the meeting log.\
+    """Log an agreement in the meeting log.
+
     See [meetbot plugin usage]({% link _usage/meetbot-plugin.md %})
     """
     if not is_meeting_running(trigger.sender):
@@ -412,8 +412,8 @@ def meetingagreed(bot, trigger):
 @plugin.command("link")
 @plugin.example(".link http://example.com")
 def meetinglink(bot, trigger):
-    """
-    Log a link in the meeing log.\
+    """Log a link in the meeing log.
+
     See [meetbot plugin usage]({% link _usage/meetbot-plugin.md %})
     """
     if not is_meeting_running(trigger.sender):
@@ -445,8 +445,8 @@ def meetinglink(bot, trigger):
 @plugin.command("info")
 @plugin.example(".info all board members present")
 def meetinginfo(bot, trigger):
-    """
-    Log an informational item in the meeting log.\
+    """Log an informational item in the meeting log.
+
     See [meetbot plugin usage]({% link _usage/meetbot-plugin.md %})
     """
     if not is_meeting_running(trigger.sender):
@@ -538,8 +538,7 @@ def take_comment(bot, trigger):
 
 @plugin.command("comments")
 def show_comments(bot, trigger):
-    """
-    Show the comments that have been logged for this meeting with .comment.
+    """Show the comments that have been logged for this meeting with .comment.
 
     See [meetbot plugin usage]({% link _usage/meetbot-plugin.md %})
     """

--- a/sopel/modules/ping.py
+++ b/sopel/modules/ping.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-ping.py - Sopel Ping Plugin
+"""ping.py - Sopel Ping Plugin.
+
 Copyright 2008 (?), Sean B. Palmer, inamidst.com
 
 https://sopel.chat

--- a/sopel/modules/pronouns.py
+++ b/sopel/modules/pronouns.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-pronouns.py - Sopel Pronouns Plugin
+"""pronouns.py - Sopel Pronouns Plugin.
+
 Copyright © 2016, Elsie Powell
 Licensed under the Eiffel Forum License 2.
 

--- a/sopel/modules/py.py
+++ b/sopel/modules/py.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-py.py - Sopel Python Eval Plugin
+"""py.py - Sopel Python Eval Plugin.
+
 Copyright 2008, Sean B. Palmer, inamidst.com
 Licensed under the Eiffel Forum License 2.
 

--- a/sopel/modules/rand.py
+++ b/sopel/modules/rand.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-rand.py - Rand Plugin
+"""rand.py - Rand Plugin.
+
 Copyright 2013, Ari Koivula, <ari@koivu.la>
 Licensed under the Eiffel Forum License 2.
 

--- a/sopel/modules/rand.py
+++ b/sopel/modules/rand.py
@@ -22,7 +22,7 @@ from sopel import plugin
 @plugin.example('.rand 10 99', r'random\(10, 99\): \d\d', re=True, repeat=10)
 @plugin.output_prefix('[rand] ')
 def rand(bot, trigger):
-    """Replies with a random number between first and second argument."""
+    """Reply with a random number between first and second argument."""
     arg1 = trigger.group(3)
     arg2 = trigger.group(4)
 

--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-reddit.py - Sopel Reddit Plugin
+"""reddit.py - Sopel Reddit Plugin.
+
 Copyright 2012, Elsie Powell, embolalia.com
 Copyright 2019, dgw, technobabbl.es
 Copyright 2019, deathbybandaid, deathbybandaid.net

--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -361,9 +361,9 @@ def auto_subreddit_info(bot, trigger, match):
 @plugin.example('.setsfw false')
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def set_channel_sfw(bot, trigger):
-    """
-    Sets the Safe for Work status (true or false) for the current
-    channel. Defaults to false.
+    """Set the Safe for Work status for the current channel.
+
+    Defaults to false.
     """
     param = 'true'
     if trigger.group(2) and trigger.group(3):
@@ -380,9 +380,9 @@ def set_channel_sfw(bot, trigger):
 @plugin.example('.getsfw [channel]')
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def get_channel_sfw(bot, trigger):
-    """
-    Gets the preferred channel's Safe for Work status, or the current
-    channel's status if no channel given.
+    """Get the preferred channel's Safe for Work status.
+
+    Checks current channel if none is specified.
     """
     channel = trigger.group(2)
     if not channel:
@@ -408,8 +408,8 @@ def get_channel_sfw(bot, trigger):
 @plugin.example('.setspoilfree false')
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def set_channel_spoiler_free(bot, trigger):
-    """
-    Sets the Spoiler-Free status (true or false) for the current channel.
+    """Set the Spoiler-Free status for the current channel.
+
     Defaults to false.
     """
     param = 'true'
@@ -427,9 +427,9 @@ def set_channel_spoiler_free(bot, trigger):
 @plugin.example('.getspoilfree [channel]')
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def get_channel_spoiler_free(bot, trigger):
-    """
-    Gets the channel's Spoiler-Free status, or the current channel's
-    status if no channel given.
+    """Get a channel's Spoiler-Free status.
+
+    Checks current channel if none is specified.
     """
     channel = trigger.group(2)
     if not channel:

--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -217,7 +217,7 @@ def say_post_info(bot, trigger, id_, show_link=True, show_comments_link=False):
 @plugin.url(comment_url)
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def comment_info(bot, trigger, match):
-    """Shows information about the linked comment"""
+    """Show information about the linked comment."""
     try:
         c = bot.memory['reddit_praw'].comment(match.group(1))
     except prawcore.exceptions.NotFound:
@@ -250,7 +250,7 @@ def comment_info(bot, trigger, match):
 
 
 def subreddit_info(bot, trigger, match, commanded=False):
-    """Shows information about the given subreddit"""
+    """Show information about the given subreddit."""
     match_lower = match.lower()
     if match_lower in ['all', 'popular']:
         message = ('[REDDIT] {link}{nsfw} | {public_description}')
@@ -313,7 +313,7 @@ def subreddit_info(bot, trigger, match, commanded=False):
 
 
 def redditor_info(bot, trigger, match, commanded=False):
-    """Shows information about the given Redditor"""
+    """Show information about the given Redditor."""
     try:
         u = bot.memory['reddit_praw'].redditor(match)
         u.id  # shortcut to check if the user exists or not

--- a/sopel/modules/reload.py
+++ b/sopel/modules/reload.py
@@ -36,7 +36,7 @@ def _load(bot, plugin):
 @plugin.require_admin
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def f_reload(bot, trigger):
-    """Reloads a plugin (for use by admins only)."""
+    """Reload a plugin (for use by admins only)."""
     name = trigger.group(2)
 
     if not name or name == '*' or name.upper() == 'ALL THE THINGS':
@@ -61,7 +61,7 @@ def f_reload(bot, trigger):
 @plugin.require_admin
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def f_update(bot, trigger):
-    """Pulls the latest versions of all plugins from Git (for use by admins only)."""
+    """Pull the latest versions of all plugins from Git (for use by admins only)."""
     proc = subprocess.Popen('/usr/bin/git pull',
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE, shell=True)
@@ -76,7 +76,7 @@ def f_update(bot, trigger):
 @plugin.require_admin
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def f_load(bot, trigger):
-    """Loads a plugin (for use by admins only)."""
+    """Load a plugin (for use by admins only)."""
     name = trigger.group(2)
     if not name:
         bot.reply('Load what?')

--- a/sopel/modules/reload.py
+++ b/sopel/modules/reload.py
@@ -116,7 +116,7 @@ def f_load(bot, trigger):
 @plugin.require_privmsg
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def pm_f_reload(bot, trigger):
-    """Wrapper for allowing delivery of .reload command via PM"""
+    """Allow .reload command via PM."""
     f_reload(bot, trigger)
 
 
@@ -124,7 +124,7 @@ def pm_f_reload(bot, trigger):
 @plugin.require_privmsg
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def pm_f_update(bot, trigger):
-    """Wrapper for allowing delivery of .update command via PM"""
+    """Allow .update command via PM."""
     f_update(bot, trigger)
 
 
@@ -134,5 +134,5 @@ def pm_f_update(bot, trigger):
 @plugin.require_privmsg
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def pm_f_load(bot, trigger):
-    """Wrapper for allowing delivery of .load command via PM"""
+    """Allow .load command via PM."""
     f_load(bot, trigger)

--- a/sopel/modules/reload.py
+++ b/sopel/modules/reload.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-reload.py - Sopel Plugin Reloader Plugin
+"""reload.py - Sopel Plugin Reloader Plugin.
+
 Copyright 2008, Sean B. Palmer, inamidst.com
 Licensed under the Eiffel Forum License 2.
 

--- a/sopel/modules/remind.py
+++ b/sopel/modules/remind.py
@@ -220,7 +220,7 @@ PERIODS = '|'.join(SCALING.keys())
 @plugin.command('in')
 @plugin.example('.in 3h45m Go to class')
 def remind_in(bot, trigger):
-    """Gives you a reminder in the given amount of time."""
+    """Give you a reminder in the given amount of time."""
     if not trigger.group(2):
         bot.reply("Missing arguments for reminder command.")
         return plugin.NOLIMIT
@@ -454,7 +454,7 @@ def parse_regex_match(match, default_timezone=None):
                 user_help=True)
 @plugin.example('.at 00:01 25/12 Open your gift!', user_help=True)
 def remind_at(bot, trigger):
-    """Gives you a reminder at the given time.
+    """Give you a reminder at the given time.
 
     Takes ``hh:mm:ssTimezone Date message`` where seconds, Timezone, and Date
     are optional.

--- a/sopel/modules/remind.py
+++ b/sopel/modules/remind.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-remind.py - Sopel Reminder Plugin
+"""remind.py - Sopel Reminder Plugin.
+
 Copyright 2011, Sean B. Palmer, inamidst.com
 Copyright 2019, dgw, technobabbl.es
 Licensed under the Eiffel Forum License 2.
@@ -27,7 +27,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def get_filename(bot):
-    """Get the remind database's filename
+    """Get the remind database's filename.
 
     :param bot: instance of Sopel
     :type bot: :class:`sopel.bot.Sopel`
@@ -42,7 +42,7 @@ def get_filename(bot):
 
 
 def load_database(filename):
-    """Load the remind database from a file
+    """Load the remind database from a file.
 
     :param str filename: absolute path to the remind database file
     :return: a :class:`dict` of reminders stored by timestamp
@@ -84,7 +84,7 @@ def load_database(filename):
 
 
 def dump_database(filename, data):
-    """Dump the remind database into a file
+    """Dump the remind database into a file.
 
     :param str filename: absolute path to the remind database file
     :param dict data: remind database to dump
@@ -102,7 +102,7 @@ def dump_database(filename, data):
 
 
 def create_reminder(bot, trigger, duration, message):
-    """Create a reminder into the ``bot``'s database and reply to the sender
+    """Create a reminder into the ``bot``'s database and reply to the sender.
 
     :param bot: the bot's instance
     :type bot: :class:`~sopel.bot.SopelWrapper`
@@ -126,7 +126,7 @@ def create_reminder(bot, trigger, duration, message):
 
 
 def setup(bot):
-    """Load the remind database"""
+    """Load the remind database."""
     bot.rfn = get_filename(bot)
 
     # Pre-7.0 migration logic. Remove in 8.0 or 9.0.
@@ -151,7 +151,7 @@ def setup(bot):
 
 
 def shutdown(bot):
-    """Dump the remind database before shutdown"""
+    """Dump the remind database before shutdown."""
     dump_database(bot.rfn, bot.rdb)
     bot.rdb = {}
     del bot.rfn
@@ -160,7 +160,7 @@ def shutdown(bot):
 
 @plugin.interval(2.5)
 def remind_monitoring(bot):
-    """Check for reminder"""
+    """Check for reminder."""
     now = int(time.time())
     unixtimes = [int(key) for key in bot.rdb]
     oldtimes = [t for t in unixtimes if t <= now]
@@ -290,7 +290,8 @@ REGEX_AT = re.compile(
 
 
 class TimeReminder(object):
-    """Time reminder for the ``at`` command"""
+    """Time reminder for the ``at`` command."""
+
     def __init__(self,
                  hour,
                  minute,
@@ -374,7 +375,7 @@ class TimeReminder(object):
     __hash__ = None
 
     def get_duration(self, today=None):
-        """Get the duration between the reminder and ``today``
+        """Get the duration between the reminder and ``today``.
 
         :param today: aware datetime to compare to; defaults to current time
         :type today: aware :class:`datetime.datetime`
@@ -420,7 +421,7 @@ class TimeReminder(object):
 
 
 def parse_regex_match(match, default_timezone=None):
-    """Parse a time reminder from ``match``
+    """Parse a time reminder from ``match``.
 
     :param match: :obj:`~.REGEX_AT`'s matching result
     :param default_timezone: timezone used when ``match`` doesn't have one;

--- a/sopel/modules/safety.py
+++ b/sopel/modules/safety.py
@@ -120,7 +120,7 @@ def _download_malwaredomains_db(path):
 @plugin.priority('high')
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def url_handler(bot, trigger):
-    """Checks for malicious URLs"""
+    """Check for malicious URLs."""
     check = True    # Enable URL checking
     strict = False  # Strict mode: kick on malicious URL
     positives = 0   # Number of engines saying it's malicious
@@ -228,7 +228,7 @@ def toggle_safety(bot, trigger):
 # Code above also calls this if there are too many cache entries
 @plugin.interval(24 * 60 * 60)
 def _clean_cache(bot):
-    """Cleans up old entries in URL safety cache."""
+    """Clean up old entries in URL safety cache."""
     if bot.memory['safety_cache_lock'].acquire(False):
         LOGGER.info('Starting safety cache cleanup...')
         try:

--- a/sopel/modules/safety.py
+++ b/sopel/modules/safety.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-safety.py - Alerts about malicious URLs
+"""safety.py - Alerts about malicious URLs.
+
 Copyright © 2014, Elad Alfassa, <elad@fedoraproject.org>
 Licensed under the Eiffel Forum License 2.
 
@@ -58,12 +58,12 @@ class SafetySection(types.StaticSection):
 
 
 def configure(config):
-    """
+    r"""
     | name | example | purpose |
     | ---- | ------- | ------- |
-    | enabled\\_by\\_default | True | Enable URL safety in all channels where it isn't explicitly disabled. |
-    | known\\_good | sopel.chat,dftba.net | List of "known good" domains to ignore. |
-    | vt\\_api\\_key | 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef | Optional VirusTotal API key to improve malicious URL detection |
+    | enabled\_by\_default | True | Enable URL safety in all channels where it isn't explicitly disabled. |
+    | known\_good | sopel.chat,dftba.net | List of "known good" domains to ignore. |
+    | vt\_api\_key | 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef | Optional VirusTotal API key to improve malicious URL detection |
     """
     config.define_section('safety', SafetySection)
     config.safety.configure_setting(
@@ -209,7 +209,7 @@ def url_handler(bot, trigger):
 @plugin.command('safety')
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def toggle_safety(bot, trigger):
-    """Set safety setting for channel"""
+    """Set safety setting for channel."""
     if not trigger.admin and bot.channels[trigger.sender].privileges[trigger.nick] < plugin.OP:
         bot.reply('Only channel operators can change safety settings')
         return

--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -91,7 +91,7 @@ def duck_api(query):
     vcr=True)
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def duck(bot, trigger):
-    """Queries DuckDuckGo for the specified input."""
+    """Query DuckDuckGo for the specified input."""
     query = trigger.group(2)
     if not query:
         bot.reply('{prefix}{command} what?'.format(
@@ -126,7 +126,7 @@ def duck(bot, trigger):
 @plugin.example('.bing sopel.chat irc bot')
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def bing(bot, trigger):
-    """Queries Bing for the specified input."""
+    """Query Bing for the specified input."""
     if not trigger.group(2):
         bot.reply('{}bing what?'.format(bot.settings.core.help_prefix))
         return
@@ -142,7 +142,7 @@ def bing(bot, trigger):
 @plugin.example('.search sopel irc bot')
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def search(bot, trigger):
-    """Searches both Bing and DuckDuckGo."""
+    """Search both Bing and DuckDuckGo."""
     if not trigger.group(2):
         bot.reply('{}search for what?'.format(bot.settings.core.help_prefix))
         return
@@ -168,7 +168,7 @@ def search(bot, trigger):
 @plugin.example('.suggest lkashdfiauwgaef', 'Sorry, no result.', online=True, vcr=True)
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def suggest(bot, trigger):
-    """Suggests terms starting with given input"""
+    """Suggest terms starting with given input."""
     if not trigger.group(2):
         bot.reply('{}suggest what?'.format(bot.settings.core.help_prefix))
         return

--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-search.py - Sopel Search Engine Plugin
+"""search.py - Sopel Search Engine Plugin.
+
 Copyright 2008-9, Sean B. Palmer, inamidst.com
 Copyright 2012, Elsie Powell, embolalia.com
 Licensed under the Eiffel Forum License 2.

--- a/sopel/modules/seen.py
+++ b/sopel/modules/seen.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-seen.py - Sopel Seen Plugin
+"""seen.py - Sopel Seen Plugin.
+
 Copyright 2008, Sean B. Palmer, inamidst.com
 Copyright © 2012, Elad Alfassa <elad@fedoraproject.org>
 Copyright 2019, Sopel contributors

--- a/sopel/modules/seen.py
+++ b/sopel/modules/seen.py
@@ -20,7 +20,7 @@ from sopel.tools.time import seconds_to_human
 @plugin.command('seen')
 @plugin.output_prefix('[seen] ')
 def seen(bot, trigger):
-    """Reports when and where the user was last seen."""
+    """Report when and where the user was last seen."""
     if not trigger.group(2):
         bot.reply(
             "Use `%sseen <nick>` to know when <nick> was last seen."

--- a/sopel/modules/tell.py
+++ b/sopel/modules/tell.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-tell.py - Sopel Tell and Ask Plugin
+"""tell.py - Sopel Tell and Ask Plugin.
+
 Copyright 2008, Sean B. Palmer, inamidst.com
 Copyright 2019, dgw, technobabbl.es
 Licensed under the Eiffel Forum License 2.
@@ -134,7 +134,7 @@ def shutdown(bot):
 @plugin.nickname_command('tell', 'ask')
 @plugin.example('$nickname, tell dgw he broke something again.')
 def f_remind(bot, trigger):
-    """Give someone a message the next time they're seen"""
+    """Give someone a message the next time they're seen."""
     teller = trigger.nick
     verb = trigger.group(1)
 

--- a/sopel/modules/tld.py
+++ b/sopel/modules/tld.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-tld.py - Sopel TLD Plugin
+"""tld.py - Sopel TLD Plugin.
+
 Copyright 2009-10, Michael Yanovich, yanovich.net
 Copyright 2020, dgw, technobabbl.es
 Licensed under the Eiffel Forum License 2.

--- a/sopel/modules/translate.py
+++ b/sopel/modules/translate.py
@@ -86,7 +86,7 @@ def translate(text, in_lang='auto', out_lang='en'):
 @plugin.priority('low')
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def tr(bot, trigger):
-    """Translates a phrase, with an optional language hint."""
+    """Translate a phrase, with an optional language hint."""
     in_lang, out_lang, phrase = trigger.groups()
 
     if (len(phrase) > 350) and (not trigger.admin):
@@ -136,7 +136,7 @@ def tr(bot, trigger):
                 online=True, vcr=True)
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def tr2(bot, trigger):
-    """Translates a phrase, with an optional language hint."""
+    """Translate a phrase, with an optional language hint."""
     command = trigger.group(2)
 
     if not command:

--- a/sopel/modules/translate.py
+++ b/sopel/modules/translate.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-translate.py - Sopel Translation Plugin
+"""translate.py - Sopel Translation Plugin.
+
 Copyright 2008, Sean B. Palmer, inamidst.com
 Copyright 2013-2014, Elad Alfassa <elad@fedoraproject.org>
 Licensed under the Eiffel Forum License 2.

--- a/sopel/modules/unicode_info.py
+++ b/sopel/modules/unicode_info.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-unicode_info.py - Sopel Codepoints Plugin
+"""unicode_info.py - Sopel Codepoints Plugin.
+
 Copyright 2013, Elsie Powell, embolalia.com
 Copyright 2008, Sean B. Palmer, inamidst.com
 Licensed under the Eiffel Forum License 2.
@@ -26,7 +26,7 @@ if sys.version_info.major >= 3:
 
 
 def get_codepoint_name(char):
-    """Retrieve the code point (and name, if possible) for a given character"""
+    """Retrieve the code point (and name, if possible) for a given character."""
     # Get the hex value for the code point, and drop the 0x from the front
     point = unicode(hex(ord(char)))[2:]
 

--- a/sopel/modules/units.py
+++ b/sopel/modules/units.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-units.py - Sopel Unit Conversion Plugin
+"""units.py - Sopel Unit Conversion Plugin.
+
 Copyright © 2013, Elad Alfassa, <elad@fedoraproject.org>
 Copyright © 2013, Dimitri Molenaars, <tyrope@tyrope.nl>
 Licensed under the Eiffel Forum License 2.
@@ -43,7 +43,7 @@ def k_to_c(temp):
 @plugin.example('.temp 100K', '-173.15°C = -279.67°F = 100.00K')
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def temperature(bot, trigger):
-    """Convert temperatures"""
+    """Convert temperatures."""
     try:
         source = find_temp.match(trigger.group(2)).groups()
     except (AttributeError, TypeError):
@@ -86,7 +86,7 @@ def temperature(bot, trigger):
 @plugin.example('.length 3 parsec', '92570329129020.20km = 57520535754731.61 miles')
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def distance(bot, trigger):
-    """Convert distances"""
+    """Convert distances."""
     try:
         source = find_length.match(trigger.group(2)).groups()
     except (AttributeError, TypeError):
@@ -157,7 +157,7 @@ def distance(bot, trigger):
 @plugin.command('weight', 'mass')
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def mass(bot, trigger):
-    """Convert mass"""
+    """Convert mass."""
     try:
         source = find_mass.match(trigger.group(2)).groups()
     except (AttributeError, TypeError):

--- a/sopel/modules/uptime.py
+++ b/sopel/modules/uptime.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-uptime.py - Sopel Uptime Plugin
+"""uptime.py - Sopel Uptime Plugin.
+
 Copyright 2014, Fabian Neundorf
 Licensed under the Eiffel Forum License 2.
 

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -159,10 +159,7 @@ def shutdown(bot):
     online=True, vcr=True)
 @plugin.output_prefix('[url] ')
 def title_command(bot, trigger):
-    """
-    Show the title or URL information for the given URL, or the last URL seen
-    in this channel.
-    """
+    """Show title or URL info for a given URL or the last URL in the channel."""
     if not trigger.group(2):
         if trigger.sender not in bot.memory['last_seen_url']:
             return
@@ -188,10 +185,10 @@ def title_command(bot, trigger):
 @plugin.rule(r'(?u).*(https?://\S+).*')
 @plugin.output_prefix('[url] ')
 def title_auto(bot, trigger):
-    """
-    Automatically show titles for URLs. For shortened URLs/redirects, find
-    where the URL redirects to and show the title for that (or call a function
-    from another plugin to give more information).
+    """Automatically show titles for URLs.
+
+    For shortened URLs/redirects, find where the URL redirects to and show the title
+    for that (or call a function from another plugin to give more information).
     """
     # Enabled or disabled by feature flag
     if not bot.settings.url.enable_auto_title:

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-url.py - Sopel URL Title Plugin
+"""url.py - Sopel URL Title Plugin.
+
 Copyright 2010-2011, Michael Yanovich (yanovich.net) & Kenneth Sham
 Copyright 2012-2013, Elsie Powell
 Copyright 2013, Lior Ramati <firerogue517@gmail.com>
@@ -73,15 +73,15 @@ class UrlSection(types.StaticSection):
 
 
 def configure(config):
-    """
+    r"""
     | name | example | purpose |
     | ---- | ------- | ------- |
     | enable_auto_title | yes | Enable auto-title. |
-    | exclude | https?://git\\\\.io/.* | A list of regular expressions for URLs for which the title should not be shown. |
-    | exclusion\\_char | ! | A character (or string) which, when immediately preceding a URL, will stop the URL's title from being shown. |
-    | shorten\\_url\\_length | 72 | If greater than 0, the title fetcher will include a TinyURL version of links longer than this many characters. |
-    | enable\\_private\\_resolution | False | Enable URL lookups for RFC1918 addresses. |
-    | enable\\_dns\\_resolution | False | Enable DNS resolution for all domains to validate if there are RFC1918 resolutions. |
+    | exclude | https?://git\\.io/.* | A list of regular expressions for URLs for which the title should not be shown. |
+    | exclusion\_char | ! | A character (or string) which, when immediately preceding a URL, will stop the URL's title from being shown. |
+    | shorten\_url\_length | 72 | If greater than 0, the title fetcher will include a TinyURL version of links longer than this many characters. |
+    | enable\_private\_resolution | False | Enable URL lookups for RFC1918 addresses. |
+    | enable\_dns\_resolution | False | Enable DNS resolution for all domains to validate if there are RFC1918 resolutions. |
     """
     config.define_section('url', UrlSection)
     config.url.configure_setting(
@@ -364,7 +364,7 @@ def get_hostname(url):
 
 
 def get_or_create_shorturl(bot, url):
-    """Get or create a short URL for ``url``
+    """Get or create a short URL for ``url``.
 
     :param bot: Sopel instance
     :param str url: URL to get or create a short URL for
@@ -386,7 +386,7 @@ def get_or_create_shorturl(bot, url):
 
 
 def get_tinyurl(url):
-    """Returns a shortened tinyURL link of the URL"""
+    """Returns a shortened tinyURL link of the URL."""
     base_url = "https://tinyurl.com/api-create.php"
     tinyurl = "%s?%s" % (base_url, web.urlencode({'url': url}))
     try:

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -386,7 +386,7 @@ def get_or_create_shorturl(bot, url):
 
 
 def get_tinyurl(url):
-    """Returns a shortened tinyURL link of the URL."""
+    """Return a shortened tinyURL link of the URL."""
     base_url = "https://tinyurl.com/api-create.php"
     tinyurl = "%s?%s" % (base_url, web.urlencode({'url': url}))
     try:

--- a/sopel/modules/version.py
+++ b/sopel/modules/version.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-version.py - Sopel Version Plugin
+"""version.py - Sopel Version Plugin.
+
 Copyright 2009, Silas Baronda
 Copyright 2014, Dimitri Molenaars <tyrope@tyrope.nl>
 Licensed under the Eiffel Forum License 2.

--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-wikipedia.py - Sopel Wikipedia Plugin
+"""wikipedia.py - Sopel Wikipedia Plugin.
+
 Copyright 2013 Elsie Powell - embolalia.com
 Licensed under the Eiffel Forum License 2.
 
@@ -100,10 +100,10 @@ def setup(bot):
 
 
 def configure(config):
-    """
+    r"""
     | name | example | purpose |
     | ---- | ------- | ------- |
-    | default\\_lang | en | The default language to find articles from (same as Wikipedia language subdomain) |
+    | default\_lang | en | The default language to find articles from (same as Wikipedia language subdomain) |
     """
     config.define_section('wikipedia', WikipediaSection)
     config.wikipedia.configure_setting(
@@ -133,7 +133,7 @@ def choose_lang(bot, trigger):
 
 
 def mw_search(server, query, num):
-    """Search a MediaWiki site
+    """Search a MediaWiki site.
 
     Searches the specified MediaWiki server for the given query, and returns
     the specified number of results.

--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -168,7 +168,7 @@ def say_snippet(bot, trigger, server, query, show_url=True):
 
 
 def mw_snippet(server, query):
-    """Retrieves a snippet of the given page from the given MediaWiki server."""
+    """Retrieve a snippet of the given page from the given MediaWiki server."""
     snippet_url = ('https://' + server + '/w/api.php?format=json'
                    '&action=query&prop=extracts&exintro&explaintext'
                    '&exchars=300&redirects&titles=')
@@ -242,7 +242,7 @@ def mw_section(server, query, section):
 @plugin.url(r'https?:\/\/([a-z]+\.wikipedia\.org)\/wiki\/((?!File\:)[^ #]+)#?([^ ]*)')
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def mw_info(bot, trigger, match=None):
-    """Retrieves and outputs a snippet of the linked page."""
+    """Retrieve and outputs a snippet of the linked page."""
     if match.group(3):
         if match.group(3).startswith('cite_note-'):  # Don't bother trying to retrieve a snippet when cite-note is linked
             say_snippet(bot, trigger, match.group(1), unquote(match.group(2)), show_url=False)

--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -197,10 +197,7 @@ def say_section(bot, trigger, server, query, section):
 
 
 def mw_section(server, query, section):
-    """
-    Retrieves a snippet from the specified section from the given page
-    on the given server.
-    """
+    """Retrieve a snippet of a section section of a page."""
     sections_url = ('https://{0}/w/api.php?format=json&redirects'
                     '&action=parse&prop=sections&page={1}'
                     .format(server, query))

--- a/sopel/modules/wiktionary.py
+++ b/sopel/modules/wiktionary.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-wiktionary.py - Sopel Wiktionary Plugin
+"""wiktionary.py - Sopel Wiktionary Plugin.
+
 Copyright 2009, Sean B. Palmer, inamidst.com
 Licensed under the Eiffel Forum License 2.
 

--- a/sopel/modules/xkcd.py
+++ b/sopel/modules/xkcd.py
@@ -59,7 +59,7 @@ def web_search(query):
 @plugin.example(".xkcd", user_help=True)
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def xkcd(bot, trigger):
-    """Finds an xkcd comic strip.
+    """Find an xkcd comic strip.
 
     Takes one of 3 inputs:
 

--- a/sopel/modules/xkcd.py
+++ b/sopel/modules/xkcd.py
@@ -1,6 +1,6 @@
 # coding=utf-8
-"""
-xkcd.py - Sopel xkcd Plugin
+"""xkcd.py - Sopel xkcd Plugin.
+
 Copyright 2010, Michael Yanovich (yanovich.net), and Morgan Goose
 Copyright 2012, Lior Ramati
 Copyright 2013, Elsie Powell (embolalia.com)

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""This contains decorators and other tools for creating Sopel plugins."""
+"""Decorators and other tools for creating Sopel plugins."""
 # Copyright 2013, Ari Koivula, <ari@koivu.la>
 # Copyright © 2013, Elad Alfassa <elad@fedoraproject.org>
 # Copyright 2013, Lior Ramati <firerogue517@gmail.com>

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -46,7 +46,7 @@ __all__ = [
 
 
 NOLIMIT = 1
-"""Return value for ``callable``\\s, which suppresses rate limiting.
+r"""Return value for ``callable``\s, which suppresses rate limiting.
 
 Returning this value means the triggering user will not be prevented from
 triggering the same callable again within the rate limit. This can be used,
@@ -363,7 +363,7 @@ def echo(function=None):
 
 
 def command(*command_list):
-    """Decorate a function to set one or more commands that should trigger it.
+    r"""Decorate a function to set one or more commands that should trigger it.
 
     :param str command_list: one or more command name(s) to match
 
@@ -375,11 +375,11 @@ def command(*command_list):
     Example::
 
         @command("hello")
-            # If the command prefix is "\\.", this would trigger on lines
+            # If the command prefix is "\.", this would trigger on lines
             # starting with ".hello".
 
         @command('j', 'join')
-            # If the command prefix is "\\.", this would trigger on lines
+            # If the command prefix is "\.", this would trigger on lines
             # starting with either ".j" or ".join".
 
     You can use a space in the command name to implement subcommands::
@@ -1004,7 +1004,7 @@ def url_lazy(*loaders):
 
 
 class example(object):
-    """Decorate a function with an example, and optionally test output.
+    r"""Decorate a function with an example, and optionally test output.
 
     :param str msg: the example command (required; see below)
     :param str result: the command's expected output (optional; see below)
@@ -1044,7 +1044,7 @@ class example(object):
     test suite is run, using ``msg`` as input. The exact behavior of the tests
     depends on the remaining optional ``example`` arguments.
 
-    Passing ``re=True``, in particular, is useful for matching ``result``\\s
+    Passing ``re=True``, in particular, is useful for matching ``result``\s
     that are random and/or dependent on an external API. This way, an example
     test can check the format of the result without caring about the exact data.
 
@@ -1069,6 +1069,7 @@ class example(object):
     `VCR.py <https://github.com/kevin1024/vcrpy>`_ & `pytest-vcr
     <https://github.com/ktosiek/pytest-vcr>`_)
     """
+
     def __init__(self, msg, result=None, privmsg=False, admin=False,
                  owner=False, repeat=1, re=False, ignore=None,
                  user_help=False, online=False, vcr=False):

--- a/sopel/plugins/__init__.py
+++ b/sopel/plugins/__init__.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Sopel's plugins interface
+"""Sopel's plugins interface.
 
 .. versionadded:: 7.0
 
@@ -57,7 +57,7 @@ def _list_plugin_filenames(directory):
 
 
 def find_internal_plugins():
-    """List internal plugins
+    """List internal plugins.
 
     :return: Yield instance of :class:`~.handlers.PyModulePlugin`
              configured for ``sopel.modules.*``
@@ -72,7 +72,7 @@ def find_internal_plugins():
 
 
 def find_sopel_modules_plugins():
-    """List plugins from ``sopel_modules.*``
+    """List plugins from ``sopel_modules.*``.
 
     :return: Yield instance of :class:`~.handlers.PyModulePlugin`
              configured for ``sopel_modules.*``
@@ -88,7 +88,7 @@ def find_sopel_modules_plugins():
 
 
 def find_entry_point_plugins(group='sopel.plugins'):
-    """List plugins from a setuptools entry point group
+    """List plugins from a setuptools entry point group.
 
     :param str group: setuptools entry point group to look for
                       (defaults to ``sopel.plugins``)
@@ -100,7 +100,7 @@ def find_entry_point_plugins(group='sopel.plugins'):
 
 
 def find_directory_plugins(directory):
-    """List plugins from a ``directory``
+    """List plugins from a ``directory``.
 
     :param str directory: Directory path to search
     :return: Yield instance of :class:`~.handlers.PyFilePlugin`
@@ -111,7 +111,7 @@ def find_directory_plugins(directory):
 
 
 def enumerate_plugins(settings):
-    """Yield Sopel's plugins
+    """Yield Sopel's plugins.
 
     :param settings: Sopel's configuration
     :type settings: :class:`sopel.config.Config`
@@ -181,7 +181,7 @@ def enumerate_plugins(settings):
 
 
 def get_usable_plugins(settings):
-    """Get usable plugins, unique per name
+    """Get usable plugins, unique per name.
 
     :param settings: Sopel's configuration
     :type settings: :class:`sopel.config.Config`

--- a/sopel/plugins/exceptions.py
+++ b/sopel/plugins/exceptions.py
@@ -12,6 +12,7 @@ class PluginError(Exception):
 
 class PluginNotRegistered(PluginError):
     """Exception raised when a plugin is not registered."""
+
     def __init__(self, name):
         message = 'Plugin "%s" not registered' % name
         self.plugin_name = name

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Sopel's plugin handlers
+"""Sopel's plugin handlers.
 
 .. versionadded:: 7.0
 
@@ -74,8 +74,9 @@ class AbstractPluginHandler(object):
     (commands, jobs, etc.), configuring it, and running any required actions
     on shutdown (either upon exiting Sopel or unloading that plugin).
     """
+
     def load(self):
-        """Load the plugin
+        """Load the plugin.
 
         This method must be called first, in order to setup, register, shutdown,
         or configure the plugin later.
@@ -83,7 +84,7 @@ class AbstractPluginHandler(object):
         raise NotImplementedError
 
     def reload(self):
-        """Reload the plugin
+        """Reload the plugin.
 
         This method can be called once the plugin is already loaded. It will
         take care of reloading the plugin from its source.
@@ -91,7 +92,7 @@ class AbstractPluginHandler(object):
         raise NotImplementedError
 
     def get_label(self):
-        """Retrieve a display label for the plugin
+        """Retrieve a display label for the plugin.
 
         :return: A human readable label for display purpose
         :rtype: str
@@ -101,7 +102,7 @@ class AbstractPluginHandler(object):
         raise NotImplementedError
 
     def get_meta_description(self):
-        """Retrieve a meta description for the plugin
+        """Retrieve a meta description for the plugin.
 
         :return: meta description information
         :rtype: :class:`dict`
@@ -117,7 +118,7 @@ class AbstractPluginHandler(object):
         raise NotImplementedError
 
     def is_loaded(self):
-        """Tell if the plugin is loaded or not
+        """Tell if the plugin is loaded or not.
 
         :return: ``True`` if the plugin is loaded, ``False`` otherwise
         :rtype: bool
@@ -128,7 +129,7 @@ class AbstractPluginHandler(object):
         raise NotImplementedError
 
     def setup(self, bot):
-        """Setup the plugin with the ``bot``
+        """Set up the plugin with the ``bot``.
 
         :param bot: instance of Sopel
         :type bot: :class:`sopel.bot.Sopel`
@@ -136,7 +137,7 @@ class AbstractPluginHandler(object):
         raise NotImplementedError
 
     def has_setup(self):
-        """Tell if the plugin has a setup action
+        """Tell if the plugin has a setup action.
 
         :return: ``True`` if the plugin has a setup, ``False`` otherwise
         :rtype: bool
@@ -144,7 +145,7 @@ class AbstractPluginHandler(object):
         raise NotImplementedError
 
     def register(self, bot):
-        """Register the plugin with the ``bot``
+        """Register the plugin with the ``bot``.
 
         :param bot: instance of Sopel
         :type bot: :class:`sopel.bot.Sopel`
@@ -152,7 +153,7 @@ class AbstractPluginHandler(object):
         raise NotImplementedError
 
     def unregister(self, bot):
-        """Unregister the plugin from the ``bot``
+        """Unregister the plugin from the ``bot``.
 
         :param bot: instance of Sopel
         :type bot: :class:`sopel.bot.Sopel`
@@ -160,7 +161,7 @@ class AbstractPluginHandler(object):
         raise NotImplementedError
 
     def shutdown(self, bot):
-        """Take action on bot's shutdown
+        """Take action on bot's shutdown.
 
         :param bot: instance of Sopel
         :type bot: :class:`sopel.bot.Sopel`
@@ -168,7 +169,7 @@ class AbstractPluginHandler(object):
         raise NotImplementedError
 
     def has_shutdown(self):
-        """Tell if the plugin has a shutdown action
+        """Tell if the plugin has a shutdown action.
 
         :return: ``True`` if the plugin has a ``shutdown`` action, ``False``
                  otherwise
@@ -177,7 +178,7 @@ class AbstractPluginHandler(object):
         raise NotImplementedError
 
     def configure(self, settings):
-        """Configure Sopel's ``settings`` for this plugin
+        """Configure Sopel's ``settings`` for this plugin.
 
         :param settings: Sopel's configuration
         :type settings: :class:`sopel.config.Config`
@@ -187,7 +188,7 @@ class AbstractPluginHandler(object):
         raise NotImplementedError
 
     def has_configure(self):
-        """Tell if the plugin has a configure action
+        """Tell if the plugin has a configure action.
 
         :return: ``True`` if the plugin has a ``configure`` action, ``False``
                  otherwise
@@ -197,7 +198,7 @@ class AbstractPluginHandler(object):
 
 
 class PyModulePlugin(AbstractPluginHandler):
-    """Sopel plugin loaded from a Python module or package
+    """Sopel plugin loaded from a Python module or package.
 
     A :class:`PyModulePlugin` represents a Sopel plugin that is a Python
     module (or package) that can be imported directly.
@@ -221,6 +222,7 @@ class PyModulePlugin(AbstractPluginHandler):
         True
 
     """
+
     PLUGIN_TYPE = 'python-module'
 
     def __init__(self, name, package=None):
@@ -295,7 +297,7 @@ class PyModulePlugin(AbstractPluginHandler):
 
 
 class PyFilePlugin(PyModulePlugin):
-    """Sopel plugin loaded from the filesystem outside of the Python path
+    """Sopel plugin loaded from the filesystem outside of the Python path.
 
     This plugin handler can be used to load a Sopel plugin from the
     filesystem, either a Python ``.py`` file or a directory containing an
@@ -310,6 +312,7 @@ class PyFilePlugin(PyModulePlugin):
     In this example, the plugin ``custom`` is loaded from its filename despite
     not being in the Python path.
     """
+
     PLUGIN_TYPE = 'python-file'
 
     def __init__(self, filename):
@@ -375,7 +378,7 @@ class PyFilePlugin(PyModulePlugin):
         self._module = self._load()
 
     def reload(self):
-        """Reload the plugin
+        """Reload the plugin.
 
         Unlike :class:`PyModulePlugin`, it is not possible to use the
         ``reload`` function (either from `imp` or `importlib`), because the
@@ -385,7 +388,7 @@ class PyFilePlugin(PyModulePlugin):
 
 
 class EntryPointPlugin(PyModulePlugin):
-    """Sopel plugin loaded from a ``setuptools`` entry point
+    """Sopel plugin loaded from a ``setuptools`` entry point.
 
     :param entry_point: a ``setuptools`` entry point object
 
@@ -435,6 +438,7 @@ class EntryPointPlugin(PyModulePlugin):
         .. __: https://setuptools.readthedocs.io/en/stable/setuptools.html#dynamic-discovery-of-services-and-plugins
 
     """
+
     PLUGIN_TYPE = 'setup-entrypoint'
 
     def __init__(self, entry_point):

--- a/sopel/plugins/jobs.py
+++ b/sopel/plugins/jobs.py
@@ -27,7 +27,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class Scheduler(jobs.Scheduler):
-    """Plugins's Job Scheduler
+    """Plugins's Job Scheduler.
 
     :param manager: bot instance passed to jobs as argument
     :type manager: :class:`sopel.bot.Sopel`
@@ -50,6 +50,7 @@ class Scheduler(jobs.Scheduler):
         a job, plugin authors should use :func:`sopel.plugin.interval`.
 
     """
+
     def __init__(self, manager):
         super(Scheduler, self).__init__(manager)
         self._jobs = tools.SopelMemoryWithDefault(list)

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -140,6 +140,7 @@ class Manager(object):
     :meth:`get_triggered_rules`, which returns a list of ``(rule, match)``,
     sorted by priorities (high first, medium second, and low last).
     """
+
     def __init__(self):
         self._rules = tools.SopelMemoryWithDefault(list)
         self._commands = tools.SopelMemoryWithDefault(dict)
@@ -403,6 +404,7 @@ class AbstractRule(object):
     * and finally, trigger execution (i.e. actually doing something)
 
     """
+
     @classmethod
     def from_callable(cls, settings, handler):
         """Instantiate a rule object from ``settings`` and ``handler``.
@@ -641,13 +643,13 @@ class AbstractRule(object):
 
 
 class Rule(AbstractRule):
-    """Generic rule definition.
+    r"""Generic rule definition.
 
     A generic rule (or simply "a rule") uses regular expressions to match
     at most once per IRC line per regular expression, i.e. you can trigger
     between 0 and the number of regex the rule has per IRC line.
 
-    Here is an example with a rule with the pattern ``r'hello (\\w+)'``:
+    Here is an example with a rule with the pattern ``r'hello (\w+)'``:
 
     .. code-block:: irc
 
@@ -659,6 +661,7 @@ class Rule(AbstractRule):
     Generic rules are not triggered by any specific name, unlike commands which
     have names and aliases.
     """
+
     @classmethod
     def kwargs_from_callable(cls, handler):
         """Generate the keyword arguments to create a new instance.
@@ -938,6 +941,7 @@ class NamedRuleMixin(object):
 
     A named rule can be invoked by using one of its aliases, also.
     """
+
     @property
     def name(self):
         return self._name
@@ -1017,6 +1021,7 @@ class Command(NamedRuleMixin, Rule):
         <Bot> You just invoked the command 'dummy' (as 'dummy-alias')
 
     """
+
     @classmethod
     def from_callable(cls, settings, handler):
         prefix = settings.core.prefix
@@ -1124,6 +1129,7 @@ class NickCommand(NamedRuleMixin, Rule):
 
     Apart from that, it behaves exactly like a :class:`generic rule <Rule>`.
     """
+
     @classmethod
     def from_callable(cls, settings, handler):
         nick = settings.core.nick
@@ -1225,6 +1231,7 @@ class ActionCommand(NamedRuleMixin, Rule):
 
     Apart from that, it behaves exactly like a :class:`generic rule <Rule>`.
     """
+
     INTENT_REGEX = re.compile(r'ACTION', re.IGNORECASE)
 
     @classmethod
@@ -1288,14 +1295,14 @@ class ActionCommand(NamedRuleMixin, Rule):
 
 
 class FindRule(Rule):
-    """Anonymous find rule definition.
+    r"""Anonymous find rule definition.
 
     A find rule is like an anonymous rule with a twist: instead of matching
     only once per IRC line, a find rule will execute for each non-overlapping
     match for each of its regular expressions.
 
     For example, to match for each word starting with the letter ``h`` in a line,
-    you can use the pattern ``h\\w+``:
+    you can use the pattern ``h\w+``:
 
     .. code-block:: irc
 
@@ -1311,6 +1318,7 @@ class FindRule(Rule):
         see the official Python documentation.
 
     """
+
     @classmethod
     def from_callable(cls, settings, handler):
         regexes = tuple(handler.find_rules)
@@ -1326,14 +1334,14 @@ class FindRule(Rule):
 
 
 class SearchRule(Rule):
-    """Anonymous search rule definition.
+    r"""Anonymous search rule definition.
 
     A search rule is like an anonymous rule with a twist: it will execute
     exactly once per regular expression that matches anywhere in a line, not
     just from the start.
 
     For example, to search if any word starts with the letter ``h`` in a line,
-    you can use the pattern ``h\\w+``:
+    you can use the pattern ``h\w+``:
 
     .. code-block:: irc
 
@@ -1351,6 +1359,7 @@ class SearchRule(Rule):
         see the official Python documentation.
 
     """
+
     @classmethod
     def from_callable(cls, settings, handler):
         regexes = tuple(handler.search_rules)
@@ -1367,7 +1376,7 @@ class SearchRule(Rule):
 
 
 class URLCallback(Rule):
-    """URL callback rule definition.
+    r"""URL callback rule definition.
 
     A URL callback rule (or simply "a URL rule") detects URLs in a trigger
     then it uses regular expressions to match at most once per URL per regular
@@ -1375,7 +1384,7 @@ class URLCallback(Rule):
     callback has per URL in the IRC line.
 
     Here is an example with a URL rule with the pattern
-    ``r'https://example\\.com/(.*)'``:
+    ``r'https://example\.com/(.*)'``:
 
     .. code-block:: irc
 
@@ -1402,6 +1411,7 @@ class URLCallback(Rule):
         removed in Sopel 9.
 
     """
+
     @classmethod
     def from_callable(cls, settings, handler):
         execute_handler = handler

--- a/sopel/test_tools.py
+++ b/sopel/test_tools.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""This module has classes and functions that can help in writing tests.
+"""Classes and functions that can help in writing tests.
 
 .. note::
 

--- a/sopel/tests/__init__.py
+++ b/sopel/tests/__init__.py
@@ -7,7 +7,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 
 def rawlist(*args):
-    """Build a list of raw IRC messages from the lines given as ``*args``.
+    r"""Build a list of raw IRC messages from the lines given as ``*args``.
 
     :return: a list of raw IRC messages as seen by the bot
     :rtype: list
@@ -16,6 +16,6 @@ def rawlist(*args):
     care about encoding or this pesky carriage return::
 
         >>> rawlist('PRIVMSG :Hello!')
-        [b'PRIVMSG :Hello!\\r\\n']
+        [b'PRIVMSG :Hello!\r\n']
     """
     return ['{0}\r\n'.format(arg).encode('utf-8') for arg in args]

--- a/sopel/tests/factories.py
+++ b/sopel/tests/factories.py
@@ -19,6 +19,7 @@ class BotFactory(object):
         The :func:`~sopel.tests.pytest_plugin.botfactory` fixture can be used
         to instantiate this factory.
     """
+
     def preloaded(self, settings, preloads=None):
         """Create a bot and preload its plugins.
 
@@ -71,6 +72,7 @@ class ConfigFactory(object):
         The :func:`~sopel.tests.pytest_plugin.configfactory` fixture can be
         used to instantiate this factory.
     """
+
     def __init__(self, tmpdir):
         self.tmpdir = tmpdir
 
@@ -88,6 +90,7 @@ class TriggerFactory(object):
         The :func:`~sopel.tests.pytest_plugin.triggerfactory` fixture can be
         used to instantiate this factory.
     """
+
     def wrapper(self, mockbot, raw, pattern=None):
         trigger = self(mockbot, raw, pattern=pattern)
         return bot.SopelWrapper(mockbot, trigger)
@@ -108,6 +111,7 @@ class IRCFactory(object):
         The :func:`~sopel.tests.pytest_plugin.ircfactory` fixture can be used
         to create this factory.
     """
+
     def __call__(self, mockbot):
         return MockIRCServer(mockbot)
 
@@ -120,5 +124,6 @@ class UserFactory(object):
         The :func:`~sopel.tests.pytest_plugin.userfactory` fixture can be used
         to create this factory.
     """
+
     def __call__(self, nick=None, user=None, host=None):
         return MockUser(nick, user, host)

--- a/sopel/tests/mocks.py
+++ b/sopel/tests/mocks.py
@@ -15,6 +15,7 @@ class MockIRCBackend(AbstractIRCBackend):
     This backend doesn't require an actual connection. Instead, it stores every
     message sent in the :attr:`message_sent` list.
     """
+
     def __init__(self, *args, **kwargs):
         super(MockIRCBackend, self).__init__(*args, **kwargs)
         self.message_sent = []
@@ -43,6 +44,7 @@ class MockIRCServer(object):
     create such mock object, either directly or by using ``py.test`` and the
     :func:`~sopel.tests.pytest_plugin.ircfactory` fixture.
     """
+
     def __init__(self, bot):
         self.bot = bot
 
@@ -103,7 +105,7 @@ class MockIRCServer(object):
         self.bot.on_message(message)
 
     def mode_set(self, channel, flags, users):
-        """Send a MODE event for a ``channel``
+        """Send a MODE event for a ``channel``.
 
         :param str channel: channel receiving the MODE event
         :param str flags: MODE flags set
@@ -196,6 +198,7 @@ class MockUser(object):
     create such mock object, either directly or by using ``py.test`` and the
     :func:`~sopel.tests.pytest_plugin.userfactory` fixture.
     """
+
     def __init__(self, nick=None, user=None, host=None):
         self.nick = nick or 'Test'
         self.user = user or self.nick.lower()

--- a/sopel/tests/mocks.py
+++ b/sopel/tests/mocks.py
@@ -50,7 +50,7 @@ class MockIRCServer(object):
 
     @property
     def chanserv(self):
-        """ChanServ's message prefix."""
+        """Message prefix for ChanServ."""
         return 'ChanServ!ChanServ@services.'
 
     def channel_joined(self, channel, users=None):

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Useful miscellaneous tools and shortcuts for Sopel plugins
+"""Useful miscellaneous tools and shortcuts for Sopel plugins.
 
 *Availability: 3+*
 """
@@ -391,14 +391,15 @@ def get_sendable_message(text, max_length=400):
 # to the built-in ``collections`` module.
 # It is now deprecated.
 class Ddict(dict):
-    """A default dict implementation available for Python 2.x support.
+    r"""A default dict implementation available for Python 2.x support.
 
-    It was used to make multi-dimensional ``dict``\\s easy to use when the
+    It was used to make multi-dimensional ``dict``\s easy to use when the
     bot worked with Python version < 2.5.
 
     .. deprecated:: 7.0
         Use :class:`collections.defaultdict` instead.
     """
+
     @deprecated('use "collections.defaultdict" instead', '7.0', '8.0')
     def __init__(self, default=None):
         self.default = default
@@ -410,14 +411,15 @@ class Ddict(dict):
 
 
 class Identifier(unicode):
-    """A `unicode` subclass which acts appropriately for IRC identifiers.
+    r"""A `unicode` subclass which acts appropriately for IRC identifiers.
 
     When used as normal `unicode` objects, case will be preserved.
     However, when comparing two Identifier objects, or comparing a Identifier
     object with a `unicode` object, the comparison will be case insensitive.
     This case insensitivity includes the case convention conventions regarding
-    ``[]``, ``{}``, ``|``, ``\\``, ``^`` and ``~`` described in RFC 2812.
+    ``[]``, ``{}``, ``|``, ``\``, ``^`` and ``~`` described in RFC 2812.
     """
+
     # May want to tweak this and update documentation accordingly when dropping
     # Python 2 support, since in py3 plain str is Unicode and a "unicode" type
     # no longer exists. Probably lots of code will need tweaking, tbh.
@@ -459,14 +461,14 @@ class Identifier(unicode):
 
     @staticmethod
     def _lower_swapped(identifier):
-        """Backward-compatible version of :meth:`_lower`.
+        r"""Backward-compatible version of :meth:`_lower`.
 
         :param str identifier: the identifier (nickname or channel) to convert
         :return: RFC 2812-non-compliant lowercase version of ``identifier``
         :rtype: str
 
         This is what the old :meth:`_lower` function did before Sopel 7.0. It maps
-        ``{}``, ``[]``, ``|``, ``\\``, ``^``, and ``~`` incorrectly.
+        ``{}``, ``[]``, ``|``, ``\``, ``^``, and ``~`` incorrectly.
 
         You shouldn't use this unless you need to migrate stored values from the
         previous, incorrect "lowercase" representation to the correct one.
@@ -515,7 +517,7 @@ class Identifier(unicode):
         return not (self == other)
 
     def is_nick(self):
-        """Check if the Identifier is a nickname (i.e. not a channel)
+        """Check if the Identifier is a nickname (i.e. not a channel).
 
         :return: ``True`` if this :py:class:`Identifier` is a nickname;
                  ``False`` if it appears to be a channel
@@ -616,7 +618,7 @@ def check_pid(pid):
 
 
 def get_hostmask_regex(mask):
-    """Get a compiled regex pattern for an IRC hostmask
+    """Get a compiled regex pattern for an IRC hostmask.
 
     :param str mask: the hostmask that the pattern should match
     :return: a compiled regex pattern matching the given ``mask``
@@ -665,6 +667,7 @@ class SopelMemory(dict):
     .. versionchanged:: 6.0
         Renamed from ``WillieMemory`` to ``SopelMemory``
     """
+
     def __init__(self, *args):
         dict.__init__(self, *args)
         self.lock = threading.Lock()
@@ -697,7 +700,7 @@ class SopelMemory(dict):
 
     @deprecated
     def contains(self, key):
-        """Check if ``key`` is in the memory
+        """Check if ``key`` is in the memory.
 
         :param str key: key to check for
 
@@ -716,6 +719,7 @@ class SopelMemoryWithDefault(defaultdict):
     .. versionchanged:: 6.0
         Renamed to ``SopelMemoryWithDefault``
     """
+
     def __init__(self, *args):
         defaultdict.__init__(self, *args)
         self.lock = threading.Lock()
@@ -742,7 +746,7 @@ class SopelMemoryWithDefault(defaultdict):
 
     @deprecated
     def contains(self, key):
-        """Check if ``key`` is in the memory
+        """Check if ``key`` is in the memory.
 
         :param str key: key to check for
 
@@ -783,6 +787,7 @@ class SopelIdentifierMemory(SopelMemory):
 
     .. versionadded:: 7.1
     """
+
     def __getitem__(self, key):
         return super(SopelIdentifierMemory, self).__getitem__(Identifier(key))
 

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -55,7 +55,7 @@ def deprecated(
     warning_in=None,
     func=None,
 ):
-    """Decorator to mark deprecated functions in Sopel's API
+    """Mark deprecated functions in Sopel's API. Decorator.
 
     :param str reason: optional text added to the deprecation warning
     :param str version: optional version number when the decorated function

--- a/sopel/tools/_events.py
+++ b/sopel/tools/_events.py
@@ -3,11 +3,12 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 
 class events(object):
-    """An enumeration of all the standardized and notable IRC numeric events
+    """An enumeration of all the standardized and notable IRC numeric events.
 
     This allows you to do, for example, ``@plugin.event(events.RPL_WELCOME)``
     rather than ``@plugin.event('001')``
     """
+
     # ###################################################### Non-RFC / Non-IRCv3
     # Only add things here if they're actually in common use across multiple
     # ircds.

--- a/sopel/tools/calculation.py
+++ b/sopel/tools/calculation.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Tools to help safely do calculations from user input"""
+"""Tools to help safely do calculations from user input."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import ast
@@ -22,7 +22,8 @@ class ExpressionEvaluator:
     """
 
     class Error(Exception):
-        """Internal exception type for :class:`ExpressionEvaluator`\\s."""
+        r"""Internal exception type for :class:`ExpressionEvaluator`\s."""
+
         pass
 
     def __init__(self, bin_ops=None, unary_ops=None):

--- a/sopel/tools/jobs.py
+++ b/sopel/tools/jobs.py
@@ -64,6 +64,7 @@ class Scheduler(threading.Thread):
         rapid changes between versions without much (or any) warning.
 
     """
+
     def __init__(self, manager):
         threading.Thread.__init__(self)
         self.manager = manager
@@ -252,6 +253,7 @@ class Job(object):
         generic job scheduler.
 
     """
+
     @classmethod
     def kwargs_from_callable(cls, handler):
         """Generate the keyword arguments to create a new instance.
@@ -268,7 +270,6 @@ class Job(object):
         The expected attributes are the ones set by decorators from the
         :mod:`sopel.plugin` module.
         """
-
         return {
             'plugin': getattr(handler, 'plugin_name', None),
             'label': getattr(handler, 'rule_label', None),

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -15,6 +15,7 @@ class User(object):
     :param str user: the user's local username ("user" in `user@host.name`)
     :param str host: the user's hostname ("host.name" in `user@host.name`)
     """
+
     def __init__(self, nick, user, host):
         assert isinstance(nick, Identifier)
         self.nick = nick
@@ -59,6 +60,7 @@ class Channel(object):
     :param name: the channel name
     :type name: :class:`~.tools.Identifier`
     """
+
     def __init__(self, name):
         assert isinstance(name, Identifier)
         self.name = name

--- a/sopel/tools/web.py
+++ b/sopel/tools/web.py
@@ -1,7 +1,5 @@
 # coding=utf-8
-"""
-The ``tools.web`` package contains utility functions for interaction with web
-applications, APIs, or websites in your plugins.
+"""``tools.web``: Utility functions for interacting with web apps, APIs, sites.
 
 .. versionadded:: 7.0
 

--- a/sopel/tools/web.py
+++ b/sopel/tools/web.py
@@ -148,7 +148,7 @@ def quote(string, safe='/'):
 
 # six-like shim for Unicode safety
 def unquote(string):
-    """Decodes a URL-encoded string.
+    """Decode a URL-encoded string.
 
     :param str string: the string to decode
     :return str: the decoded ``string``
@@ -185,7 +185,7 @@ def urlencode_non_ascii(b):
 
 
 def iri_to_uri(iri):
-    """Decodes an internationalized domain name (IDN)."""
+    """Decode an internationalized domain name (IDN)."""
     parts = urlparse(iri)
     parts_seq = (part.encode('idna') if parti == 1 else urlencode_non_ascii(part.encode('utf-8')) for parti, part in enumerate(parts))
     if sys.version_info.major > 2:
@@ -207,7 +207,7 @@ else:
 # Functions for URL detection
 
 def trim_url(url):
-    """Removes extra punctuation from URLs found in text.
+    """Remove extra punctuation from URLs found in text.
 
     :param str url: the raw URL match
     :return str: the cleaned URL
@@ -234,7 +234,7 @@ def trim_url(url):
 
 
 def search_urls(text, exclusion_char=None, clean=False, schemes=None):
-    """Extracts all URLs in ``text``.
+    """Extract all URLs in ``text``.
 
     :param str text: the text to search for URLs
     :param str exclusion_char: optional character that, if placed before a URL

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -106,6 +106,7 @@ class PreTrigger(object):
         The sender's local username.
 
     """
+
     component_regex = re.compile(r'([^!]*)!?([^@]*)@?(.*)')
     intent_regex = re.compile('\x01(\\S+) ?(.*)\x01')
 
@@ -201,7 +202,7 @@ class PreTrigger(object):
 
 
 class Trigger(unicode):
-    """A line from the server, which has matched a callable's rules.
+    r"""A line from the server, which has matched a callable's rules.
 
     :param config: Sopel's current configuration settings object
     :type config: :class:`~sopel.config.Config`
@@ -220,11 +221,12 @@ class Trigger(unicode):
     command decorators auto-generate rules containing specific numbered groups
     that are documented separately. (See :attr:`group` below.)
 
-    Note that CTCP messages (``PRIVMSG``\\es and ``NOTICE``\\es which start
-    and end with ``'\\x01'``) will have the ``'\\x01'`` bytes stripped, and
+    Note that CTCP messages (``PRIVMSG``\es and ``NOTICE``\es which start
+    and end with ``'\x01'``) will have the ``'\x01'`` bytes stripped, and
     the command (e.g. ``ACTION``) placed mapped to the ``'intent'`` key in
     :attr:`Trigger.tags`.
     """
+
     sender = property(lambda self: self._pretrigger.sender)
     """Where the message arrived from.
 

--- a/sopel/web.py
+++ b/sopel/web.py
@@ -152,7 +152,8 @@ def post(uri, query, limit_bytes=None, timeout=20, verify_ssl=True, return_heade
 
 # solely for use by get_urllib_object()
 class MockHttpResponse(httplib.HTTPResponse):
-    "Mock HTTPResponse with data that comes from requests."
+    """Mock HTTPResponse with data that comes from requests."""
+
     def __init__(self, response):
         self.headers = response.headers
         self.status = response.status_code

--- a/sopel/web.py
+++ b/sopel/web.py
@@ -171,10 +171,11 @@ class MockHttpResponse(httplib.HTTPResponse):
 # input URI is UTF-8
 @deprecated
 def get_urllib_object(uri, timeout, headers=None, verify_ssl=True, data=None):  # pragma: no cover
-    """Return an HTTPResponse object for `uri` and `timeout` and `headers`. Deprecated
+    """Perform a HTTP request.
 
+    Deprecated.
+    Returns a HTTPResponse object.
     """
-
     if headers is None:
         headers = default_headers
     else:

--- a/test/cli/test_cli_run.py
+++ b/test/cli/test_cli_run.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Tests for command handling"""
+"""Tests for command handling."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import argparse
@@ -37,7 +37,7 @@ def cd(newdir):
 
 @pytest.fixture
 def config_dir(tmpdir):
-    """Pytest fixture used to generate a temporary configuration directory"""
+    """Pytest fixture used to generate a temporary configuration directory."""
     test_dir = tmpdir.mkdir("config")
     test_dir.join('config.cfg').write('')
     test_dir.join('extra.ini').write('')
@@ -48,7 +48,7 @@ def config_dir(tmpdir):
 
 
 def test_build_parser_legacy():
-    """Assert parser's namespace exposes legacy's options (default values)"""
+    """Assert parser's namespace exposes legacy's options (default values)."""
     parser = build_parser()
     options = parser.parse_args(['legacy'])
 
@@ -178,7 +178,7 @@ def test_build_parser_legacy_list_config():
 
 
 def test_build_parser_start():
-    """Assert parser's namespace exposes start's options (default values)"""
+    """Assert parser's namespace exposes start's options (default values)."""
     parser = build_parser()
     options = parser.parse_args(['start'])
 
@@ -229,7 +229,7 @@ def test_build_parser_start_quiet():
 
 
 def test_build_parser_stop():
-    """Assert parser's namespace exposes stop's options (default values)"""
+    """Assert parser's namespace exposes stop's options (default values)."""
     parser = build_parser()
     options = parser.parse_args(['stop'])
 
@@ -280,7 +280,7 @@ def test_build_parser_stop_quiet():
 
 
 def test_build_parser_restart():
-    """Assert parser's namespace exposes restart's options (default values)"""
+    """Assert parser's namespace exposes restart's options (default values)."""
     parser = build_parser()
     options = parser.parse_args(['restart'])
 
@@ -319,7 +319,7 @@ def test_build_parser_restart_quiet():
 
 
 def test_build_parser_configure():
-    """Assert parser's namespace exposes configure's options (default values)"""
+    """Assert parser's namespace exposes configure's options (default values)."""
     parser = build_parser()
     options = parser.parse_args(['configure'])
 
@@ -358,7 +358,7 @@ def test_build_parser_configure_modules():
 
 
 def test_get_configuration(tmpdir):
-    """Assert function returns a Sopel ``Config`` object"""
+    """Assert function returns a Sopel ``Config`` object."""
     working_dir = tmpdir.mkdir("working")
     working_dir.join('default.cfg').write('\n'.join([
         '[core]',
@@ -375,7 +375,7 @@ def test_get_configuration(tmpdir):
 
 
 def test_get_pid_filename_default(configfactory):
-    """Assert function returns the default filename from given ``pid_dir``"""
+    """Assert function returns the default filename from given ``pid_dir``."""
     pid_dir = '/pid'
     settings = configfactory('default.cfg', TMP_CONFIG)
 
@@ -384,7 +384,7 @@ def test_get_pid_filename_default(configfactory):
 
 
 def test_get_pid_filename_named(configfactory):
-    """Assert function returns a specific filename when config (with extension) is set"""
+    """Assert function returns a specific filename when config (with extension) is set."""
     pid_dir = '/pid'
     settings = configfactory('test.cfg', TMP_CONFIG)
 
@@ -393,7 +393,7 @@ def test_get_pid_filename_named(configfactory):
 
 
 def test_get_pid_filename_ext_not_cfg(configfactory):
-    """Assert function keeps the config file extension when it is not cfg"""
+    """Assert function keeps the config file extension when it is not cfg."""
     pid_dir = '/pid'
     settings = configfactory('test.ini', TMP_CONFIG)
 
@@ -402,7 +402,7 @@ def test_get_pid_filename_ext_not_cfg(configfactory):
 
 
 def test_get_running_pid(tmpdir):
-    """Assert function retrieves an integer from a given filename"""
+    """Assert function retrieves an integer from a given filename."""
     pid_file = tmpdir.join('sopel.pid')
     pid_file.write('7814')
 
@@ -411,7 +411,7 @@ def test_get_running_pid(tmpdir):
 
 
 def test_get_running_pid_not_integer(tmpdir):
-    """Assert function returns None when the content is not an Integer"""
+    """Assert function returns None when the content is not an Integer."""
     pid_file = tmpdir.join('sopel.pid')
     pid_file.write('')
 
@@ -425,7 +425,7 @@ def test_get_running_pid_not_integer(tmpdir):
 
 
 def test_get_running_pid_no_file(tmpdir):
-    """Assert function returns None when there is no such file"""
+    """Assert function returns None when there is no such file."""
     pid_file = tmpdir.join('sopel.pid')
 
     result = get_running_pid(pid_file.strpath)

--- a/test/cli/test_cli_utils.py
+++ b/test/cli/test_cli_utils.py
@@ -41,7 +41,7 @@ def cd(newdir):
 
 @pytest.fixture
 def config_dir(tmpdir):
-    """Pytest fixture used to generate a temporary configuration directory"""
+    """Pytest fixture used to generate a temporary configuration directory."""
     test_dir = tmpdir.mkdir("config")
     test_dir.join('config.cfg').write('')
     test_dir.join('extra.ini').write('')
@@ -53,7 +53,7 @@ def config_dir(tmpdir):
 
 @pytest.fixture
 def env_dir(tmpdir):
-    """Pytest fixture used to generate an extra (external) config directory"""
+    """Pytest fixture used to generate an extra (external) config directory."""
     test_dir = tmpdir.mkdir("fromenv")
     test_dir.join('fromenv.cfg').write('')
 
@@ -76,7 +76,7 @@ def test_yellow():
 
 
 def test_enumerate_configs(config_dir):
-    """Assert function retrieves only .cfg files by default"""
+    """Assert function retrieves only .cfg files by default."""
     results = list(enumerate_configs(config_dir.strpath))
 
     assert 'config.cfg' in results
@@ -92,7 +92,7 @@ def test_enumerate_configs_not_a_directory():
 
 
 def test_enumerate_configs_extension(config_dir):
-    """Assert function retrieves only files with the given extension"""
+    """Assert function retrieves only files with the given extension."""
     results = list(enumerate_configs(config_dir.strpath, '.ini'))
 
     assert 'config.cfg' not in results
@@ -103,7 +103,7 @@ def test_enumerate_configs_extension(config_dir):
 
 
 def test_find_config_local(tmpdir, config_dir):
-    """Assert function retrieves configuration file from working dir first"""
+    """Assert function retrieves configuration file from working dir first."""
     working_dir = tmpdir.mkdir("working")
     working_dir.join('local.cfg').write('')
 
@@ -116,7 +116,7 @@ def test_find_config_local(tmpdir, config_dir):
 
 
 def test_find_config_default(tmpdir, config_dir):
-    """Assert function retrieves configuration file from given config dir"""
+    """Assert function retrieves configuration file from given config dir."""
     working_dir = tmpdir.mkdir("working")
     working_dir.join('local.cfg').write('')
 
@@ -129,7 +129,7 @@ def test_find_config_default(tmpdir, config_dir):
 
 
 def test_find_config_extension(tmpdir, config_dir):
-    """Assert function retrieves configuration file with the given extension"""
+    """Assert function retrieves configuration file with the given extension."""
     working_dir = tmpdir.mkdir("working")
     working_dir.join('local.cfg').write('')
 
@@ -140,8 +140,7 @@ def test_find_config_extension(tmpdir, config_dir):
 
 
 def test_add_common_arguments():
-    """Assert function adds the ``-c``/``--config`` and ``--configdir`` options
-    """
+    """Assert function adds the ``-c``/``--config`` and ``--configdir`` options."""
     parser = argparse.ArgumentParser()
     add_common_arguments(parser)
 

--- a/test/cli/test_cli_utils.py
+++ b/test/cli/test_cli_utils.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Tests for sopel.cli.utils"""
+"""Tests for ``sopel.cli.utils``."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import argparse

--- a/test/irc/test_irc_abstract_backends.py
+++ b/test/irc/test_irc_abstract_backends.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Tests for core ``sopel.irc.backends``"""
+"""Tests for core ``sopel.irc.backends``."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 

--- a/test/irc/test_irc_isupport.py
+++ b/test/irc/test_irc_isupport.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Tests for core ``sopel.irc.isupport``"""
+"""Tests for core ``sopel.irc.isupport``."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest

--- a/test/modules/test_modules_isup.py
+++ b/test/modules/test_modules_isup.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Tests for Sopel's ``remind`` plugin"""
+"""Tests for Sopel's ``remind`` plugin."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest

--- a/test/modules/test_modules_remind.py
+++ b/test/modules/test_modules_remind.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Tests for Sopel's ``remind`` plugin"""
+"""Tests for Sopel's ``remind`` plugin."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from datetime import datetime
@@ -235,7 +235,7 @@ def test_timereminder_get_duration(tz_name,
                                    date1, date2, date3,
                                    expected1,
                                    expected2):
-    """Assert result of ``get_duration`` from reminder
+    """Assert result of ``get_duration`` from reminder.
 
     :param str tz_name: the timezone used to generate aware today & reminder
     :param str date1: numeric value given for date1 of reminder

--- a/test/modules/test_modules_tell.py
+++ b/test/modules/test_modules_tell.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Tests for Sopel's ``tell`` plugin"""
+"""Tests for Sopel's ``tell`` plugin."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime

--- a/test/modules/test_modules_url.py
+++ b/test/modules/test_modules_url.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Tests for Sopel's ``url`` plugin"""
+"""Tests for Sopel's ``url`` plugin."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import re

--- a/test/plugins/test_plugins_rules.py
+++ b/test/plugins/test_plugins_rules.py
@@ -527,7 +527,7 @@ def test_rule_get_test_parameters():
 
 
 def test_rule_get_doc():
-    doc = 'This is the doc you are looking for.'
+    doc = 'Docstring example to look for.'
     regex = re.compile('.*')
     rule = rules.Rule([regex], doc=doc)
 
@@ -1039,7 +1039,7 @@ def test_kwargs_from_callable_examples(mockbot):
     @module.rule(r'hello', r'hi', r'hey', r'hello|hi')
     @module.example('hello')
     def handler(wrapped, trigger):
-        """This is the doc you are looking for."""
+        """Docstring example to look for."""
         wrapped.reply('Hi!')
 
     loader.clean_callable(handler, mockbot.settings)
@@ -1064,7 +1064,7 @@ def test_kwargs_from_callable_examples(mockbot):
     assert 'doc' in kwargs
     assert kwargs['usages'] == (expected,)
     assert kwargs['tests'] == tuple(), 'There must be no test'
-    assert kwargs['doc'] == 'This is the doc you are looking for.'
+    assert kwargs['doc'] == 'Docstring example to look for.'
 
 
 def test_kwargs_from_callable_examples_test(mockbot):
@@ -1190,7 +1190,7 @@ def test_kwargs_from_callable_examples_doc(mockbot):
     @module.rule(r'hello', r'hi', r'hey', r'hello|hi')
     @module.example('hello')
     def handler(wrapped, trigger):
-        """This is the doc you are looking for.
+        """Docstring example to look for.
 
         And now with extended text, for testing purpose only.
         """
@@ -1221,7 +1221,7 @@ def test_kwargs_from_callable_examples_doc(mockbot):
     assert kwargs['usages'] == expected_usages
     assert kwargs['tests'] == tuple(), 'There must be no test'
     assert kwargs['doc'] == (
-        'This is the doc you are looking for.\n'
+        'Docstring example to look for.\n'
         '\n'
         'And now with extended text, for testing purpose only.'
     ), 'The docstring must have been cleaned.'
@@ -1405,7 +1405,7 @@ def test_command_get_usages():
 
 
 def test_command_get_doc():
-    doc = 'This is the doc you are looking for.'
+    doc = 'Docstring example to look for.'
     rule = rules.Command('hello', r'\.', doc=doc)
 
     assert rule.get_doc() == doc
@@ -1857,7 +1857,7 @@ def test_nick_command_get_usages():
 
 
 def test_nick_command_get_doc():
-    doc = 'This is the doc you are looking for.'
+    doc = 'Docstring example to look for.'
     rule = rules.NickCommand('TestBot', 'hello', doc=doc)
 
     assert rule.get_doc() == doc

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Tests for core ``sopel.bot`` module"""
+"""Tests for core ``sopel.bot`` module."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import re
@@ -874,7 +874,7 @@ def test_unregister_url_callback(tmpconfig):
 
 
 def test_unregister_url_callback_no_memory(tmpconfig):
-    """Test unregister_url_callback behavior when bot.memory empty"""
+    """Test unregister_url_callback behavior when bot.memory empty."""
     test_pattern = r'https://(www\.)?example\.com'
 
     def url_handler(*args, **kwargs):
@@ -887,7 +887,7 @@ def test_unregister_url_callback_no_memory(tmpconfig):
 
 # Remove once manual callback management is deprecated (8.0)
 def test_unregister_url_callback_manual(tmpconfig):
-    """Test unregister_url_callback removes a specific callback that was added manually"""
+    """Test unregister_url_callback removes a specific callback that was added manually."""
     test_pattern = r'https://(www\.)?example\.com'
 
     def url_handler(*args, **kwargs):

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -352,19 +352,19 @@ def test_register_callables(tmpconfig):
     @module.commands('do')
     @module.example('.do nothing')
     def command_do(bot, trigger):
-        """The do command does nothing."""
+        """Do nothing."""
         pass
 
     @module.commands('main sub')
     @module.example('.main sub')
     def command_main_sub(bot, trigger):
-        """A command with subcommand sub."""
+        """Do nothing, but with a subcommand."""
         pass
 
     @module.commands('main other')
     @module.example('.main other')
     def command_main_other(bot, trigger):
-        """A command with subcommand other."""
+        """Do nothing, but with a different subcommand."""
         pass
 
     @module.nickname_commands('info')
@@ -491,7 +491,7 @@ def test_register_callables(tmpconfig):
 
     assert sopel.doc == {
         'do': (
-            ['The do command does nothing.'],
+            ['Do nothing.'],
             ['.do nothing'],
         ),
         'info': (
@@ -499,11 +499,11 @@ def test_register_callables(tmpconfig):
             ['TestBot: info about this'],
         ),
         'main sub': (
-            ['A command with subcommand sub.'],
+            ['Do nothing, but with a subcommand.'],
             ['.main sub'],
         ),
         'main other': (
-            ['A command with subcommand other.'],
+            ['Do nothing, but with a different subcommand.'],
             ['.main other'],
         ),
         'mixed': (

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -260,7 +260,7 @@ def test_configparser_multi_lines(multi_fakeconfig):
 
 
 def test_save_unmodified_config(multi_fakeconfig):
-    """Assert type attributes are kept as they should be"""
+    """Assert type attributes are kept as they should be."""
     multi_fakeconfig.save()
     saved_config = config.Config(multi_fakeconfig.filename)
     saved_config.define_section('fake', FakeConfigSection)
@@ -300,7 +300,7 @@ def test_save_unmodified_config(multi_fakeconfig):
 
 
 def test_save_modified_config(multi_fakeconfig):
-    """Assert modified values are restored properly"""
+    """Assert modified values are restored properly."""
     multi_fakeconfig.fake.choiceattr = 'spam'
     multi_fakeconfig.spam.eggs = [
         'one',

--- a/test/test_coretasks.py
+++ b/test/test_coretasks.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""coretasks.py tests"""
+"""coretasks.py tests."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -3,7 +3,8 @@
 
 TODO: Most of these tests assume functionality tested in other tests. This is
 enough to get everything working (and is better than nothing), but best
-practice would probably be not to do that."""
+practice would probably be not to do that.
+"""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import json

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Tests for message formatting"""
+"""Tests for message formatting."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest

--- a/test/test_irc.py
+++ b/test/test_irc.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Tests for core ``sopel.irc``"""
+"""Tests for core ``sopel.irc``."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -87,7 +87,7 @@ ignored_trickster._sopel_callable = True
 
 @pytest.fixture
 def func():
-    """Pytest fixture to get a function that will return True all the time"""
+    """Pytest fixture to get a function that will return True all the time."""
     def bot_command():
         """Test callable defined as a pytest fixture."""
         return True

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Tests for sopel.module decorators
+"""Tests for sopel.module decorators.
 
 .. important::
 

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Tests for sopel.plugin decorators"""
+"""Tests for sopel.plugin decorators."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from sopel import plugin

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -14,9 +14,9 @@ enable = coretasks
 
 
 def test_bot_legacy_permissions(configfactory, botfactory, triggerfactory):
-    """
-    Make sure permissions match after being updated from both RPL_NAMREPLY
-    and RPL_WHOREPLY, #1482
+    """Check permissions match when updated with RPL_NAMREPLY and RPL_WHOREPLY.
+
+    #1482
     """
     mockbot = botfactory(configfactory('default.cfg', TMP_CONFIG))
     nick = tools.Identifier("Admin")

--- a/test/test_regression.py
+++ b/test/test_regression.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Regression tests"""
+"""Regression tests."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from sopel import coretasks, tools

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Tests sopel.tools"""
+"""Tests for ``sopel.tools``."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from datetime import timedelta

--- a/test/test_trigger.py
+++ b/test/test_trigger.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Tests for message parsing"""
+"""Tests for message parsing."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime

--- a/test/tools/test_tools_jobs.py
+++ b/test/tools/test_tools_jobs.py
@@ -203,7 +203,7 @@ def test_job_from_callable(mockconfig):
     @module.interval(5)
     @plugin.label('testjob')
     def handler(manager):
-        """The job's docstring."""
+        """Test job handler docstring."""
         return 'tested'
 
     loader.clean_callable(handler, mockconfig)
@@ -218,7 +218,7 @@ def test_job_from_callable(mockconfig):
     assert job.execute(None) == 'tested'
     assert job.get_job_label() == 'testjob'
     assert job.get_plugin_name() == 'testplugin'
-    assert job.get_doc() == "The job's docstring."
+    assert job.get_doc() == "Test job handler docstring."
     assert str(job) == '<Job testplugin.testjob [5s]>'
 
 

--- a/test/tools/test_tools_jobs.py
+++ b/test/tools/test_tools_jobs.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Tests for Job Scheduler"""
+"""Tests for Job Scheduler."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import time

--- a/test/tools/test_tools_web.py
+++ b/test/tools/test_tools_web.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Tests Sopel's web tools"""
+"""Tests Sopel's web tools."""
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import pytest


### PR DESCRIPTION
### Description
Adds flake8-docstrings and starts cleanup for putting it in use.

First commit is only requirements, config, spacing changes, raw strings for backslashes, and punctuation. No new or meaningfully changed docstrings.

Second adds minor rephrases and reformats, like "Gets xyz" → "Get xyz".

Third adds restructures and rephrases. A couple are check-dodging ("Home directory for...") but I [disagree with D401 on properties](https://github.com/PyCQA/pydocstyle/issues/301) anyway

Relates to #1765

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
