### PR TITLE
requirements: update flake8

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,7 @@
 coveralls<2.0; python_version < '3.5'
 coveralls>=2.0; python_version >= '3.5'
 flake8<3.6.0; python_version == '3.3'
-flake8>=3.7.0,<3.8.0; python_version != '3.3'
+flake8>=3.8.0,<3.9.0; python_version != '3.3'
 flake8-coding
 flake8-future-import<0.4.6
 flake8-import-order; python_version > '3.3'

--- a/sopel/modules/help.py
+++ b/sopel/modules/help.py
@@ -275,8 +275,8 @@ def help(bot, trigger):
                     bot.reply('The documentation for this command is too long; '
                               'I\'m sending it to you in a private message.')
 
-                def msgfun(l):
-                    bot.say(l, trigger.nick)
+                def msgfun(text):
+                    bot.say(text, trigger.nick)
             else:
                 msgfun = respond
 


### PR DESCRIPTION
### Description
Fix the only thing newer flake8 complains about so I can use my system copy, and updates flake8 in dev-requirements.
It doesn't officially support python 3.3, but neither did the last version.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
