### PR TITLE
coretasks: track all channel modes

### DIFF
--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -80,6 +80,19 @@ class Channel(object):
         self.topic = ''
         """The topic of the channel."""
 
+        self.modes = {}
+        """The channel's modes.
+
+        For type A modes (nick/address list), the value is a set. For type B
+        (parameter) or C (parameter when setting), the value is a string. For
+        type D, the value is ``True``.
+
+        .. note::
+
+            Type A modes may only contain changes the bot has observed. Sopel
+            does not automatically populate all modes and lists.
+        """
+
         self.last_who = None
         """The last time a WHO was requested for the channel."""
 


### PR DESCRIPTION
### Description
Depends on #2015. Implements most of #1789. Groundwork for #1842.

Teach Sopel to track all channel modes in `channel.modes`. Uses `isupport.PREFIX` to check valid user priv modes and `isupport.CHANMODES` to see what's valid and what's expecting arguments. Also reduces the number of panic WHOs we need to send.

Sends a MODE query after a JOIN is received to populate initial modes and implements RPL_CHANNELMODEIS.
It may or may not be worth also sending a `MODE +b` and parsing that to get the initial ban list. Would require implementing RPL_BANLIST.

It may be good to test sending WHO and MODE after a channel join, I didn't see it tested but my attempt wasn't working and it's late.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
