### PR TITLE
plugin: new `require_bot_privilege` decorator

### DIFF
--- a/docs/source/plugin/anatomy.rst
+++ b/docs/source/plugin/anatomy.rst
@@ -80,6 +80,18 @@ better to limit who can trigger them. There are decorators for that:
   trigger the rule
 * :func:`sopel.plugin.require_owner`: only the bot's owner can trigger the rule
 
+Sometimes it's not the channel privilege level of the user who triggers a
+command that matters, but the **bot's** privilege level. For that, there are
+two options:
+
+* :func:`sopel.plugin.require_bot_privilege`: this decorator is similar to
+  the ``require_privilege`` decorator, but it checks the bot's privilege level
+  instead of the user's; works only for channel messages, not private messages;
+  and you probably want to use it with the ``require_chanmsg`` decorator.
+* :meth:`bot.has_channel_privilege() <sopel.bot.Sopel.has_channel_privilege>`
+  is a method that can be used to check the bot's privilege level in a channel,
+  which can be used in any callable.
+
 .. __: https://ircv3.net/specs/extensions/account-tag-3.2
 
 Rate limiting

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -205,7 +205,7 @@ class Sopel(irc.AbstractBot):
 
         :param str channel: a channel the bot is in
         :param int privilege: privilege level to check
-        :raise RuntimeError: when the channel is unknown
+        :raise ValueError: when the channel is unknown
 
         This method checks the bot's privilege level in a channel, i.e. if it
         has this level or higher privileges::
@@ -216,9 +216,10 @@ class Sopel(irc.AbstractBot):
 
         The ``channel`` argument can be either a :class:`str` or a
         :class:`sopel.tools.Identifier`, as long as Sopel joined said channel.
+        If the channel is unknown, a :exc:`ValueError` will be raised.
         """
         if channel not in self.channels:
-            raise RuntimeError('Unknown channel %s' % channel)
+            raise ValueError('Unknown channel %s' % channel)
 
         return self.channels[channel].has_privilege(self.nick, privilege)
 

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -200,6 +200,28 @@ class Sopel(irc.AbstractBot):
 
         return self.users.get(self.nick).hostmask
 
+    def has_channel_privilege(self, channel, privilege):
+        """Tell if the bot has a ``privilege`` level or above in a ``channel``.
+
+        :param str channel: a channel the bot is in
+        :param int privilege: privilege level to check
+        :raise RuntimeError: when the channel is unknown
+
+        This method checks the bot's privilege level in a channel, i.e. if it
+        has this level or higher privileges::
+
+            >>> bot.channels['#chan'].privileges[bot.nick] = plugin.OP
+            >>> bot.has_channel_privilege('#chan', plugin.VOICE)
+            True
+
+        The ``channel`` argument can be either a :class:`str` or a
+        :class:`sopel.tools.Identifier`, as long as Sopel joined said channel.
+        """
+        if channel not in self.channels:
+            raise RuntimeError('Unknown channel %s' % channel)
+
+        return self.channels[channel].privileges[self.nick] >= privilege
+
     # signal handlers
 
     def set_signal_handlers(self):

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -220,7 +220,7 @@ class Sopel(irc.AbstractBot):
         if channel not in self.channels:
             raise RuntimeError('Unknown channel %s' % channel)
 
-        return self.channels[channel].privileges[self.nick] >= privilege
+        return self.channels[channel].has_privilege(self.nick, privilege)
 
     # signal handlers
 

--- a/sopel/modules/adminchannel.py
+++ b/sopel/modules/adminchannel.py
@@ -28,16 +28,14 @@ def default_mask(trigger):
 
 
 @plugin.require_chanmsg
-@plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV)
+@plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV, reply=True)
+@plugin.require_bot_privilege(plugin.OP, ERROR_MESSAGE_NOT_OP, reply=True)
 @plugin.command('op')
 def op(bot, trigger):
     """
     Command to op users in a room. If no nick is given,
     Sopel will op the nick who sent the command
     """
-    if bot.channels[trigger.sender].privileges[bot.nick] < plugin.OP:
-        bot.reply(ERROR_MESSAGE_NOT_OP)
-        return
     nick = trigger.group(2)
     channel = trigger.sender
     if not nick:
@@ -46,16 +44,14 @@ def op(bot, trigger):
 
 
 @plugin.require_chanmsg
-@plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV)
+@plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV, reply=True)
+@plugin.require_bot_privilege(plugin.OP, ERROR_MESSAGE_NOT_OP, reply=True)
 @plugin.command('deop')
 def deop(bot, trigger):
     """
     Command to deop users in a room. If no nick is given,
     Sopel will deop the nick who sent the command
     """
-    if bot.channels[trigger.sender].privileges[bot.nick] < plugin.OP:
-        bot.reply(ERROR_MESSAGE_NOT_OP)
-        return
     nick = trigger.group(2)
     channel = trigger.sender
     if not nick:
@@ -64,16 +60,14 @@ def deop(bot, trigger):
 
 
 @plugin.require_chanmsg
-@plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV)
+@plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV, reply=True)
+@plugin.require_bot_privilege(plugin.HALFOP, ERROR_MESSAGE_NOT_OP, reply=True)
 @plugin.command('voice')
 def voice(bot, trigger):
     """
     Command to voice users in a room. If no nick is given,
     Sopel will voice the nick who sent the command
     """
-    if bot.channels[trigger.sender].privileges[bot.nick] < plugin.HALFOP:
-        bot.reply(ERROR_MESSAGE_NOT_OP)
-        return
     nick = trigger.group(2)
     channel = trigger.sender
     if not nick:
@@ -82,16 +76,14 @@ def voice(bot, trigger):
 
 
 @plugin.require_chanmsg
-@plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV)
+@plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV, reply=True)
+@plugin.require_bot_privilege(plugin.HALFOP, ERROR_MESSAGE_NOT_OP, reply=True)
 @plugin.command('devoice')
 def devoice(bot, trigger):
     """
     Command to devoice users in a room. If no nick is given,
     Sopel will devoice the nick who sent the command
     """
-    if bot.channels[trigger.sender].privileges[bot.nick] < plugin.HALFOP:
-        bot.reply(ERROR_MESSAGE_NOT_OP)
-        return
     nick = trigger.group(2)
     channel = trigger.sender
     if not nick:
@@ -100,14 +92,12 @@ def devoice(bot, trigger):
 
 
 @plugin.require_chanmsg
-@plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV)
+@plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV, reply=True)
+@plugin.require_bot_privilege(plugin.HALFOP, ERROR_MESSAGE_NOT_OP, reply=True)
 @plugin.command('kick')
 @plugin.priority('high')
 def kick(bot, trigger):
     """Kick a user from the channel."""
-    if bot.channels[trigger.sender].privileges[bot.nick] < plugin.HALFOP:
-        bot.reply(ERROR_MESSAGE_NOT_OP)
-        return
     text = trigger.group().split()
     argc = len(text)
     if argc < 2:
@@ -153,7 +143,8 @@ def configureHostMask(mask):
 
 
 @plugin.require_chanmsg
-@plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV)
+@plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV, reply=True)
+@plugin.require_bot_privilege(plugin.HALFOP, ERROR_MESSAGE_NOT_OP, reply=True)
 @plugin.command('ban')
 @plugin.priority('high')
 def ban(bot, trigger):
@@ -161,9 +152,6 @@ def ban(bot, trigger):
 
     The bot must be a channel operator for this command to work.
     """
-    if bot.channels[trigger.sender].privileges[bot.nick] < plugin.HALFOP:
-        bot.reply(ERROR_MESSAGE_NOT_OP)
-        return
     text = trigger.group().split()
     argc = len(text)
     if argc < 2:
@@ -183,16 +171,14 @@ def ban(bot, trigger):
 
 
 @plugin.require_chanmsg
-@plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV)
+@plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV, reply=True)
+@plugin.require_bot_privilege(plugin.HALFOP, ERROR_MESSAGE_NOT_OP, reply=True)
 @plugin.command('unban')
 def unban(bot, trigger):
     """Unban a user from the channel
 
     The bot must be a channel operator for this command to work.
     """
-    if bot.channels[trigger.sender].privileges[bot.nick] < plugin.HALFOP:
-        bot.reply(ERROR_MESSAGE_NOT_OP)
-        return
     text = trigger.group().split()
     argc = len(text)
     if argc < 2:
@@ -212,16 +198,14 @@ def unban(bot, trigger):
 
 
 @plugin.require_chanmsg
-@plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV)
+@plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV, reply=True)
+@plugin.require_bot_privilege(plugin.OP, ERROR_MESSAGE_NOT_OP, reply=True)
 @plugin.command('quiet')
 def quiet(bot, trigger):
     """Quiet a user
 
     The bot must be a channel operator for this command to work.
     """
-    if bot.channels[trigger.sender].privileges[bot.nick] < plugin.OP:
-        bot.reply(ERROR_MESSAGE_NOT_OP)
-        return
     text = trigger.group().split()
     argc = len(text)
     if argc < 2:
@@ -241,16 +225,14 @@ def quiet(bot, trigger):
 
 
 @plugin.require_chanmsg
-@plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV)
+@plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV, reply=True)
+@plugin.require_bot_privilege(plugin.OP, ERROR_MESSAGE_NOT_OP, reply=True)
 @plugin.command('unquiet')
 def unquiet(bot, trigger):
     """Unquiet a user
 
     The bot must be a channel operator for this command to work.
     """
-    if bot.channels[trigger.sender].privileges[bot.nick] < plugin.OP:
-        bot.reply(ERROR_MESSAGE_NOT_OP)
-        return
     text = trigger.group().split()
     argc = len(text)
     if argc < 2:
@@ -270,7 +252,8 @@ def unquiet(bot, trigger):
 
 
 @plugin.require_chanmsg
-@plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV)
+@plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV, reply=True)
+@plugin.require_bot_privilege(plugin.OP, ERROR_MESSAGE_NOT_OP, reply=True)
 @plugin.command('kickban', 'kb')
 @plugin.example('.kickban [#chan] user1 user!*@* get out of here')
 @plugin.priority('high')
@@ -279,9 +262,6 @@ def kickban(bot, trigger):
 
     The bot must be a channel operator for this command to work.
     """
-    if bot.channels[trigger.sender].privileges[bot.nick] < plugin.HALFOP:
-        bot.reply(ERROR_MESSAGE_NOT_OP)
-        return
     text = trigger.group().split()
     argc = len(text)
     if argc < 4:

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -69,6 +69,13 @@ HALFOP = 2
 """Privilege level for the +h channel permission
 
 .. versionadded:: 4.1
+
+.. important::
+
+    Not all IRC networks support this privilege mode. If you are writing a
+    plugin for public distribution, ensure your code behaves sensibly if only
+    ``+v`` (voice) and ``+o`` (op) modes exist.
+
 """
 
 OP = 4
@@ -81,12 +88,26 @@ ADMIN = 8
 """Privilege level for the +a channel permission
 
 .. versionadded:: 4.1
+
+.. important::
+
+    Not all IRC networks support this privilege mode. If you are writing a
+    plugin for public distribution, ensure your code behaves sensibly if only
+    ``+v`` (voice) and ``+o`` (op) modes exist.
+
 """
 
 OWNER = 16
 """Privilege level for the +q channel permission
 
 .. versionadded:: 4.1
+
+.. important::
+
+    Not all IRC networks support this privilege mode. If you are writing a
+    plugin for public distribution, ensure your code behaves sensibly if only
+    ``+v`` (voice) and ``+o`` (op) modes exist.
+
 """
 
 OPER = 32
@@ -96,6 +117,13 @@ Note: Except for these (non-standard) channel modes, Sopel does not monitor or
 store any user's OPER status.
 
 .. versionadded:: 7.0.0
+
+.. important::
+
+    Not all IRC networks support this privilege mode. If you are writing a
+    plugin for public distribution, ensure your code behaves sensibly if only
+    ``+v`` (voice) and ``+o`` (op) modes exist.
+
 """
 
 

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import functools
 
+from sopel import plugin
 from sopel.tools import Identifier
 
 
@@ -107,8 +108,192 @@ class Channel(object):
         """
         assert isinstance(user, User)
         self.users[user.nick] = user
-        self.privileges[user.nick] = privs
+        self.privileges[user.nick] = privs or 0
         user.channels[self.name] = self
+
+    def has_privilege(self, nick, privilege):
+        """Tell if a user has a ``privilege`` level or above in this channel.
+
+        :param str nick: a user's nick in this channel
+        :param int privilege: privilege level to check
+        :rtype: bool
+
+        This method checks the user's privilege level in this channel, i.e. if
+        it has this level or higher privileges::
+
+            >>> channel.add_user(some_user, plugin.OP)
+            >>> channel.has_privilege(some_user.nick, plugin.VOICE)
+            True
+
+        The ``nick`` argument can be either a :class:`str` or a
+        :class:`sopel.tools.Identifier`. If the user is not in this channel,
+        it will be considered as not having any privilege.
+
+        .. seealso::
+
+            There are other methods to check the exact privilege level of a
+            user, such as :meth:`is_oper`, :meth:`is_owner`, :meth:`is_admin`,
+            :meth:`is_op`, :meth:`is_halfop`, and :meth:`is_voiced`.
+
+        """
+        return self.privileges.get(Identifier(nick), 0) >= privilege
+
+    def is_oper(self, nick):
+        """Tell if a user has the OPER (operator) privilege level.
+
+        :param str nick: a user's nick in this channel
+        :rtype: bool
+
+        Unlike :meth:`has_privilege`, this method checks if the user has been
+        explicitly granted the OPER privilege level::
+
+            >>> channel.add_user(some_user, plugin.OPER)
+            >>> channel.is_oper(some_user.nick)
+            True
+            >>> channel.is_voiced(some_user.nick)
+            False
+
+        Note that you can always have more than one privilege level::
+
+            >>> channel.add_user(some_user, plugin.OPER | plugin.VOICE)
+            >>> channel.is_oper(some_user.nick)
+            True
+            >>> channel.is_voiced(some_user.nick)
+            True
+
+        """
+        return self.privileges.get(Identifier(nick), 0) & plugin.OPER
+
+    def is_owner(self, nick):
+        """Tell if a user has the OWNER privilege level.
+
+        :param str nick: a user's nick in this channel
+        :rtype: bool
+
+        Unlike :meth:`has_privilege`, this method checks if the user has been
+        explicitly granted the OWNER privilege level::
+
+            >>> channel.add_user(some_user, plugin.OWNER)
+            >>> channel.is_owner(some_user.nick)
+            True
+            >>> channel.is_voiced(some_user.nick)
+            False
+
+        Note that you can always have more than one privilege level::
+
+            >>> channel.add_user(some_user, plugin.OWNER | plugin.VOICE)
+            >>> channel.is_owner(some_user.nick)
+            True
+            >>> channel.is_voiced(some_user.nick)
+            True
+
+        """
+        return self.privileges.get(Identifier(nick), 0) & plugin.OWNER
+
+    def is_admin(self, nick):
+        """Tell if a user has the ADMIN privilege level.
+
+        :param str nick: a user's nick in this channel
+        :rtype: bool
+
+        Unlike :meth:`has_privilege`, this method checks if the user has been
+        explicitly granted the ADMIN privilege level::
+
+            >>> channel.add_user(some_user, plugin.ADMIN)
+            >>> channel.is_admin(some_user.nick)
+            True
+            >>> channel.is_voiced(some_user.nick)
+            False
+
+        Note that you can always have more than one privilege level::
+
+            >>> channel.add_user(some_user, plugin.ADMIN | plugin.VOICE)
+            >>> channel.is_admin(some_user.nick)
+            True
+            >>> channel.is_voiced(some_user.nick)
+            True
+
+        """
+        return self.privileges.get(Identifier(nick), 0) & plugin.ADMIN
+
+    def is_op(self, nick):
+        """Tell if a user has the OP privilege level.
+
+        :param str nick: a user's nick in this channel
+        :rtype: bool
+
+        Unlike :meth:`has_privilege`, this method checks if the user has been
+        explicitly granted the OP privilege level::
+
+            >>> channel.add_user(some_user, plugin.OP)
+            >>> channel.is_op(some_user.nick)
+            True
+            >>> channel.is_voiced(some_user.nick)
+            False
+
+        Note that you can always have more than one privilege level::
+
+            >>> channel.add_user(some_user, plugin.OP | plugin.VOICE)
+            >>> channel.is_op(some_user.nick)
+            True
+            >>> channel.is_voiced(some_user.nick)
+            True
+
+        """
+        return self.privileges.get(Identifier(nick), 0) & plugin.OP
+
+    def is_halfop(self, nick):
+        """Tell if a user has the HALFOP privilege level.
+
+        :param str nick: a user's nick in this channel
+        :rtype: bool
+
+        Unlike :meth:`has_privilege`, this method checks if the user has been
+        explicitly granted the HALFOP privilege level::
+
+            >>> channel.add_user(some_user, plugin.HALFOP)
+            >>> channel.is_halfop(some_user.nick)
+            True
+            >>> channel.is_voiced(some_user.nick)
+            False
+
+        Note that you can always have more than one privilege level::
+
+            >>> channel.add_user(some_user, plugin.HALFOP | plugin.VOICE)
+            >>> channel.is_halfop(some_user.nick)
+            True
+            >>> channel.is_voiced(some_user.nick)
+            True
+
+        """
+        return self.privileges.get(Identifier(nick), 0) & plugin.HALFOP
+
+    def is_voiced(self, nick):
+        """Tell if a user has the VOICE privilege level.
+
+        :param str nick: a user's nick in this channel
+        :rtype: bool
+
+        Unlike :meth:`has_privilege`, this method checks if the user has been
+        explicitly granted the VOICE privilege level::
+
+            >>> channel.add_user(some_user, plugin.VOICE)
+            >>> channel.is_voiced(some_user.nick)
+            True
+            >>> channel.add_user(some_user, plugin.OP)
+            >>> channel.is_voiced(some_user.nick)
+            False
+
+        Note that you can always have more than one privilege level::
+
+            >>> channel.add_user(some_user, plugin.VOICE | plugin.OP)
+            >>> channel.is_voiced(some_user.nick)
+            True
+            >>> channel.is_op(some_user.nick)
+            True
+
+        """
+        return self.privileges.get(Identifier(nick), 0) & plugin.VOICE
 
     def rename_user(self, old, new):
         """Rename a user.

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -135,6 +135,12 @@ class Channel(object):
             user, such as :meth:`is_oper`, :meth:`is_owner`, :meth:`is_admin`,
             :meth:`is_op`, :meth:`is_halfop`, and :meth:`is_voiced`.
 
+        .. important::
+
+            Not all IRC networks support all privilege levels. If you intend
+            for your plugin to run on any network, it is safest to rely only
+            on the presence of standard modes: ``+v`` (voice) and ``+o`` (op).
+
         """
         return self.privileges.get(Identifier(nick), 0) >= privilege
 
@@ -160,6 +166,12 @@ class Channel(object):
             True
             >>> channel.is_voiced(some_user.nick)
             True
+
+        .. important::
+
+            Not all IRC networks support this privilege mode. If you are
+            writing a plugin for public distribution, ensure your code behaves
+            sensibly if only ``+v`` (voice) and ``+o`` (op) modes exist.
 
         """
         return self.privileges.get(Identifier(nick), 0) & plugin.OPER
@@ -187,6 +199,12 @@ class Channel(object):
             >>> channel.is_voiced(some_user.nick)
             True
 
+        .. important::
+
+            Not all IRC networks support this privilege mode. If you are
+            writing a plugin for public distribution, ensure your code behaves
+            sensibly if only ``+v`` (voice) and ``+o`` (op) modes exist.
+
         """
         return self.privileges.get(Identifier(nick), 0) & plugin.OWNER
 
@@ -212,6 +230,12 @@ class Channel(object):
             True
             >>> channel.is_voiced(some_user.nick)
             True
+
+        .. important::
+
+            Not all IRC networks support this privilege mode. If you are
+            writing a plugin for public distribution, ensure your code behaves
+            sensibly if only ``+v`` (voice) and ``+o`` (op) modes exist.
 
         """
         return self.privileges.get(Identifier(nick), 0) & plugin.ADMIN
@@ -264,6 +288,12 @@ class Channel(object):
             True
             >>> channel.is_voiced(some_user.nick)
             True
+
+        .. important::
+
+            Not all IRC networks support this privilege mode. If you are
+            writing a plugin for public distribution, ensure your code behaves
+            sensibly if only ``+v`` (voice) and ``+o`` (op) modes exist.
 
         """
         return self.privileges.get(Identifier(nick), 0) & plugin.HALFOP

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -772,7 +772,7 @@ def test_has_channel_privilege_no_privilege(ircfactory, botfactory, tmpconfig):
     name = Identifier('#adminchannel')
 
     # unknown channel
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         sopel.has_channel_privilege('#adminchannel', plugin.VOICE)
 
     # join channel
@@ -793,7 +793,7 @@ def test_has_channel_privilege_no_privilege(ircfactory, botfactory, tmpconfig):
     assert not sopel.has_channel_privilege('#adminchannel', plugin.OPER)
 
     # unknown channel
-    with pytest.raises(RuntimeError):
+    with pytest.raises(ValueError):
         sopel.has_channel_privilege('#anotherchannel', plugin.VOICE)
 
 

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -763,6 +763,179 @@ def test_call_rule_rate_limited_global(mockbot):
 
 
 # -----------------------------------------------------------------------------
+# Channel privileges
+
+
+def test_has_channel_privilege_no_privilege(ircfactory, botfactory, tmpconfig):
+    sopel = botfactory.preloaded(tmpconfig)
+    server = ircfactory(sopel)
+    name = Identifier('#adminchannel')
+
+    # unknown channel
+    with pytest.raises(RuntimeError):
+        sopel.has_channel_privilege('#adminchannel', plugin.VOICE)
+
+    # join channel
+    server.channel_joined('#adminchannel')
+
+    # check privileges
+    assert not sopel.has_channel_privilege(name, plugin.VOICE)
+    assert not sopel.has_channel_privilege('#adminchannel', plugin.VOICE)
+    assert not sopel.has_channel_privilege(name, plugin.HALFOP)
+    assert not sopel.has_channel_privilege('#adminchannel', plugin.HALFOP)
+    assert not sopel.has_channel_privilege(name, plugin.OP)
+    assert not sopel.has_channel_privilege('#adminchannel', plugin.OP)
+    assert not sopel.has_channel_privilege(name, plugin.ADMIN)
+    assert not sopel.has_channel_privilege('#adminchannel', plugin.ADMIN)
+    assert not sopel.has_channel_privilege(name, plugin.OWNER)
+    assert not sopel.has_channel_privilege('#adminchannel', plugin.OWNER)
+    assert not sopel.has_channel_privilege(name, plugin.OPER)
+    assert not sopel.has_channel_privilege('#adminchannel', plugin.OPER)
+
+    # unknown channel
+    with pytest.raises(RuntimeError):
+        sopel.has_channel_privilege('#anotherchannel', plugin.VOICE)
+
+
+def test_has_channel_privilege_voice(ircfactory, botfactory, tmpconfig):
+    sopel = botfactory.preloaded(tmpconfig)
+    server = ircfactory(sopel)
+    name = Identifier('#adminchannel')
+
+    # join channel
+    server.channel_joined('#adminchannel')
+    server.mode_set('#adminchannel', '+v', [sopel.nick])
+
+    assert sopel.has_channel_privilege(name, plugin.VOICE)
+    assert sopel.has_channel_privilege('#adminchannel', plugin.VOICE)
+    assert not sopel.has_channel_privilege(name, plugin.HALFOP)
+    assert not sopel.has_channel_privilege('#adminchannel', plugin.HALFOP)
+    assert not sopel.has_channel_privilege(name, plugin.OP)
+    assert not sopel.has_channel_privilege('#adminchannel', plugin.OP)
+    assert not sopel.has_channel_privilege(name, plugin.ADMIN)
+    assert not sopel.has_channel_privilege('#adminchannel', plugin.ADMIN)
+    assert not sopel.has_channel_privilege(name, plugin.OWNER)
+    assert not sopel.has_channel_privilege('#adminchannel', plugin.OWNER)
+    assert not sopel.has_channel_privilege(name, plugin.OPER)
+    assert not sopel.has_channel_privilege('#adminchannel', plugin.OPER)
+
+
+def test_has_channel_privilege_halfop(ircfactory, botfactory, tmpconfig):
+    sopel = botfactory.preloaded(tmpconfig)
+    server = ircfactory(sopel)
+    name = Identifier('#adminchannel')
+
+    # join channel
+    server.channel_joined('#adminchannel')
+    server.mode_set('#adminchannel', '+h', [sopel.nick])
+
+    assert sopel.has_channel_privilege(name, plugin.VOICE)
+    assert sopel.has_channel_privilege('#adminchannel', plugin.VOICE)
+    assert sopel.has_channel_privilege(name, plugin.HALFOP)
+    assert sopel.has_channel_privilege('#adminchannel', plugin.HALFOP)
+    assert not sopel.has_channel_privilege(name, plugin.OP)
+    assert not sopel.has_channel_privilege('#adminchannel', plugin.OP)
+    assert not sopel.has_channel_privilege(name, plugin.ADMIN)
+    assert not sopel.has_channel_privilege('#adminchannel', plugin.ADMIN)
+    assert not sopel.has_channel_privilege(name, plugin.OWNER)
+    assert not sopel.has_channel_privilege('#adminchannel', plugin.OWNER)
+    assert not sopel.has_channel_privilege(name, plugin.OPER)
+    assert not sopel.has_channel_privilege('#adminchannel', plugin.OPER)
+
+
+def test_has_channel_privilege_op(ircfactory, botfactory, tmpconfig):
+    sopel = botfactory.preloaded(tmpconfig)
+    server = ircfactory(sopel)
+    name = Identifier('#adminchannel')
+
+    # join channel
+    server.channel_joined('#adminchannel')
+    server.mode_set('#adminchannel', '+o', [sopel.nick])
+
+    assert sopel.has_channel_privilege(name, plugin.VOICE)
+    assert sopel.has_channel_privilege('#adminchannel', plugin.VOICE)
+    assert sopel.has_channel_privilege(name, plugin.HALFOP)
+    assert sopel.has_channel_privilege('#adminchannel', plugin.HALFOP)
+    assert sopel.has_channel_privilege(name, plugin.OP)
+    assert sopel.has_channel_privilege('#adminchannel', plugin.OP)
+    assert not sopel.has_channel_privilege(name, plugin.ADMIN)
+    assert not sopel.has_channel_privilege('#adminchannel', plugin.ADMIN)
+    assert not sopel.has_channel_privilege(name, plugin.OWNER)
+    assert not sopel.has_channel_privilege('#adminchannel', plugin.OWNER)
+    assert not sopel.has_channel_privilege(name, plugin.OPER)
+    assert not sopel.has_channel_privilege('#adminchannel', plugin.OPER)
+
+
+def test_has_channel_privilege_admin(ircfactory, botfactory, tmpconfig):
+    sopel = botfactory.preloaded(tmpconfig)
+    server = ircfactory(sopel)
+    name = Identifier('#adminchannel')
+
+    # join channel
+    server.channel_joined('#adminchannel')
+    server.mode_set('#adminchannel', '+a', [sopel.nick])
+
+    assert sopel.has_channel_privilege(name, plugin.VOICE)
+    assert sopel.has_channel_privilege('#adminchannel', plugin.VOICE)
+    assert sopel.has_channel_privilege(name, plugin.HALFOP)
+    assert sopel.has_channel_privilege('#adminchannel', plugin.HALFOP)
+    assert sopel.has_channel_privilege(name, plugin.OP)
+    assert sopel.has_channel_privilege('#adminchannel', plugin.OP)
+    assert sopel.has_channel_privilege(name, plugin.ADMIN)
+    assert sopel.has_channel_privilege('#adminchannel', plugin.ADMIN)
+    assert not sopel.has_channel_privilege(name, plugin.OWNER)
+    assert not sopel.has_channel_privilege('#adminchannel', plugin.OWNER)
+    assert not sopel.has_channel_privilege(name, plugin.OPER)
+    assert not sopel.has_channel_privilege('#adminchannel', plugin.OPER)
+
+
+def test_has_channel_privilege_owner(ircfactory, botfactory, tmpconfig):
+    sopel = botfactory.preloaded(tmpconfig)
+    server = ircfactory(sopel)
+    name = Identifier('#adminchannel')
+
+    # join channel
+    server.channel_joined('#adminchannel')
+    server.mode_set('#adminchannel', '+q', [sopel.nick])
+
+    assert sopel.has_channel_privilege(name, plugin.VOICE)
+    assert sopel.has_channel_privilege('#adminchannel', plugin.VOICE)
+    assert sopel.has_channel_privilege(name, plugin.HALFOP)
+    assert sopel.has_channel_privilege('#adminchannel', plugin.HALFOP)
+    assert sopel.has_channel_privilege(name, plugin.OP)
+    assert sopel.has_channel_privilege('#adminchannel', plugin.OP)
+    assert sopel.has_channel_privilege(name, plugin.ADMIN)
+    assert sopel.has_channel_privilege('#adminchannel', plugin.ADMIN)
+    assert sopel.has_channel_privilege(name, plugin.OWNER)
+    assert sopel.has_channel_privilege('#adminchannel', plugin.OWNER)
+    assert not sopel.has_channel_privilege(name, plugin.OPER)
+    assert not sopel.has_channel_privilege('#adminchannel', plugin.OPER)
+
+
+def test_has_channel_privilege_operator(ircfactory, botfactory, tmpconfig):
+    sopel = botfactory.preloaded(tmpconfig)
+    server = ircfactory(sopel)
+    name = Identifier('#adminchannel')
+
+    # join channel
+    server.channel_joined('#adminchannel')
+    server.mode_set('#adminchannel', '+y', [sopel.nick])
+
+    assert sopel.has_channel_privilege(name, plugin.VOICE)
+    assert sopel.has_channel_privilege('#adminchannel', plugin.VOICE)
+    assert sopel.has_channel_privilege(name, plugin.HALFOP)
+    assert sopel.has_channel_privilege('#adminchannel', plugin.HALFOP)
+    assert sopel.has_channel_privilege(name, plugin.OP)
+    assert sopel.has_channel_privilege('#adminchannel', plugin.OP)
+    assert sopel.has_channel_privilege(name, plugin.ADMIN)
+    assert sopel.has_channel_privilege('#adminchannel', plugin.ADMIN)
+    assert sopel.has_channel_privilege(name, plugin.OWNER)
+    assert sopel.has_channel_privilege('#adminchannel', plugin.OWNER)
+    assert sopel.has_channel_privilege(name, plugin.OPER)
+    assert sopel.has_channel_privilege('#adminchannel', plugin.OPER)
+
+
+# -----------------------------------------------------------------------------
 # URL Callbacks
 
 def test_search_url_callbacks(tmpconfig):

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -254,3 +254,20 @@ def test_sopel_identifier_memory_id():
     assert memory[user] == test_value
     assert memory['Exirel'] == test_value
     assert memory['exirel'] == test_value
+
+
+def test_sopel_identifier_memory_channel_str():
+    channel = tools.Identifier('#adminchannel')
+    memory = tools.SopelIdentifierMemory()
+    test_value = 'perfect'
+
+    memory['#adminchannel'] = test_value
+    assert channel in memory
+    assert '#adminchannel' in memory
+    assert '#AdminChannel' in memory
+    assert 'adminchannel' not in memory
+    assert 'Exirel' not in memory
+
+    assert memory[channel] == test_value
+    assert memory['#adminchannel'] == test_value
+    assert memory['#AdminChannel'] == test_value

--- a/test/tools/test_tools_target.py
+++ b/test/tools/test_tools_target.py
@@ -1,0 +1,214 @@
+# coding=utf-8
+"""Tests for targets: Channel & User"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from sopel import plugin
+from sopel.tools import Identifier, target
+
+
+def test_channel():
+    name = Identifier('#chan')
+    channel = target.Channel(name)
+
+    assert channel.name == name
+    assert not channel.users
+    assert not channel.privileges
+    assert channel.topic == ''
+    assert channel.last_who is None
+
+
+def test_channel_add_user():
+    channel = target.Channel(Identifier('#chan'))
+    user = target.User(Identifier('TestUser'), 'example', 'example.com')
+
+    channel.add_user(user)
+
+    assert user.nick in channel.users
+    assert channel.users[user.nick] is user
+
+    assert user.nick in channel.privileges
+    assert channel.privileges[user.nick] == 0
+
+    assert channel.name in user.channels
+
+
+def test_channel_add_user_voiced():
+    channel = target.Channel(Identifier('#chan'))
+    user = target.User(Identifier('TestUser'), 'example', 'example.com')
+
+    channel.add_user(user, plugin.VOICE)
+
+    assert user.nick in channel.users
+    assert channel.users[user.nick] is user
+
+    assert user.nick in channel.privileges
+    assert channel.privileges[user.nick] == plugin.VOICE
+
+
+def test_channel_add_user_multi_privileges():
+    channel = target.Channel(Identifier('#chan'))
+    user = target.User(Identifier('TestUser'), 'example', 'example.com')
+
+    channel.add_user(user, plugin.VOICE | plugin.OP)
+
+    assert user.nick in channel.users
+    assert channel.users[user.nick] is user
+
+    assert user.nick in channel.privileges
+    assert channel.privileges[user.nick] & plugin.VOICE == plugin.VOICE
+    assert channel.privileges[user.nick] & plugin.OP == plugin.OP
+
+
+def test_channel_add_user_replace():
+    channel = target.Channel(Identifier('#chan'))
+    user = target.User(Identifier('TestUser'), 'example', 'example.com')
+
+    channel.add_user(user, plugin.VOICE)
+    channel.add_user(user, plugin.OP)
+
+    assert user.nick in channel.users
+    assert channel.users[user.nick] is user
+
+    assert user.nick in channel.privileges
+    assert channel.privileges[user.nick] == plugin.OP
+    assert channel.privileges[user.nick] & plugin.VOICE == 0, (
+        'This user must be replaced, without previous privileges')
+
+
+def test_channel_has_privilege():
+    channel = target.Channel(Identifier('#chan'))
+    user = target.User(Identifier('TestUser'), 'example', 'example.com')
+
+    # unknown user
+    assert not channel.has_privilege(user.nick, plugin.VOICE)
+    assert not channel.has_privilege(user.nick, plugin.OP)
+
+    # user added without privileges
+    channel.add_user(user)
+    assert not channel.has_privilege(user.nick, plugin.VOICE)
+    assert not channel.has_privilege(user.nick, plugin.OP)
+
+    # user added with VOICE privilege
+    channel.add_user(user, plugin.VOICE)
+    assert channel.has_privilege(user.nick, plugin.VOICE)
+    assert not channel.has_privilege(user.nick, plugin.OP)
+
+    # user added with OP privilege
+    channel.add_user(user, plugin.OP)
+    assert channel.has_privilege(user.nick, plugin.VOICE)
+    assert channel.has_privilege(user.nick, plugin.OP)
+
+    # user added with both VOICE & OP privilege
+    channel.add_user(user, plugin.VOICE | plugin.OP)
+    assert channel.has_privilege(user.nick, plugin.VOICE)
+    assert channel.has_privilege(user.nick, plugin.OP)
+
+
+def test_channel_is_priv_level_unknown_user():
+    channel = target.Channel(Identifier('#chan'))
+    user = target.User(Identifier('TestUser'), 'example', 'example.com')
+
+    assert not channel.is_oper(user.nick)
+    assert not channel.is_owner(user.nick)
+    assert not channel.is_admin(user.nick)
+    assert not channel.is_op(user.nick)
+    assert not channel.is_halfop(user.nick)
+    assert not channel.is_voiced(user.nick)
+
+
+def test_channel_is_priv_level_unprivileged_user():
+    channel = target.Channel(Identifier('#chan'))
+    user = target.User(Identifier('TestUser'), 'example', 'example.com')
+
+    channel.add_user(user)
+
+    assert not channel.is_oper(user.nick)
+    assert not channel.is_owner(user.nick)
+    assert not channel.is_admin(user.nick)
+    assert not channel.is_op(user.nick)
+    assert not channel.is_halfop(user.nick)
+    assert not channel.is_voiced(user.nick)
+
+
+def test_channel_is_priv_level_voiced_user():
+    channel = target.Channel(Identifier('#chan'))
+    user = target.User(Identifier('TestUser'), 'example', 'example.com')
+
+    channel.add_user(user, plugin.VOICE)
+
+    assert not channel.is_oper(user.nick)
+    assert not channel.is_owner(user.nick)
+    assert not channel.is_admin(user.nick)
+    assert not channel.is_op(user.nick)
+    assert not channel.is_halfop(user.nick)
+    assert channel.is_voiced(user.nick)
+
+
+def test_channel_is_priv_level_halfop_user():
+    channel = target.Channel(Identifier('#chan'))
+    user = target.User(Identifier('TestUser'), 'example', 'example.com')
+
+    channel.add_user(user, plugin.HALFOP)
+
+    assert not channel.is_oper(user.nick)
+    assert not channel.is_owner(user.nick)
+    assert not channel.is_admin(user.nick)
+    assert not channel.is_op(user.nick)
+    assert channel.is_halfop(user.nick)
+    assert not channel.is_voiced(user.nick)
+
+
+def test_channel_is_priv_level_op_user():
+    channel = target.Channel(Identifier('#chan'))
+    user = target.User(Identifier('TestUser'), 'example', 'example.com')
+
+    channel.add_user(user, plugin.OP)
+
+    assert not channel.is_oper(user.nick)
+    assert not channel.is_owner(user.nick)
+    assert not channel.is_admin(user.nick)
+    assert channel.is_op(user.nick)
+    assert not channel.is_halfop(user.nick)
+    assert not channel.is_voiced(user.nick)
+
+
+def test_channel_is_priv_level_admin_user():
+    channel = target.Channel(Identifier('#chan'))
+    user = target.User(Identifier('TestUser'), 'example', 'example.com')
+
+    channel.add_user(user, plugin.ADMIN)
+
+    assert not channel.is_oper(user.nick)
+    assert not channel.is_owner(user.nick)
+    assert channel.is_admin(user.nick)
+    assert not channel.is_op(user.nick)
+    assert not channel.is_halfop(user.nick)
+    assert not channel.is_voiced(user.nick)
+
+
+def test_channel_is_priv_level_owner_user():
+    channel = target.Channel(Identifier('#chan'))
+    user = target.User(Identifier('TestUser'), 'example', 'example.com')
+
+    channel.add_user(user, plugin.OWNER)
+
+    assert not channel.is_oper(user.nick)
+    assert channel.is_owner(user.nick)
+    assert not channel.is_admin(user.nick)
+    assert not channel.is_op(user.nick)
+    assert not channel.is_halfop(user.nick)
+    assert not channel.is_voiced(user.nick)
+
+
+def test_channel_is_priv_level_oper_user():
+    channel = target.Channel(Identifier('#chan'))
+    user = target.User(Identifier('TestUser'), 'example', 'example.com')
+
+    channel.add_user(user, plugin.OPER)
+
+    assert channel.is_oper(user.nick)
+    assert not channel.is_owner(user.nick)
+    assert not channel.is_admin(user.nick)
+    assert not channel.is_op(user.nick)
+    assert not channel.is_halfop(user.nick)
+    assert not channel.is_voiced(user.nick)


### PR DESCRIPTION
### Description

This wasn't requested, and probably not needed that much. However, when reading the code for #1981 I realized that we repeat a lot of code, so I figured out I could add these:

* `bot.has_channel_privilege(channel, level)` will tell you if the **bot** itself has the right privilege level,
* `plugin.require_bot_privilege` is a new decorator that uses this new method,

which is probably useful only for channel administration. Probably.

Anyway, it has tests, and it gave me some ideas for the future (in particular, how we could manage more complex privilege check). So it's good!

### Second round description

OK, after second thought, I realized I could improve the `sopel.tools.target.Channel` class, by adding privilege related methods, and use one of these methods into the bot.

However, I found out that there is no test for `Channel` (or `User`), and that's not good, so I kind of hijacked this PR to add these tests, while trying to stay on topic.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
