### PR TITLE
cli.config: implement `set` and `unset` subcommands

### DIFF
--- a/sopel/cli/config.py
+++ b/sopel/cli/config.py
@@ -62,6 +62,27 @@ def build_parser():
     get_parser.add_argument('option')
     utils.add_common_arguments(get_parser)
 
+    # sopel-config set <section> <key> <value>
+    set_parser = subparsers.add_parser(
+        'set',
+        help="Set a configuration option's value",
+        description="Set a configuration option's value",
+    )
+    set_parser.add_argument('section')
+    set_parser.add_argument('option')
+    set_parser.add_argument('value')
+    utils.add_common_arguments(set_parser)
+
+    # sopel-config unset <section> <key>
+    unset_parser = subparsers.add_parser(
+        'unset',
+        help="Unset a configuration option",
+        description="Unset a configuration option",
+    )
+    unset_parser.add_argument('section')
+    unset_parser.add_argument('option')
+    utils.add_common_arguments(unset_parser)
+
     return parser
 
 
@@ -167,6 +188,78 @@ def handle_get(options):
     return 0  # successful operation
 
 
+def handle_set(options):
+    """Set the ``<section> <key>`` setting to ``<value>``.
+
+    :param options: parsed arguments
+    :type options: :class:`argparse.Namespace`
+    :return: 0 if everything went fine;
+             1 if the section and/or key does not exist;
+             2 if the settings can't be loaded
+    """
+    try:
+        settings = utils.load_settings(options)
+    except Exception as error:
+        tools.stderr(error)
+        return 2
+
+    section = options.section
+    option = options.option
+    value = options.value
+
+    # Make sure the section exists
+    if not settings.parser.has_section(section):
+        try:
+            settings.parser.add_section(section)
+        except (TypeError, ValueError):
+            tools.stderr('Invalid section name "%s"' % section)
+            return 1
+
+    # Update the option & save config file
+    settings.parser.set(section, option, value)
+    settings.save()
+    print('Updated option "{}.{}"'.format(section, option))
+    return 0  # successful operation
+
+
+def handle_unset(options):
+    """Unset the setting value of ``<section> <key>``.
+
+    :param options: parsed arguments
+    :type options: :class:`argparse.Namespace`
+    :return: 0 if everything went fine;
+             1 if the section and/or key does not exist;
+             2 if the settings can't be loaded
+    """
+    try:
+        settings = utils.load_settings(options)
+    except Exception as error:
+        tools.stderr(error)
+        return 2
+
+    section = options.section
+    option = options.option
+
+    # Make sure the section exists
+    if not settings.parser.has_section(section):
+        tools.stderr('Section "%s" does not exist' % section)
+        return 1
+
+    # Unset the option
+    removed = settings.parser.remove_option(section, option)
+    # Remove section completely if empty
+    if len(settings.parser.options(section)) == 0:
+        settings.parser.remove_section(section)
+    # Save config file
+    settings.save()
+    # Report result
+    if removed:
+        print('Unset option "{}.{}"'.format(section, option))
+    else:
+        print('Option "{}.{}" was not set'.format(section, option))
+    return 0  # successful operation
+
+
 def main():
     """Console entry point for ``sopel-config``."""
     parser = build_parser()
@@ -184,3 +277,7 @@ def main():
         return handle_init(options)
     elif action == 'get':
         return handle_get(options)
+    elif action == 'set':
+        return handle_set(options)
+    elif action == 'unset':
+        return handle_unset(options)


### PR DESCRIPTION
### Description
If @Exirel can submit PRs that weren't "requested" by an issue, then so can I! 😛

Honestly, this was going to happen sooner or later. It's the next natural evolution of the `sopel-config` CLI.

**Why now?** I was working on an out-of-tree plugin and kept needing to edit the config file due to shortcomings in the configuration wizard UX (namely, you can't unset a value through a prompt in `sopel-plugins configure <plugin_name>`).

While I've never been terribly fond of how the configuration wizard works—goodness knows it needs an overhaul—fixing that was too big of a project to start late on a Sunday night. This, by comparison, took less than half an hour to build out and (manually) test. Since we don't have _any_ unit tests for large portions of the CLI module (other than `cli.run` and `cli.utils`), I didn't worry about adding any for these new subcommands just yet.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches