### PR TITLE
currency: add thousands separator, dynamic precision, and optional HTTPS for Fixer

### DIFF
--- a/sopel/modules/currency.py
+++ b/sopel/modules/currency.py
@@ -141,7 +141,7 @@ def exchange(bot, match):
     query = match.string
 
     targets = query.split()
-    amount = targets.pop(0)
+    amount_in = targets.pop(0)
     base = targets.pop(0)
     targets.pop(0)
 
@@ -149,7 +149,7 @@ def exchange(bot, match):
     # amount, base, _, *targets = query.split()
 
     try:
-        amount = float(amount)
+        amount = float(amount_in)
     except ValueError:
         bot.reply(UNRECOGNIZED_INPUT)
         return
@@ -161,7 +161,7 @@ def exchange(bot, match):
         bot.reply("Zero is zero, no matter what country you're in.")
         return
 
-    out_string = '{} {} is'.format(amount, base.upper())
+    out_string = '{} {} is'.format(amount_in, base.upper())
 
     unsupported_currencies = []
     for target in targets:
@@ -259,10 +259,10 @@ def update_rates(bot):
 
 @plugin.command('cur', 'currency', 'exchange')
 @plugin.example('.cur 100 usd in btc cad eur',
-                r'100\.0 USD is [\d\.]+ BTC, [\d\.]+ CAD, [\d\.]+ EUR',
+                r'100 USD is [\d\.]+ BTC, [\d\.]+ CAD, [\d\.]+ EUR',
                 re=True, online=True, vcr=True)
 @plugin.example('.cur 100 usd in btc cad eur can aux',
-                r'100\.0 USD is [\d\.]+ BTC, [\d\.]+ CAD, [\d\.]+ EUR, \(unsupported: CAN, AUX\)',
+                r'100 USD is [\d\.]+ BTC, [\d\.]+ CAD, [\d\.]+ EUR, \(unsupported: CAN, AUX\)',
                 re=True, online=True, vcr=True)
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def exchange_cmd(bot, trigger):

--- a/sopel/modules/currency.py
+++ b/sopel/modules/currency.py
@@ -22,7 +22,7 @@ from sopel.config import types
 PLUGIN_OUTPUT_PREFIX = '[currency] '
 FIAT_PROVIDERS = {
     'exchangerate.host': 'https://api.exchangerate.host/latest?base=EUR',
-    'fixer.io': 'https://data.fixer.io/api/latest?base=EUR&access_key={}',
+    'fixer.io': 'http://data.fixer.io/api/latest?base=EUR&access_key={}',
     'ratesapi.io': 'https://api.ratesapi.io/api/latest?base=EUR',
 }
 CRYPTO_URL = 'https://api.coingecko.com/api/v3/exchange_rates'

--- a/sopel/modules/currency.py
+++ b/sopel/modules/currency.py
@@ -97,10 +97,17 @@ def build_reply(amount, base, target, out_string):
     rate = float(rate_raw)
     result = float(rate * amount)
 
-    if target == 'BTC':
-        return out_string + ' {:.5f} {},'.format(result, target)
+    digits = 0
+    # up to 10 (8+2) digits precision when result is less than 1
+    # as smaller results need more precision
+    while digits < 8 and 1 / 10**digits > result:
+        digits += 1
 
-    return out_string + ' {:.2f} {},'.format(result, target)
+    digits += 2
+
+    out_string += ' {value:,.{precision}f} {currency},'.format(value=result, precision=digits, currency=target)
+
+    return out_string
 
 
 def exchange(bot, match):


### PR DESCRIPTION
### Description
The current code only adds more precision when converting bitcoin. Other crypto currencies are also valued such that they return very small numbers.
This change finds the required amount of digits to display at least 2 non-zero decimals.

It also adds thousands separators to the reply.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

One issue was reported by make qa, but in help.py (ambiguous variable name l) 
