### PR TITLE
requirements, url: adapt to urllib3 exception type change

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,11 @@ geoip2>=4.0,<5.0; python_version >= '3.6'
 maxminddb<2.0; python_version < '3.6'
 ipaddress<2.0; python_version < '3.3'
 requests>=2.0.0,<3.0.0
+# transitive dependency of requests
+# 2.0 will drop EOL Python 2.7 & 3.5, just like Sopel 8 plans to
+urllib3<1.27; python_version != '3.3' and python_version != '3.4'
 urllib3<1.23; python_version == '3.3'
+urllib3<1.25; python_version == '3.4'
 dnspython<2.0; python_version == '2.7'
 dnspython<1.16.0; python_version == '3.3'
 dnspython<3.0; python_version >= '3.4'

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -17,6 +17,7 @@ import re
 
 import dns.resolver
 import requests
+from urllib3.exceptions import LocationValueError
 
 from sopel import plugin, tools
 from sopel.config import types
@@ -325,7 +326,8 @@ def find_title(url, verify=True):
         return None
     except (
         requests.exceptions.InvalidURL,  # e.g. http:///
-        UnicodeError,  # e.g. http://.example.com
+        UnicodeError,  # e.g. http://.example.com (urllib3<1.26)
+        LocationValueError,  # e.g. http://.example.com (urllib3>=1.26)
     ):
         LOGGER.debug('Invalid URL: %s', url)
         return None


### PR DESCRIPTION
### Description
urllib3 1.26 changed its `UnicodeError` to a custom exception type, breaking some of our `url` plugin's tests (plus the real-world behavior they check, of course). Now `urllib3.exceptions.LocationParseError` is raised (a subclass of `urllib3.exceptions.LocationValueError`) instead.

The solution is threefold:

1. Distrust urllib3's point releases; pin it to 1.26.x or lower now
2. Catch the custom exception type's superclass now
3. Stop catching `UnicodeError` and drop our support for urllib3<1.26 in Sopel 8 (or switch to urllib3 2.0+ only, if it's released by then)

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
Probably will backport this to 7.0.x and cut a new release. Don't want to touch that branch any more, but I think it's going to be impossible to get a working new Sopel install on v7.0.6 because of this change.