### PR TITLE
tell: remove @ from start of nicknames

### DIFF
--- a/sopel/modules/tell.py
+++ b/sopel/modules/tell.py
@@ -158,6 +158,9 @@ def f_remind(bot, trigger):
         bot.reply('That nickname is too long.')
         return
 
+    if tellee[0] == '@':
+        tellee = tellee[1:]
+
     if tellee == bot.nick:
         bot.reply("I'm here now; you can tell me whatever you want!")
         return


### PR DESCRIPTION
Because our users apparently think they're still mentioning users on discord and need this.

### Description
Removes @ if at start of nicknames
### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [ ] I have tested the functionality of the things this change touches
