### PR TITLE
modules: use `bot.say()`'s `trailing` parameter

### DIFF
--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -13,7 +13,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import datetime as dt
 import re
 import sys
-import textwrap
 
 import praw
 import prawcore
@@ -238,15 +237,12 @@ def comment_info(bot, trigger, match):
 
     # stolen from the function I (dgw) wrote for our github plugin
     lines = [line for line in c.body.splitlines() if line and line[0] != '>']
-    short = textwrap.wrap(lines[0], 250)[0]
-    if len(lines) > 1 or short != lines[0]:
-        short += ' […]'
 
     message = message.format(
         author=author, points=c.score, points_text=points_text,
-        posted=posted, comment=short)
+        posted=posted, comment=' '.join(lines))
 
-    bot.say(message)
+    bot.say(message, trailing=' […]')
 
 
 def subreddit_info(bot, trigger, match, commanded=False):
@@ -309,7 +305,8 @@ def subreddit_info(bot, trigger, match, commanded=False):
     message = message.format(
         link=link, nsfw=nsfw, subscribers='{:,}'.format(s.subscribers),
         created=created, public_description=s.public_description)
-    bot.say(message)
+
+    bot.say(message, trailing=' […]')
 
 
 def redditor_info(bot, trigger, match, commanded=False):

--- a/sopel/modules/tld.py
+++ b/sopel/modules/tld.py
@@ -310,11 +310,8 @@ def gettld(bot, trigger):
             items.append('{}: {}'.format(field, value))
 
     message = ' | '.join(items)
-    usable, excess = tools.get_sendable_message(message)
-    if excess:
-        message = usable + ' […]'
 
-    bot.say(message)
+    bot.say(message, trailing=' […]')
 
 
 @plugin.command('tldcache')

--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -193,7 +193,7 @@ def say_section(bot, trigger, server, query, section):
         return
 
     msg = '{} - {} | "{}"'.format(page_name, section.replace('_', ' '), snippet)
-    bot.say(msg)
+    bot.say(msg, trailing=' […]"')
 
 
 def mw_section(server, query, section):
@@ -225,15 +225,7 @@ def mw_section(server, query, section):
     parser = WikiParser(section.replace('_', ' '))
     parser.feed(data['parse']['text']['*'])
     text = parser.get_result()
-    text = ' '.join(text.split())   # collapse multiple whitespace chars
-
-    trimmed = False
-
-    while len(text) > (420 - len(query) - len(section) - 18):
-        text = text.rsplit(None, 1)[0]
-        trimmed = True
-    if trimmed:
-        text += '...'
+    text = ' '.join(text.split())  # collapse multiple whitespace chars
 
     return text
 

--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -152,26 +152,33 @@ def mw_search(server, query, num):
 def say_snippet(bot, trigger, server, query, show_url=True):
     page_name = query.replace('_', ' ')
     query = quote(query.replace(' ', '_'))
+    url = 'https://{}/wiki/{}'.format(server, query)
+
+    # If the trigger looks like another instance of this plugin, assume it is
+    if trigger.startswith(PLUGIN_OUTPUT_PREFIX) and trigger.endswith(' | ' + url):
+        return
+
     try:
         snippet = mw_snippet(server, query)
     except KeyError:
         if show_url:
             bot.reply("Error fetching snippet for \"{}\".".format(page_name))
         return
-    msg = '{} | "{}"'.format(page_name, snippet)
-    msg_url = msg + ' | https://{}/wiki/{}'.format(server, query)
-    if msg_url == trigger:  # prevents triggering on another instance of Sopel
-        return
+
+    msg = '{} | "{}'.format(page_name, snippet)
+
+    trailing = '"'
     if show_url:
-        msg = msg_url
-    bot.say(msg)
+        trailing += ' | ' + url
+
+    bot.say(msg, trailing=' […]' + trailing)
 
 
 def mw_snippet(server, query):
     """Retrieves a snippet of the given page from the given MediaWiki server."""
     snippet_url = ('https://' + server + '/w/api.php?format=json'
                    '&action=query&prop=extracts&exintro&explaintext'
-                   '&exchars=300&redirects&titles=')
+                   '&exchars=500&redirects&titles=')
     snippet_url += query
     snippet = get(snippet_url).json()
     snippet = snippet['query']['pages']

--- a/sopel/modules/wiktionary.py
+++ b/sopel/modules/wiktionary.py
@@ -124,9 +124,7 @@ def wiktionary(bot, trigger):
     if len(result) < 150:
         result = format(word, definitions, 5)
 
-    if len(result) > 300:
-        result = result[:295] + '[…]'
-    bot.say(result)
+    bot.say(result, trailing=' […]')
 
 
 @plugin.command('ety')
@@ -146,6 +144,4 @@ def wiktionary_ety(bot, trigger):
 
     result = "{}: {}".format(word, etymology)
 
-    if len(result) > 300:
-        result = result[:295] + '[...]'
-    bot.say(result)
+    bot.say(result, trailing=' […]')

--- a/sopel/modules/wiktionary.py
+++ b/sopel/modules/wiktionary.py
@@ -119,9 +119,9 @@ def wiktionary(bot, trigger):
             return
 
     result = format(word, definitions)
-    if len(result) < 150:
+    if len(result) < 300:
         result = format(word, definitions, 3)
-    if len(result) < 150:
+    if len(result) < 300:
         result = format(word, definitions, 5)
 
     bot.say(result, trailing=' […]')


### PR DESCRIPTION
### Description
This updates every core plugin I could find with an existing handler for "too long" output (`instagram`, `reddit`, `tld`, `wiktionary`, & `wikipedia`) to use `bot.say()`'s new `trailing` parameter from #1958.

Two things that _might_ be worth amending, if others think my thought process or assumptions were wrong:

* `instagram`: I rearranged the output to put the caption (most likely to be over-length) at the end. A subsequent commit to this branch (to `wikipedia`) showed a neat hack that would allow leaving the caption where it was, in the middle of the line, but it seems to make the most sense at the end anyway.
* `reddit`: I did _not_ change submission output to use `trailing`, because:
  * The title is the very first thing in the output
  * The submission's link might also be very long, and we can't truncate those
  * If the link is long enough, it plus the rest of the metadata could be longer than allowed anyway, even without the title
  * Basically, there were too many edge cases I could see, so I didn't touch the current post/submission behavior

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches