### PR TITLE
coretasks: NAMESX when multi-prefix is not available

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -237,6 +237,10 @@ def startup(bot, trigger):
 @module.rule('are supported by this server')
 def handle_isupport(bot, trigger):
     """Handle ``RPL_ISUPPORT`` events."""
+    # remember if NAMESX is known to be supported, before parsing RPL_ISUPPORT
+    namesx_support = 'NAMESX' in bot.isupport
+
+    # parse ISUPPORT message from server
     parameters = {}
     for arg in trigger.args:
         try:
@@ -247,6 +251,14 @@ def handle_isupport(bot, trigger):
             LOGGER.warning('Unable to parse ISUPPORT parameter: %r', arg)
 
     bot._isupport = bot._isupport.apply(**parameters)
+
+    # was NAMESX support status updated?
+    if not namesx_support and 'NAMESX' in bot.isupport:
+        # yes it was!
+        if 'multi-prefix' not in bot.server_capabilities:
+            # and the server doesn't have the multi-prefix capability
+            # so we can ask the server to use the NAMESX feature
+            bot.write(('PROTOCTL', 'NAMESX'))
 
 
 @module.priority('high')


### PR DESCRIPTION
### Description

As per the discussion in #1496 this makes Sopel send a `PROTOCTL NAMESX`  command when:

1. we receive a RPL_ISUPPORT message from the server
2. multi-prefix is not an available capability
3. NAMESX is now activated

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
