### PR TITLE
coretasks: WHOX availability checks use ISUPPORT

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -524,18 +524,10 @@ def _remove_from_channel(bot, nick, channel):
                 bot.users.pop(nick, None)
 
 
-def _whox_enabled(bot):
-    # Either privilege tracking or away notification. For simplicity, both
-    # account notify and extended join must be there for account tracking.
-    return (('account-notify' in bot.enabled_capabilities and
-             'extended-join' in bot.enabled_capabilities) or
-            'away-notify' in bot.enabled_capabilities)
-
-
 def _send_who(bot, channel):
-    if _whox_enabled(bot):
+    if 'WHOX' in bot.isupport:
         # WHOX syntax, see http://faerion.sourceforge.net/doc/irc/whox.var
-        # Needed for accounts in who replies. The random integer is a param
+        # Needed for accounts in WHO replies. The random integer is a param
         # to identify the reply as one from this command, because if someone
         # else sent it, we have no fucking way to know what the format is.
         rand = str(randint(0, 999))
@@ -1062,7 +1054,7 @@ def recv_who(bot, trigger):
 @module.priority('high')
 @module.unblockable
 def end_who(bot, trigger):
-    if _whox_enabled(bot):
+    if 'WHOX' in bot.isupport:
         who_reqs.pop(trigger.args[1], None)
 
 


### PR DESCRIPTION
### Description
Now that the bot tracks advertised ISUPPORT tokens, there's no longer any reason to guess based on enabled capabilities. If WHOX is advertised in ISUPPORT, use it. If it isn't advertised, don't use it. Simple.

Eliminated the function call for efficiency, since it's easy to put back if the logic becomes more complex again in the future. There were only two call sites.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
This could have unintended consequences if servers that advertise the account-tracking capabilities Sopel used as heuristics before don't advertise the WHOX token in ISUPPORT, but (unless deeper research proves otherwise) that sounds like incorrect implementation on the server side.

Related: #1496