### PR TITLE
instagram: remove "deprecated" (actually removed) oEmbed fallback

### DIFF
--- a/sopel/modules/instagram.py
+++ b/sopel/modules/instagram.py
@@ -47,24 +47,11 @@ def instaparse(bot, trigger, match):
     try:
         bot.say(parse_insta_json(json))
     except ParseError:
-        try:
-            json = get_oembed_json(instagram_url)
-            bot.say(parse_oembed_json(json))
-        except ParseError:
-            LOGGER.exception(
-                "Unable to find Instagram's payload for URL %s", instagram_url)
-            bot.say(
-                "Unable to parse this Instagram URL. "
-                "It's probably a temporary error; try again in a bit.")
-        else:
-            LOGGER.info(
-                "Used fallback to oEmbed metadata; "
-                "Sopel's IP may be blocked by Instagram.")
-
-
-def get_oembed_json(url):
-    response = get("https://api.instagram.com/oembed/?url={}".format(url))
-    return response.json()
+        LOGGER.exception(
+            "Unable to find Instagram's payload for URL %s", instagram_url)
+        bot.say(
+            "Unable to fetch info about this Instagram URL. "
+            "Instagram is probably blocking my IP address. :(")
 
 
 def get_insta_json(url):
@@ -164,12 +151,3 @@ def parse_insta_json(json):
 
     # Build the message
     return ' | '.join(parts)
-
-
-def parse_oembed_json(json):
-    if not json:
-        raise ParseError("No valid JSON returned")
-    return "Post by {} | {}".format(
-        json['author_name'],
-        json['title']
-    )


### PR DESCRIPTION
### Description
As reported in #1996, Facebook "deprecated" the oEmbed API endpoint. However, instead of a true deprecation where the endpoint simply starts returning a warning (or even just is marked as deprecated in docs), FB essentially *removed* the endpoint. It no longer returns valid JSON at all, let alone the expected result. Sopel receives plain text stating that the endpoint is "deprecated", with a link for more details.

The replacement API endpoint requires an API key, and this seems like a good time to consider removing the Instagram plugin to its own package. I will prepare that change separately, mostly so this fix can be easily cherry-picked into 7.0.x for maintenance, but also because it could be enough to wait for removing the plugin entirely until Sopel 8.0.

I'm not personally signed up for Instagram's developer program, so it wouldn't be fair if I alleged that FB never sent a warning before this endpoint stopped working. They might have. I'm just taking issue with the use of the term "deprecated" for something that is *nonfunctional* rather than merely unmaintained or scheduled for removal.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches (note: minimally)

### Notes
Requesting review from @kwaaak specifically, as the original plugin author.
@cottongin I'd love a review from you, too, since the fallback logic I'm gutting is from your PR #1911.

I intend to backport this tweak onto 7.0.x, for release as soon as this is merged, since the "Unexpected error" messages described in #1996 are pretty ugly.