### PR TITLE
plugins: improve docstrings according to project standards

### DIFF
--- a/sopel/plugins/__init__.py
+++ b/sopel/plugins/__init__.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-"""Sopel's plugins interface
+"""Sopel's plugins interface.
 
 .. versionadded:: 7.0
 
@@ -57,10 +57,13 @@ def _list_plugin_filenames(directory):
 
 
 def find_internal_plugins():
-    """List internal plugins
+    """List internal plugins.
 
-    :return: Yield instance of :class:`~.handlers.PyModulePlugin`
+    :return: yield instances of :class:`~.handlers.PyModulePlugin`
              configured for ``sopel.modules.*``
+
+    Internal plugins can be found under ``sopel.modules``. This list does not
+    include the ``coretasks`` plugin.
     """
     plugin_dir = imp.find_module(
         'modules',
@@ -72,10 +75,14 @@ def find_internal_plugins():
 
 
 def find_sopel_modules_plugins():
-    """List plugins from ``sopel_modules.*``
+    """List plugins from ``sopel_modules.*``.
 
-    :return: Yield instance of :class:`~.handlers.PyModulePlugin`
+    :return: yield instances of :class:`~.handlers.PyModulePlugin`
              configured for ``sopel_modules.*``
+
+    Before entry point plugins, the only way to package a plugin was to follow
+    :pep:`382` by using the ``sopel_modules`` namespace. This function is
+    responsible to load such plugins.
     """
     try:
         import sopel_modules
@@ -88,30 +95,35 @@ def find_sopel_modules_plugins():
 
 
 def find_entry_point_plugins(group='sopel.plugins'):
-    """List plugins from a setuptools entry point group
+    """List plugins from a setuptools entry point group.
 
     :param str group: setuptools entry point group to look for
                       (defaults to ``sopel.plugins``)
-    :return: Yield instance of :class:`~.handlers.EntryPointPlugin`
+    :return: yield instances of :class:`~.handlers.EntryPointPlugin`
              created from setuptools entry point given ``group``
+
+    This function finds plugins declared under a setuptools entry point; by
+    default it uses the ``sopel.plugins`` entry point.
     """
     for entry_point in pkg_resources.iter_entry_points(group):
         yield handlers.EntryPointPlugin(entry_point)
 
 
 def find_directory_plugins(directory):
-    """List plugins from a ``directory``
+    """List plugins from a ``directory``.
 
-    :param str directory: Directory path to search
-    :return: Yield instance of :class:`~.handlers.PyFilePlugin`
+    :param str directory: directory path to search
+    :return: yield instances of :class:`~.handlers.PyFilePlugin`
              found in ``directory``
+
+    This function looks for single file and folder plugins in a directory.
     """
     for _, abspath in _list_plugin_filenames(directory):
         yield handlers.PyFilePlugin(abspath)
 
 
 def enumerate_plugins(settings):
-    """Yield Sopel's plugins
+    """Yield Sopel's plugins.
 
     :param settings: Sopel's configuration
     :type settings: :class:`sopel.config.Config`
@@ -181,7 +193,7 @@ def enumerate_plugins(settings):
 
 
 def get_usable_plugins(settings):
-    """Get usable plugins, unique per name
+    """Get usable plugins, unique per name.
 
     :param settings: Sopel's configuration
     :type settings: :class:`sopel.config.Config`

--- a/sopel/plugins/jobs.py
+++ b/sopel/plugins/jobs.py
@@ -27,7 +27,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 class Scheduler(jobs.Scheduler):
-    """Plugins's Job Scheduler
+    """Plugin job scheduler.
 
     :param manager: bot instance passed to jobs as argument
     :type manager: :class:`sopel.bot.Sopel`

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -540,7 +540,7 @@ class AbstractRule(object):
 
         :param bot: Sopel instance
         :type bot: :class:`sopel.bot.Sopel`
-        :param pretrigger: Line to match
+        :param pretrigger: line to match
         :type pretrigger: :class:`sopel.trigger.PreTrigger`
 
         This method must return a list of `match objects`__.
@@ -1546,7 +1546,7 @@ class URLCallback(Rule):
 
         :param bot: Sopel instance
         :type bot: :class:`sopel.bot.Sopel`
-        :param pretrigger: Line to match
+        :param pretrigger: line to match
         :type pretrigger: :class:`sopel.trigger.PreTrigger`
 
         This method looks for :attr:`URLs in the IRC line


### PR DESCRIPTION
### Description

Part of #1565 for `sopel.plugins`.

Most of the changes are missing `.` and removing initial capital letter in `param/return` tags.

Then I tried to improve the docstrings for `sopel.plugins.handlers`, in a somewhat better version.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
