### PR TITLE
sopel: using utcnow and fixing minor issues with datetime

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -932,7 +932,7 @@ class Sopel(irc.AbstractBot):
 
         if trigger:
             message = '{} from {} at {}. Message was: {}'.format(
-                message, trigger.nick, str(datetime.now()), trigger.group(0)
+                message, trigger.nick, str(datetime.utcnow()), trigger.group(0)
             )
 
         LOGGER.exception(message)

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -280,12 +280,15 @@ class AbstractBot(object):
 
         if self.error_count > 10:
             # quit if too many errors
-            if (datetime.now() - self.last_error_timestamp).seconds < 5:
+            dt = datetime.utcnow() - self.last_error_timestamp
+            dt_seconds = dt.total_seconds()
+            if dt_seconds < 5:
                 LOGGER.error('Too many errors, can\'t continue')
                 os._exit(1)
-            # TODO: should we reset error_count?
+            # remove 1 error per full 5s that passed since last error
+            self.error_count = max(0, self.error_count - dt_seconds // 5)
 
-        self.last_error_timestamp = datetime.now()
+        self.last_error_timestamp = datetime.utcnow()
         self.error_count = self.error_count + 1
 
     def change_current_nick(self, new_nick):

--- a/sopel/irc/backends.py
+++ b/sopel/irc/backends.py
@@ -45,7 +45,8 @@ LOGGER = logging.getLogger(__name__)
 def _send_ping(backend):
     if not backend.is_connected():
         return
-    time_passed = (datetime.datetime.utcnow() - backend.last_event_at).seconds
+    dt = datetime.datetime.utcnow() - backend.last_event_at
+    time_passed = dt.total_seconds()
     if time_passed > backend.ping_timeout:
         try:
             backend.send_ping(backend.host)
@@ -57,7 +58,8 @@ def _send_ping(backend):
 def _check_timeout(backend):
     if not backend.is_connected():
         return
-    time_passed = (datetime.datetime.utcnow() - backend.last_event_at).seconds
+    dt = datetime.datetime.utcnow() - backend.last_event_at
+    time_passed = dt.total_seconds()
     if time_passed > backend.server_timeout:
         LOGGER.error(
             'Server timeout detected after %ss; closing.', time_passed)

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -236,11 +236,11 @@ class Trigger(unicode):
     time = property(lambda self: self._pretrigger.time)
     """When the message was received.
 
-    :type: :class:`~datetime.datetime` object
+    :type: naïve :class:`~datetime.datetime` object (no timezone)
 
     If the IRC server supports ``server-time``, :attr:`time` will give that
     value. Otherwise, :attr:`time` will use the time when the message was
-    received by Sopel.
+    received by Sopel. In both cases, this time is in UTC.
     """
     raw = property(lambda self: self._pretrigger.line)
     """The entire raw IRC message, as sent from the server.


### PR DESCRIPTION
### Description

This is related to  #1647. It doesn't fix it but we may consider it done nonetheless.

What I looked at was how we use datetime internally and in various plugins, to check if everything was working fine. Result is: no, but it's OK, I fixed it with this PR.

The biggest issue I found was a repeated usage of `timedelta.seconds` that I replaced by `timedelta.total_seconds()`.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches