### PR TITLE
remind: .reminders count/forget command

### DIFF
--- a/sopel/modules/remind.py
+++ b/sopel/modules/remind.py
@@ -516,8 +516,13 @@ def manage_reminders(bot, trigger):
     optional and can be either a channel name, your nick, or * (for all).
     """
     owner = trigger.nick
-    action = trigger.group(3) or 'count'
-    target = trigger.group(4) or trigger.sender
+    action = trigger.group(3) or trigger.sender
+    target = trigger.group(4)
+
+    if action not in ['count', 'forget'] and not target:
+        # assume `.reminders` or `.reminders #channel`
+        # in that case, invalid action will just count 0 reminder
+        action, target = 'count', action
 
     if action == 'count':
         tpl = 'You have {count} reminders for all channels.'
@@ -562,3 +567,9 @@ def manage_reminders(bot, trigger):
             bot.reply('I forgot your private reminders.')
         else:
             bot.reply('I forgot your reminders in %s' % target)
+
+    else:
+        bot.reply(
+            'Unrecognized action. '
+            'Usage: {}reminders [count|forget [nickname|channel|*]]'
+            .format(bot.config.core.help_prefix))


### PR DESCRIPTION
### Description

Fix #1746 

Add a new `reminders` command with subcommands:

* `.reminders` will use the `count` subcommand by default
* `.reminders count` will count all reminders in the current target (either the current channel or in private messages)
* `.reminders forget` will forget all reminders in the current target (either the current channel or in private messages)
* using a third argument will limit each action to that target
* using `*` (wildcard) as the target will act on all possible targets, i.e. all the channels and in private messages

For example `.reminders count *` will give you the sum of all reminders from every channels and every private message for **you** (and you only); and using `.reminders forget` in a private message will make the bot forget about your private reminders only.

Note: I decided to do something simple, that doesn't try to be too smart, it's not made for admin to reset everything, etc. but I think it's already a good improvement. I wish I had time to rework the plugin (there is a repo for that, I know!), but for now, and for 7.1, that will do.

Also: yay, a Feature  PR and not a Bugfix/Documentation/Tweak PR!

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
