### PR TITLE
build: fix geoip requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pytz
 praw>=4.0.0,<6.0.0
 # transitive dependency of praw; v0.18 introduced f-string syntax
 update-checker<0.18; python_version < '3.6'
-geoip2<3.0; python_version <= '3.5' and python_version != '2.7'
+geoip2<3.0; python_version == '3.5' and python_version != '2.7'
 geoip2>=3.0,<4.0; python_version == '2.7'
 geoip2>=4.0,<5.0; python_version >= '3.6'
 # transitive dependency of geoip2; v2 dropped py2.7 & py3 < 3.6


### PR DESCRIPTION
Seems to actually only apply to 3.5 so seeing if this might fix the bug I just raised as my slightly tipsy self can't see anything else that could be wrong

### Description
Properly pins geoip2
Resolves #2009 (possibly)
### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [ ] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [ ] I have tested the functionality of the things this change touches
