### PR TITLE
rules: add get-all methods for all types of rules

### DIFF
--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -316,14 +316,54 @@ class Manager(object):
         return _has_labeled_rule(self._url_callbacks, label, plugin)
 
     def get_all_commands(self):
-        """Retrieve all the registered commands, by plugin."""
+        """Retrieve all the registered commands, by plugin.
+
+        :return: a list of 2-value tuples as ``(key, value)``, where each key
+                 is a plugin name, and the value is a ``dict`` of its
+                 :term:`commands <Command>`
+        """
         # expose a copy of the registered commands
         return self._commands.items()
 
     def get_all_nick_commands(self):
-        """Retrieve all the registered nick commands, by plugin."""
+        """Retrieve all the registered nick commands, by plugin.
+
+        :return: a list of 2-value tuples as ``(key, value)``, where each key
+                 is a plugin name, and the value is a ``dict`` of its
+                 :term:`nick commands <Nick command>`
+        """
         # expose a copy of the registered commands
         return self._nick_commands.items()
+
+    def get_all_action_commands(self):
+        """Retrieve all the registered action commands, by plugin.
+
+        :return: a list of 2-value tuples as ``(key, value)``, where each key
+                 is a plugin name, and the value is a ``dict`` of its
+                 :term:`action commands <Action command>`
+        """
+        # expose a copy of the registered action commands
+        return self._action_commands.items()
+
+    def get_all_generic_rules(self):
+        """Retrieve all the registered generic rules, by plugin.
+
+        :return: a list of 2-value tuples as ``(key, value)``, where each key
+                 is a plugin name, and the value is a ``list`` of its
+                 :term:`generic rules <Generic rule>`
+        """
+        # expose a copy of the registered generic rules
+        return self._rules.items()
+
+    def get_all_url_callbacks(self):
+        """Retrieve all the registered URL callbacks, by plugin.
+
+        :return: a list of 2-value tuples as ``(key, value)``, where each key
+                 is a plugin name, and the value is a ``list`` of its
+                 :term:`URL callbacks <URL callback>`
+        """
+        # expose a copy of the registered generic rules
+        return self._url_callbacks.items()
 
     def get_triggered_rules(self, bot, pretrigger):
         """Get triggered rules with their match objects, sorted by priorities.

--- a/test/plugins/test_plugins_rules.py
+++ b/test/plugins/test_plugins_rules.py
@@ -58,6 +58,14 @@ def test_manager_rule(mockbot):
     assert result_rule == rule
     assert result_match.group(0) == 'Hello, world'
 
+    assert list(manager.get_all_commands()) == []
+    assert list(manager.get_all_nick_commands()) == []
+    assert list(manager.get_all_action_commands()) == []
+    assert list(manager.get_all_generic_rules()) == [
+        ('testplugin', [rule]),
+    ]
+    assert list(manager.get_all_url_callbacks()) == []
+
 
 def test_manager_find(mockbot):
     regex = re.compile(r'\w+')
@@ -89,6 +97,14 @@ def test_manager_find(mockbot):
     assert result_rule == rule
     assert result_match.group(0) == 'world', 'The second must match on "world"'
 
+    assert list(manager.get_all_commands()) == []
+    assert list(manager.get_all_nick_commands()) == []
+    assert list(manager.get_all_action_commands()) == []
+    assert list(manager.get_all_generic_rules()) == [
+        ('testplugin', [rule]),
+    ]
+    assert list(manager.get_all_url_callbacks()) == []
+
 
 def test_manager_search(mockbot):
     regex = re.compile(r'\w+')
@@ -110,6 +126,14 @@ def test_manager_search(mockbot):
     result_rule, result_match = items[0]
     assert result_rule == rule
     assert result_match.group(0) == 'Hello'
+
+    assert list(manager.get_all_commands()) == []
+    assert list(manager.get_all_nick_commands()) == []
+    assert list(manager.get_all_action_commands()) == []
+    assert list(manager.get_all_generic_rules()) == [
+        ('testplugin', [rule]),
+    ]
+    assert list(manager.get_all_url_callbacks()) == []
 
 
 def test_manager_command(mockbot):
@@ -134,6 +158,9 @@ def test_manager_command(mockbot):
         ('testplugin', {'hello': command}),
     ]
     assert list(manager.get_all_nick_commands()) == []
+    assert list(manager.get_all_action_commands()) == []
+    assert list(manager.get_all_generic_rules()) == []
+    assert list(manager.get_all_url_callbacks()) == []
 
 
 def test_manager_nick_command(mockbot):
@@ -158,6 +185,9 @@ def test_manager_nick_command(mockbot):
     assert list(manager.get_all_nick_commands()) == [
         ('testplugin', {'hello': command}),
     ]
+    assert list(manager.get_all_action_commands()) == []
+    assert list(manager.get_all_generic_rules()) == []
+    assert list(manager.get_all_url_callbacks()) == []
 
 
 def test_manager_action_command(mockbot):
@@ -180,6 +210,11 @@ def test_manager_action_command(mockbot):
 
     assert list(manager.get_all_commands()) == []
     assert list(manager.get_all_nick_commands()) == []
+    assert list(manager.get_all_action_commands()) == [
+        ('testplugin', {'hello': command}),
+    ]
+    assert list(manager.get_all_generic_rules()) == []
+    assert list(manager.get_all_url_callbacks()) == []
 
 
 def test_manager_rule_and_command(mockbot):
@@ -204,6 +239,11 @@ def test_manager_rule_and_command(mockbot):
         ('testplugin', {'hello': command}),
     ]
     assert list(manager.get_all_nick_commands()) == []
+    assert list(manager.get_all_action_commands()) == []
+    assert list(manager.get_all_generic_rules()) == [
+        ('testplugin', [rule]),
+    ]
+    assert list(manager.get_all_url_callbacks()) == []
 
 
 def test_manager_url_callback(mockbot):
@@ -232,6 +272,14 @@ def test_manager_url_callback(mockbot):
     assert manager.check_url_callback(mockbot, 'https://example.com/')
     assert manager.check_url_callback(mockbot, 'https://example.com/test')
     assert not manager.check_url_callback(mockbot, 'https://not-example.com/')
+
+    assert list(manager.get_all_commands()) == []
+    assert list(manager.get_all_nick_commands()) == []
+    assert list(manager.get_all_action_commands()) == []
+    assert list(manager.get_all_generic_rules()) == []
+    assert list(manager.get_all_url_callbacks()) == [
+        ('testplugin', [rule]),
+    ]
 
 
 def test_manager_unregister_plugin(mockbot):


### PR DESCRIPTION
### Description

When I implemented the new rule system, I made the methods that were necessary to be backward compatible with the bot's doc, which is used by the help plugin, but nothing more.

However, now that I have extended that to all type of rules (including commands and URL callback), it was time to add the appropriate methods for all types of rules.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
