### PR TITLE
find: format replacement text instead of "meant"

### DIFF
--- a/sopel/modules/find.py
+++ b/sopel/modules/find.py
@@ -142,7 +142,7 @@ def findandreplace(bot, trigger):
         return
 
     old = trigger.group(2).replace(r'\/', '/')
-    new = trigger.group(3).replace(r'\/', '/')
+    new = bold(trigger.group(3)).replace(r'\/', '/')
     me = False  # /me command
     flags = (trigger.group(4) or '')
 
@@ -185,7 +185,7 @@ def findandreplace(bot, trigger):
 
     # output
     if not me:
-        new_phrase = '%s to say: %s' % (bold('meant'), new_phrase)
+        new_phrase = 'meant to say: %s' % new_phrase
     if trigger.group(1):
         phrase = '%s thinks %s %s' % (trigger.nick, rnick, new_phrase)
     else:

--- a/sopel/modules/find.py
+++ b/sopel/modules/find.py
@@ -172,11 +172,12 @@ def findandreplace(bot, trigger):
             line = line[8:]
         else:
             me = False
-        new_phrase = repl(line)
-        if new_phrase != line:  # we are done
+        replaced = repl(line)
+        if replaced != line:  # we are done
+            new_phrase = replaced
             break
 
-    if not new_phrase or new_phrase == line:
+    if not new_phrase:
         return  # Didn't find anything
 
     # Save the new "edited" message.


### PR DESCRIPTION
### Description
This simply applies the bold formatting to whatever the new replacement text is rather than the "meant" text.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
