### PR TITLE
isupport: return empty CHANMODES if unavailable

### DIFF
--- a/sopel/irc/isupport.py
+++ b/sopel/irc/isupport.py
@@ -267,7 +267,7 @@ class ISupport(object):
 
     @property
     def CHANMODES(self):
-        """Expose ``CHANMODES`` as a dict, if advertised by the server.
+        """Expose ``CHANMODES`` as a dict.
 
         This exposes information about 4 types of channel modes::
 
@@ -279,9 +279,7 @@ class ISupport(object):
                 'D': 'imnpst',
             }
 
-        This attribute is not available if the server does not provide the
-        right information, and accessing it will raise an
-        :exc:`AttributeError`.
+        The values are empty if the server does not provide this information.
 
         .. seealso::
 
@@ -289,7 +287,7 @@ class ISupport(object):
 
         """
         if 'CHANMODES' not in self:
-            raise AttributeError('CHANMODES')
+            return {"A": "", "B": "", "C": "", "D": ""}
 
         return dict(zip('ABCD', self['CHANMODES'][:4]))
 

--- a/test/irc/test_irc_isupport.py
+++ b/test/irc/test_irc_isupport.py
@@ -162,10 +162,8 @@ def test_isupport_chanmodes():
 def test_isupport_chanmodes_undefined():
     instance = isupport.ISupport()
 
-    assert not hasattr(instance, 'CHANMODES')
-
-    with pytest.raises(AttributeError):
-        instance.CHANMODES
+    assert set(instance.CHANMODES.keys()) == set("ABCD")
+    assert set(instance.CHANMODES.values()) == {""}
 
 
 def test_isupport_maxlist():


### PR DESCRIPTION
### Description
Reduce boilerplate necessary for plugins that use `isupport.CHANMODES` by returning `{"A": "", ...}` instead of raising AttributeError if the server hasn't given us info.
See https://github.com/sopel-irc/sopel/pull/1980#discussion_r554754569

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
