### PR TITLE
logging: don't crash if backend is uninitialized

### DIFF
--- a/sopel/logger.py
+++ b/sopel/logger.py
@@ -29,7 +29,7 @@ class IrcLoggingHandler(logging.Handler):
         :param record: the log record to output
         :type record: :class:`logging.LogRecord`
         """
-        if not self._bot.backend.is_connected():
+        if self._bot.backend is None or not self._bot.backend.is_connected():
             # Don't emit logs when the bot is not connected.
             return
 


### PR DESCRIPTION
### Description
When `core.logging_channel` is used, errors early in startup cause an exception that halts the bot. (bdc10e037dc2bea81bf87871a2c18c61fe02cf99, current master)

### Repro
sopel.cfg
```ini
[core]
host = fake.local
logging_channel = #services
owner = mal
enable = version
foo = bar
```
Start the bot: `sopel start -c sopel.cfg`

### Current Result
```
  File "sopel/logger.py", line 32, in emit
    if not self._bot.backend.is_connected():
AttributeError: 'NoneType' object has no attribute 'is_connected'
```
<details><summary>full logs</summary>

```
(env) [mal@nova sopel-test]$ sopel start -c sopel.cfg
Sopel 7.1.0.dev0 (running on Python 3.8.5)
https://sopel.chat/

Loaded config file: /home/mal/sources/sopel-test/sopel.cfg
[2021-01-23 03:18:54,137] sopel.bot            INFO     - Loading plugins...
[2021-01-23 03:18:54,142] sopel.bot            INFO     - Plugin loaded: version
[2021-01-23 03:18:54,149] sopel.bot            INFO     - Plugin loaded: coretasks
[2021-01-23 03:18:54,150] sopel.bot            INFO     - Registered 1 plugins, 0 failed, 39 disabled
[2021-01-23 03:18:54,150] sopel.bot            WARNING  - Config option `core.foo` is not defined by its section and may not be recognized by Sopel.
Unexpected error in bot setup
Traceback (most recent call last):
  File "/home/mal/sources/sopel-test/env/bin/sopel", line 8, in <module>
    sys.exit(main())
  File "/home/mal/sources/sopel-test/env/lib/python3.8/site-packages/sopel/cli/run.py", line 714, in main
    return command(opts)
  File "/home/mal/sources/sopel-test/env/lib/python3.8/site-packages/sopel/cli/run.py", line 439, in command_start
    ret = run(settings, pid_file_path)
  File "/home/mal/sources/sopel-test/env/lib/python3.8/site-packages/sopel/cli/run.py", line 75, in run
    p.setup()
  File "/home/mal/sources/sopel-test/env/lib/python3.8/site-packages/sopel/bot.py", line 280, in setup
    self.post_setup()
  File "/home/mal/sources/sopel-test/env/lib/python3.8/site-packages/sopel/bot.py", line 369, in post_setup
    LOGGER.warning(
  File "/usr/lib/python3.8/logging/__init__.py", line 1446, in warning
    self._log(WARNING, msg, args, **kwargs)
  File "/usr/lib/python3.8/logging/__init__.py", line 1577, in _log
    self.handle(record)
  File "/usr/lib/python3.8/logging/__init__.py", line 1587, in handle
    self.callHandlers(record)
  File "/usr/lib/python3.8/logging/__init__.py", line 1649, in callHandlers
    hdlr.handle(record)
  File "/usr/lib/python3.8/logging/__init__.py", line 950, in handle
    self.emit(record)
  File "/home/mal/sources/sopel-test/env/lib/python3.8/site-packages/sopel/logger.py", line 32, in emit
    if not self._bot.backend.is_connected():
AttributeError: 'NoneType' object has no attribute 'is_connected'
(env) [mal@nova sopel-test]$ 
```
</details>

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
