### PR TITLE
reddit: show singular "comment" in post output when appropriate

### DIFF
--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -143,9 +143,10 @@ def say_post_info(bot, trigger, id_, show_link=True, show_comments_link=False):
     try:
         s = bot.memory['reddit_praw'].submission(id=id_)
 
-        message = ('{title} {link}{nsfw} | {points} {points_text} '
-                   '({percent}) | {comments} comments | Posted by {author} | '
-                   'Created at {created}{comments_link}')
+        message = (
+            '{title} {link}{nsfw} | {points} {points_text} ({percent}) | '
+            '{comments} {comments_text} | Posted by {author} | '
+            'Created at {created}{comments_link}')
 
         subreddit = s.subreddit.display_name
         if not show_link:
@@ -193,6 +194,8 @@ def say_post_info(bot, trigger, id_, show_link=True, show_comments_link=False):
 
         percent = color('{:.1%}'.format(s.upvote_ratio), point_color)
 
+        comments_text = 'comment' if s.num_comments == 1 else 'comments'
+
         comments_link = ''
         if show_comments_link:
             try:
@@ -204,8 +207,8 @@ def say_post_info(bot, trigger, id_, show_link=True, show_comments_link=False):
         title = unescape(s.title)
         message = message.format(
             title=title, link=link, nsfw=nsfw, points=s.score, points_text=points_text,
-            percent=percent, comments=s.num_comments, author=author, created=created,
-            comments_link=comments_link)
+            percent=percent, comments=s.num_comments, comments_text=comments_text,
+            author=author, created=created, comments_link=comments_link)
 
         bot.say(message)
     except prawcore.exceptions.NotFound:


### PR DESCRIPTION
### Description
Just a grammar issue that's been annoying me for too long already. Tested with a very imaginative "random" Reddit submission ID, 123456 😼

Before (emphasis added):
> [reddit] I'm thinking about getting a dog and YouTubed ways to train them. Then I came across this video (http://www.youtube.com/watch?v=b9upM4RbIeU&feature=g-vrec) to r/funny | 0 points (50.0%) | **1 comments** | Posted by cocobunny | Created at Thursday, October 25, 2012 15:53:08 -0500

After (emphasis again added):
> [reddit] I'm thinking about getting a dog and YouTubed ways to train them. Then I came across this video (http://www.youtube.com/watch?v=b9upM4RbIeU&feature=g-vrec) to r/funny | 0 points (50.0%) | **1 comment** | Posted by cocobunny | Created at Thursday, October 25, 2012 15:53:08 -0500

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches