### PR TITLE
tools, loader, plugins.rules: deprecate compile_rule

### DIFF
--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -16,7 +16,7 @@ import re
 import sys
 
 from sopel.config.core_section import COMMAND_DEFAULT_HELP_PREFIX
-from sopel.tools import compile_rule, itervalues
+from sopel.tools import itervalues
 
 
 if sys.version_info.major >= 3:
@@ -65,7 +65,6 @@ def clean_callable(func, config):
     limiting, commands, rules, and other features.
     """
     nick = config.core.nick
-    alias_nicks = config.core.alias_nicks
     help_prefix = config.core.help_prefix
     func._docs = {}
     doc = trim_docstring(func.__doc__)
@@ -98,25 +97,8 @@ def clean_callable(func, config):
         else:
             func.event = [event.upper() for event in func.event]
 
-    if hasattr(func, 'rule'):
-        if isinstance(func.rule, basestring):
-            func.rule = [func.rule]
-        func.rule = [
-            compile_rule(nick, rule, alias_nicks)
-            for rule in func.rule
-        ]
-
-    if hasattr(func, 'find_rules'):
-        func.find_rules = [
-            compile_rule(nick, rule, alias_nicks)
-            for rule in func.find_rules
-        ]
-
-    if hasattr(func, 'search_rules'):
-        func.search_rules = [
-            compile_rule(nick, rule, alias_nicks)
-            for rule in func.search_rules
-        ]
+    if hasattr(func, 'rule') and isinstance(func.rule, basestring):
+        func.rule = [func.rule]
 
     if any(hasattr(func, attr) for attr in ['commands', 'nickname_commands', 'action_commands']):
         if hasattr(func, 'example'):

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -12,6 +12,7 @@
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import logging
 import re
 import sys
 
@@ -21,6 +22,9 @@ from sopel.tools import itervalues
 
 if sys.version_info.major >= 3:
     basestring = (str, bytes)
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 def trim_docstring(doc):
@@ -97,7 +101,16 @@ def clean_callable(func, config):
         else:
             func.event = [event.upper() for event in func.event]
 
+    # TODO: remove in Sopel 8
+    # Stay compatible with old Phenny/Jenni "modules" (plugins)
+    # that set the attribute directly
     if hasattr(func, 'rule') and isinstance(func.rule, basestring):
+        LOGGER.warning(
+            'The `rule` attribute of %s.%s should be a list, not a string; '
+            'this behavior is deprecated in Sopel 7.1 '
+            'and will be removed in Sopel 8. '
+            'To prevent this problem always use `sopel.plugin.rule(%r)`.',
+            func.__module__, func.__name__, func.rule)
         func.rule = [func.rule]
 
     if any(hasattr(func, attr) for attr in ['commands', 'nickname_commands', 'action_commands']):

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -189,6 +189,7 @@ def get_input(prompt):
         return raw_input(prompt).decode('utf8')
 
 
+@deprecated('rule compilation tools are now private', '7.1', '8.0')
 def compile_rule(nick, pattern, alias_nicks):
     """Compile a rule regex and fill in nickname placeholders.
 
@@ -202,27 +203,19 @@ def compile_rule(nick, pattern, alias_nicks):
     :rtype: :ref:`re.Pattern <python:re-objects>`
 
     Will not recompile an already compiled pattern.
+
+    .. deprecated:: 7.1
+
+        Rule regexp tools are now part of the internal machinery. This function
+        is deprecated and will be removed in Sopel 8.
+
     """
     # Not sure why this happens on reloads, but it shouldn't cause problems…
     if isinstance(pattern, _regex_type):
         return pattern
 
-    if alias_nicks:
-        nicks = list(alias_nicks)  # alias_nicks.copy() doesn't work in py2
-        nicks.append(nick)
-        nicks = map(re.escape, nicks)
-        nick = '(?:%s)' % '|'.join(nicks)
-    else:
-        nick = re.escape(nick)
-
-    pattern = pattern.replace('$nickname', nick)
-    pattern = pattern.replace('$nick ', r'{}[,:]\s*'.format(nick))  # @rule('$nick hi')
-    pattern = pattern.replace('$nick', r'{}[,:]\s+'.format(nick))  # @rule('$nickhi')
-    flags = re.IGNORECASE
-    if '\n' in pattern:
-        # See https://docs.python.org/3/library/re.html#re.VERBOSE
-        flags |= re.VERBOSE
-    return re.compile(pattern, flags)
+    from sopel.plugins.rules import _compile_pattern
+    return _compile_pattern(pattern, nick, aliases=alias_nicks)
 
 
 @deprecated('command regexp tools are now private', '7.1', '8.0')
@@ -233,6 +226,12 @@ def get_command_regexp(prefix, command):
     :param str command: the name of the command
     :return: a compiled regexp object that implements the command
     :rtype: :ref:`re.Pattern <python:re-objects>`
+
+    .. deprecated:: 7.1
+
+        Command regexp tools are now part of the internal machinery. This
+        function is deprecated and will be removed in Sopel 8.
+
     """
     # Must defer import to avoid cyclic dependency
     from sopel.plugins.rules import Command
@@ -248,6 +247,12 @@ def get_command_pattern(prefix, command):
     :param str command: the command name
     :return: a regex pattern that will match the given command
     :rtype: str
+
+    .. deprecated:: 7.1
+
+        Command regexp tools are now part of the internal machinery. This
+        function is deprecated and will be removed in Sopel 8.
+
     """
     # Must defer import to avoid cyclic dependency
     from sopel.plugins.rules import Command
@@ -264,6 +269,12 @@ def get_nickname_command_regexp(nick, command, alias_nicks):
                              instead of ``nick``
     :return: a compiled regex pattern that implements the given nickname command
     :rtype: :ref:`re.Pattern <python:re-objects>`
+
+    .. deprecated:: 7.1
+
+        Command regexp tools are now part of the internal machinery. This
+        function is deprecated and will be removed in Sopel 8.
+
     """
     # Must defer import to avoid cyclic dependency
     from sopel.plugins.rules import NickCommand
@@ -284,6 +295,12 @@ def get_nickname_command_pattern(command):
     :param str command: the command name
     :return: a regex pattern that will match the given nickname command
     :rtype: str
+
+    .. deprecated:: 7.1
+
+        Command regexp tools are now part of the internal machinery. This
+        function is deprecated and will be removed in Sopel 8.
+
     """
     # Must defer import to avoid cyclic dependency
     from sopel.plugins.rules import NickCommand
@@ -297,6 +314,12 @@ def get_action_command_regexp(command):
     :param str command: the name of the command
     :return: a compiled regexp object that implements the command
     :rtype: :ref:`re.Pattern <python:re-objects>`
+
+    .. deprecated:: 7.1
+
+        Command regexp tools are now part of the internal machinery. This
+        function is deprecated and will be removed in Sopel 8.
+
     """
     # Must defer import to avoid cyclic dependency
     from sopel.plugins.rules import ActionCommand
@@ -311,6 +334,12 @@ def get_action_command_pattern(command):
     :param str command: the command name
     :return: a regex pattern that will match the given command
     :rtype: str
+
+    .. deprecated:: 7.1
+
+        Command regexp tools are now part of the internal machinery. This
+        function is deprecated and will be removed in Sopel 8.
+
     """
     # Must defer import to avoid cyclic dependency
     from sopel.plugins.rules import ActionCommand

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -355,7 +355,7 @@ def test_clean_callable_rule(tmpconfig, func):
     assert len(func.rule) == 1
 
     # Test the regex is compiled properly
-    regex = func.rule[0]
+    regex = re.compile(func.rule[0])
     assert regex.match('abc')
     assert regex.match('abcd')
     assert not regex.match('efg')
@@ -377,7 +377,8 @@ def test_clean_callable_rule(tmpconfig, func):
     # idempotency
     loader.clean_callable(func, tmpconfig)
     assert len(func.rule) == 1
-    assert regex in func.rule
+    assert regex not in func.rule
+    assert r'abc' in func.rule
 
     assert func.unblockable is False
     assert func.priority == 'medium'
@@ -395,54 +396,46 @@ def test_clean_callable_rule_string(tmpconfig, func):
     assert len(func.rule) == 1
 
     # Test the regex is compiled properly
-    regex = func.rule[0]
-    assert regex.match('abc')
-    assert regex.match('abcd')
-    assert not regex.match('efg')
+    assert func.rule[0] == r'abc'
 
     # idempotency
     loader.clean_callable(func, tmpconfig)
     assert len(func.rule) == 1
-    assert regex in func.rule
+    assert func.rule[0] == r'abc'
 
 
 def test_clean_callable_rule_nick(tmpconfig, func):
-    """Assert ``$nick`` in a rule will match ``TestBot: `` or ``TestBot, ``."""
+    """Assert ``$nick`` in a rule is not replaced (deprecated feature)."""
     setattr(func, 'rule', [r'$nickhello'])
     loader.clean_callable(func, tmpconfig)
 
     assert hasattr(func, 'rule')
     assert len(func.rule) == 1
 
-    # Test the regex is compiled properly
-    regex = func.rule[0]
-    assert regex.match('TestBot: hello')
-    assert regex.match('TestBot, hello')
-    assert not regex.match('TestBot not hello')
+    # Test the regex is not compiled
+    assert func.rule[0] == r'$nickhello'
 
     # idempotency
     loader.clean_callable(func, tmpconfig)
     assert len(func.rule) == 1
-    assert regex in func.rule
+    assert func.rule[0] == r'$nickhello'
 
 
 def test_clean_callable_rule_nickname(tmpconfig, func):
-    """Assert ``$nick`` in a rule will match ``TestBot``."""
+    """Assert ``$nickname`` in a rule is not replaced (deprecated feature)."""
     setattr(func, 'rule', [r'$nickname\s+hello'])
     loader.clean_callable(func, tmpconfig)
 
     assert hasattr(func, 'rule')
     assert len(func.rule) == 1
 
-    # Test the regex is compiled properly
-    regex = func.rule[0]
-    assert regex.match('TestBot hello')
-    assert not regex.match('TestBot not hello')
+    # Test the regex is not compiled
+    assert func.rule[0] == r'$nickname\s+hello'
 
     # idempotency
     loader.clean_callable(func, tmpconfig)
     assert len(func.rule) == 1
-    assert regex in func.rule
+    assert func.rule[0] == r'$nickname\s+hello'
 
 
 def test_clean_callable_find_rules(tmpconfig, func):
@@ -454,7 +447,7 @@ def test_clean_callable_find_rules(tmpconfig, func):
     assert not hasattr(func, 'rule')
 
     # Test the regex is compiled properly
-    regex = func.find_rules[0]
+    regex = re.compile(func.find_rules[0])
     assert regex.findall('abc')
     assert regex.findall('abcd')
     assert not regex.findall('adbc')
@@ -477,7 +470,8 @@ def test_clean_callable_find_rules(tmpconfig, func):
     loader.clean_callable(func, tmpconfig)
     assert hasattr(func, 'find_rules')
     assert len(func.find_rules) == 1
-    assert regex in func.find_rules
+    assert regex not in func.find_rules
+    assert r'abc' in func.find_rules
     assert not hasattr(func, 'rule')
 
     assert func.unblockable is False
@@ -497,7 +491,7 @@ def test_clean_callable_search_rules(tmpconfig, func):
     assert not hasattr(func, 'rule')
 
     # Test the regex is compiled properly
-    regex = func.search_rules[0]
+    regex = re.compile(func.search_rules[0])
     assert regex.search('abc')
     assert regex.search('xyzabc')
     assert regex.search('abcd')
@@ -521,7 +515,8 @@ def test_clean_callable_search_rules(tmpconfig, func):
     loader.clean_callable(func, tmpconfig)
     assert hasattr(func, 'search_rules')
     assert len(func.search_rules) == 1
-    assert regex in func.search_rules
+    assert regex not in func.search_rules
+    assert func.search_rules[0] == r'abc'
     assert not hasattr(func, 'rule')
 
     assert func.unblockable is False


### PR DESCRIPTION
### Description

See #1887.

This is only a draft, because it introduces a major change in `loader.clean_callable`: since `compile_rule` becomes deprecated, it is not used anymore by `loader.clean_callable`. It means that this function doesn't compile patterns anymore. So, even though it doesn't change *anything* for plugins that don't tinker with `loader` themselves (but why would they?), it doesn't generate any change and it should be transparent.

The documentation says that `sopel.loader` is for internal purpose, that it may and probably will change without warning, and that the documentation for this module is here for internal dev only. So, technically, it's **not** a breaking change, because that part of the API is documented as **not public**.

However, if we want to minimize the risk of a plugin relying on internal stuff (again: they should not), I've solutions to deal with that.

@dgw I need your opinion on that one!

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
