### PR TITLE
url: urlexclude/allow commands; auto-title ignores URLs in ANY other command

### DIFF
--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -288,8 +288,8 @@ def title_auto(bot, trigger):
     if not bot.settings.url.enable_auto_title:
         return
 
-    # Avoid fetching links from the "title" command
-    if re.match(bot.config.core.prefix + 'title', trigger):
+    # Avoid fetching links from another command
+    if re.match(bot.config.core.prefix + r'\S+', trigger):
         return
 
     # Avoid fetching known malicious links


### PR DESCRIPTION
### Description

Close #1870

And because nothing is simple: I also added aliases for `urlpban` and `urlpunban` to ban/unban patterns instead of URL directly.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
