### PR TITLE
url: restore error output when not all `.title` URLs could be fetched

### DIFF
--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -174,16 +174,30 @@ def title_command(bot, trigger):
         else:
             urls = [bot.memory['last_seen_url'][trigger.sender]]
     else:
-        urls = web.search_urls(
-            trigger,
-            exclusion_char=bot.config.url.exclusion_char)
+        urls = list(  # needs to be a list so len() can be checked later
+            web.search_urls(
+                trigger,
+                exclusion_char=bot.config.url.exclusion_char
+            )
+        )
 
+    result_count = 0
     for url, title, domain, tinyurl in process_urls(bot, trigger, urls):
         message = '%s | %s' % (title, domain)
         if tinyurl:
             message += ' ( %s )' % tinyurl
         bot.reply(message)
         bot.memory['last_seen_url'][trigger.sender] = url
+        result_count += 1
+
+    expected_count = len(urls)
+    if result_count < expected_count:
+        if expected_count == 1:
+            bot.reply("Sorry, fetching that title failed. Make sure the site is working.")
+        elif result_count == 0:
+            bot.reply("Sorry, I couldn't fetch titles for any of those.")
+        else:
+            bot.reply("I couldn't get all of the titles, but I fetched what I could!")
 
 
 @plugin.rule(r'(?u).*(https?://\S+).*')


### PR DESCRIPTION
### Description
Tin. Goes slightly beyond the previous error messages with a special case for failing to fetch all URLs in a list of 2+. Fixes #1946.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make quality` (I didn't touch anything covered by tests)
- [x] I have tested the functionality of the things this change touches