### PR TITLE
rules: fix deprecated usage of tools.compile_rule

### DIFF
--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -1316,9 +1316,10 @@ class NickCommand(NamedRuleMixin, Rule):
         name = [self.escape_name(self._name)]
         aliases = [self.escape_name(alias) for alias in self._aliases]
         pattern = r'|'.join(name + aliases)
-        return tools.compile_rule(
-            self._nick,
+
+        return _compile_pattern(
             self.PATTERN_TEMPLATE.format(command=pattern),
+            self._nick,
             self._nick_aliases)
 
 


### PR DESCRIPTION
### Description

Sorry, I forgot this one in #2027 

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
