### PR TITLE
build: replace flake8 config vars

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -39,9 +39,9 @@ pytest11 =
     pytest-sopel = sopel.tests.pytest_plugin
 
 [flake8]
-max-line-length = 79
-application-import-names = sopel
-import-order-style = google
+max_line_length = 79
+application_import_names = sopel
+import_order_style = google
 ignore =
     # Line length limit. Acceptable (for now).
     E501,
@@ -68,4 +68,4 @@ exclude =
     env/*,
     contrib/*,
     conftest.py
-accept-encodings = utf-8
+accept_encodings = utf-8


### PR DESCRIPTION
### Description
Use _ rather than - in flake8 config.

Per https://www.irccloud.com/pastebin/ZBa64Gr6 when creating a wheel using pyproject-build from Sopel master on Python 3.7+

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [ ] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [ ] I have tested the functionality of the things this change touches
