### PR TITLE
irc: timeout and logs

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -188,6 +188,13 @@ By default, if Sopel doesn't get a PING from the server every 120s, it will
 consider that the connection has timed out. This amount of time can be modified
 with the :attr:`~CoreSection.timeout` directive.
 
+Internally, Sopel will try to send a ``PING`` either:
+
+* every 50s
+* or 50s after the last message was received by the bot
+
+This value can be modified with the :attr:`~CoreSection.timeout_ping_interval`.
+
 SSL Connection
 --------------
 

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -248,18 +248,18 @@ class Sopel(irc.AbstractBot):
     def _signal_handler(self, sig, frame):
         if sig in QUIT_SIGNALS:
             if self.backend.is_connected():
-                LOGGER.warning('Got quit signal, sending QUIT to server.')
+                LOGGER.warning("Got quit signal, sending QUIT to server.")
                 self.quit('Closing')
             else:
                 self.hasquit = True  # mark the bot as "want to quit"
-                LOGGER.warning('Got quit signal.')
+                LOGGER.warning("Got quit signal.")
                 raise KeyboardInterrupt
         elif sig in RESTART_SIGNALS:
             if self.backend.is_connected():
-                LOGGER.warning('Got restart signal, sending QUIT to server.')
+                LOGGER.warning("Got restart signal, sending QUIT to server.")
                 self.restart('Restarting')
             else:
-                LOGGER.warning('Got restart signal.')
+                LOGGER.warning("Got restart signal.")
                 self.wantsrestart = True  # mark the bot as "want to restart"
                 self.hasquit = True  # mark the bot as "want to quit"
                 raise KeyboardInterrupt
@@ -310,7 +310,7 @@ class Sopel(irc.AbstractBot):
         load_error = 0
         load_disabled = 0
 
-        LOGGER.info('Loading plugins...')
+        LOGGER.info("Loading plugins...")
         usable_plugins = plugins.get_usable_plugins(self.settings)
         for name, info in usable_plugins.items():
             plugin, is_enabled = info
@@ -322,11 +322,11 @@ class Sopel(irc.AbstractBot):
                 plugin.load()
             except Exception as e:
                 load_error = load_error + 1
-                LOGGER.exception('Error loading %s: %s', name, e)
+                LOGGER.exception("Error loading %s: %s", name, e)
             except SystemExit:
                 load_error = load_error + 1
                 LOGGER.exception(
-                    'Error loading %s (plugin tried to exit)', name)
+                    "Error loading %s (plugin tried to exit)", name)
             else:
                 try:
                     if plugin.has_setup():
@@ -336,15 +336,15 @@ class Sopel(irc.AbstractBot):
                     plugin.register(self)
                 except Exception as e:
                     load_error = load_error + 1
-                    LOGGER.exception('Error in %s setup: %s', name, e)
+                    LOGGER.exception("Error in %s setup: %s", name, e)
                 else:
                     load_success = load_success + 1
-                    LOGGER.info('Plugin loaded: %s', name)
+                    LOGGER.info("Plugin loaded: %s", name)
 
         total = sum([load_success, load_error, load_disabled])
         if total and load_success:
             LOGGER.info(
-                'Registered %d plugins, %d failed, %d disabled',
+                "Registered %d plugins, %d failed, %d disabled",
                 (load_success - 1),
                 load_error,
                 load_disabled)
@@ -392,8 +392,8 @@ class Sopel(irc.AbstractBot):
             for option_name in settings.parser.options(section_name):
                 if not hasattr(section, option_name):
                     LOGGER.warning(
-                        'Config option `%s.%s` is not defined by its section '
-                        'and may not be recognized by Sopel.',
+                        "Config option `%s.%s` is not defined by its section "
+                        "and may not be recognized by Sopel.",
                         section_name,
                         option_name,
                     )
@@ -420,13 +420,13 @@ class Sopel(irc.AbstractBot):
         # tear down
         plugin.shutdown(self)
         plugin.unregister(self)
-        LOGGER.info('Unloaded plugin %s', name)
+        LOGGER.info("Unloaded plugin %s", name)
         # reload & setup
         plugin.reload()
         plugin.setup(self)
         plugin.register(self)
         meta = plugin.get_meta_description()
-        LOGGER.info('Reloaded %s plugin %s from %s',
+        LOGGER.info("Reloaded %s plugin %s from %s",
                     meta['type'], name, meta['source'])
 
     def reload_plugins(self):
@@ -441,7 +441,7 @@ class Sopel(irc.AbstractBot):
         for name, plugin in registered:
             plugin.shutdown(self)
             plugin.unregister(self)
-            LOGGER.info('Unloaded plugin %s', name)
+            LOGGER.info("Unloaded plugin %s", name)
 
         # reload & setup all plugins
         for name, plugin in registered:
@@ -449,7 +449,7 @@ class Sopel(irc.AbstractBot):
             plugin.setup(self)
             plugin.register(self)
             meta = plugin.get_meta_description()
-            LOGGER.info('Reloaded %s plugin %s from %s',
+            LOGGER.info("Reloaded %s plugin %s from %s",
                         meta['type'], name, meta['source'])
 
     def add_plugin(self, plugin, callables, jobs, shutdowns, urls):
@@ -668,7 +668,7 @@ class Sopel(irc.AbstractBot):
                         self.settings, func)
                     self._rules_manager.register_url_callback(rule)
                 except plugins.exceptions.PluginError as err:
-                    LOGGER.error('Cannot register URL callback: %s', err)
+                    LOGGER.error("Cannot register URL callback: %s", err)
 
     @deprecated(
         reason="Replaced by `say` method.",
@@ -1020,33 +1020,33 @@ class Sopel(irc.AbstractBot):
 
     def _shutdown(self):
         """Internal bot shutdown method."""
-        LOGGER.info('Shutting down')
+        LOGGER.info("Shutting down")
         # Stop Job Scheduler
-        LOGGER.info('Stopping the Job Scheduler.')
+        LOGGER.info("Stopping the Job Scheduler.")
         self._scheduler.stop()
 
         try:
             self._scheduler.join(timeout=15)
         except RuntimeError:
-            LOGGER.exception('Unable to stop the Job Scheduler.')
+            LOGGER.exception("Unable to stop the Job Scheduler.")
         else:
-            LOGGER.info('Job Scheduler stopped.')
+            LOGGER.info("Job Scheduler stopped.")
 
         self._scheduler.clear_jobs()
 
         # Shutdown plugins
         LOGGER.info(
-            'Calling shutdown for %d plugins.', len(self.shutdown_methods))
+            "Calling shutdown for %d plugins.", len(self.shutdown_methods))
 
         for shutdown_method in self.shutdown_methods:
             try:
                 LOGGER.debug(
-                    'Calling %s.%s',
+                    "Calling %s.%s",
                     shutdown_method.__module__,
                     shutdown_method.__name__)
                 shutdown_method(self)
             except Exception as e:
-                LOGGER.exception('Error calling shutdown method: %s', e)
+                LOGGER.exception("Error calling shutdown method: %s", e)
 
         # Avoid calling shutdown methods if we already have.
         self.shutdown_methods = []

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -1138,27 +1138,39 @@ class CoreSection(StaticSection):
 
     timeout_ping_interval = ValidatedAttribute('timeout_ping_interval',
                                                int,
-                                               default=50)
+                                               default=0)
     """The number of seconds before sending a PING command to the server.
 
-    :default: ``50``
+    :default: (auto)
 
     The default value is made to send at least 2 PINGs before the bot thinks
     there is a timeout, given that :attr:`timeout` is 120s by default:
 
-    * t+50s: first PING
-    * t+100s: second PING
+    * t+54s: first PING
+    * t+108s: second PING
     * t+120s: if no response, then a timeout is detected
 
     This makes the timeout detection more lenient and forgiving, by allowing a
-    20s window for the server to send something that will prevent a timeout.
+    12s window for the server to send something that will prevent a timeout.
 
     You can change the PING interval like this:
 
     .. code-block:: ini
 
-        # PING every 90s
-        timeout_ping_interval = 90
+        # timeout up to 250s
+        timeout = 250
+        # PING every 80s (about 3 times every 240s + 10s window)
+        timeout_ping_interval = 80
+
+    .. note::
+
+        Internally, the default value is 0 and the value used will be
+        automatically calculated as 45% of the :attr:`timeout`::
+
+            ping_interval = timeout * 0.45
+
+        So for a timeout of 120s it's a PING every 54s. For a timeout of 250s
+        it's a PING every 112.5s.
 
     """
 

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -1123,7 +1123,7 @@ class CoreSection(StaticSection):
     """
 
     timeout = ValidatedAttribute('timeout', int, default=120)
-    """The number of seconds acceptable between pings before timing out.
+    """The number of seconds acceptable since the last message before timing out.
 
     :default: ``120``
 
@@ -1133,6 +1133,32 @@ class CoreSection(StaticSection):
 
         # increase to 200 seconds
         timeout = 200
+
+    """
+
+    timeout_ping_interval = ValidatedAttribute('timeout_ping_interval',
+                                               int,
+                                               default=50)
+    """The number of seconds before sending a PING command to the server.
+
+    :default: ``50``
+
+    The default value is made to send at least 2 PINGs before the bot thinks
+    there is a timeout, given that :attr:`timeout` is 120s by default:
+
+    * t+50s: first PING
+    * t+100s: second PING
+    * t+120s: if no response, then a timeout is detected
+
+    This makes the timeout detection more lenient and forgiving, by allowing a
+    20s window for the server to send something that will prevent a timeout.
+
+    You can change the PING interval like this:
+
+    .. code-block:: ini
+
+        # PING every 90s
+        timeout_ping_interval = 90
 
     """
 

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -136,7 +136,7 @@ def auth_after_register(bot):
     # nickserv-based auth method needs to check for current nick
     if auth_method == 'nickserv':
         if bot.nick != bot.settings.core.nick:
-            LOGGER.warning('Sending nickserv GHOST command.')
+            LOGGER.warning("Sending nickserv GHOST command.")
             bot.say(
                 'GHOST %s %s' % (bot.settings.core.nick, auth_password),
                 auth_target or 'NickServ')
@@ -168,14 +168,13 @@ def _execute_perform(bot):
     count = len(commands)
 
     if not count:
-        LOGGER.info('No custom command to execute.')
+        LOGGER.info("No custom command to execute.")
         return
 
-    LOGGER.info('Executing %d custom commands.', count)
+    LOGGER.info("Executing %d custom commands.", count)
     for i, command in enumerate(commands, 1):
         command = command.replace('$nickname', bot.config.core.nick)
-        LOGGER.debug(
-            'Executing custom command [%d/%d]: %s', i, count, command)
+        LOGGER.debug("Executing custom command [%d/%d]: %s", i, count, command)
         bot.write((command,))
 
 
@@ -195,8 +194,7 @@ def on_nickname_in_use(bot, trigger):
     handling), the bot will try to regain it.
     """
     LOGGER.error(
-        'Nickname already in use! '
-        '(Nick: %s; Sender: %s; Args: %r)',
+        "Nickname already in use! (Nick: %s; Sender: %s; Args: %r)",
         trigger.nick,
         trigger.sender,
         trigger.args,
@@ -262,29 +260,29 @@ def startup(bot, trigger):
 
     channels = bot.config.core.channels
     if not channels:
-        LOGGER.info('No initial channels to JOIN.')
+        LOGGER.info("No initial channels to JOIN.")
     elif bot.config.core.throttle_join:
         throttle_rate = int(bot.config.core.throttle_join)
         throttle_wait = max(bot.config.core.throttle_wait, 1)
         channels_joined = 0
 
         LOGGER.info(
-            'Joining %d channels (with JOIN throttle ON); '
-            'this may take a moment.',
+            "Joining %d channels (with JOIN throttle ON); "
+            "this may take a moment.",
             len(channels))
 
         for channel in channels:
             channels_joined += 1
             if not channels_joined % throttle_rate:
                 LOGGER.debug(
-                    'Waiting %ds before next JOIN batch.',
+                    "Waiting %ds before next JOIN batch.",
                     throttle_wait)
                 time.sleep(throttle_wait)
             bot.join(channel)
     else:
         LOGGER.info(
-            'Joining %d channels (with JOIN throttle OFF); '
-            'this may take a moment.',
+            "Joining %d channels (with JOIN throttle OFF); "
+            "this may take a moment.",
             len(channels))
 
         for channel in bot.config.core.channels:
@@ -324,7 +322,7 @@ def handle_isupport(bot, trigger):
             parameters[key] = value
         except ValueError:
             # ignore malformed parameter: log a warning and continue
-            LOGGER.warning('Unable to parse ISUPPORT parameter: %r', arg)
+            LOGGER.warning("Unable to parse ISUPPORT parameter: %r", arg)
 
     bot._isupport = bot._isupport.apply(**parameters)
 
@@ -348,7 +346,7 @@ def parse_reply_myinfo(bot, trigger):
     bot._myinfo = MyInfo(*trigger.args[0:3])
 
     LOGGER.info(
-        'Received RPL_MYINFO from server: %s, %s, %s',
+        "Received RPL_MYINFO from server: %s, %s, %s",
         bot._myinfo.client,
         bot._myinfo.servername,
         bot._myinfo.version,
@@ -382,7 +380,7 @@ def enable_service_auth(bot, trigger):
     bot.say('Success! I will now use network services to identify you as my '
             'owner.')
     LOGGER.info(
-        'User %s set %s as owner account.',
+        "User %s set %s as owner account.",
         trigger.nick,
         trigger.account,
     )
@@ -400,19 +398,19 @@ def retry_join(bot, trigger):
     if channel in bot.memory['retry_join'].keys():
         bot.memory['retry_join'][channel] += 1
         if bot.memory['retry_join'][channel] > 10:
-            LOGGER.warning('Failed to join %s after 10 attempts.', channel)
+            LOGGER.warning("Failed to join %s after 10 attempts.", channel)
             return
-        LOGGER.info('Rejoining channel "%s" failed, will retry in 6s.', channel)
+        LOGGER.info(
+            "Rejoining channel %r failed, will retry in 6s.",
+            str(channel))
         time.sleep(6)
     else:
         bot.memory['retry_join'][channel] = 0
 
     attempt = bot.memory['retry_join'][channel] + 1
     LOGGER.info(
-        'Trying to rejoin channel "%s" (attempt %d/10)',
-        channel,
-        attempt,
-    )
+        "Trying to rejoin channel %r (attempt %d/10)",
+        str(channel), attempt)
     bot.join(channel)
 
 
@@ -494,7 +492,7 @@ def _parse_modes(bot, args):
     channel_name = Identifier(args[0])
     if channel_name.is_nick():
         # We don't do anything with user modes
-        LOGGER.debug('Ignoring user modes: %r', args)
+        LOGGER.debug("Ignoring user modes: %r", args)
         return
 
     channel = bot.channels[channel_name]
@@ -504,7 +502,7 @@ def _parse_modes(bot, args):
     # assumption that the MODE message is more-or-less compliant.
     if len(args) < 2 or not all(args):
         LOGGER.debug(
-            'The server sent a possibly malformed MODE message: %r', args)
+            "The server sent a possibly malformed MODE message: %r", args)
 
     modestring = args[1]
     params = args[2:]
@@ -601,8 +599,8 @@ def _parse_modes(bot, args):
             _send_who(bot, channel_name)
             return
 
-    LOGGER.info('Updated mode for "%s" channel.', channel.name)
-    LOGGER.debug('Channel "%s" mode: %r', channel.name, channel.modes)
+    LOGGER.info("Updated mode for channel: %s", channel.name)
+    LOGGER.debug("Channel %r mode: %r", str(channel.name), channel.modes)
 
 
 @module.event('NICK')
@@ -642,7 +640,7 @@ def track_nicks(bot, trigger):
     if old in bot.users:
         bot.users[new] = bot.users.pop(old)
 
-    LOGGER.info('User named "%s" is now known as "%s".', old, str(new))
+    LOGGER.info("User named %r is now known as %r.", old, str(new))
 
 
 @module.rule('(.*)')
@@ -655,7 +653,7 @@ def track_part(bot, trigger):
     nick = trigger.nick
     channel = trigger.sender
     _remove_from_channel(bot, nick, channel)
-    LOGGER.info('User "%s" left a channel: %s', str(nick), channel)
+    LOGGER.info("User %r left a channel: %s", str(nick), channel)
 
 
 @module.event('KICK')
@@ -668,9 +666,9 @@ def track_kick(bot, trigger):
     channel = trigger.sender
     _remove_from_channel(bot, nick, channel)
     LOGGER.info(
-        'User "%s" got kicked by "%s" from a channel: %s',
+        "User %r got kicked by %r from a channel: %s",
         str(nick),
-        trigger.nick,
+        str(trigger.nick),
         channel,
     )
 
@@ -739,7 +737,7 @@ def _periodic_send_who(bot):
 
     if selected_channel is not None:
         # selected_channel's last who is either none or the oldest valid
-        LOGGER.debug('Sending WHO for channel: %s', selected_channel)
+        LOGGER.debug("Sending WHO for channel: %s", selected_channel)
         _send_who(bot, selected_channel)
 
 
@@ -762,16 +760,18 @@ def track_join(bot, trigger):
 
     # did *we* just join?
     if trigger.nick == bot.nick:
-        LOGGER.info('Channel joined: %s', channel)
+        LOGGER.info("Channel joined: %s", channel)
         if bot.settings.core.throttle_join:
-            LOGGER.debug('JOIN event added to queue for channel: %s', channel)
+            LOGGER.debug("JOIN event added to queue for channel: %s", channel)
             bot.memory['join_events_queue'].append(channel)
         else:
             LOGGER.debug("Send MODE and direct WHO for channel: %s", channel)
             bot.write(["MODE", channel])
             _send_who(bot, channel)
     else:
-        LOGGER.info('Channel "%s" joined by user: %s', channel, trigger.nick)
+        LOGGER.info(
+            "Channel %r joined by user: %s",
+            str(channel), trigger.nick)
 
     # set initial values
     bot.privileges[channel][trigger.nick] = 0
@@ -800,7 +800,7 @@ def track_quit(bot, trigger):
         channel.clear_user(trigger.nick)
     bot.users.pop(trigger.nick, None)
 
-    LOGGER.info('User quit: %s', trigger.nick)
+    LOGGER.info("User quit: %s", trigger.nick)
 
     if trigger.nick == bot.settings.core.nick and trigger.nick != bot.nick:
         # old nick is now available, let's change nick again
@@ -887,7 +887,7 @@ def receive_cap_ls_reply(bot, trigger):
         return
 
     LOGGER.info(
-        'Client capability negotiation list: %s',
+        "Client capability negotiation list: %s",
         ', '.join(batched_caps.keys()),
     )
     bot.server_capabilities = batched_caps
@@ -906,13 +906,13 @@ def receive_cap_ls_reply(bot, trigger):
             bot._cap_reqs[cap] = [CapReq('', 'coretasks')]
 
     def acct_warn(bot, cap):
-        LOGGER.info('Server does not support %s, or it conflicts with a custom '
-                    'plugin. User account validation unavailable or limited.',
+        LOGGER.info("Server does not support %s, or it conflicts with a custom "
+                    "plugin. User account validation unavailable or limited.",
                     cap[1:])
         if bot.config.core.owner_account or bot.config.core.admin_accounts:
             LOGGER.warning(
-                'Owner or admin accounts are configured, but %s is not '
-                'supported by the server. This may cause unexpected behavior.',
+                "Owner or admin accounts are configured, but %s is not "
+                "supported by the server. This may cause unexpected behavior.",
                 cap[1:])
     auth_caps = ['account-notify', 'extended-join', 'account-tag']
     for cap in auth_caps:
@@ -947,7 +947,7 @@ def receive_cap_ls_reply(bot, trigger):
         bot.write(('CAP', 'REQ', 'sasl'))
     else:
         bot.write(('CAP', 'END'))
-        LOGGER.info('End of client capability negotiation requests.')
+        LOGGER.info("End of client capability negotiation requests.")
 
 
 def receive_cap_ack_sasl(bot):
@@ -1039,7 +1039,7 @@ def auth_proceed(bot, trigger):
         return
     sasl_username = sasl_username or bot.nick
     sasl_token = _make_sasl_plain_token(sasl_username, sasl_password)
-    LOGGER.info('Sending SASL Auth token.')
+    LOGGER.info("Sending SASL Auth token.")
     send_authenticate(bot, sasl_token)
 
 
@@ -1059,9 +1059,9 @@ def sasl_success(bot, trigger):
 
     In this case, the SASL auth is a success, so we can close the negotiation.
     """
-    LOGGER.info('Successful SASL Auth.')
+    LOGGER.info("Successful SASL Auth.")
     bot.write(('CAP', 'END'))
-    LOGGER.info('End of client capability negotiation requests.')
+    LOGGER.info("End of client capability negotiation requests.")
 
 
 @plugin.event(events.ERR_SASLFAIL)
@@ -1074,7 +1074,8 @@ def sasl_success(bot, trigger):
 def sasl_fail(bot, trigger):
     """SASL Auth Failed: log the error and quit."""
     LOGGER.error(
-        'SASL Auth Failed; check your configuration: %s', str(trigger))
+        "SASL Auth Failed; check your configuration: %s",
+        str(trigger))
     bot.quit('SASL Auth Failed')
 
 
@@ -1117,7 +1118,7 @@ def sasl_mechs(bot, trigger):
         bot.quit('Wrong SASL configuration.')
     else:
         LOGGER.info(
-            'Selected SASL mechanism is %s, advertised: %s',
+            "Selected SASL mechanism is %s, advertised: %s",
             mech,
             ', '.join(supported_mechs),
         )
@@ -1233,7 +1234,7 @@ def account_notify(bot, trigger):
     if account == '*':
         account = None
     bot.users[trigger.nick].account = account
-    LOGGER.info('Update account for nick "%s": %s', trigger.nick, account)
+    LOGGER.info("Update account for nick %r: %s", trigger.nick, account)
 
 
 @module.event(events.RPL_WHOSPCRPL)
@@ -1246,7 +1247,9 @@ def recv_whox(bot, trigger):
         # Ignored, some plugin probably called WHO
         return
     if len(trigger.args) != 8:
-        return LOGGER.warning('While populating `bot.accounts` a WHO response was malformed.')
+        LOGGER.warning(
+            "While populating `bot.accounts` a WHO response was malformed.")
+        return
     _, _, channel, user, host, nick, status, account = trigger.args
     away = 'G' in status
     modes = ''.join([c for c in status if c in '~&@%+!'])
@@ -1326,7 +1329,7 @@ def track_notify(bot, trigger):
     user = bot.users[trigger.nick]
     user.away = bool(trigger.args)
     state_change = 'went away' if user.away else 'came back'
-    LOGGER.info('User %s: %s', state_change, trigger.nick)
+    LOGGER.info("User %s: %s", state_change, trigger.nick)
 
 
 @module.event('TOPIC')

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -141,7 +141,7 @@ class AbstractBot(object):
                 :class:`~sopel.irc.abstract_backends.AbstractIRCBackend`
         """
         timeout = int(self.settings.core.timeout)
-        ping_timeout = timeout / 2
+        ping_timeout = int(self.settings.core.timeout_ping_interval)
         backend_class = AsynchatBackend
         backend_args = [self]
         backend_kwargs = {

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -141,12 +141,12 @@ class AbstractBot(object):
                 :class:`~sopel.irc.abstract_backends.AbstractIRCBackend`
         """
         timeout = int(self.settings.core.timeout)
-        ping_timeout = int(self.settings.core.timeout_ping_interval)
+        ping_interval = int(self.settings.core.timeout_ping_interval)
         backend_class = AsynchatBackend
         backend_args = [self]
         backend_kwargs = {
             'server_timeout': timeout,
-            'ping_timeout': ping_timeout,
+            'ping_interval': ping_interval,
         }
 
         if self.settings.core.use_ssl:

--- a/sopel/irc/backends.py
+++ b/sopel/irc/backends.py
@@ -62,7 +62,7 @@ def _send_ping(backend):
         last_event = max(events)
         dt = datetime.datetime.utcnow() - last_event
         time_passed = dt.total_seconds()
-        need_ping = time_passed > backend.ping_timeout
+        need_ping = time_passed > backend.ping_interval
 
     # Send PING only if needed
     if need_ping:
@@ -96,16 +96,16 @@ class AsynchatBackend(AbstractIRCBackend, asynchat.async_chat):
     :param bot: a Sopel instance
     :type bot: :class:`sopel.bot.Sopel`
     :param int server_timeout: connection timeout in seconds
-    :param int ping_timeout: ping timeout in seconds
+    :param int ping_interval: ping interval in seconds
     """
-    def __init__(self, bot, server_timeout=None, ping_timeout=None, **kwargs):
+    def __init__(self, bot, server_timeout=None, ping_interval=None, **kwargs):
         AbstractIRCBackend.__init__(self, bot)
         asynchat.async_chat.__init__(self)
         self.writing_lock = threading.RLock()
         self.set_terminator(b'\n')
         self.buffer = ''
         self.server_timeout = server_timeout or 120
-        self.ping_timeout = ping_timeout or (self.server_timeout / 2.4)
+        self.ping_interval = ping_interval or (self.server_timeout / 2.4)
         self.last_event_at = None
         self.last_ping_at = None
         self.host = None

--- a/sopel/irc/backends.py
+++ b/sopel/irc/backends.py
@@ -63,6 +63,11 @@ def _check_timeout(backend):
     if time_passed > backend.server_timeout:
         LOGGER.error(
             'Server timeout detected after %ss; closing.', time_passed)
+        # discard buffers: no need to read/write anything more, just quit
+        LOGGER.debug('Discard current buffers.')
+        backend.discard_buffers()
+        LOGGER.debug('Waiting on asynchat to close connection.')
+        # close once done
         backend.close_when_done()
 
 
@@ -103,6 +108,9 @@ class AsynchatBackend(AbstractIRCBackend, asynchat.async_chat):
 
     def on_irc_error(self, pretrigger):
         if self.bot.hasquit:
+            # discard buffers: no need to read/write anything more, just quit
+            self.discard_buffers()
+            # close when done
             self.close_when_done()
 
     def irc_send(self, data):

--- a/sopel/irc/backends.py
+++ b/sopel/irc/backends.py
@@ -97,6 +97,10 @@ class AsynchatBackend(AbstractIRCBackend, asynchat.async_chat):
     :type bot: :class:`sopel.bot.Sopel`
     :param int server_timeout: connection timeout in seconds
     :param int ping_interval: ping interval in seconds
+
+    The ``server_timeout`` option defaults to ``120`` seconds if not provided.
+
+    The ``ping_interval`` defaults to ``server_timeout * 0.45`` if not specified.
     """
     def __init__(self, bot, server_timeout=None, ping_interval=None, **kwargs):
         AbstractIRCBackend.__init__(self, bot)
@@ -105,7 +109,7 @@ class AsynchatBackend(AbstractIRCBackend, asynchat.async_chat):
         self.set_terminator(b'\n')
         self.buffer = ''
         self.server_timeout = server_timeout or 120
-        self.ping_interval = ping_interval or (self.server_timeout / 2.4)
+        self.ping_interval = ping_interval or (self.server_timeout * 0.45)
         self.last_event_at = None
         self.last_ping_at = None
         self.host = None

--- a/sopel/irc/backends.py
+++ b/sopel/irc/backends.py
@@ -86,9 +86,8 @@ def _check_timeout(backend):
         # discard buffers: no need to read/write anything more, just quit
         LOGGER.debug('Discard current buffers.')
         backend.discard_buffers()
-        LOGGER.debug('Waiting on asynchat to close connection.')
-        # close once done
-        backend.close_when_done()
+        # close now
+        backend.handle_close()
 
 
 class AsynchatBackend(AbstractIRCBackend, asynchat.async_chat):
@@ -126,9 +125,10 @@ class AsynchatBackend(AbstractIRCBackend, asynchat.async_chat):
     def on_irc_error(self, pretrigger):
         if self.bot.hasquit:
             # discard buffers: no need to read/write anything more, just quit
+            LOGGER.debug('Discard current buffers.')
             self.discard_buffers()
-            # close when done
-            self.close_when_done()
+            # close now
+            self.handle_close()
 
     def irc_send(self, data):
         """Send an IRC line as raw ``data`` to the socket connection.
@@ -184,7 +184,7 @@ class AsynchatBackend(AbstractIRCBackend, asynchat.async_chat):
         self.bot.on_connect()
 
     def handle_close(self):
-        """Called when the socket is closed."""
+        """Called when the connection must be closed."""
         LOGGER.debug('Stopping timeout watchdog')
         self.timeout_scheduler.stop()
         LOGGER.info('Closing connection')


### PR DESCRIPTION
### Description

In an attempt to fix a bug (see #2038) I added more logs (not sure it will be that useful in the end) and changed slightly how the bot manage its PING and timeout:

* remember the last time a PING was sent
* check for PING more often
* make the PING interval configurable (`core.timeout_ping_interval`)
* check for timeout more often (but keep the same delta)
* clear the buffer on timeout and IRC error

My current test didn't allow me to check if it actually solves the issue, but the change could help with that and it's still better than before anyway.

In theory, I could have removed the `os._exit` in `sopel.cli.run`, because locally it works quite nicely without it now, but that will be for another time.

I assign this PR to @dgw as he needs to install this branch on a test instance, and see how it behaves for a few days (hopefully, without any new issue, or at least with something more detailed).

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
