### PR TITLE
Make ConfigurationNotFound error more user friendly

### DIFF
--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -145,7 +145,7 @@ def plugins_wizard(filename):
         settings.save()
     except Exception:  # TODO: Be specific
         tools.stderr("We've encountered an error while writing the configuration file."
-                     "This shouldn't happen. Check your permissions settings to make sure nothing is wrong.")
+                     "This shouldn't happen. Check your permissions settings to make sure nothing is out of place.")
         raise
 
     return settings

--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -144,8 +144,8 @@ def plugins_wizard(filename):
     try:
         settings.save()
     except Exception:  # TODO: Be specific
-        tools.stderr("Encountered an error while writing the config file. "
-                     "This shouldn't happen. Check permissions.")
+        tools.stderr("We've encountered an error while writing the configuration file."
+                     "This shouldn't happen. Check your permissions settings to make sure nothing is wrong.")
         raise
 
     return settings


### PR DESCRIPTION
### Description
This PR SHOULD solve box 2 in issue #2036, making the ConfigurationNotFound error in CLI more user-friendly. I've rewrote the error response to detail what should be done to double-check all config files.

This is my first PR on GitHub, so feel free to point out I did something wrong, I'd like feedback :)