### PR TITLE
reload: only act on `python-file` plugins

### DIFF
--- a/sopel/modules/reload.py
+++ b/sopel/modules/reload.py
@@ -40,8 +40,8 @@ def f_reload(bot, trigger):
     name = trigger.group(2)
 
     if not name or name == '*' or name.upper() == 'ALL THE THINGS':
-        bot.reload_plugins()
-        bot.say('done')
+        bot.reload_plugins(plugin_types=['python-file'])
+        bot.say("done: Reloaded all 'python-file' plugins.")
         return
 
     if not bot.has_plugin(name):

--- a/sopel/modules/reload.py
+++ b/sopel/modules/reload.py
@@ -48,6 +48,14 @@ def f_reload(bot, trigger):
         bot.reply('"%s" not loaded; try the `load` command.' % name)
         return
 
+    plugin_meta = bot.get_plugin_meta(name)
+
+    if plugin_meta['type'] != 'python-file':
+        bot.reply(
+            "Reloading '%s' plugins is likely to cause glitches. "
+            "Please restart me instead." % plugin_meta['type'])
+        return
+
     bot.reload_plugin(name)
     plugin_meta = bot.get_plugin_meta(name)
     bot.say('done: %s reloaded (%s from %s)' % (


### PR DESCRIPTION
### Description
Given the numerous issues with trying to live-reload plugins that live in namespace packages or entry-points, I have started on making the `reload` plugin act only on plugins that it's likely to successfully reload.

The approach might be stupid. Or maybe it's brilliant. Possibly, nothing will make sense, since I wrote this in bits and pieces over several brief coding sessions spanning at least a week.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [ ] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [ ] I have tested the functionality of the things this change touches

### Notes
Not exhaustively tested yet. I finished the last bit of stuff I wanted to write before opening a PR just before (actually just after) the checkout deadline for our hotel. 😁