### PR TITLE
config.types, test: add `BooleanAttribute` setting type

### DIFF
--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -30,8 +30,9 @@ import getpass
 import os.path
 import re
 import sys
+import traceback
 
-from sopel.tools import get_input
+from sopel.tools import get_input, stderr
 
 if sys.version_info.major >= 3:
     unicode = str
@@ -299,10 +300,24 @@ class ValidatedAttribute(BaseValidated):
                  is_secret=False):
         super(ValidatedAttribute, self).__init__(
             name, default=default, is_secret=is_secret)
+
         if parse == bool:
             parse = _parse_boolean
             if not serialize or serialize == bool:
                 serialize = _serialize_boolean
+
+            # deprecation warning
+            # can't use tools.deprecated in this case, unfortunately
+            # we need this to be conditional
+            msg = (
+                'Deprecated since 7.1, '
+                'will be removed in 9.0: '
+                'Use BooleanAttribute instead of ValidatedAttribute with parse=bool')
+            stderr(msg)
+            # Only display the last stack frame
+            trace = traceback.extract_stack()
+            stderr(traceback.format_list(trace[:-1])[-1][:-1])
+
         self.parse = parse or self.parse
         self.serialize = serialize or self.serialize
 

--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -329,6 +329,82 @@ class ValidatedAttribute(BaseValidated):
         return super(ValidatedAttribute, self).configure(prompt, default, parent, section_name)
 
 
+class BooleanAttribute(BaseValidated):
+    """A descriptor for Boolean settings in a :class:`StaticSection`.
+
+    :param str name: the attribute name to use in the config file
+    :param bool default: the default value to use if this setting is not
+                         present in the config file
+
+    If the ``default`` value is not specified, it will be ``False``.
+    """
+    def __init__(self, name, default=False):
+        super(BooleanAttribute, self).__init__(
+            name, default=default, is_secret=False)
+
+    def configure(self, prompt, default, parent, section_name):
+        """Parse and return a value from user's input.
+
+        :param str prompt: text to show the user
+        :param bool default: default value used if no input given
+        :param parent: usually the parent Config object
+        :type parent: :class:`~sopel.config.Config`
+        :param str section_name: the name of the containing section
+
+        This method displays the ``prompt`` and waits for user's input on the
+        terminal. If no input is provided (i.e. the user just presses "Enter"),
+        the ``default`` value is returned instead.
+        """
+        prompt = '{} ({})'.format(prompt, 'Y/n' if default else 'y/N')
+        value = get_input(prompt + ' ') or default
+        section = getattr(parent, section_name)
+        return self._parse(value, parent, section)
+
+    def serialize(self, value):
+        """Convert a Boolean value to a string for saving to the config file.
+
+        :param bool value: the value to serialize
+        """
+        return 'true' if self.parse(value) else 'false'
+
+    def parse(self, value):
+        """Parse a limited set of values/objects into Boolean representations.
+
+        :param mixed value: the value to parse
+
+        The literal values ``True`` or ``1`` will be parsed as ``True``. The
+        strings ``'1'``, ``'yes'``, ``'y'``, ``'true'``, ``'enable'``,
+        ``'enabled'``, and ``'on'`` will also be parsed as ``True``,
+        regardless of case. All other values will be parsed as ``False``.
+        """
+        if value is True or value == 1:
+            return True
+        if isinstance(value, basestring):
+            return value.lower() in [
+                '1',
+                'enable',
+                'enabled',
+                'on',
+                'true',
+                'y',
+                'yes',
+            ]
+        return bool(value)
+
+    def _parse(self, value, settings, section):
+        return self.parse(value)
+
+    def __set__(self, instance, value):
+        if value is None:
+            instance._parser.remove_option(instance._section_name, self.name)
+            return
+
+        settings = instance._parent
+        section = getattr(settings, instance._section_name)
+        value = self._serialize(value, settings, section)
+        instance._parser.set(instance._section_name, self.name, value)
+
+
 class SecretAttribute(ValidatedAttribute):
     """A config attribute containing a value which must be kept secret.
 

--- a/test/config/test_config_types.py
+++ b/test/config/test_config_types.py
@@ -174,6 +174,72 @@ def test_validated_serialize_bool_custom():
     assert option.serialize('enabled') == 'fixed value'
 
 
+def test_boolean_attribute():
+    option = types.BooleanAttribute('foo')
+    assert option.name == 'foo'
+    assert option.default is False
+
+
+def test_boolean_parse():
+    option = types.BooleanAttribute('foo')
+    assert option.parse('string') is False
+    assert option.parse('1') is True
+    assert option.parse('') is False
+    assert option.parse(1) is True
+
+    # true-ish values
+    assert option.parse('yes') is True
+    assert option.parse('YES') is True
+    assert option.parse('yES') is True
+    assert option.parse('y') is True
+    assert option.parse('Y') is True
+    assert option.parse('true') is True
+    assert option.parse('True') is True
+    assert option.parse('TRUE') is True
+    assert option.parse('trUE') is True
+    assert option.parse('on') is True
+    assert option.parse('ON') is True
+    assert option.parse('On') is True
+    assert option.parse('enable') is True
+    assert option.parse('enabled') is True
+
+    # everything else
+    assert option.parse('no') is False
+    assert option.parse('off') is False
+    assert option.parse('disable') is False
+    assert option.parse('disabled') is False
+
+
+def test_boolean_serialize():
+    option = types.BooleanAttribute('foo')
+    assert option.serialize(True) == 'true'
+    assert option.serialize('string') == 'false'
+    assert option.serialize('1') == 'true'
+    assert option.serialize('') == 'false'
+    assert option.serialize(1) == 'true'
+
+    # true-ish values
+    assert option.serialize('yes') == 'true'
+    assert option.serialize('YES') == 'true'
+    assert option.serialize('yES') == 'true'
+    assert option.serialize('y') == 'true'
+    assert option.serialize('Y') == 'true'
+    assert option.serialize('true') == 'true'
+    assert option.serialize('True') == 'true'
+    assert option.serialize('TRUE') == 'true'
+    assert option.serialize('trUE') == 'true'
+    assert option.serialize('on') == 'true'
+    assert option.serialize('ON') == 'true'
+    assert option.serialize('On') == 'true'
+    assert option.serialize('enable') == 'true'
+    assert option.serialize('enabled') == 'true'
+
+    # everything else
+    assert option.serialize('no') == 'false'
+    assert option.serialize('disable') == 'false'
+    assert option.serialize('disabled') == 'false'
+
+
 def test_secret_attribute():
     option = types.SecretAttribute('foo')
     assert option.name == 'foo'


### PR DESCRIPTION
### Description
Was going to move the helper functions used in `ValidatedAttribute` when `parse == bool`, but it would've required some ridiculous polymorphism. Better to just leave the old stuff—which will also make it easier to mark as deprecated.

Maybe we need to add tests that cover the `default` parameter to some or all of these setting types? I'll chew on that.

When complete, this will implement and close #2019.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches