### PR TITLE
irc: more ways for `bot.say()` to help with overlength messages

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -1209,7 +1209,7 @@ class SopelWrapper(object):
     def __setattr__(self, attr, value):
         return setattr(self._bot, attr, value)
 
-    def say(self, message, destination=None, max_messages=1, trailing=''):
+    def say(self, message, destination=None, max_messages=1, trailing='', finial=''):
         """Override ``Sopel.say`` to use trigger source by default.
 
         :param str message: message to say
@@ -1227,7 +1227,7 @@ class SopelWrapper(object):
         """
         if destination is None:
             destination = self._trigger.sender
-        self._bot.say(self._out_pfx + message, destination, max_messages, trailing)
+        self._bot.say(self._out_pfx + message, destination, max_messages, trailing, finial)
 
     def action(self, message, destination=None):
         """Override ``Sopel.action`` to use trigger source by default.

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -1215,15 +1215,22 @@ class SopelWrapper(object):
         :param str message: message to say
         :param str destination: channel or nickname; defaults to
             :attr:`trigger.sender <sopel.trigger.Trigger.sender>`
-        :param int max_messages: split ``text`` into at most this many messages
-                                 if it is too long to fit in one (optional)
+        :param int max_messages: split ``message`` into at most this many
+                                 messages if it is too long to fit into one
+                                 line (optional)
+        :param str trailing: string to indicate that the ``message`` was
+                             truncated (optional)
+        :param str finial: string that should always appear at the end of
+                           ``message`` (optional)
 
         The ``destination`` will default to the channel in which the
         trigger happened (or nickname, if received in a private message).
 
         .. seealso::
 
-            :meth:`sopel.bot.Sopel.say`
+            For more details about the optional arguments to this wrapper
+            method, consult the documentation for :meth:`sopel.bot.Sopel.say`.
+
         """
         if destination is None:
             destination = self._trigger.sender

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -1209,7 +1209,7 @@ class SopelWrapper(object):
     def __setattr__(self, attr, value):
         return setattr(self._bot, attr, value)
 
-    def say(self, message, destination=None, max_messages=1, trailing='', finial=''):
+    def say(self, message, destination=None, max_messages=1, truncation='', trailing=''):
         """Override ``Sopel.say`` to use trigger source by default.
 
         :param str message: message to say
@@ -1218,10 +1218,10 @@ class SopelWrapper(object):
         :param int max_messages: split ``message`` into at most this many
                                  messages if it is too long to fit into one
                                  line (optional)
-        :param str trailing: string to indicate that the ``message`` was
-                             truncated (optional)
-        :param str finial: string that should always appear at the end of
-                           ``message`` (optional)
+        :param str truncation: string to indicate that the ``message`` was
+                               truncated (optional)
+        :param str trailing: string that should always appear at the end of
+                             ``message`` (optional)
 
         The ``destination`` will default to the channel in which the
         trigger happened (or nickname, if received in a private message).
@@ -1234,7 +1234,7 @@ class SopelWrapper(object):
         """
         if destination is None:
             destination = self._trigger.sender
-        self._bot.say(self._out_pfx + message, destination, max_messages, trailing, finial)
+        self._bot.say(self._out_pfx + message, destination, max_messages, truncation, trailing)
 
     def action(self, message, destination=None):
         """Override ``Sopel.action`` to use trigger source by default.

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -536,16 +536,18 @@ class AbstractBot(object):
         else:
             self.say(text, dest)
 
-    def say(self, text, recipient, max_messages=1, trailing=''):
+    def say(self, text, recipient, max_messages=1, trailing='', finial=''):
         """Send a PRIVMSG to a user or channel.
 
         :param str text: the text to send
         :param str recipient: the message recipient
         :param int max_messages: split ``text`` into at most this many messages
                                  if it is too long to fit in one (optional)
-        :param str trailing: text to append if ``text`` is too long to fit in
+        :param str trailing: string to append if ``text`` is too long to fit in
                              a single message, or into the last message if
                              ``max_messages`` is greater than 1 (optional)
+        :param str finial: string to append after ``text`` and (if used)
+                           ``trailing`` (optional)
 
         By default, this will attempt to send the entire ``text`` in one
         message. If the text is too long for the server, it may be truncated.
@@ -556,20 +558,46 @@ class AbstractBot(object):
         nickname and hostmask), or exactly at the "safe length" if no such
         space character exists.
 
-        If the ``text`` is too long to fit into the specified number of
-        messages using the above splitting, the final message will contain the
-        entire remainder, which may be truncated by the server.
+        If the ``text`` is too long to fit into the specified number of messages
+        using the above splitting, the final message will contain the entire
+        remainder, which may be truncated by the server. You can specify
+        ``trailing`` to tell Sopel how it should indicate that the remaining
+        ``text`` was cut off. Note that the ``trailing`` parameter must include
+        leading whitespace if you desire any between it and the truncated text.
 
-        The ``trailing`` parameter allows gracefully terminating a ``text``
-        that is too long to fit in the specified number of messages. The final
-        message (or only message, if ``max_messages`` is left at the default
-        value of 1) will be truncated slightly to fit the ``trailing`` string.
-        Note that the ``trailing`` parameter must include leading whitespace
-        if you desire any between it and the truncated text.
+        The ``finial`` parameter is *always* appended to ``text``, after the
+        point where ``trailing`` would be inserted if necessary. It's useful for
+        making sure e.g. a link is always included, even if the summary your
+        plugin fetches is too long to fit.
+
+        Here are some examples of how the ``trailing`` and ``finial`` parameters
+        work, using an artificially low maximum line length::
+
+            # bot.say() outputs <text> + <trailing?> + <finial>
+            #                   always    if needed       always
+
+            bot.say(
+                '"This is a short quote.',
+                trailing=' […]',
+                finial='"')
+            # Sopel says: "This is a short quote."
+
+            bot.say(
+                '"This quote is very long and will not fit on a line.',
+                trailing=' […]',
+                finial='"')
+            # Sopel says: "This quote is very long […]"
+
+            bot.say(
+                # note the " included at the end this time
+                '"This quote is very long and will not fit on a line."',
+                trailing=' […]')
+            # Sopel says: "This quote is very long […]
+            # The ending " goes missing
 
         .. versionadded:: 7.1
 
-            The ``trailing`` parameter.
+            The ``trailing`` and ``finial`` parameters.
 
         """
         excess = ''
@@ -577,7 +605,7 @@ class AbstractBot(object):
             # Make sure we are dealing with a Unicode string
             text = text.decode('utf-8')
 
-        if max_messages > 1 or trailing:
+        if max_messages > 1 or trailing or finial:
             # Handle message splitting/truncation only if needed
             try:
                 hostmask_length = len(self.hostmask)
@@ -604,13 +632,21 @@ class AbstractBot(object):
                 - 2  # space after recipient, colon before text
                 - 2  # trailing CRLF
             )
+
+            if max_messages == 1 and finial:
+                safe_length -= len(finial.encode('utf-8'))
             text, excess = tools.get_sendable_message(text, safe_length)
 
-        if max_messages == 1 and excess and trailing:
-            # only append `trailing` if this is the last message AND it's still too long
-            safe_length -= len(trailing.encode('utf-8'))
-            text, excess = tools.get_sendable_message(text, safe_length)
-            text += trailing
+        if max_messages == 1:
+            if excess and trailing:
+                # only append `trailing` if this is the last message AND it's still too long
+                safe_length -= len(trailing.encode('utf-8'))
+                text, excess = tools.get_sendable_message(text, safe_length)
+                text += trailing
+
+            # ALWAYS append `finial`;
+            # its length is included when determining if truncation happened above
+            text += finial
 
         flood_max_wait = self.settings.core.flood_max_wait
         flood_burst_lines = self.settings.core.flood_burst_lines
@@ -688,4 +724,4 @@ class AbstractBot(object):
         # Now that we've sent the first part, we need to send the rest if
         # requested. Doing so recursively seems simpler than iteratively.
         if max_messages > 1 and excess:
-            self.say(excess, recipient, max_messages - 1, trailing)
+            self.say(excess, recipient, max_messages - 1, trailing, finial)

--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -245,7 +245,7 @@ def comment_info(bot, trigger, match):
         author=author, points=c.score, points_text=points_text,
         posted=posted, comment=' '.join(lines))
 
-    bot.say(message, trailing=' […]')
+    bot.say(message, truncation=' […]')
 
 
 def subreddit_info(bot, trigger, match, commanded=False):
@@ -309,7 +309,7 @@ def subreddit_info(bot, trigger, match, commanded=False):
         link=link, nsfw=nsfw, subscribers='{:,}'.format(s.subscribers),
         created=created, public_description=s.public_description)
 
-    bot.say(message, trailing=' […]')
+    bot.say(message, truncation=' […]')
 
 
 def redditor_info(bot, trigger, match, commanded=False):

--- a/sopel/modules/tld.py
+++ b/sopel/modules/tld.py
@@ -339,7 +339,7 @@ def gettld(bot, trigger):
 
     message = ' | '.join(items)
 
-    bot.say(message, trailing=' […]')
+    bot.say(message, truncation=' […]')
 
 
 @plugin.command('tldcache')

--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -167,11 +167,11 @@ def say_snippet(bot, trigger, server, query, show_url=True):
 
     msg = '{} | "{}'.format(page_name, snippet)
 
-    trailing = '"'
+    finial = '"'
     if show_url:
-        trailing += ' | ' + url
+        finial += ' | ' + url
 
-    bot.say(msg, trailing=' […]' + trailing)
+    bot.say(msg, trailing=' […]', finial=finial)
 
 
 def mw_snippet(server, query):

--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -167,11 +167,11 @@ def say_snippet(bot, trigger, server, query, show_url=True):
 
     msg = '{} | "{}'.format(page_name, snippet)
 
-    finial = '"'
+    trailing = '"'
     if show_url:
-        finial += ' | ' + url
+        trailing += ' | ' + url
 
-    bot.say(msg, trailing=' […]', finial=finial)
+    bot.say(msg, truncation=' […]', trailing=trailing)
 
 
 def mw_snippet(server, query):
@@ -200,7 +200,7 @@ def say_section(bot, trigger, server, query, section):
         return
 
     msg = '{} - {} | "{}"'.format(page_name, section.replace('_', ' '), snippet)
-    bot.say(msg, trailing=' […]"')
+    bot.say(msg, truncation=' […]"')
 
 
 def mw_section(server, query, section):

--- a/sopel/modules/wiktionary.py
+++ b/sopel/modules/wiktionary.py
@@ -124,7 +124,7 @@ def wiktionary(bot, trigger):
     if len(result) < 300:
         result = format(word, definitions, 5)
 
-    bot.say(result, trailing=' […]')
+    bot.say(result, truncation=' […]')
 
 
 @plugin.command('ety')
@@ -144,4 +144,4 @@ def wiktionary_ety(bot, trigger):
 
     result = "{}: {}".format(word, etymology)
 
-    bot.say(result, trailing=' […]')
+    bot.say(result, truncation=' […]')

--- a/test/test_irc.py
+++ b/test/test_irc.py
@@ -267,59 +267,59 @@ def test_say_long_extra_multi_message_multibyte_recipient(bot):
     )
 
 
-def test_say_long_trailing_fit(bot):
+def test_say_long_truncation_fit(bot):
     """Test optional truncation indicator with message that fits in one line."""
     text = 'a' * (512 - prefix_length(bot) - len('PRIVMSG #sopel :\r\n') - 3)
-    bot.say(text + 'ttt', '#sopel', trailing='...')
+    bot.say(text + 'ttt', '#sopel', truncation='...')
 
     assert bot.backend.message_sent == rawlist(
         'PRIVMSG #sopel :%s' % text + 'ttt',  # nothing is truncated or replaced
     )
 
 
-def test_say_long_trailing_extra(bot):
+def test_say_long_truncation_extra(bot):
     """Test optional truncation indicator with message that is too long."""
     text = 'a' * (512 - prefix_length(bot) - len('PRIVMSG #sopel :\r\n') - 3)
-    bot.say(text + 'ttt' + 'b', '#sopel', trailing='...')
+    bot.say(text + 'ttt' + 'b', '#sopel', truncation='...')
 
     assert bot.backend.message_sent == rawlist(
-        # 'b' is truncated; 'ttt' is replaced by `trailing`
+        # 'b' is truncated; 'ttt' is replaced by `truncation`
         'PRIVMSG #sopel :%s' % text + '...',
     )
 
 
-def test_say_long_trailing_extra_multi_message(bot):
+def test_say_long_truncation_extra_multi_message(bot):
     """Test optional truncation indicator with message splitting."""
     msg1 = 'a' * (512 - prefix_length(bot) - len('PRIVMSG #sopel :\r\n'))
     msg2 = msg1[:-3] + 'ttt'
-    bot.say(msg1 + msg2 + 'b', '#sopel', max_messages=2, trailing='...')
+    bot.say(msg1 + msg2 + 'b', '#sopel', max_messages=2, truncation='...')
 
     assert bot.backend.message_sent == rawlist(
         # split as expected
         'PRIVMSG #sopel :%s' % msg1,
-        # 'b' is truncated; 'ttt' is replaced by `trailing`
+        # 'b' is truncated; 'ttt' is replaced by `truncation`
         'PRIVMSG #sopel :%s' % msg2.replace('ttt', '...'),
     )
 
 
-def test_say_long_trailing_extra_multi_message_multibyte(bot):
+def test_say_long_truncation_extra_multi_message_multibyte(bot):
     """Test optional truncation indicator with message splitting."""
     msg1 = 'a' * (512 - prefix_length(bot) - len('PRIVMSG #sopel :\r\n'))
     msg2 = msg1[:-3] + 'ttt'
-    bot.say(msg1 + msg2 + 'b', '#sopel', max_messages=2, trailing='…')
+    bot.say(msg1 + msg2 + 'b', '#sopel', max_messages=2, truncation='…')
 
     assert bot.backend.message_sent == rawlist(
         # split as expected
         'PRIVMSG #sopel :%s' % msg1,
-        # 'b' is truncated; 'ttt' is replaced by `trailing`
+        # 'b' is truncated; 'ttt' is replaced by `truncation`
         'PRIVMSG #sopel :%s' % msg2.replace('ttt', '…'),
     )
 
 
-def test_say_finial(bot):
-    """Test optional finial string."""
+def test_say_trailing(bot):
+    """Test optional trailing string."""
     text = '"This is a test quote.'
-    bot.say(text, '#sopel', finial='"')
+    bot.say(text, '#sopel', trailing='"')
 
     assert bot.backend.message_sent == rawlist(
         # combined
@@ -327,16 +327,16 @@ def test_say_finial(bot):
     )
 
 
-def test_say_long_trailing_finial(bot):
-    """Test optional truncation indicator AND finial string together."""
+def test_say_long_truncation_trailing(bot):
+    """Test optional truncation indicator AND trailing string together."""
     msg1 = 'a' * (512 - prefix_length(bot) - len('PRIVMSG #sopel :\r\n'))
     msg2 = msg1[:-4] + 'bbbc'
-    bot.say(msg1 + msg2 + 'd', '#sopel', max_messages=2, trailing='…', finial='q')
+    bot.say(msg1 + msg2 + 'd', '#sopel', max_messages=2, truncation='…', trailing='q')
 
     assert bot.backend.message_sent == rawlist(
         # split as expected
         'PRIVMSG #sopel :%s' % msg1,
-        # 'd' is truncated; 'bbb' is replaced by `trailing`; 'c' is replaced by `finial`
+        # 'd' is truncated; 'bbb' is replaced by `truncation`; 'c' is replaced by `trailing`
         'PRIVMSG #sopel :%s' % msg2.replace('bbb', '…').replace('c', 'q')
     )
 

--- a/test/test_irc.py
+++ b/test/test_irc.py
@@ -316,6 +316,31 @@ def test_say_long_trailing_extra_multi_message_multibyte(bot):
     )
 
 
+def test_say_finial(bot):
+    """Test optional finial string."""
+    text = '"This is a test quote.'
+    bot.say(text, '#sopel', finial='"')
+
+    assert bot.backend.message_sent == rawlist(
+        # combined
+        'PRIVMSG #sopel :%s' % text + '"'
+    )
+
+
+def test_say_long_trailing_finial(bot):
+    """Test optional truncation indicator AND finial string together."""
+    msg1 = 'a' * (512 - prefix_length(bot) - len('PRIVMSG #sopel :\r\n'))
+    msg2 = msg1[:-4] + 'bbbc'
+    bot.say(msg1 + msg2 + 'd', '#sopel', max_messages=2, trailing='…', finial='q')
+
+    assert bot.backend.message_sent == rawlist(
+        # split as expected
+        'PRIVMSG #sopel :%s' % msg1,
+        # 'd' is truncated; 'bbb' is replaced by `trailing`; 'c' is replaced by `finial`
+        'PRIVMSG #sopel :%s' % msg2.replace('bbb', '…').replace('c', 'q')
+    )
+
+
 def test_say_no_repeat_protection(bot):
     # five is fine
     bot.say('hello', '#sopel')


### PR DESCRIPTION
### Description
Addresses a shortcoming of the `trailing` parameter, which alone is insufficient to handle some common output patterns used by Sopel's own core plugins.

For example, the `wikipedia` plugin outputs article snippets in between quotation marks. Long snippets are truncated and the quote closed by the `trailing` parameter, but short snippets never invoke `trailing`. They lose both the closing quote AND the URL linking to the full article.

With these now _two_ optional parameters (`truncation` and `trailing`), it will be easier for plugins to include variable-length data in "the middle" of a message and still guarantee that any important information at the end of the line will be shown.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
~~The name `finial` is the best idea I could think up while writing this patch, but there's probably a better option out there. What I _want_ is `finally`, but that's a reserved word…~~ Replaced "finial" with "trailing", and renamed the existing "trailing" parameter to "truncation" (short for "truncation indicator").

When writing the new parameter, I thought more core plugins would use it. Looks like only `wikipedia` needs the extra finesse, but that's fine. I have a few external plugins that will take advantage.

And yes, I'm fully aware that this approaches over-engineering. 🙃