### PR TITLE
currency: improve error handling

### DIFF
--- a/sopel/modules/currency.py
+++ b/sopel/modules/currency.py
@@ -193,7 +193,6 @@ def update_rates(bot):
 
     response.raise_for_status()
     rates_fiat = response.json()
-    rates_updated = time.time()
 
     rates = rates_fiat['rates']
     rates['EUR'] = 1.0  # Put this here to make logic easier
@@ -203,6 +202,10 @@ def update_rates(bot):
     for rate in rates_crypto['rates']:
         if rate.upper() not in rates:
             rates[rate.upper()] = rates_crypto['rates'][rate]['value'] * eur_btc_rate
+
+    # if an error aborted the operation prematurely, we want the next call to retry updating rates
+    # therefore we'll update the stored timestamp at the last possible moment
+    rates_updated = time.time()
 
 
 @plugin.command('cur', 'currency', 'exchange')

--- a/sopel/modules/currency.py
+++ b/sopel/modules/currency.py
@@ -97,9 +97,11 @@ def exchange(bot, match):
         bot.reply("Something went wrong while I was getting the exchange rate.")
         LOGGER.error("Error in GET request: {}".format(err))
         return
-    except ValueError:
-        bot.reply("Error: Got malformed data.")
-        LOGGER.error("Invalid json on update_rates")
+    except (KeyError, ValueError) as err:
+        bot.reply("Error: Could not update exchange rates. Try again later.")
+        LOGGER.error("{} on update_rates".format(
+            'Invalid JSON' if type(err).__name__ == 'ValueError' else 'Missing JSON value',
+        ))
         return
     except FixerError as err:
         bot.reply('Sorry, something went wrong with Fixer')


### PR DESCRIPTION
### Description
This fixes two gaps in the `currency` plugin's error handling:

  1. `KeyError` was not handled. Such an exception could result if the exchange rate API returns valid JSON that doesn't contain the expected keys (perhaps an error reply).
  2. `rates_updated` was refreshed before executing all code that could prematurely terminate the update operation, leading to some (but not all) of the data being stale for at least 24 hours until the next full `update_rates()` run.

Additionally, catching `KeyError` will allow the bot to continue converting the input as normal if it has rates cached.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - Theoretically, at least. I don't have a good way to generate API errors at will. A good future enhancement would be writing a test suite for this plugin in `test/modules/test_modules_currency.py` that explicitly feeds it bad JSON (invalid, missing expected keys, etc.) to verify that the error handling works as expected.

### Notes
Discovered point 1 above when I ran the `.cur` command for the first time in a while and it presumably tried to update the exchange rates, but couldn't find `rates_fiat['rates']`. Running the command again succeeded, hence my decision to add "Try again later." as part of the revised error message.

Possible future enhancement: adding a note to the conversion output if the cached rates are older than 2-3x the refresh interval.