### PR TITLE
find_updates, test: create test to verify error case behavior

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -12,6 +12,7 @@ pytest-vcr==1.0.2; python_version != '3.3'
 pytest-vcr==0.3.0; python_version == '3.3'
 PyYAML<5.1; python_version == '3.3'
 PyYAML<5.3; python_version == '3.4'
+requests-mock==1.9.1
 setuptools<40.0; python_version == '3.3'
 sphinx
 # autoprogram extension added type annotations in 0.1.6

--- a/sopel/modules/find_updates.py
+++ b/sopel/modules/find_updates.py
@@ -23,6 +23,7 @@ from sopel import (
 
 
 wait_time = 24 * 60 * 60  # check once per day
+max_failures = 4
 version_url = 'https://sopel.chat/latest.json'
 stable_message = (
     'A new Sopel version, {}, is available; I am running {}. Please update '
@@ -70,7 +71,7 @@ def check_version(bot):
         success = False
 
     if not success:
-        if bot.memory.get('update_failures', 0) <= 4:
+        if bot.memory.get('update_failures', 0) <= max_failures:
             # not enough failures to worry; silently ignore this one
             return
 

--- a/test/modules/test_modules_find_updates.py
+++ b/test/modules/test_modules_find_updates.py
@@ -1,0 +1,48 @@
+# coding=utf-8
+"""Tests for Sopel's ``find_updates`` plugin"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import pytest
+import requests.exceptions
+
+from sopel.modules import find_updates
+
+
+TMP_CONFIG = """
+[core]
+owner = Admin
+nick = Sopel
+enable =
+    find_updates
+host = chat.freenode.net
+"""
+
+
+@pytest.fixture
+def mockbot(configfactory, botfactory):
+    tmpconfig = configfactory('default.ini', TMP_CONFIG)
+    return botfactory(tmpconfig)
+
+
+def test_check_version_request_fails(mockbot, requests_mock):
+    """Test normal stable update check."""
+    requests_mock.get(
+        find_updates.version_url,
+        exc=requests.exceptions.RequestException,
+    )
+
+    # check as many times as are expected to be silent
+    # we're checking *before* it fails, so the failure count here is lower
+    # than when check_version() compares with <= afterward
+    while mockbot.memory.get('update_failures', 0) < find_updates.max_failures:
+        find_updates.check_version(mockbot)
+
+        assert len(mockbot.backend.message_sent) == 0, (
+            'check_version() should fail silently until max_failures is reached')
+
+    # this is check number max_failures; *now* it should fail loudly
+    find_updates.check_version(mockbot)
+
+    assert len(mockbot.backend.message_sent) == 2, (
+        'check_version() is expected to send two lines to IRC if it has been '
+        'unable to fetch update info for max_failures tries')


### PR DESCRIPTION
### Description
Validates the behavior fixed in #2052.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - On Python 3.8, _and_ (accidentally) 3.3. The latter's the version I was worried about breaking, anyway.
- [x] I have tested the functionality of the things this change touches

### Notes
Haven't milestoned this yet, as I'm not sure if I want to add a new dependency (even only for dev) on 7.1.x this late. Looking for second opinions before I decide!