### PR TITLE
tools: Convert `deprecated` decorator to use logging output

### DIFF
--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -175,17 +175,21 @@ def deprecated(
             if mod:
                 module_name = mod.__name__
             if module_name:
-                if 'sopel.' in module_name:
+                if module_name.startswith('sopel.'):
                     # core, or core plugin
                     logger = logging.getLogger(module_name)
                 else:
                     # probably a plugin; use Sopel's public API for getting the
                     # logger for a plugin
-                    logger = get_logger(module_name.replace('sopel_modules.', ''))
+                    if module_name.startswith('sopel_modules.'):
+                        # namespace package plugins have a prefix, obviously
+                        # TODO: use str.removeprefix() when we drop Python<3.9
+                        module_name = module_name.replace('sopel_modules.', '', 1)
+                    logger = get_logger(module_name)
             else:
                 # don't know the module/plugin name, but we want to make sure
-                # the log line is still output, so fudge it
-                logger = logging.getLogger('sopel.<unknown>')
+                # the log line is still output, so just get *something*
+                logger = logging.getLogger(__name__)
 
             # Format only the desired stack frame
             trace = traceback.extract_stack()


### PR DESCRIPTION
### Description
No more `stderr()` calls!

One notable exception: If a `core` section setting uses some deprecated behavior, that warning will not be logged in the usual way because logging isn't set up yet. The bot _has_ to load its core settings before it can get logging up, since that's where the logging itself is configured. Core plugins' `StaticSection`s get loaded later, after logging is available, so they work as expected.

We core devs will just have to pay attention to the console output during testing in the future if any more config stuff used by the `core` section gets deprecated. It's not something that end-users (or even plugin devs) will need to worry about.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - Before: Lots of deprecation warnings from core plugins about using `BooleanAttribute` instead of `ValidatedAttribute` with `parse=bool`, printed directly to the console.
  - After: Same warnings, but they all go through the logging formatter instead and appear in the log file. (Well, _almost_ all; see note above).

### Notes
I worked on this quite intently for a day or two last month, but a new work project began consuming the majority of my thoughts and I forgot to even mention this, let alone propose it as a pull request. I remembered this upon reviewing my list of local branches after cleaning up a bunch of merged work.

My next PR will probably be to replace the deprecated behavior that spawned all these warnings, because I didn't do so in #2044. This patch is best tested first, since these are the _only_ deprecation warnings present in Sopel's own code at this point.