### PR TITLE
core, modules: replace deprecated uses of `parse=bool` in settings

### DIFF
--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -5,6 +5,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import os.path
 
 from sopel.config.types import (
+    BooleanAttribute,
     ChoiceAttribute,
     FilenameAttribute,
     ListAttribute,
@@ -685,7 +686,7 @@ class CoreSection(StaticSection):
 
     """
 
-    log_raw = ValidatedAttribute('log_raw', bool, default=False)
+    log_raw = BooleanAttribute('log_raw', default=False)
     """Whether a log of raw lines as sent and received should be kept.
 
     :default: ``no``
@@ -937,7 +938,7 @@ class CoreSection(StaticSection):
 
     """
 
-    not_configured = ValidatedAttribute('not_configured', bool, default=False)
+    not_configured = BooleanAttribute('not_configured', default=False)
     """For package maintainers. Not used in normal configurations.
 
     :default: ``False``
@@ -1035,7 +1036,7 @@ class CoreSection(StaticSection):
 
     """
 
-    reply_errors = ValidatedAttribute('reply_errors', bool, default=True)
+    reply_errors = BooleanAttribute('reply_errors', default=True)
     """Whether to reply to the sender of a message that triggered an error.
 
     :default: ``True``
@@ -1174,7 +1175,7 @@ class CoreSection(StaticSection):
 
     """
 
-    use_ssl = ValidatedAttribute('use_ssl', bool, default=False)
+    use_ssl = BooleanAttribute('use_ssl', default=False)
     """Whether to use a SSL/TLS encrypted connection.
 
     :default: ``False``
@@ -1200,7 +1201,7 @@ class CoreSection(StaticSection):
 
     """
 
-    verify_ssl = ValidatedAttribute('verify_ssl', bool, default=True)
+    verify_ssl = BooleanAttribute('verify_ssl', default=True)
     """Whether to require a trusted certificate for encrypted connections.
 
     :default: ``True``

--- a/sopel/modules/admin.py
+++ b/sopel/modules/admin.py
@@ -28,10 +28,9 @@ ERROR_NOTHING_TO_SAY = 'I need a channel and a message to talk.'
 
 
 class AdminSection(types.StaticSection):
-    hold_ground = types.ValidatedAttribute('hold_ground', bool, default=False)
+    hold_ground = types.BooleanAttribute('hold_ground', default=False)
     """Auto re-join on kick"""
-    auto_accept_invite = types.ValidatedAttribute('auto_accept_invite', bool,
-                                                  default=True)
+    auto_accept_invite = types.BooleanAttribute('auto_accept_invite', default=True)
     """Auto-join channels when invited"""
 
 

--- a/sopel/modules/currency.py
+++ b/sopel/modules/currency.py
@@ -40,9 +40,7 @@ rates_updated = 0.0
 class CurrencySection(types.StaticSection):
     fixer_io_key = types.ValidatedAttribute('fixer_io_key', default=None)
     """Optional API key for Fixer.io (increases currency support)"""
-    auto_convert = types.ValidatedAttribute('auto_convert',
-                                            parse=bool,
-                                            default=False)
+    auto_convert = types.BooleanAttribute('auto_convert', default=False)
     """Whether to convert currencies without an explicit command"""
 
 

--- a/sopel/modules/help.py
+++ b/sopel/modules/help.py
@@ -182,9 +182,8 @@ class HelpSection(types.StaticSection):
                                          REPLY_METHODS,
                                          default='channel')
     """Where/how to reply to help commands (public/private)."""
-    show_server_host = types.ValidatedAttribute('show_server_host',
-                                                bool,
-                                                default=True)
+    show_server_host = types.BooleanAttribute('show_server_host',
+                                              default=True)
     """Show the IRC server's hostname/IP in the first line of the help listing?"""
 
 

--- a/sopel/modules/safety.py
+++ b/sopel/modules/safety.py
@@ -47,9 +47,7 @@ cache_limit = 512
 
 
 class SafetySection(types.StaticSection):
-    enabled_by_default = types.ValidatedAttribute('enabled_by_default',
-                                                  bool,
-                                                  default=True)
+    enabled_by_default = types.BooleanAttribute('enabled_by_default', default=True)
     """Whether to enable URL safety in all channels where it isn't explicitly disabled."""
     known_good = types.ListAttribute('known_good')
     """List of "known good" domains to ignore."""

--- a/sopel/modules/tell.py
+++ b/sopel/modules/tell.py
@@ -25,8 +25,8 @@ LOGGER = logging.getLogger(__name__)
 
 
 class TellSection(types.StaticSection):
-    use_private_reminder = types.ValidatedAttribute(
-        'use_private_reminder', parse=bool, default=False)
+    use_private_reminder = types.BooleanAttribute(
+        'use_private_reminder', default=False)
     """When set to ``true``, Sopel will send reminder as private message."""
     maximum_public = types.ValidatedAttribute(
         'maximum_public', parse=int, default=4)

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -54,8 +54,8 @@ MAX_BYTES = 655360 * 2
 
 
 class UrlSection(types.StaticSection):
-    enable_auto_title = types.ValidatedAttribute(
-        'enable_auto_title', bool, default=True)
+    enable_auto_title = types.BooleanAttribute(
+        'enable_auto_title', default=True)
     """Enable auto-title (enabled by default)"""
     # TODO some validation rules maybe?
     exclude = types.ListAttribute('exclude')
@@ -65,11 +65,11 @@ class UrlSection(types.StaticSection):
     shorten_url_length = types.ValidatedAttribute(
         'shorten_url_length', int, default=0)
     """If greater than 0, the title fetcher will include a TinyURL version of links longer than this many characters."""
-    enable_private_resolution = types.ValidatedAttribute(
-        'enable_private_resolution', bool, default=False)
+    enable_private_resolution = types.BooleanAttribute(
+        'enable_private_resolution', default=False)
     """Enable URL lookups for RFC1918 addresses"""
-    enable_dns_resolution = types.ValidatedAttribute(
-        'enable_dns_resolution', bool, default=False)
+    enable_dns_resolution = types.BooleanAttribute(
+        'enable_dns_resolution', default=False)
     """Enable DNS resolution for all domains to validate if there are RFC1918 resolutions"""
 
 


### PR DESCRIPTION
### Description
This just eliminates a bunch of deprecation warnings that we probably don't want to ship in 7.1.0.

These should have been fixed as part of #2044, but past-me was apparently quite lazy. 🙃
However they were also the inspiration for, and an easy way to test, #2058. 🙂

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches