### PR TITLE
wiktionary: fix fetching etymology containing citations

### DIFF
--- a/sopel/modules/wiktionary.py
+++ b/sopel/modules/wiktionary.py
@@ -18,7 +18,7 @@ from sopel.tools import web
 PLUGIN_OUTPUT_PREFIX = '[wiktionary] '
 
 uri = 'https://en.wiktionary.org/w/index.php?title=%s&printable=yes'
-r_sup = re.compile(r'<sup[^>]+>.+</sup>')  # Superscripts that are references only, not ordinal indicators, etc...
+r_sup = re.compile(r'<sup[^>]+>.+?</sup>')  # Superscripts that are references only, not ordinal indicators, etc...
 r_tag = re.compile(r'<[^>]+>')
 r_ul = re.compile(r'(?ims)<ul>.*?</ul>')
 

--- a/sopel/modules/wiktionary.py
+++ b/sopel/modules/wiktionary.py
@@ -73,12 +73,12 @@ def wikt(word):
                     break
 
         if not is_new_mode:
+            if (mode == 'etymology') and ('<p>' in line):
+                etymology = text(line)
             # 'id="' can occur in definition lines <li> when <sup> tag is used for references;
             # make sure those are not excluded (see e.g., abecedarian).
-            if ('id="' in line) and ('<li>' not in line):
+            elif ('id="' in line) and ('<li>' not in line):
                 mode = None
-            elif (mode == 'etymology') and ('<p>' in line):
-                etymology = text(line)
             elif (mode is not None) and ('<li>' in line):
                 definitions.setdefault(mode, []).append(text(line))
 


### PR DESCRIPTION
### Description
I noticed that fetching etymology from Wiktionary would fail sometimes, even though the section was there. Tracked down the exact code path with the help of `pdb`. Two related fixes:

* Don't check for extraneous `id` attributes in the HTML when in `etymology` mode (in `wikt()` function)
* Allow for multiple citations (`<sup>`/`</sup>` pairs) in one line when stripping HTML (in `text()` function)

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
I really want to convert this to a proper parser, but don't want to further delay 7.1. Onto the idea pile it goes.