### PR TITLE
tests: `MockIRCServer` methods should block by default

### DIFF
--- a/sopel/tests/factories.py
+++ b/sopel/tests/factories.py
@@ -34,7 +34,7 @@ class BotFactory(object):
         every other plugin from ``preloads``::
 
             factory = BotFactory()
-            bot = factory.with_autoloads(settings, ['emoticons', 'remind'])
+            bot = factory.preloaded(settings, ['emoticons', 'remind'])
 
         .. note::
 

--- a/sopel/tests/factories.py
+++ b/sopel/tests/factories.py
@@ -108,8 +108,8 @@ class IRCFactory(object):
         The :func:`~sopel.tests.pytest_plugin.ircfactory` fixture can be used
         to create this factory.
     """
-    def __call__(self, mockbot):
-        return MockIRCServer(mockbot)
+    def __call__(self, mockbot, join_threads=True):
+        return MockIRCServer(mockbot, join_threads)
 
 
 class UserFactory(object):

--- a/sopel/tests/mocks.py
+++ b/sopel/tests/mocks.py
@@ -44,9 +44,14 @@ class MockIRCServer(object):
     The default ``join_threads`` behavior is suitable for testing most common
     plugin callables, and ensures that all callables dispatched by the ``bot``
     in response to messages sent via this ``MockIRCServer`` are finished
-    running before execution can continue. This parameter exists only in case
-    some advanced plugin design requires the automatic management of triggered
-    threads to be disabled for successful testing.
+    running before execution can continue. If set to ``False``, the mock
+    server will not wait for the bot to finish processing threaded
+    :term:`callables <Plugin callable>` before returning.
+
+    .. note::
+
+        You can override ``join_threads`` on a per-method-call basis with the
+        ``blocking`` arguments to the instance methods below.
 
     The :class:`~sopel.tests.factories.IRCFactory` factory can be used to
     create such mock object, either directly or by using ``py.test`` and the
@@ -59,18 +64,21 @@ class MockIRCServer(object):
     def __init__(self, bot, join_threads=True):
         self.bot = bot
         self.join_threads = join_threads
+        # TODO: `blocking` method args below should be made kwarg-ONLY in py3
 
     @property
     def chanserv(self):
         """ChanServ's message prefix."""
         return 'ChanServ!ChanServ@services.'
 
-    def channel_joined(self, channel, users=None):
+    def channel_joined(self, channel, users=None, blocking=None):
         """Send events as if the bot just joined a channel.
 
         :param str channel: channel to send message for
         :param list users: list (or tuple) of nicknames that will be present
                            in the ``RPL_NAMREPLY`` event
+        :param bool blocking: whether to block until all triggered threads
+                              have finished (optional)
 
         This will send 2 messages to the bot:
 
@@ -91,6 +99,19 @@ class MockIRCServer(object):
 
         This is particularly useful to populate the bot's memory of who is in
         a channel.
+
+        If ``blocking`` is ``True``, this method will wait to join all running
+        triggers' threads before returning. Setting it to ``False`` will skip
+        this step. If not specified, this :class:`MockIRCServer` instance's
+        ``join_threads`` argument will be obeyed.
+
+        .. versionadded:: 7.1
+
+            The ``blocking`` parameter.
+
+        .. seealso::
+
+            The ``join_threads`` argument to :class:`MockIRCServer`.
 
         .. note::
 
@@ -116,22 +137,37 @@ class MockIRCServer(object):
         )
         self.bot.on_message(message)
 
-        if self.join_threads:
+        if (blocking is None and self.join_threads) or blocking:
             for t in self.bot.running_triggers:
                 t.join()
 
-    def mode_set(self, channel, flags, users):
+    def mode_set(self, channel, flags, users, blocking=None):
         """Send a MODE event for a ``channel``
 
         :param str channel: channel receiving the MODE event
         :param str flags: MODE flags set
         :param list users: users getting the MODE flags
+        :param bool blocking: whether to block until all triggered threads
+                              have finished (optional)
 
         This will send a MODE message as if ``ChanServ`` added/removed channel
         modes for a set of ``users``. This method assumes the ``flags``
         parameter follows the `IRC specification for MODE`__::
 
             factory.mode_set('#test', '+vo-v', ['UserV', UserOP', 'UserAnon'])
+
+        If ``blocking`` is ``True``, this method will wait to join all running
+        triggers' threads before returning. Setting it to ``False`` will skip
+        this step. If not specified, this :class:`MockIRCServer` instance's
+        ``join_threads`` argument will be obeyed.
+
+        .. versionadded:: 7.1
+
+            The ``blocking`` parameter.
+
+        .. seealso::
+
+            The ``join_threads`` argument to :class:`MockIRCServer`.
 
         .. __: https://tools.ietf.org/html/rfc1459#section-4.2.3
         """
@@ -143,21 +179,36 @@ class MockIRCServer(object):
         )
         self.bot.on_message(message)
 
-        if self.join_threads:
+        if (blocking is None and self.join_threads) or blocking:
             for t in self.bot.running_triggers:
                 t.join()
 
-    def join(self, user, channel):
+    def join(self, user, channel, blocking=None):
         """Send a ``channel`` JOIN event from ``user``.
 
         :param user: factory for the user who joins the ``channel``
         :type user: :class:`MockUser`
         :param str channel: channel the ``user`` joined
+        :param bool blocking: whether to block until all triggered threads
+                              have finished (optional)
 
         This will send a ``JOIN`` message as if ``user`` just joined the
         channel::
 
             factory.join(MockUser('NewUser'), '#test')
+
+        If ``blocking`` is ``True``, this method will wait to join all running
+        triggers' threads before returning. Setting it to ``False`` will skip
+        this step. If not specified, this :class:`MockIRCServer` instance's
+        ``join_threads`` argument will be obeyed.
+
+        .. versionadded:: 7.1
+
+            The ``blocking`` parameter.
+
+        .. seealso::
+
+            The ``join_threads`` argument to :class:`MockIRCServer`.
 
         .. seealso::
 
@@ -166,22 +217,37 @@ class MockIRCServer(object):
         """
         self.bot.on_message(user.join(channel))
 
-        if self.join_threads:
+        if (blocking is None and self.join_threads) or blocking:
             for t in self.bot.running_triggers:
                 t.join()
 
-    def say(self, user, channel, text):
+    def say(self, user, channel, text, blocking=None):
         """Send a ``PRIVMSG`` to ``channel`` by ``user``.
 
         :param user: factory for the user who sends a message to ``channel``
         :type user: :class:`MockUser`
         :param str channel: recipient of the ``user``'s ``PRIVMSG``
         :param str text: content of the message sent to the ``channel``
+        :param bool blocking: whether to block until all triggered threads
+                              have finished (optional)
 
         This will send a ``PRIVMSG`` message as if ``user`` sent it to the
         ``channel``, and the server forwarded it to its clients::
 
             factory.say(MockUser('NewUser'), '#test', '.shrug')
+
+        If ``blocking`` is ``True``, this method will wait to join all running
+        triggers' threads before returning. Setting it to ``False`` will skip
+        this step. If not specified, this :class:`MockIRCServer` instance's
+        ``join_threads`` argument will be obeyed.
+
+        .. versionadded:: 7.1
+
+            The ``blocking`` parameter.
+
+        .. seealso::
+
+            The ``join_threads`` argument to :class:`MockIRCServer`.
 
         .. seealso::
 
@@ -190,21 +256,36 @@ class MockIRCServer(object):
         """
         self.bot.on_message(user.privmsg(channel, text))
 
-        if self.join_threads:
+        if (blocking is None and self.join_threads) or blocking:
             for t in self.bot.running_triggers:
                 t.join()
 
-    def pm(self, user, text):
+    def pm(self, user, text, blocking=None):
         """Send a ``PRIVMSG`` to the bot by a ``user``.
 
         :param user: factory for the user object who sends a message
         :type user: :class:`MockUser`
         :param str text: content of the message sent to the bot
+        :param bool blocking: whether to block until all triggered threads
+                              have finished (optional)
 
         This will send a ``PRIVMSG`` message as forwarded by the server for
         a ``user`` sending it to the bot::
 
             factory.pm(MockUser('NewUser'), 'A private word.')
+
+        If ``blocking`` is ``True``, this method will wait to join all running
+        triggers' threads before returning. Setting it to ``False`` will skip
+        this step. If not specified, this :class:`MockIRCServer` instance's
+        ``join_threads`` argument will be obeyed.
+
+        .. versionadded:: 7.1
+
+            The ``blocking`` parameter.
+
+        .. seealso::
+
+            The ``join_threads`` argument to :class:`MockIRCServer`.
 
         .. seealso::
 
@@ -214,7 +295,7 @@ class MockIRCServer(object):
         """
         self.bot.on_message(user.privmsg(self.bot.nick, text))
 
-        if self.join_threads:
+        if (blocking is None and self.join_threads) or blocking:
             for t in self.bot.running_triggers:
                 t.join()
 

--- a/sopel/tests/mocks.py
+++ b/sopel/tests/mocks.py
@@ -75,7 +75,7 @@ class MockIRCServer(object):
         of users automatically, and you **should not** pass it in the ``users``
         parameter.
 
-        This is particulary useful to populate the bot's memory of who is in
+        This is particularly useful to populate the bot's memory of who is in
         a channel.
 
         .. note::

--- a/sopel/tests/pytest_plugin.py
+++ b/sopel/tests/pytest_plugin.py
@@ -228,7 +228,7 @@ def ircfactory():
             irc = ircfactory(bot)
             user = userfactory('User')
 
-            irc.say(user, '#test', '.mycommand'))
+            irc.say(user, '#test', '.mycommand')
 
             assert bot.backend.message_sent == rawlist(
                 'PRIVMSG #test :My plugin replied this.'

--- a/test/modules/test_modules_isup.py
+++ b/test/modules/test_modules_isup.py
@@ -87,10 +87,6 @@ def test_isup_command_ok(irc, bot, user, requests_mock):
 
     irc.pm(user, '.isup example.com')
 
-    for t in bot.running_triggers:
-        # TODO: remove when botfactory can force everything to be unthreaded
-        t.join()
-
     assert len(bot.backend.message_sent) == 1, (
         '.isup command should output exactly one line')
     assert bot.backend.message_sent == rawlist(
@@ -108,10 +104,6 @@ def test_isup_command_http_error(irc, bot, user, requests_mock):
 
     irc.pm(user, '.isup example.com')
 
-    for t in bot.running_triggers:
-        # TODO: remove when botfactory can force everything to be unthreaded
-        t.join()
-
     assert len(bot.backend.message_sent) == 1, (
         '.isup command should output exactly one line')
     assert bot.backend.message_sent == rawlist(
@@ -127,10 +119,6 @@ def test_isup_command_unparseable(irc, bot, user, requests_mock):
     )
 
     irc.pm(user, '.isup .foo')
-
-    for t in bot.running_triggers:
-        # TODO: remove when botfactory can force everything to be unthreaded
-        t.join()
 
     assert len(bot.backend.message_sent) == 1, (
         '.isup command should output exactly one line')
@@ -170,10 +158,6 @@ def test_isup_command_requests_error(irc, bot, user, requests_mock, exc, result)
 
     irc.pm(user, '.isup {}'.format(url))
 
-    for t in bot.running_triggers:
-        # TODO: remove when botfactory can force everything to be unthreaded
-        t.join()
-
     assert len(bot.backend.message_sent) == 1, (
         '.isup command should output exactly one line')
     assert bot.backend.message_sent == rawlist(
@@ -188,10 +172,6 @@ def test_isupinsecure_command(irc, bot, user, requests_mock):
     )
 
     irc.pm(user, '.isupinsecure https://example.com')
-
-    for t in bot.running_triggers:
-        # TODO: remove when botfactory can force everything to be unthreaded
-        t.join()
 
     assert len(bot.backend.message_sent) == 1, (
         '.isupinsecure command should output exactly one line')


### PR DESCRIPTION
### Description
tl;dr: Threaded callables can cause race conditions during tests, but the `MockIRCServer` is in a perfect position to make sure they don't (and it now does so).

I had a very interesting time this past weekend, trying to write tests for #2063 that simply wouldn't work, no matter what I did, until eventually the idea came to me: "Try it with the plugin callable set to unthreaded." After that, and an IRC discussion wherein @Exirel reminded me that the `bot.running_triggers` property exists, those tests got written and merged.

Now this new feature inspired by the above process is ready to be "formally" proposed. I spent some time on the documentation for it, proved the concept by running the test suite on _three_ local Python versions (2.7, 3.3, and 3.8), and am reasonably confident that this is ready for the "bikeshedding" or "nitpicking" stage—that is, developed enough as a concept that I won't need to rewrite the whole patch based on feedback. 😉

I elected to go with the simpler Boolean argument value for the overriding (`blocking`) argument on each method. Also proposed was a numeric value that would allow a test writer to specify the `timeout` for `threading.Thread.join()`, but that seems needlessly complex. I can't see a use for tests where a call would _sometimes_ block and _sometimes_ time out—such a test would be prone to intermittent failures, and thus not very useful for CI. 😁

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
Of course, if I've made any silly assumptions about things like never needing to set a `timeout` on `threading.Thread.join()` sometimes, that's what the PR discussion is for!

The `versionadded` directives are committed separately, so I can easily update them if for some reason this doesn't go into 7.1. Otherwise, I plan to squash them into the relevant code commits before merging.