### PR TITLE
find: don't output useless bold formatting for empty replacement

### DIFF
--- a/sopel/modules/find.py
+++ b/sopel/modules/find.py
@@ -163,9 +163,13 @@ def findandreplace(bot, trigger):
 
     sep = trigger.group('sep')
     old = trigger.group('old').replace('\\%s' % sep, sep)
-    new = bold(trigger.group('new')).replace('\\%s' % sep, sep)
+    new = trigger.group('new')
     me = False  # /me command
     flags = trigger.group('flags') or ''
+
+    # only clean/format the new string if it's non-empty
+    if new:
+        new = bold(new.replace('\\%s' % sep, sep))
 
     # If g flag is given, replace all. Otherwise, replace once.
     if 'g' in flags:


### PR DESCRIPTION
### Description
Tin. I did a `s/something //` replacement to delete an extra word recently and realized that the line contained two useless bold formatting bytes anyway, because that's how the logic was written and I didn't think of this case during review of #2014.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches