### PR TITLE
docs: plugin tests & minor improvement

### DIFF
--- a/docs/source/plugin.rst
+++ b/docs/source/plugin.rst
@@ -9,6 +9,7 @@ Plugins: Developer Overview
    plugin/anatomy
    plugin/bot
    plugin/decorators
+   plugin/test
    plugin/advanced
    plugin/internals
 

--- a/docs/source/plugin/test.rst
+++ b/docs/source/plugin/test.rst
@@ -1,0 +1,318 @@
+.. _plugin-test:
+
+===============
+Automated tests
+===============
+
+Testing a plugin manually can become tedious and it is an activity prone to
+human mistakes. To help automate testing, Sopel provides a
+:mod:`pytest plugin <sopel.tests.pytest_plugin>` with a set of testing tools
+such as :mod:`factories <sopel.tests.factories>` and
+:mod:`mock objects <sopel.tests.mocks>`.
+
+.. contents::
+   :local:
+   :depth: 2
+
+The pytest plugin
+=================
+
+Sopel's testing tools rely on pytest: when you install Sopel, it declares a
+pytest plugin named ``pytest-sopel``. Then you can `install pytest`__ and start
+writing your tests—no configuration required!
+
+Assuming your test files are in the ``test`` folder in your project directory::
+
+    project_dir/
+        myplugin/
+            __init__.py
+            config.py
+            commands.py
+        test/
+            test_command.py
+            test_config.py
+        README.md
+        setup.py
+        setup.cfg
+
+You can run your test suite with::
+
+    py.test -v test/
+
+.. __: https://docs.pytest.org/en/stable/getting-started.html
+
+.. note::
+
+    This document assumes that your tests are in the ``test`` folder.
+
+Example
+=======
+
+Testing a plugin is not easy, as commands and rules tend to need a lot of
+context and setup, so first here is an example. Later sections of this document
+will discuss the different parts required for this example.
+
+.. code-block::
+
+    import pytest
+    from sopel.tests import rawlist
+
+
+    TEST_NAME = 'test.cfg'
+    TEST_CONFIG = """
+    [core]
+    owner = OwnerNick
+    nick = TestBot
+    """
+
+
+    @pytest.fixture
+    def bot(configfactory, botfactory):
+        settings = configfactory(TEST_NAME, TEST_CONFIG)
+        return botfactory.preloaded(settings, ['myplugin'])
+
+
+    @pytest.fixture
+    def irc(bot, ircfactory):
+        return ircfactory(bot)
+
+
+    @pytest.fixture
+    def user(userfactory):
+        return userfactory('MyNick')
+
+
+    @pytest.fixture
+    def owner(userfactory):
+        return userfactory('OwnerNick')
+
+
+    def test_my_command(bot, irc, user):
+        irc.pm(user, '.mycommand arg')
+
+        assert bot.backend.message_sent == rawlist(
+            'PRIVMSG MyNick :Command answer to a regular user.'
+        )
+
+
+    def test_my_command_owner(bot, irc, owner):
+        irc.pm(owner, '.mycommand arg')
+
+        assert bot.backend.message_sent == rawlist(
+            'PRIVMSG MyNick :Command answer to my owner.'
+        )
+
+
+Test setup
+==========
+
+Before you can actually test a rule or a command, you will need to set up:
+
+* a test configuration
+* a test bot
+* a test server and test users
+* or a test trigger
+
+For that, Sopel provides factories through pytest fixtures. In the above
+example, these factories are used to create custom pytest fixtures.
+
+.. seealso::
+
+    Sopel uses a lot of fixtures both from pytest and custom ones specificaly
+    made for its test suite. Check the `pytest fixtures documentation`__ to
+    learn more about them as well as how to create your own.
+
+.. __: https://docs.pytest.org/en/stable/fixture.html
+
+Test configuration
+------------------
+
+The configuration file is the first thing the test bot will require, and you
+may need it too. You can use the
+:func:`~sopel.tests.pytest_plugin.configfactory` fixture::
+
+    TEST_NAME = 'test.cfg'
+    TEST_CONFIG = """
+    [core]
+    owner = testnick
+    nick = TestBot
+    """
+
+    def test_my_command(configfactory):
+        tmpconfig = configfactory(TEST_NAME, TEST_CONFIG)
+
+If you have a custom section for your plugin, you will need to declare it, as
+you would do in your :func:`setup` function::
+
+    from your_plugin.config import MyPluginSection
+
+    def test_my_command(configfactory):
+        tmpconfig = configfactory(TEST_NAME, TEST_CONFIG)
+        tmpconfig.define_section('myplugin', MyPluginSection)
+
+And since we are using pytest, you can create your own local fixture for that::
+
+    @pytest.fixture
+    def tmpconfig(configfactory):
+        return configfactory(TEST_NAME, TMP_CONFIG)
+
+    def test_my_command(tmpconfig):
+        tmpconfig.define_section('myplugin', MyPluginSection)
+
+If all you need is a test configuration, you could put the section definition
+within your fixture. However, there are other options available to you when you
+use a test bot.
+
+Test bot
+--------
+
+Now that you have a test configuration available through your custom
+``tmpconfig`` fixture, you may want a test bot. Use the
+:func:`~sopel.tests.pytest_plugin.botfactory` fixture for that::
+
+    def test_my_command(tmpconfig, botfactory):
+        bot = botfactory(tmpconfig)
+
+However at this point, the bot doesn't know about your plugin, so it hasn't
+run the setup phase. You can do that with the
+:meth:`~sopel.tests.factories.BotFactory.preloaded` method::
+
+    def test_my_command(tmpconfig, botfactory):
+        bot = botfactory.preloaded(tmpconfig, ['myplugin'])
+        assert bot.has_plugin('myplugin')  # should be True
+
+.. important::
+
+    When using the :meth:`~sopel.tests.factories.BotFactory.preloaded` method,
+    you must not define your config sections manually, as this should be done
+    by your ``setup`` plugin hook.
+
+Of course, if you want to reuse the same test bot in all your tests, you can
+create a fixture for that::
+
+    @pytest.fixture
+    def bot(configfactory, botfactory):
+        settings = configfactory(TEST_NAME, TEST_CONFIG)
+        return botfactory.preloaded(settings, ['myplugin'])
+
+And then use it in your tests::
+
+    def test_my_command(bot):
+        assert bot.has_plugin('myplugin')  # should be True
+
+The ``bot`` created by the factory is a regular instance of
+:class:`sopel.bot.Sopel` with a
+:class:`test IRC backend <sopel.tests.mocks.MockIRCBackend>` instead of a
+regular one. This backend doesn't send anything over the network and instead
+it registers everything into its ``message_sent`` list::
+
+    from sopel.tests import rawlist
+
+
+    def test_my_command(bot):
+        bot.say('Hi!', '#channel')
+        assert len(bot.backend.message_sent) == 1
+        assert bot.backend.message_sent == rawlist(
+            'PRIVMSG #channel :Hi!',
+        )
+
+.. seealso::
+
+    For more information about the :func:`~sopel.tests.rawlist` function,
+    see the `Checking the bot's output`_ section.
+
+Test Server and test Users
+--------------------------
+
+Now that you have a test bot properly set up, it's time for the last parts
+of your test setup: a test server with test users. As usual, there are fixtures
+to help you. The :func:`~sopel.tests.pytest_plugin.ircfactory` can be used to
+create a test server, and the :func:`~sopel.tests.pytest_plugin.userfactory`
+can create test users::
+
+    @pytest.fixture
+    def irc(bot, ircfactory):
+        return ircfactory(bot)
+
+    def test_my_command(bot, irc, userfactory):
+        user = userfactory('MyNick')
+        irc.pm(user, '.mycommand arg')
+
+        assert bot.backend.message_sent == rawlist(
+            'PRIVMSG MyNick :Command answer to a regular user.'
+        )
+
+    def test_my_command_owner(bot, irc, userfactory):
+        owner = userfactory('OwnerNick')
+        irc.pm(owner, '.mycommand arg')
+
+        assert bot.backend.message_sent == rawlist(
+            'PRIVMSG MyNick :Command answer to my owner.'
+        )
+
+As usual, you can create custom fixtures for the test server (as above) and for
+your test users, for example, one for a regular user, and one for the owner::
+
+    @pytest.fixture
+    def user(userfactory):
+        return userfactory('MyNick')
+
+
+    @pytest.fixture
+    def owner(userfactory):
+        return userfactory('OwnerNick')
+
+Channel messages
+................
+
+A bot can join channels, and so does your test bot: by using the test server,
+you can make the bot join a channel, or add new users to a channel while the
+bot is already in it::
+
+    def test_my_command(bot, irc, user, owner):
+        # bot joins #channel with the owner in it
+        irc.channel_join('#channel', users=[owner])
+
+        # user joins #channel after
+        irc.join(user, '#channel')
+
+        # user talks into a channel
+        irc.say(user, '.mycommand arg')
+
+        assert bot.backend.message_sent == rawlist(
+            'PRIVMSG #channel :MyNick: my reply into a channel.'
+        )
+
+You can automate this setup within your fixture::
+
+    @pytest.fixture
+    def irc(bot, user, owner, ircfactory):
+        irc = ircfactory(bot)
+        irc.channel_join('#channel', users=[owner, user])
+        return irc
+
+And now you are all set up to test your plugin's commands and rules!
+
+Checking the bot's output
+=========================
+
+Once you have a test bot (or a wrapped version for your command), you can check
+what the bot said after running your command thanks to the
+:func:`~sopel.tests.rawlist` function::
+
+    from sopel.tests import rawlist
+
+    def test_my_command(bot):
+        bot.say('hi!', '#channel')
+        bot.say('how are you?', 'TestUser')
+        assert bot.backend.message_sent == rawlist(
+            'PRIVMSG #channel :Hi!',
+            'PRIVMSG TestUser :how are you?',
+        )
+
+The test bot has a :class:`test backend <sopel.tests.mocks.MockIRCBackend>`
+that registers everything the bot tried to send to the IRC server without
+actually sending anything to any server.
+
+The ``rawlist`` function is a convenient helper that helps you compare what was
+registered by properly encoding and formatting your lines.

--- a/docs/source/plugin/test.rst
+++ b/docs/source/plugin/test.rst
@@ -276,6 +276,9 @@ bot is already in it::
         # user joins #channel after
         irc.join(user, '#channel')
 
+        # clear messages on join
+        bot.backend.clear_message_sent()
+
         # user talks into a channel
         irc.say(user, '.mycommand arg')
 
@@ -287,9 +290,12 @@ You can automate this setup within your fixture::
 
     @pytest.fixture
     def irc(bot, user, owner, ircfactory):
-        irc = ircfactory(bot)
-        irc.channel_join('#channel', users=[owner, user])
-        return irc
+        test_server = ircfactory(bot)
+        # auto-join channels
+        test_server.channel_join('#channel', users=[owner, user])
+        # clear messages on join
+        bot.backend.clear_message_sent()
+        return test_server
 
 And now you are all set up to test your plugin's commands and rules!
 

--- a/docs/source/tests.rst
+++ b/docs/source/tests.rst
@@ -6,6 +6,12 @@ Testing tools
     :local:
     :depth: 2
 
+Common tools
+============
+
+.. automodule:: sopel.tests
+   :members:
+
 Fixtures with py.test
 =====================
 
@@ -23,7 +29,6 @@ Mocks
 
 .. automodule:: sopel.tests.mocks
    :members:
-
 
 Old testing tools
 =================

--- a/sopel/tests/mocks.py
+++ b/sopel/tests/mocks.py
@@ -12,15 +12,49 @@ from sopel.irc.abstract_backends import AbstractIRCBackend
 class MockIRCBackend(AbstractIRCBackend):
     """Fake IRC connection backend for testing purpose.
 
+    :param bot: a Sopel instance
+    :type bot: :class:`sopel.bot.Sopel`
+
     This backend doesn't require an actual connection. Instead, it stores every
     message sent in the :attr:`message_sent` list.
+
+    You can use the :func:`~sopel.tests.rawlist` function to compare the
+    messages easily, and the :meth:`clear_message_sent` method to clear
+    previous messages::
+
+        >>> from sopel.tests import rawlist, mocks
+        >>> backend = mocks.MockIRCBackend(bot=None)
+        >>> backend.irc_send(b'PRIVMSG #channel :Hi!\\r\\n')
+        >>> backend.message_sent == rawlist('PRIVMSG #channel :Hi!')
+        True
+        >>> backend.clear_message_sent()
+        [b'PRIVMSG #channel :Hi!\\r\\n']
+        >>> backend.message_sent
+        []
+
+    .. seealso::
+
+        The
+        :class:`parent class <sopel.irc.abstract_backends.AbstractIRCBackend>`
+        contains all the methods that can be used on this test backend.
+
     """
     def __init__(self, *args, **kwargs):
         super(MockIRCBackend, self).__init__(*args, **kwargs)
         self.message_sent = []
-        """List of raw messages sent by the bot."""
+        """List of raw messages sent by the bot.
+
+        This list will be populated each time the :meth:`irc_send` method is
+        used: it will contain the raw IRC lines the bot wanted to send.
+
+        You can clear this list with the :meth:`clear_message_sent` method, or
+        use the :func:`~sopel.tests.rawlist` function to compare it.
+        """
         self.connected = False
-        """Convenient status flag."""
+        """Convenient status flag.
+
+        Set to ``True`` to make the bot think it is connected.
+        """
 
     def is_connected(self):
         return self.connected
@@ -28,6 +62,20 @@ class MockIRCBackend(AbstractIRCBackend):
     def irc_send(self, data):
         """Store ``data`` into :attr:`message_sent`."""
         self.message_sent.append(data)
+
+    def clear_message_sent(self):
+        """Clear and return previous messages sent.
+
+        :return: a copy of the cleared messages sent
+        :rtype: :class:`list`
+
+        .. versionadded:: 7.1
+        """
+        # make a copy
+        sent = list(self.message_sent)
+        # clear the message sent
+        self.message_sent = []
+        return sent
 
 
 class MockIRCServer(object):

--- a/test/tests/test_tests_mocks.py
+++ b/test/tests/test_tests_mocks.py
@@ -1,0 +1,34 @@
+# coding=utf-8
+"""Tests for ``sopel.tests.mocks`` module"""
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from sopel.tests.mocks import MockIRCBackend
+
+
+def test_backend_irc_send():
+    backend = MockIRCBackend(bot=None)
+    backend.irc_send('a')
+
+    assert len(backend.message_sent) == 1
+    assert backend.message_sent == ['a']
+
+    backend.irc_send('b')
+
+    assert len(backend.message_sent) == 2
+    assert backend.message_sent == ['a', 'b']
+
+    backend.irc_send(b'c')
+
+    assert len(backend.message_sent) == 3
+    assert backend.message_sent == ['a', 'b', b'c']
+
+
+def test_backend_clear_message_sent():
+    items = ['a', 'b', 'c']
+    backend = MockIRCBackend(bot=None)
+    backend.message_sent = items
+
+    result = backend.clear_message_sent()
+    assert result == items
+    assert result is not items, 'The result should be a copy.'
+    assert not backend.message_sent, '`message_sent` must be empty'


### PR DESCRIPTION
### Description

After discussing #2065 it appears that "how to test a plugin" isn't well documented, so here is a PR for that.

I think there are more that can be written, in particular about factories and how to use them.

I also added a convenient method to clear `backend.message_sent`, so you don't have to do it manually. It's useful when you have a bunch of automated messages, or when you don't want to write more than one test method for different yet very similar use cases (for example: trigger by a regular user vs admin vs owner).

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
