### PR TITLE
loader: use `inspect` to make callable docs consistent

### DIFF
--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -12,12 +12,13 @@
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import inspect
 import logging
 import re
 import sys
 
 from sopel.config.core_section import COMMAND_DEFAULT_HELP_PREFIX
-from sopel.tools import itervalues
+from sopel.tools import deprecated, itervalues
 
 
 if sys.version_info.major >= 3:
@@ -27,6 +28,11 @@ if sys.version_info.major >= 3:
 LOGGER = logging.getLogger(__name__)
 
 
+@deprecated(
+    reason="Replaced by simple logic using inspect.getdoc()",
+    version='7.1',
+    removed_in='8.0',
+)
 def trim_docstring(doc):
     """Get the docstring as a series of lines that can be sent.
 
@@ -71,8 +77,12 @@ def clean_callable(func, config):
     nick = config.core.nick
     help_prefix = config.core.help_prefix
     func._docs = {}
-    doc = trim_docstring(func.__doc__)
+    doc = []
     examples = []
+
+    docstring = inspect.getdoc(func)
+    if docstring:
+        doc = docstring.splitlines()
 
     func.thread = getattr(func, 'thread', True)
 


### PR DESCRIPTION
### Description
Our own `trim_docstring` function is OK, but definitely not perfect. What it returns can be inconsistently indented depending on whether the docstring passed in is single- or multi-line, or whether a multi-line docstring starts on line 0 or line 1 (next to or below the `"""`). It's nice to have consistent indentation.

I don't have any strong feelings about where to implement this. Maybe it would make more sense to apply `inspect.cleandoc()` inside the logic of `trim_docstring` instead of using `inspect.getdoc()` on the callable. Either way, our help infrastructure will be easier to improve if we eliminate anything like this that can cause inconsistent output.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - ~~Not tested yet (see notes)~~ CI did its job
- [x] I have tested the functionality of the things this change touches
  - Well, I did when I wrote the patch last year…

### Notes
I know this has a merge conflict; it's an old branch I found while cleaning up now that most of 7.1.0's stuff is merged. I'll take care of that (or overwrite the branch with a different approach) when the time comes.