### PR TITLE
Substitute Libera Chat for all public-facing references to freenode

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Sopel's IRC channel
-    url: https://webchat.freenode.net/#sopel
-    about: "For more interactive help, ask in #sopel on freenode. We're usually there daily."
+    url: https://kiwiirc.com/client/irc.libera.chat/#sopel
+    about: "For more interactive help, ask in #sopel on Libera Chat. We're usually there daily."

--- a/NEWS
+++ b/NEWS
@@ -967,8 +967,8 @@ Now that Sopel 6.6.0 is released, the focus will shift from preparing the new
 release to migrating the website and documentation off of Embolalia's personal
 infrastructure. Once this migration is complete, Sopel's [documentation][docs]
 will be updated to reflect the changes/additions listed below. Questions about
-the new (and old) API methods are welcome in [#sopel][] on Freenode, of course,
-as always. Thank you for bearing with this transitional period!
+the new (and old) API methods are welcome in [#sopel][] on Libera Chat, of
+course, as always. Thank you for bearing with this transitional period!
 
 Importantly, a couple of broken modules have been removed in this release. For
 easy reference, they and their PyPI-installable replacements are listed near
@@ -1026,7 +1026,7 @@ journey at [#1446][] for the time being.
 
 
   [docs]: https://sopel.chat/docs/
-  [#sopel]: irc://chat.freenode.net/sopel
+  [#sopel]: irc://irc.libera.chat/sopel
   [GitHub milestones]: https://github.com/sopel-irc/sopel/milestones
   [#1200]: https://github.com/sopel-irc/sopel/issues/1200
   [#1291]: https://github.com/sopel-irc/sopel/issues/1291

--- a/README.rst
+++ b/README.rst
@@ -81,7 +81,7 @@ and other `usage information <https://sopel.chat/usage/>`_.
 Questions?
 ----------
 
-Join us in `#sopel <irc://irc.freenode.net/#sopel>`_ on Freenode.
+Join us in `#sopel <irc://irc.libera.chat/#sopel>`_ on Libera Chat.
 
 Donations
 ---------

--- a/contrib/sopel.cfg
+++ b/contrib/sopel.cfg
@@ -9,7 +9,7 @@
 [core]
 nick=sopel
 not_configured=True
-host=chat.freenode.net
+host=irc.libera.chat
 port=6697
 use_ssl=True
 verify_ssl=True

--- a/docs/source/cli.rst
+++ b/docs/source/cli.rst
@@ -117,13 +117,13 @@ For example, take this stripped-down config file:
 
     [core]
     nick = ConfigFileNick
-    host = chat.freenode.net
+    host = irc.libera.chat
 
     [plugin_name]
     api_key = abad1dea
 
 Sopel would take the nickname ``ConfigFileNick`` when connecting to IRC at
-``chat.freenode.net``, and the ``plugin_name`` plugin would use the API key
+``irc.libera.chat``, and the ``plugin_name`` plugin would use the API key
 ``abad1dea`` when communicating with its remote service.
 
 However, by setting the environment variables:
@@ -134,7 +134,7 @@ However, by setting the environment variables:
     SOPEL_PLUGIN_NAME_API_KEY=1337c0ffee9001
 
 Sopel would take the nickname ``EnvVarNick`` when connecting to IRC (still at
-``chat.freenode.net``; that value isn't overridden or lost), and the
+``irc.libera.chat``; that value isn't overridden or lost), and the
 ``plugin_name`` plugin would use the API key ``1337c0ffee9001``, instead.
 
 .. versionadded:: 7.0

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -10,7 +10,7 @@ A typical configuration file looks like this::
 
     [core]
     nick = Sopel
-    host = chat.freenode.net
+    host = irc.libera.chat
     use_ssl = true
     port = 6697
     owner = dgw
@@ -122,10 +122,10 @@ on the IRC server the bot connects to.
    The list of available modes depends on the implementation of the IRC server,
    and its configuration.
 
-   For example, the `user modes on freenode`__ is different from the list of
-   available `user modes on an UnrealIRCd server`__.
+   For example, the `user modes on Libera Chat`__ are different from the list
+   of available `user modes on an UnrealIRCd server`__.
 
-   .. __: https://freenode.net/kb/answer/usermodes
+   .. __: https://libera.chat/guides/usermodes
    .. __: https://www.unrealircd.org/docs/User_modes
 
 Owner & Admins
@@ -167,14 +167,14 @@ IRC Server
 To connect to a server, your bot needs these directives:
 
 * :attr:`~CoreSection.host`: the server's hostname. Can be a domain name
-  (like ``chat.freenode.net``) or an IP address.
+  (like ``irc.libera.chat``) or an IP address.
 * :attr:`~CoreSection.port`: optional, the port to connect to. Usually 6697 for
   SSL connection and 6667 for unsecure connection, the default value the bot
   will use to connect to the server.
 * :attr:`~CoreSection.use_ssl`: connect using SSL (see below)::
 
     [core]
-    host = chat.freenode.net
+    host = irc.libera.chat
     port = 6697
     use_ssl = true
 

--- a/sopel/config/__init__.py
+++ b/sopel/config/__init__.py
@@ -19,7 +19,7 @@ The configuration file being:
 
     [core]
     nick = Sopel
-    host = irc.freenode.org
+    host = irc.libera.chat
     use_ssl = true
     port = 6697
     owner = dgw
@@ -125,8 +125,8 @@ class Config(object):
         self.basename = basename
         """The config's base filename, i.e. the filename without the extension.
 
-        If the filename is ``freenode.config.cfg``, then the ``basename`` will
-        be ``freenode.config``.
+        If the filename is ``libera.config.cfg``, then the ``basename`` will
+        be ``libera.config``.
         """
         self.parser = ConfigParser.RawConfigParser(allow_no_value=True)
         """The configuration parser object that does the heavy lifting.

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -648,16 +648,16 @@ class CoreSection(StaticSection):
         """
         return self._parent.homedir
 
-    host = ValidatedAttribute('host', default='chat.freenode.net')
+    host = ValidatedAttribute('host', default='irc.libera.chat')
     """The IRC server to connect to.
 
-    :default: ``chat.freenode.net``
+    :default: ``irc.libera.chat``
 
     **Required**:
 
     .. code-block:: ini
 
-        host = chat.freenode.net
+        host = irc.libera.chat
 
     """
 

--- a/sopel/modules/find_updates.py
+++ b/sopel/modules/find_updates.py
@@ -82,7 +82,7 @@ def check_version(bot):
             .format(version_url), bot.config.core.owner)
         bot.say(
             "[update] If this issue persists, please alert the Sopel dev team "
-            "in #sopel on freenode, or open a GitHub issue: "
+            "in #sopel on Libera Chat, or open a GitHub issue: "
             "https://github.com/sopel-irc/sopel/issues",
             bot.config.core.owner)
         return

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -148,9 +148,9 @@ class PreTrigger(object):
         #             print(text)    # 'foo bar!'
         #             print(argstr)  # ':nick!ident@domain PRIVMSG #sopel'
         #             print(args)    # [':nick!ident@domain', 'PRIVMSG', '#sopel', 'foo bar!']
-        # Example 2:  line = 'irc.freenode.net MODE Sopel +i'
+        # Example 2:  line = 'irc.libera.chat MODE Sopel +i'
         #             print(text)    # '+i'
-        #             print(args)    # ['irc.freenode.net', 'MODE', 'Sopel', '+i']
+        #             print(args)    # ['irc.libera.chat', 'MODE', 'Sopel', '+i']
         if ' :' in line:
             argstr, self.text = line.split(' :', 1)
             self.args = argstr.split(' ')


### PR DESCRIPTION
### Description
Tin.

I elected to leave the tests alone, since those could just as well use `irc.example.com` and work exactly the same way.

Updated the NEWS entry for v6.6.0 just so future release archives and changelog pages on the website won't point people to an abandoned channel on freenode. Probably could leave it alone, but it's easy to update along with everything else.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches