### PR TITLE
build: remove EOL Python versions from Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,6 @@ dist: bionic  # most recent base image by default
 language: python
 jobs:
   include:
-    - name: "Python 2.7 on Bionic"
-      python: 2.7
-    - name: "Python 3.3 on Trusty"
-      python: 3.3
-      dist: trusty  # trusty is the last image to officially support py3.3
-    - name: "Python 3.4 on Xenial"
-      python: 3.4
-      dist: xenial  # xenial is the last image to officially support py3.4
-    - name: "Python 3.5 on Xenial"
-      python: 3.5
-      dist: xenial  # xenial is the last image to officially support py3.5
     - name: "Python 3.6 on Bionic"
       python: 3.6
     - name: "Python 3.7 on Bionic"
@@ -35,8 +24,6 @@ cache:
   directories:
     - $HOME/.cache/pip
 install:
-  # setuptools should be left alone once we drop Python 3.3 support
-  - pip install --upgrade "setuptools<=39.2.0; python_version < '3.9'"
   - pip install --upgrade -r requirements.txt -r dev-requirements.txt
   - python setup.py develop
 script:


### PR DESCRIPTION
### Description
Oldest tested Python platform is now Python 3.6, set to reach end-of-life in December 2021.

This will help us conserve build credits, since Travis CI shifted to requiring manual grants of credits for open source projects on their newer infrastructure, leaving behind the straightforward system that had been in place for many years on their .org platform.

Somewhat related to this: We will be focusing more attention on a move to GitHub Actions in the coming weeks...

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
Doing this separately from #2062 as it's time-sensitive: Travis will shut down the .org platform and force us onto their strictly metered .com infrastructure in just over a week, so it's important to get this merged as soon as the 7.1.0 release is cut and stretch our credit balance as far as possible while we hopefully migrate everything to GHA.