### PR TITLE
tld: fix `.tldcache clear` command breaking `.tld` until manual update

### DIFF
--- a/sopel/modules/tld.py
+++ b/sopel/modules/tld.py
@@ -382,17 +382,15 @@ def tld_cache_command(bot, trigger):
         bot.reply("Requesting updated IANA list and Wikipedia data.")
         update_caches(bot, force=True)
     elif subcommand == 'clear':
-        for key in [
-            'tld_list_cache',
-            'tld_list_cache_updated',
-            'tld_data_cache',
-            'tld_data_cache_updated',
-        ]:
-            bot.db.delete_plugin_value('tld', key)
-            try:
-                del bot.memory[key]
-            except KeyError:
-                pass
+        bot.db.delete_plugin_value('tld', 'tld_data_cache')
+        bot.memory['tld_data_cache'] = {}
+        bot.db.delete_plugin_value('tld', 'tld_list_cache')
+        bot.memory['tld_list_cache'] = []
+        bot.db.delete_plugin_value('tld', 'tld_data_cache_updated')
+        bot.memory['tld_data_cache_updated'] = DEFAULT_CACHE_DATETIME
+        bot.db.delete_plugin_value('tld', 'tld_list_cache_updated')
+        bot.memory['tld_list_cache_updated'] = DEFAULT_CACHE_DATETIME
+
         bot.reply("Cleared all cached TLD data.")
     else:
         bot.reply(


### PR DESCRIPTION
### Description
Tin. Using `del bot.memory[key]` is not safe; the keys used by this plugin must be reset to their default values.

Workaround in 7.1.0 is to run `.tldcache update` immediately after `.tldcache clear`, or to run ONLY the `update` subcommand.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
This is what I get for trying to be cute with the loop-based approach.