### PR TITLE
gha: only run jobs when events are for 'sopel-irc' owned repos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
 
 jobs:
   tests:
+    if: ${{ github.repository_owner == 'sopel-irc' }}
     name: Test suite
     runs-on: ubuntu-latest
     strategy:
@@ -47,6 +48,7 @@ jobs:
           COVERALLS_PARALLEL: true
 
   coveralls:
+    if: ${{ github.repository_owner == 'sopel-irc' }}
     # Would be very nice to find an alternative implementation that doesn't
     # pollute the list of checks on PRs someday, but this seems unlikely.
     name: Finalize job on coveralls.io


### PR DESCRIPTION
### Description
As of right now, the GitHub Actions CI workflow will run on forks too.
This PR checks the workflow context to see if events are for the 'sopel-irc' owner, and only runs jobs if so. This check can/should be moved/updated as new jobs are defined, or if the event/branch filter for the CI workflow changes.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches<sup>1</sup>
> <sup>1</sup>As best as possible. Confirmed that adding this prevents from running on my fork.