### PR TITLE
config: fix BooleanAttribute default=True

### DIFF
--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -404,9 +404,6 @@ class BooleanAttribute(BaseValidated):
             ]
         return bool(value)
 
-    def _parse(self, value, settings, section):
-        return self.parse(value)
-
     def __set__(self, instance, value):
         if value is None:
             instance._parser.remove_option(instance._section_name, self.name)

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -72,6 +72,8 @@ class FakeConfigSection(types.StaticSection):
     valattr = types.ValidatedAttribute('valattr')
     listattr = types.ListAttribute('listattr')
     choiceattr = types.ChoiceAttribute('choiceattr', ['spam', 'egg', 'bacon'])
+    booleanattr = types.BooleanAttribute('booleanattr')
+    booleanattr_true = types.BooleanAttribute('booleanattr', default=True)
     af_fileattr = types.FilenameAttribute('af_fileattr', relative=False, directory=False)
     ad_fileattr = types.FilenameAttribute('ad_fileattr', relative=False, directory=True)
     rf_fileattr = types.FilenameAttribute('rf_fileattr', relative=True, directory=False)
@@ -202,6 +204,11 @@ def test_choiceattribute_when_not_in_set(fakeconfig):
 def test_choiceattribute_when_valid(fakeconfig):
     fakeconfig.fake.choiceattr = 'bacon'
     assert fakeconfig.fake.choiceattr == 'bacon'
+
+
+def test_booleanattribute_default(fakeconfig):
+    assert fakeconfig.fake.booleanattr is False
+    assert fakeconfig.fake.booleanattr_true is True
 
 
 def test_fileattribute_valid_absolute_file_path(fakeconfig):


### PR DESCRIPTION
### Description
Makes `default=True` work correctly for `BooleanAttribute`s - see: url.py not working in 7.1.0.

I'm not sure why that stub was overridden, but I can't think of a reason BoolAttr would need to behave differently from the normal `BaseValidated._parse()`. @dgw?

Includes lazy test of default default and default=True. It might belong in test/config/test_config_types.py but that's harder and I'm out of time and brain to melt.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
