### PR TITLE
plugins.rules: `URLCallback` shall handle invalid URLs by ignoring them

### DIFF
--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -1678,11 +1678,16 @@ class URLCallback(Rule):
         if not self.match_preconditions(bot, pretrigger):
             return
 
-        urls = (
-            url
-            for url in pretrigger.urls
-            if urlparse(url).scheme in self._schemes
-        )
+        urls = []
+        for url in pretrigger.urls:
+            try:
+                scheme = urlparse(url).scheme
+            except ValueError:
+                # skip invalid URLs
+                # we could use a comprehension if not for this...
+                continue
+            if scheme in self._schemes:
+                urls.append(url)
 
         # Parse URL for each found
         for url in urls:

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -1678,19 +1678,16 @@ class URLCallback(Rule):
         if not self.match_preconditions(bot, pretrigger):
             return
 
-        urls = []
+        # Parse only valid URLs with wanted schemes
         for url in pretrigger.urls:
             try:
-                scheme = urlparse(url).scheme
+                if urlparse(url).scheme not in self._schemes:
+                    # skip URLs with unwanted scheme
+                    continue
             except ValueError:
                 # skip invalid URLs
-                # we could use a comprehension if not for this...
                 continue
-            if scheme in self._schemes:
-                urls.append(url)
 
-        # Parse URL for each found
-        for url in urls:
             # TODO: convert to 'yield from' when dropping Python 2.7
             for result in self.parse(url):
                 yield result

--- a/test/plugins/test_plugins_rules.py
+++ b/test/plugins/test_plugins_rules.py
@@ -2609,7 +2609,7 @@ def test_url_callback_parse():
         re.escape('https://wikipedia.com/') + r'(\w+)'
     )
 
-    rule = rules.SearchRule([regex])
+    rule = rules.URLCallback([regex])
     results = list(rule.parse('https://wikipedia.com/something'))
     assert len(results) == 1, 'URLCallback on word must match only once'
     assert results[0].group(0) == 'https://wikipedia.com/something'

--- a/test/plugins/test_plugins_rules.py
+++ b/test/plugins/test_plugins_rules.py
@@ -2616,6 +2616,20 @@ def test_url_callback_parse():
     assert results[0].group(1) == 'something'
 
 
+def test_url_callback_match(mockbot):
+    regex = re.compile(r'.*')
+    rule = rules.URLCallback([regex])
+
+    line = (
+        ':Foo!foo@example.com PRIVMSG #sopel :'
+        'two links http://example.com one invalid https://[dfdsdfsdf'
+    )
+    pretrigger = trigger.PreTrigger(mockbot.nick, line)
+    matches = list(rule.match(mockbot, pretrigger))
+    assert len(matches) == 1, 'URLCallback must ignore invalid URLs'
+    assert matches[0].group(0) == 'http://example.com'
+
+
 def test_url_callback_execute(mockbot):
     regex = re.compile(r'.*')
     rule = rules.URLCallback([regex])


### PR DESCRIPTION
### Description
Invalid URLs can crash Sopel's URL handling, as reported on IRC by @RhinosF1. The traceback is included below for reference.

We handle it now by simply skipping any URL that causes the underlying library (`urllib.parse` from Python's standard library) to throw a `ValueError` when `plugins.rules.URLCallback.match()` tries to determine its scheme.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
Includes a new test verifying the behavior—and more importantly, the lack of an exception being thrown.

Also fixes an incorrect classname in one of the other `URLCallback` tests, in a separate commit.

#### Motivating traceback, reported on IRC

```
[2021-06-05 10:03:52,811] sopel.exceptions     ERROR    - Fatal error in core, handle_error() was called.
Buffer:

Last Line:
@account=mirahezebots :MirahezeRC!~MirahezeR@miraheze/bots PRIVMSG #miraheze-feed :famepediawiki 5* 14[[07Yasir Tech14]]4 !N10 02https://en.famepedia.org/w/index.php?oldid=35752&rcid=23962 5* 03YasirTech 5* (+6564) 10Created page with "{{Short description}}'''Yasir Tech''' '''(یاسر ٹیک)(यासिर टेक) [https://yasirtech.com]is an Blogger, He was born on 01 January 2009 in Firozpur in Sambh..."
[2021-06-05 10:03:52,812] sopel.exceptions     ERROR    - Fatal error traceback
Traceback (most recent call last):
  File "/usr/lib/python3.7/asyncore.py", line 83, in read
    obj.handle_read_event()
  File "/usr/lib/python3.7/asyncore.py", line 422, in handle_read_event
    self.handle_read()
  File "/usr/lib/python3.7/asynchat.py", line 171, in handle_read
    self.found_terminator()
  File "/srv/sopelbots/prodvenv/lib/python3.7/site-packages/sopel/irc/backends.py", line 241, in found_terminator
    self.bot.on_message(line)
  File "/srv/sopelbots/prodvenv/lib/python3.7/site-packages/sopel/irc/__init__.py", line 228, in on_message
    self.dispatch(pretrigger)
  File "/srv/sopelbots/prodvenv/lib/python3.7/site-packages/sopel/bot.py", line 901, in dispatch
    for rule, match in self._rules_manager.get_triggered_rules(self, pretrigger):
  File "/srv/sopelbots/prodvenv/lib/python3.7/site-packages/sopel/plugins/rules.py", line 440, in get_triggered_rules
    return tuple(sorted(matches, key=lambda x: x[0].priority_scale))
  File "/srv/sopelbots/prodvenv/lib/python3.7/site-packages/sopel/plugins/rules.py", line 431, in <genexpr>
    for match in rule.match(bot, pretrigger)
  File "/srv/sopelbots/prodvenv/lib/python3.7/site-packages/sopel/plugins/rules.py", line 1688, in match
    for url in urls:
  File "/srv/sopelbots/prodvenv/lib/python3.7/site-packages/sopel/plugins/rules.py", line 1684, in <genexpr>
    if urlparse(url).scheme in self._schemes
  File "/usr/lib/python3.7/urllib/parse.py", line 368, in urlparse
    splitresult = urlsplit(url, scheme, allow_fragments)
  File "/usr/lib/python3.7/urllib/parse.py", line 459, in urlsplit
    raise ValueError("Invalid IPv6 URL")
ValueError: Invalid IPv6 URL
[2021-06-05 10:03:52,897] sopel.exceptions     ERROR    - ----------------------------------------
```