### PR TITLE
coretasks: handle `BOT` ISUPPORT token & mode

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -311,7 +311,9 @@ def startup(bot, trigger):
 @plugin.priority('medium')
 def handle_isupport(bot, trigger):
     """Handle ``RPL_ISUPPORT`` events."""
-    # remember if NAMESX is known to be supported, before parsing RPL_ISUPPORT
+    # remember if certain actionable tokens are known to be supported,
+    # before parsing RPL_ISUPPORT
+    botmode_support = 'BOT' in bot.isupport
     namesx_support = 'NAMESX' in bot.isupport
 
     # parse ISUPPORT message from server
@@ -326,6 +328,12 @@ def handle_isupport(bot, trigger):
 
     bot._isupport = bot._isupport.apply(**parameters)
 
+    # was BOT mode support status updated?
+    if not botmode_support and 'BOT' in bot.isupport:
+        # yes it was! set our mode unless the config overrides it
+        botmode = bot.isupport['BOT']
+        if botmode not in bot.config.core.modes:
+            bot.write(('MODE', bot.nick, '+' + botmode))
     # was NAMESX support status updated?
     if not namesx_support and 'NAMESX' in bot.isupport:
         # yes it was!


### PR DESCRIPTION
### Description
If the server advertises a `BOT` token in `005 ISUPPORT`, Sopel will set that mode on itself unless that modechar appears in the value of `core.modes` in its configuration.

Implements part of #2079.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - By the power of `pytest`, yes!

### Notes
The default value of `core.modes` is `B`, which is the conventional modechar to advertise for `BOT`. Thus this won't do much on most networks unless the user overrides `core.modes` and doesn't know about this mode.

#### Support tables
Note to self: Prepped a support table update for IRCv3 [here](https://github.com/ircv3/ircv3.github.io/compare/master...dgw:sopel-bot-mode?expand=1).