### PR TITLE
coretasks: activate `message-tags` and use it to ignore other bots' tagged messages

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -904,6 +904,7 @@ def receive_cap_ls_reply(bot, trigger):
         'cap-notify',
         'server-time',
         'userhost-in-names',
+        'message-tags',
     ]
     for cap in core_caps:
         if cap not in bot._cap_reqs:

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -959,6 +959,13 @@ class Rule(AbstractRule):
         event = pretrigger.event
         intent = pretrigger.tags.get('intent')
         nick = pretrigger.nick
+        is_bot_message = (
+            (
+                'draft/bot' in pretrigger.tags or  # can be removed...someday
+                'bot' in pretrigger.tags
+            ) and
+            event in ["PRIVMSG", "NOTICE"]
+        )
         is_echo_message = (
             nick.lower() == bot.nick.lower() and
             event in ["PRIVMSG", "NOTICE"]
@@ -967,6 +974,7 @@ class Rule(AbstractRule):
         return (
             self.match_event(event) and
             self.match_intent(intent) and
+            (not is_bot_message or (is_echo_message and self.allow_echo())) and
             (not is_echo_message or self.allow_echo())
         )
 

--- a/test/plugins/test_plugins_rules.py
+++ b/test/plugins/test_plugins_rules.py
@@ -654,6 +654,23 @@ def test_rule_match_privmsg_action(mockbot):
     assert not list(rule.match(mockbot, pretrigger))
 
 
+def test_rule_match_privmsg_bot_tag(mockbot):
+    regex = re.compile(r'.*')
+    rule = rules.Rule([regex])
+
+    line = '@draft/bot :TestBot!sopel@example.com PRIVMSG #sopel :Hi!'
+    pretrigger = trigger.PreTrigger(mockbot.nick, line)
+    assert not list(rule.match(mockbot, pretrigger)), (
+        'Line with `draft/bot` tag must be ignored'
+    )
+
+    line = '@bot :TestBot!sopel@example.com PRIVMSG #sopel :Hi!'
+    pretrigger = trigger.PreTrigger(mockbot.nick, line)
+    assert not list(rule.match(mockbot, pretrigger)), (
+        'Line with final/ratified `bot` tag must be ignored'
+    )
+
+
 def test_rule_match_privmsg_echo(mockbot):
     line = ':TestBot!sopel@example.com PRIVMSG #sopel :Hi!'
     pretrigger = trigger.PreTrigger(mockbot.nick, line)


### PR DESCRIPTION
### Description
Filter out `PRIVMSG` and `NOTICE` commands that have the `bot` (or `draft/bot`) tag. Other events should be left alone until there's a decorator to opt back into them, or Sopel itself will no longer even be aware of bot users' existence on networks that implement one of these tags (which per [the spec](https://ircv3.net/specs/extensions/bot-mode) "SHOULD" be added to all commands sent, _and_ numerics caused, by a bot client).

A later pull request can introduce the needed decorator and changes to Rule constructors for certain callables to allow `bot` messages (à la `@plugin.echo`). Trying to keep stuff in manageable chunks so nobody gets burned out on reviews. 😸

Part of #2079.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - Once again, by the power of `pytest`!

### Notes
I really want to skip over the part where we have to support _only_ `draft/bot` and then come back later to add support for the final `bot` tag name. Technically we shouldn't do that if the spec isn't ratified by the time Sopel 8 goes stable, though.