### PR TITLE
cli: look harder for $PWD/cfg, don't automatically start config wizard

### DIFF
--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -344,11 +344,9 @@ def get_configuration(options):
     try:
         settings = utils.load_settings(options)
     except config.ConfigurationNotFound as error:
-        print(
-            "Welcome to Sopel!\n"
-            "I can't seem to find the configuration file, "
-            "so let's generate it!\n")
-        settings = utils.wizard(error.filename)
+        print("Welcome to Sopel!")
+        error.hint = "To start the configuration wizard, use `sopel configure`"
+        raise error
 
     settings._is_daemonized = options.daemonize
     return settings

--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -236,6 +236,8 @@ def find_config(config_dir, name, extension='.cfg'):
     if os.path.isfile(name):
         return os.path.abspath(name)
     name_ext = name + extension
+    if os.path.isfile(name_ext):
+        return os.path.abspath(name_ext)
     for filename in enumerate_configs(config_dir, extension):
         if name_ext == filename:
             return os.path.join(config_dir, name_ext)

--- a/sopel/config/__init__.py
+++ b/sopel/config/__init__.py
@@ -91,14 +91,20 @@ class ConfigurationNotFound(ConfigurationError):
     """Exception type for use when the configuration file cannot be found.
 
     :param str filename: file path that could not be found
+    :param str hint: supplemental information to show the user
     """
-    def __init__(self, filename):
+    def __init__(self, filename, hint=None):
         super(ConfigurationNotFound, self).__init__(None)
         self.filename = filename
         """Path to the configuration file that could not be found."""
+        self.hint = hint
+        """Supplemental information to show the user."""
 
     def __str__(self):
-        return 'Unable to find the configuration file %s' % self.filename
+        ret = 'Unable to find the configuration file %s' % self.filename
+        if self.hint:
+            ret += "\n" + self.hint
+        return ret
 
 
 class Config(object):

--- a/test/cli/test_cli_utils.py
+++ b/test/cli/test_cli_utils.py
@@ -112,7 +112,10 @@ def test_find_config_local(tmpdir, config_dir):
         assert found_config == working_dir.join('local.cfg').strpath
 
         found_config = find_config(config_dir.strpath, 'local')
-        assert found_config == config_dir.join('local').strpath
+        assert found_config == working_dir.join('local.cfg').strpath
+
+        found_config = find_config(config_dir.strpath, 'config')
+        assert found_config == config_dir.join('config.cfg').strpath
 
 
 def test_find_config_default(tmpdir, config_dir):


### PR DESCRIPTION
### Description
This fixes two annoyances:
- Sopel automatically adds `.cfg` when searching the config dir, but it doesn't when searching the current working directory
- If the config file is not found, it currently automatically starts the configuration wizard.

Combining these two, a user (me) will (does, regularly) `cd` to their non-default Sopel config dir, run `sopel -c mybot` expecting it to load mybot.cfg and run, but instead have Sopel create ~/.sopel/ and ~/.sopel/mybot.cfg and start the config wizard.

Searching `$PWD/{config}.{ext}` is straightforward, but not automatically running the wizard is probably subject to opinions. I changed it to the below output, but I would also be content with "Do you want to run the configuration wizard? y/n", or at least not creating the folder/file until the end of the wizard so the user has an opportunity to ^C without having to then `rm -rf ~/.sopel`

Amended "couldn't find config":
```
$ sopel -c foobar
Welcome to Sopel!
I can't seem to find the configuration file.
To start the configuration wizard, run `sopel configure`
Unable to find the configuration file /home/user/.sopel/foobar
$
```

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
