### PR TITLE
tests: fix+add ENV override tests

### DIFF
--- a/test/cli/test_cli_run.py
+++ b/test/cli/test_cli_run.py
@@ -47,6 +47,13 @@ def config_dir(tmpdir):
     return test_dir
 
 
+@pytest.fixture(autouse=True)
+def default_empty_config_env(monkeypatch):
+    """Pytest fixture used to ensure dev ENV does not bleed into tests"""
+    monkeypatch.delenv("SOPEL_CONFIG", raising=False)
+    monkeypatch.delenv("SOPEL_CONFIG_DIR", raising=False)
+
+
 def test_build_parser_legacy():
     """Assert parser's namespace exposes legacy's options (default values)"""
     parser = build_parser()

--- a/test/cli/test_cli_utils.py
+++ b/test/cli/test_cli_utils.py
@@ -51,6 +51,13 @@ def config_dir(tmpdir):
     return test_dir
 
 
+@pytest.fixture(autouse=True)
+def default_empty_config_env(monkeypatch):
+    """Pytest fixture used to ensure dev ENV does not bleed into tests"""
+    monkeypatch.delenv("SOPEL_CONFIG", raising=False)
+    monkeypatch.delenv("SOPEL_CONFIG_DIR", raising=False)
+
+
 @pytest.fixture
 def env_dir(tmpdir):
     """Pytest fixture used to generate an extra (external) config directory"""

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -246,6 +246,11 @@ def test_fileattribute_given_file_when_dir(fakeconfig):
         fakeconfig.fake.ad_fileattr = testfile
 
 
+def test_configparser_env_priority_over_file(monkeypatch, fakeconfig):
+    monkeypatch.setenv('SOPEL_CORE_OWNER', 'not_dgw')
+    assert fakeconfig.core.owner == 'not_dgw'
+
+
 def test_configparser_multi_lines(multi_fakeconfig):
     # spam
     assert multi_fakeconfig.spam.eggs == [
@@ -267,6 +272,45 @@ def test_configparser_multi_lines(multi_fakeconfig):
     ]
 
     assert multi_fakeconfig.spam.channels == TEST_CHANNELS
+
+
+def test_configparser_multi_env(monkeypatch, multi_fakeconfig):
+    monkeypatch.setenv('SOPEL_SPAM_EGGS', 'five, six, seven, eight, and a half')
+    monkeypatch.setenv('SOPEL_SPAM_BACONS', 'microwaved\nfreeze in,\n, dry, thin, and disgusting')
+    monkeypatch.setenv('SOPEL_SPAM_CHEESES', ' swiss\n  sbrinz\ncottage')
+    # Comments not allowed when passing channels via ENV
+    monkeypatch.setenv(
+        'SOPEL_SPAM_CHANNELS',
+        '"#sopel"\n&strange\n*someZnc\n"#public"\n"#frontquote\n&backquote"\n"&bothquoted"\n"*starchan"'
+    )
+
+    assert multi_fakeconfig.spam.eggs == [
+        'five',
+        'six',
+        'seven',
+        'eight',
+        'and a half',  # no-newline + comma
+    ]
+    assert multi_fakeconfig.spam.bacons == [
+        'microwaved',
+        'freeze in',
+        'dry, thin, and disgusting',
+    ]
+    assert multi_fakeconfig.spam.cheeses == [
+        'swiss',
+        'sbrinz',
+        'cottage',
+    ]
+    assert multi_fakeconfig.spam.channels == [
+        '#sopel',
+        '&strange',
+        '*someZnc',
+        '#public',
+        '"#frontquote',
+        '&backquote"',
+        '"&bothquoted"',
+        '"*starchan"'
+    ]
 
 
 def test_save_unmodified_config(multi_fakeconfig):


### PR DESCRIPTION
### Description
If a developer has ENVs set for CLI overrides (i.e., `SOPEL_CONFIG`, `SOPEL_CONFIG_DIR`), some tests in `test/cli/*` will fail due to those ENVs leaking into tests. Specifically, tests that assume:
- `options.config == 'default'`
- `options.configdir == config.DEFAULT_HOMEDIR`

Adding a `autouse=True` fixture to clear those specific vars resolves this, while retaining proper testing of ENV overrides as implemented.

Also, in the same vein, added tests for ENV overrides for actual config settings too.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)<sup>1</sup>
- [x] I have tested the functionality of the things this change touches

**Notes**
<sup>1</sup> No lie this time! Last two PRs actually failed the CLI tests referenced in this PR but I still checked the box :sweat_smile: 