### PR TITLE
irc: Use repr() and don't strip() rawlog, log charset guess failures

### DIFF
--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -335,7 +335,7 @@ class AbstractBot(object):
         if not self.settings.core.log_raw:
             return
         logger = logging.getLogger('sopel.raw')
-        logger.info('\t'.join([prefix, line.strip()]))
+        logger.info("%s\t%r", prefix, line)
 
     def cap_req(self, plugin_name, capability, arg=None, failure_callback=None,
                 success_callback=None):


### PR DESCRIPTION
### Description
Print rawlog with `repr()` so we don't need a hex editor to find problems with whitespace or non-printable characters.

Don't `.strip()` messages headed for rawlog, which currently obscures problems with whitespace.

Add logging (warning) and rawlogging of messages that couldn't be decoded, which were previously silently ignored. New rawlog prefix: `<<!`

Each part of this is a breaking change if any madman is parsing the rawlog, but I don't think we consider that part of the API...

### Concerns

QA passes, but this does change handling of IRC's message separators in ways that may have corner cases I haven't found:
- Switches asynchat to break messages on `b'\r\n'` instead of `b'\r'`. Do any real-world daemons use only `\n`?
- Puts the `\r\n` back on before decoding/logging. I'm not sure how far that goes before it hits another `.strip()`

I'm currently running it in prod (unreal 3 and inspircd 3) and haven't found any obvious problems.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches