### PR TITLE
trigger: document that `args` is a list

### DIFF
--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -347,13 +347,13 @@ class Trigger(unicode):
     See Python's :meth:`re.Match.groupdict` documentation for details.
     """
     args = property(lambda self: self._pretrigger.args)
-    """A tuple containing each of the arguments to an event.
+    """A list containing each of the arguments to an event.
 
-    :type: tuple
+    :type: list[str]
 
     These are the strings passed between the event name and the colon. For
     example, when setting ``mode -m`` on the channel ``#example``, args would
-    be ``('#example', '-m')``
+    be ``['#example', '-m']``
     """
     urls = property(lambda self: self._pretrigger.urls)
     """A tuple containing all URLs found in the text.


### PR DESCRIPTION
### Description
As far as I can see, trigger.py only ever has `args=thing.split()`, so will only ever be a list. Either the docs should reflect that, or we should tuple() those.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
