### PR TITLE
coretasks: Strip Unreal's extra empty MODE arg

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -496,10 +496,13 @@ def _parse_modes(bot, args):
         return
 
     channel = bot.channels[channel_name]
-    # Our old MODE parsing code checked for empty args. This would be a good
-    # place to re-implement that if necessary for a non-compliant IRCd, but for
-    # now just log malformed lines. After this we'll make a (possibly dangerous)
-    # assumption that the MODE message is more-or-less compliant.
+
+    # Unreal 3 sometimes sends an extraneous trailing space. If we're short an
+    # arg, we'll find out later.
+    if args[-1] == "":
+        args.pop()
+    # If any args are still empty, that's something we may not be prepared for,
+    # but let's continue anyway hoping they're trailing / not important.
     if len(args) < 2 or not all(args):
         LOGGER.debug(
             "The server sent a possibly malformed MODE message: %r", args)
@@ -598,6 +601,13 @@ def _parse_modes(bot, args):
             )
             _send_who(bot, channel_name)
             return
+
+    if param_idx != len(params):
+        LOGGER.warning(
+            "Too many arguments received for MODE: args=%r chanmodes=%r",
+            args,
+            chanmodes,
+        )
 
     LOGGER.info("Updated mode for channel: %s", channel.name)
     LOGGER.debug("Channel %r mode: %r", str(channel.name), channel.modes)

--- a/test/test_coretasks.py
+++ b/test/test_coretasks.py
@@ -134,6 +134,19 @@ def test_bot_unknown_priv_mode(mockbot, ircfactory):
     ), "The bot must treat mapped but non-PREFIX modes as unknown."
 
 
+def test_bot_extra_mode_args(mockbot, ircfactory, caplog):
+    """Test warning on extraneous MODE args."""
+    irc = ircfactory(mockbot)
+    irc.bot._isupport = isupport.ISupport(chanmodes=("b", "k", "l", "mnt", tuple()))
+    irc.channel_joined("#test", ["Alex", "Bob", "Cheryl"])
+
+    mode_msg = ":Sopel!bot@bot MODE #test +m nonsense"
+    mockbot.on_message(mode_msg)
+
+    assert mockbot.channels["#test"].modes["m"]
+    assert "Too many arguments received for MODE" in caplog.text
+
+
 def test_handle_rpl_channelmodeis(mockbot, ircfactory):
     """Test handling RPL_CHANNELMODEIS events, response to MODE query."""
     rpl_channelmodeis = " ".join([


### PR DESCRIPTION
### Description
Reduce "possibly malformed MODE" logspam, and warn with useful info if we still have extra args.

I can't think of a case where we would need a legitimate empty arg, and the continued presence of the previous comments seems to agree, so... Let's just assume a trailing space is a meaningless trailing space.

(If we're *short* args, we'll... still get an uncaught `IndexError`. Should that be handled better?)

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
