### PR TITLE
coretasks: add `userhost-in-names` CAP and `UHNAMES` ISUPPORT token

### DIFF
--- a/test/test_coretasks.py
+++ b/test/test_coretasks.py
@@ -304,6 +304,32 @@ def test_handle_isupport_namesx(mockbot):
     assert len(mockbot.backend.message_sent) == 1, 'No need to resend!'
 
 
+def test_handle_isupport_uhnames(mockbot):
+    mockbot.on_message(
+        ':irc.example.com 005 Sopel '
+        'SAFELIST ELIST=CTU CPRIVMSG CNOTICE '
+        ':are supported by this server')
+
+    assert 'UHNAMES' not in mockbot.isupport
+    assert mockbot.backend.message_sent == []
+    assert 'userhost-in-names' not in mockbot.server_capabilities
+
+    mockbot.on_message(
+        ':irc.example.com 005 Sopel '
+        'UHNAMES '
+        ':are supported by this server')
+
+    assert 'UHNAMES' in mockbot.isupport
+    assert mockbot.backend.message_sent == rawlist('PROTOCTL UHNAMES')
+
+    mockbot.on_message(
+        ':irc.example.com 005 Sopel '
+        'UHNAMES '
+        ':are supported by this server')
+
+    assert len(mockbot.backend.message_sent) == 1, 'No need to resend!'
+
+
 def test_handle_isupport_namesx_with_multi_prefix(mockbot):
     # set multi-prefix
     mockbot.server_capabilities['multi-prefix'] = None


### PR DESCRIPTION
### Description
Completes part of #971, adding support for the `userhost-in-names` IRCv3 CAP, with fallback to the older `UHNAMES` ISUPPORT token.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - **Note:** Have not explicitly tested `UHNAMES`, but [the `userhost-in-names` spec](https://ircv3.net/specs/extensions/userhost-in-names) says it's "the same extension".