### PR TITLE
safety: prevent UnicodeDecodeError on startup under py2

### DIFF
--- a/sopel/modules/safety.py
+++ b/sopel/modules/safety.py
@@ -108,7 +108,13 @@ def setup(bot):
         _download_domain_list(loc)
     with open(loc, 'r') as f:
         for line in f:
-            clean_line = unicode(line).strip().lower()
+            if sys.version_info.major < 3:
+                line = unicode(line, 'utf-8')
+            else:
+                line = unicode(line)
+
+            clean_line = line.strip().lower()
+
             if not clean_line or clean_line[0] == '#':
                 # blank line or comment
                 continue


### PR DESCRIPTION
### Description
One single comment in the StevenBlack list contains one single Unicode character that the 'ascii' codec doesn't like.

This will never be necessary on the master branch, which is about to permanently remove support for Python 2; py3 uses `utf-8` by default in its `str` constructor.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - It pained me to run Sopel under py2 again, but I did it for science.