### PR TITLE
admin: add .raw command to send raw IRC messages

### DIFF
--- a/sopel/modules/admin.py
+++ b/sopel/modules/admin.py
@@ -25,6 +25,8 @@ ERROR_PART_NO_CHANNEL = 'Which channel should I quit?'
 """Error message when channel is missing from command arguments."""
 ERROR_NOTHING_TO_SAY = 'I need a channel and a message to talk.'
 """Error message when channel and/or message are missing."""
+ERROR_NOTHING_TO_RAW = 'I need an IRC message to send.'
+"""Error message when no raw IRC message was given."""
 
 
 class AdminSection(types.StaticSection):
@@ -222,6 +224,23 @@ def quit(bot, trigger):
 
     LOGGER.info(default_message)
     bot.quit(quit_message)
+
+
+@plugin.require_privmsg
+@plugin.require_owner
+@plugin.command('raw')
+@plugin.priority('low')
+@plugin.example('.raw PRIVMSG NickServ :CERT ADD')
+def raw(bot, trigger):
+    """
+    Send a raw IRC message. Can only be done in privmsg by the bot owner.
+    This is mostly useful for debugging.
+    """
+    if trigger.group(2) is None:
+        bot.reply(ERROR_NOTHING_TO_RAW)
+        return
+
+    bot.write([trigger.group(2)])
 
 
 @plugin.require_privmsg


### PR DESCRIPTION
### Description
Adds a `.raw` command to `admin.py` to allow commanding the bot to send a raw IRC message, e.g. `.raw OPER Sopel ThisIsABadIdea123`

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
