### PR TITLE
docs: config/auth: clarify auth_username, etc

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -399,11 +399,13 @@ And for **nick-based** methods:
 * ``Q``
 * ``userserv``
 
-These additional options can be used to configure the authentication method
-and the required credentials:
+Several additional options can be used to configure the authentication method
+and the required credentials. You can follow the link for each to find more
+details:
 
-* :attr:`~CoreSection.auth_username`: account's username, if required
-* :attr:`~CoreSection.auth_password`: account's password
+* :attr:`~CoreSection.auth_username`: account's username, if used by
+  the ``auth_method``
+* :attr:`~CoreSection.auth_password`: password for authentication
 * :attr:`~CoreSection.auth_target`: authentication method's target, if required
   by the ``auth_method``:
 
@@ -428,6 +430,16 @@ And here is an example of server-based authentication using SASL::
     auth_username = BotAccount     # your bot's username
     auth_password = SopelIsGreat!  # your bot's password
     auth_target = PLAIN            # default sasl mechanism
+
+Example of authentication to a ZNC bouncer::
+
+    [core]
+    auth_method = server           # select server-based auth
+    # auth_username is not used with server authentication, so instead
+    # we combine the ZNC username, network name, and password here:
+    auth_password = Sopel/libera:SopelIsGreat!
+
+Don't forget to configure your ZNC to log in to the real network!
 
 
 Multi-stage

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -173,11 +173,12 @@ class CoreSection(StaticSection):
 
     :default:
         * ``NickServ`` if using the ``nickserv`` :attr:`auth_method`
+        * ``UserServ`` if using the ``userserv`` :attr:`auth_method`
         * ``PLAIN`` if using the ``sasl`` :attr:`auth_method`
 
-    The nickname of the NickServ service, or the name of the desired SASL
-    mechanism, if :attr:`auth_method` is set to one of these methods. This value
-    is otherwise ignored.
+    The nickname of the NickServ or UserServ service, or the name of the
+    desired SASL mechanism, if :attr:`auth_method` is set to one of these
+    methods. This value is otherwise ignored.
 
     See :ref:`Authentication`.
     """
@@ -185,7 +186,10 @@ class CoreSection(StaticSection):
     auth_username = ValidatedAttribute('auth_username')
     """The user/account name to use when authenticating.
 
-    May not apply, depending on :attr:`auth_method`. See :ref:`Authentication`.
+    Required for an :attr:`auth_method` of ``authserv``, ``Q``, or
+    ``userserv`` — otherwise ignored.
+
+    See :ref:`Authentication`.
     """
 
     auto_url_schemes = ListAttribute(


### PR DESCRIPTION
### Description
Add an example for having Sopel authenticate to ZNC, inspired by a user in IRC confused by `auth_username` not working with `auth_method=server`.

Also corrects/clarifies/creates a few other things:
- auth_password: used for server auth too, not just user
- please click the directives, I don't want to have to remember to update things in two places
- auth_method=userserv also uses auth_target
- when is auth_username ignored/required (previously: infinite docloop)

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
