### PR TITLE
tell: use correct verb when `tellee == bot.nick`; use `NICKLEN` if available

### DIFF
--- a/sopel/modules/tell.py
+++ b/sopel/modules/tell.py
@@ -162,7 +162,7 @@ def f_remind(bot, trigger):
         tellee = tellee[1:]
 
     if tellee == bot.nick:
-        bot.reply("I'm here now; you can tell me whatever you want!")
+        bot.reply("I'm here now; you can %s me whatever you want!" % verb)
         return
 
     if tellee not in (tools.Identifier(teller), bot.nick, 'me'):

--- a/sopel/modules/tell.py
+++ b/sopel/modules/tell.py
@@ -154,7 +154,7 @@ def f_remind(bot, trigger):
     if not os.path.exists(bot.tell_filename):
         return
 
-    if len(tellee) > 30:  # TODO: use server NICKLEN here when available
+    if len(tellee) > bot.isupport.get('NICKLEN', 30):
         bot.reply('That nickname is too long.')
         return
 


### PR DESCRIPTION
### Description
This is one trivial tweak plus one trivial bugfix bundled into one PR, because it would be extremely silly to make two.

- Fixed a TODO that should have been done for 7.1.0: use `NICKLEN` from `bot.isupport`
- Fixed hardcoded "tell" in the error message when `tellee == bot.nick`

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - Note that this is not tested code, so I only used `make quality`
- [x] I have tested the functionality of the things this change touches