### PR TITLE
docs: more details about users in channels

### DIFF
--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -919,6 +919,16 @@ def require_chanmsg(message=None, reply=False):
                        :meth:`~.bot.Sopel.say` when ``True``; defaults to
                        ``False``
 
+    A decorated plugin callable will be triggered only by messages from a
+    channel::
+
+        from sopel import plugin
+
+        @plugin.command('.mycommand')
+        @plugin.require_chanmsg('Channel only command.')
+        def manage_topic(bot, trigger):
+            # trigger on channel messages only
+
     If the decorated function is triggered by a private message, ``message``
     will be said if given. By default, it uses :meth:`bot.say()
     <.bot.Sopel.say>`, but when ``reply`` is true, then it uses

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -553,6 +553,17 @@ class Identifier(unicode):
 
         :return: ``True`` if this :py:class:`Identifier` is a nickname;
                  ``False`` if it appears to be a channel
+
+        ::
+
+            >>> from sopel import tools
+            >>> ident = tools.Identifier('Sopel')
+            >>> ident.is_nick()
+            True
+            >>> ident = tools.Identifier('#sopel')
+            >>> ident.is_nick()
+            False
+
         """
         return self and not self.startswith(_channel_prefixes)
 

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -232,6 +232,14 @@ class Trigger(unicode):
 
     This will be a channel name for "regular" (channel) messages, or the nick
     that sent a private message.
+
+    You can check if the trigger comes from a channel or a nick with its
+    :meth:`~sopel.tools.Identifier.is_nick` method::
+
+        if trigger.sender.is_nick():
+            # message sent from a private message
+        else:
+            # message sent from a channel
     """
     time = property(lambda self: self._pretrigger.time)
     """When the message was received.


### PR DESCRIPTION
### Description

Very often we get questions on IRC on how to get a list of users from a channel. I thought the doc was explicit enough and I was wrong. Therefore, I try to fix that issue by adding more documentation in the "Interact with the bot" chapter.

At some point, we might want a chapter just about channels, users, and privileges, but that'll be for another day. I tried to update the doc just enough to fit into the 7.1.1 release, without delaying it too much.

This new doc gives me even more ideas of methods to add on the channel object, and that too will wait Sopel 8.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
