### PR TITLE
docs: be even more specific that `owner` is ALWAYS required

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -136,6 +136,13 @@ A Sopel instance must have exactly one owner. This is configured either by
 or by :attr:`~CoreSection.owner`. If ``owner_account`` is set, ``owner`` will
 be ignored.
 
+.. important::
+
+    Even if ``owner_account`` is set, ``owner`` **must** still have a value.
+
+    This is silly, we know. The plan for Sopel 8 is to require only one value
+    or the other.
+
 The same instance can have multiple admins. Similarly, it can be configured
 by :attr:`~CoreSection.admin_accounts` or by :attr:`~CoreSection.admins`. If
 ``admin_accounts`` is set, ``admins`` will be ignored.
@@ -155,6 +162,9 @@ Example owner & admin configurations::
     admin_accounts =
             Exirel
             HumorBaby
+    # ignored when owner_account is set,
+    # but MUST NOT be empty
+    owner = dgw
 
 Both ``owner_account`` and ``admin_accounts`` are safer to use than
 nick-based matching, but the IRC server must support accounts.


### PR DESCRIPTION
### Description
Noticed that while the docstring for `core_section.CoreSection.owner` specifies that it's always required, the "Owners & Admins" docs chapter didn't say anything about it, which could lead users to be confused.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - Doesn't touch any `.py` files, so I didn't run those.
- [x] I have tested the functionality of the things this change touches
  - N/A, like the above

### Notes
Don't know yet if we'll need a 7.1.2 release, but I'm sure it'll happen. This is the first PR for it, apparently.