### PR TITLE
config: require `owner` only if no `owner_account` is set

### DIFF
--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -9,7 +9,6 @@ from sopel.config.types import (
     ChoiceAttribute,
     FilenameAttribute,
     ListAttribute,
-    NO_DEFAULT,
     SecretAttribute,
     StaticSection,
     ValidatedAttribute,
@@ -88,6 +87,17 @@ class CoreSection(StaticSection):
         with the minimal required options.
 
     """
+    def __init__(self, config, section_name, validate=True):
+        super().__init__(config, section_name, validate)
+
+        if validate:
+            # `owner` is required UNLESS `owner_account` is set
+            owner = getattr(self, 'owner', None)
+            owner_account = getattr(self, 'owner_account', None)
+            if not any([owner, owner_account]):
+                raise ValueError(
+                    'Either {sect}.owner or {sect}.owner_account is required'
+                    .format(sect=section_name))
 
     admins = ListAttribute('admins')
     """The list of people (other than the owner) who can administer the bot.
@@ -952,10 +962,10 @@ class CoreSection(StaticSection):
     won't work until the bot has been properly configured.
     """
 
-    owner = ValidatedAttribute('owner', default=NO_DEFAULT)
+    owner = ValidatedAttribute('owner')
     """The IRC name of the owner of the bot.
 
-    **Required** even if :attr:`owner_account` is set.
+    Ignored if :attr:`owner_account` is set.
     """
 
     owner_account = ValidatedAttribute('owner_account')

--- a/test/config/test_config_core_section.py
+++ b/test/config/test_config_core_section.py
@@ -1,0 +1,66 @@
+# coding=utf-8
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+import pytest
+
+from sopel import config
+
+
+FAKE_OWNER_CONFIG = """
+[core]
+owner=dgw
+"""
+
+FAKE_OWNER_ACCOUNT_CONFIG = """
+[core]
+owner_account=dgw
+"""
+
+FAKE_NO_OWNER_CONFIG = """
+[core]
+"""
+
+FAKE_EMPTY_OWNER_CONFIG = """
+[core]
+owner=
+"""
+
+FAKE_EMPTY_OWNER_ACCOUNT_CONFIG = """
+[core]
+owner_account=
+"""
+
+
+@pytest.fixture
+def tmphomedir(tmpdir):
+    sopel_homedir = tmpdir.join('.sopel')
+    sopel_homedir.mkdir()
+    sopel_homedir.join('test.tmp').write('')
+    sopel_homedir.join('test.d').mkdir()
+    return sopel_homedir
+
+
+def get_fake_config(contents, tmphomedir):
+    conf_file = tmphomedir.join('conf.cfg')
+    conf_file.write(contents)
+
+    test_settings = config.Config(conf_file.strpath)
+    return test_settings
+
+
+@pytest.mark.parametrize('contents', [
+    FAKE_OWNER_CONFIG,
+    FAKE_OWNER_ACCOUNT_CONFIG,
+])
+def test_core_section_owner_present(contents, tmphomedir):
+    get_fake_config(contents, tmphomedir)
+
+
+@pytest.mark.parametrize('contents', [
+    FAKE_NO_OWNER_CONFIG,
+    FAKE_EMPTY_OWNER_CONFIG,
+    FAKE_EMPTY_OWNER_ACCOUNT_CONFIG,
+])
+def test_core_section_owner_missing(contents, tmphomedir):
+    with pytest.raises(ValueError):
+        get_fake_config(contents, tmphomedir)


### PR DESCRIPTION
### Description
This shifts validation of the `core.owner` setting from the base `StaticSection` class to `CoreSection`, by unmarking it as required (removing `default=NO_DEFAULT`) and checking the values after loading and validating the section has succeeded via `super()`.

Comes with its own tests to validate the new behavior (a habit we should continue trying to keep up).

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
Will need to undo #2112 once that's merged, and remove any other references to `owner` being required no matter what.

Would have loved to raise `ConfigurationError` instead of `ValueError`, but `config` imports `config.core_section`:

```
ImportError: cannot import name 'ConfigurationError' from partially initialized module 'sopel.config' (most
likely due to a circular import) (/mnt/c/Users/dgw/github/sopel/sopel/config/__init__.py)
```