### PR TITLE
coretasks, test: support CHGHOST command/capability

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -1254,7 +1254,9 @@ def recv_chghost(bot, trigger):
         new_user, new_host = trigger.args
     except ValueError:
         LOGGER.warning(
-            "Ignoring CHGHOST command: too many arguments %r", trigger.args)
+            "Ignoring CHGHOST command with %s arguments: %r",
+            'extra' if len(trigger.args) > 2 else 'insufficient',
+            trigger.args)
         return
 
     bot.users[trigger.nick].user = new_user

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -916,6 +916,7 @@ def receive_cap_ls_reply(bot, trigger):
         'echo-message',
         'multi-prefix',
         'away-notify',
+        'chghost',
         'cap-notify',
         'server-time',
     ]
@@ -1237,6 +1238,30 @@ def blocks(bot, trigger):
             return
     else:
         bot.reply(STRINGS['huh'])
+
+
+@plugin.event('CHGHOST')
+@plugin.thread(False)
+@plugin.unblockable
+@plugin.priority('medium')
+def recv_chghost(bot, trigger):
+    """Track user/host changes."""
+    if trigger.nick not in bot.users:
+        bot.users[trigger.nick] = target.User(
+            trigger.nick, trigger.user, trigger.host)
+
+    try:
+        new_user, new_host = trigger.args
+    except ValueError:
+        LOGGER.warning(
+            "Ignoring CHGHOST command: too many arguments %r", trigger.args)
+        return
+
+    bot.users[trigger.nick].user = new_user
+    bot.users[trigger.nick].host = new_host
+    LOGGER.info(
+        "Update user@host for nick %r: %s@%s",
+        trigger.nick, new_user, new_host)
 
 
 @module.event('ACCOUNT')

--- a/test/test_coretasks.py
+++ b/test/test_coretasks.py
@@ -73,7 +73,7 @@ def test_bot_mixed_mode_removal(mockbot, ircfactory):
     irc.mode_set('#test', '-o+o-qa+v', [
         'Uvoice', 'Uop', 'Uvoice', 'Uvoice', 'Uvoice'])
     assert mockbot.channels["#test"].privileges[Identifier("Uop")] == OP, (
-        'OP got +o only')
+        'Uop got +o only')
     assert mockbot.channels["#test"].privileges[Identifier("Uvoice")] == VOICE, (
         'Uvoice got -o, -q, -a, then +v')
 
@@ -382,3 +382,14 @@ def test_sasl_plain_token_generation():
     assert (
         coretasks._make_sasl_plain_token('sopel', 'sasliscool') ==
         'sopel\x00sopel\x00sasliscool')
+
+
+def test_recv_chghost(mockbot, ircfactory):
+    """Ensure that CHGHOST messages are correctly handled."""
+    irc = ircfactory(mockbot)
+    irc.channel_joined("#test", ["Alex", "Bob", "Cheryl"])
+
+    mockbot.on_message(":Alex!~alex@test.local CHGHOST alex identd.confirmed")
+
+    assert mockbot.users[Identifier('Alex')].user == 'alex'
+    assert mockbot.users[Identifier('Alex')].host == 'identd.confirmed'


### PR DESCRIPTION
### Description

Reduces churn in `bot.users` and `bot.channels` on networks that support the `chghost` CAP, since they send a flood of QUIT, JOIN, and MODE lines to connected clients without `chghost` support in order to emulate the CHGHOST behavior.

Checks another box in #971. Also fixes a likely typo in a nearby coretasks test.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
[`chghost` spec](https://ircv3.net/specs/extensions/chghost) for reviewers' reference.