### PR TITLE
Replace (almost) all usage of `sopel.module` with `sopel.plugin`

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -32,7 +32,7 @@ import re
 import sys
 import time
 
-from sopel import loader, module, plugin
+from sopel import loader, plugin
 from sopel.config import ConfigurationError
 from sopel.irc import isupport
 from sopel.irc.utils import CapReq, MyInfo
@@ -65,7 +65,7 @@ def setup(bot):
     if bot.settings.core.throttle_join:
         wait_interval = max(bot.settings.core.throttle_wait, 1)
 
-        @module.interval(wait_interval)
+        @plugin.interval(wait_interval)
         @plugin.label('throttle_join')
         def processing_job(bot):
             _join_event_processing(bot)
@@ -206,9 +206,9 @@ def on_nickname_in_use(bot, trigger):
     bot.change_current_nick(bot.nick + '_')
 
 
-@module.require_privmsg("This command only works as a private message.")
-@module.require_admin("This command requires admin privileges.")
-@module.commands('execute')
+@plugin.require_privmsg("This command only works as a private message.")
+@plugin.require_admin("This command requires admin privileges.")
+@plugin.commands('execute')
 def execute_perform(bot, trigger):
     """Execute commands specified to perform on IRC server connect.
 
@@ -218,9 +218,9 @@ def execute_perform(bot, trigger):
     _execute_perform(bot)
 
 
-@module.event(events.RPL_WELCOME, events.RPL_LUSERCLIENT)
-@module.thread(False)
-@module.unblockable
+@plugin.event(events.RPL_WELCOME, events.RPL_LUSERCLIENT)
+@plugin.thread(False)
+@plugin.unblockable
 @plugin.priority('medium')
 def startup(bot, trigger):
     """Do tasks related to connecting to the network.
@@ -308,10 +308,10 @@ def startup(bot, trigger):
     _execute_perform(bot)
 
 
-@module.event(events.RPL_ISUPPORT)
-@module.thread(False)
-@module.unblockable
-@module.rule('are supported by this server')
+@plugin.event(events.RPL_ISUPPORT)
+@plugin.thread(False)
+@plugin.unblockable
+@plugin.rule('are supported by this server')
 @plugin.priority('medium')
 def handle_isupport(bot, trigger):
     """Handle ``RPL_ISUPPORT`` events."""
@@ -339,9 +339,9 @@ def handle_isupport(bot, trigger):
             bot.write(('PROTOCTL', 'NAMESX'))
 
 
-@module.event(events.RPL_MYINFO)
-@module.thread(False)
-@module.unblockable
+@plugin.event(events.RPL_MYINFO)
+@plugin.thread(False)
+@plugin.unblockable
 @plugin.priority('medium')
 def parse_reply_myinfo(bot, trigger):
     """Handle ``RPL_MYINFO`` events."""
@@ -357,9 +357,9 @@ def parse_reply_myinfo(bot, trigger):
     )
 
 
-@module.require_privmsg()
-@module.require_owner()
-@module.commands('useserviceauth')
+@plugin.require_privmsg()
+@plugin.require_owner()
+@plugin.commands('useserviceauth')
 def enable_service_auth(bot, trigger):
     """Set owner's account from an authenticated owner.
 
@@ -390,7 +390,7 @@ def enable_service_auth(bot, trigger):
     )
 
 
-@module.event(events.ERR_NOCHANMODES)
+@plugin.event(events.ERR_NOCHANMODES)
 @plugin.priority('medium')
 def retry_join(bot, trigger):
     """Give NickServ enough time to identify on a +R channel.
@@ -418,10 +418,10 @@ def retry_join(bot, trigger):
     bot.join(channel)
 
 
-@module.rule('(.*)')
-@module.event(events.RPL_NAMREPLY)
-@module.thread(False)
-@module.unblockable
+@plugin.rule('(.*)')
+@plugin.event(events.RPL_NAMREPLY)
+@plugin.thread(False)
+@plugin.unblockable
 @plugin.priority('medium')
 def handle_names(bot, trigger):
     """Handle NAMES responses.
@@ -445,12 +445,12 @@ def handle_names(bot, trigger):
     # If this ever needs to be updated, remember to change the mode handling in
     # the WHO-handler functions below, too.
     mapping = {
-        "+": module.VOICE,
-        "%": module.HALFOP,
-        "@": module.OP,
-        "&": module.ADMIN,
-        "~": module.OWNER,
-        "!": module.OPER,
+        "+": plugin.VOICE,
+        "%": plugin.HALFOP,
+        "@": plugin.OP,
+        "&": plugin.ADMIN,
+        "~": plugin.OWNER,
+        "!": plugin.OPER,
     }
 
     for name in names:
@@ -471,20 +471,20 @@ def handle_names(bot, trigger):
         bot.channels[channel].add_user(user, privs=priv)
 
 
-@module.rule('(.*)')
-@module.event('MODE')
-@module.thread(False)
-@module.unblockable
+@plugin.rule('(.*)')
+@plugin.event('MODE')
+@plugin.thread(False)
+@plugin.unblockable
 @plugin.priority('medium')
 def track_modes(bot, trigger):
     """Track changes from received MODE commands."""
     _parse_modes(bot, trigger.args)
 
 
-@module.priority('high')
-@module.event(events.RPL_CHANNELMODEIS)
-@module.thread(False)
-@module.unblockable
+@plugin.priority('high')
+@plugin.event(events.RPL_CHANNELMODEIS)
+@plugin.thread(False)
+@plugin.unblockable
 def initial_modes(bot, trigger):
     """Populate channel modes from response to MODE request sent after JOIN."""
     _parse_modes(bot, trigger.args[1:], clear=True)
@@ -514,13 +514,13 @@ def _parse_modes(bot, args, clear=False):
     params = args[2:]
 
     mapping = {
-        "v": module.VOICE,
-        "h": module.HALFOP,
-        "o": module.OP,
-        "a": module.ADMIN,
-        "q": module.OWNER,
-        "y": module.OPER,
-        "Y": module.OPER,
+        "v": plugin.VOICE,
+        "h": plugin.HALFOP,
+        "o": plugin.OP,
+        "a": plugin.ADMIN,
+        "q": plugin.OWNER,
+        "y": plugin.OPER,
+        "Y": plugin.OPER,
     }
 
     modes = {}
@@ -623,9 +623,9 @@ def _parse_modes(bot, args, clear=False):
     LOGGER.debug("Channel %r mode: %r", str(channel.name), channel.modes)
 
 
-@module.event('NICK')
-@module.thread(False)
-@module.unblockable
+@plugin.event('NICK')
+@plugin.thread(False)
+@plugin.unblockable
 @plugin.priority('medium')
 def track_nicks(bot, trigger):
     """Track nickname changes and maintain our chanops list accordingly."""
@@ -663,10 +663,10 @@ def track_nicks(bot, trigger):
     LOGGER.info("User named %r is now known as %r.", old, str(new))
 
 
-@module.rule('(.*)')
-@module.event('PART')
-@module.thread(False)
-@module.unblockable
+@plugin.rule('(.*)')
+@plugin.event('PART')
+@plugin.thread(False)
+@plugin.unblockable
 @plugin.priority('medium')
 def track_part(bot, trigger):
     """Track users leaving channels."""
@@ -676,9 +676,9 @@ def track_part(bot, trigger):
     LOGGER.info("User %r left a channel: %s", str(nick), channel)
 
 
-@module.event('KICK')
-@module.thread(False)
-@module.unblockable
+@plugin.event('KICK')
+@plugin.thread(False)
+@plugin.unblockable
 @plugin.priority('medium')
 def track_kick(bot, trigger):
     """Track users kicked from channels."""
@@ -731,7 +731,7 @@ def _send_who(bot, channel):
     bot.channels[Identifier(channel)].last_who = datetime.datetime.utcnow()
 
 
-@module.interval(30)
+@plugin.interval(30)
 def _periodic_send_who(bot):
     """Periodically send a WHO request to keep user information up-to-date."""
     if 'away-notify' in bot.enabled_capabilities:
@@ -759,9 +759,9 @@ def _periodic_send_who(bot):
         _send_who(bot, selected_channel)
 
 
-@module.event('JOIN')
-@module.thread(False)
-@module.unblockable
+@plugin.event('JOIN')
+@plugin.thread(False)
+@plugin.unblockable
 @plugin.priority('medium')
 def track_join(bot, trigger):
     """Track users joining channels.
@@ -806,9 +806,9 @@ def track_join(bot, trigger):
         user.account = trigger.args[1]
 
 
-@module.event('QUIT')
-@module.thread(False)
-@module.unblockable
+@plugin.event('QUIT')
+@plugin.thread(False)
+@plugin.unblockable
 @plugin.priority('medium')
 def track_quit(bot, trigger):
     """Track when users quit channels."""
@@ -826,9 +826,9 @@ def track_quit(bot, trigger):
         auth_after_register(bot)
 
 
-@module.event('CAP')
-@module.thread(False)
-@module.unblockable
+@plugin.event('CAP')
+@plugin.thread(False)
+@plugin.unblockable
 @plugin.priority('medium')
 def receive_cap_list(bot, trigger):
     """Handle client capability negotiation."""
@@ -1026,9 +1026,9 @@ def send_authenticate(bot, token):
         bot.write(('AUTHENTICATE', '+'))
 
 
-@module.event('AUTHENTICATE')
+@plugin.event('AUTHENTICATE')
 @plugin.thread(False)
-@module.unblockable
+@plugin.unblockable
 @plugin.priority('medium')
 def auth_proceed(bot, trigger):
     """Handle client-initiated SASL auth.
@@ -1065,9 +1065,9 @@ def _make_sasl_plain_token(account, password):
     return '\x00'.join((account, account, password))
 
 
-@module.event(events.RPL_SASLSUCCESS)
+@plugin.event(events.RPL_SASLSUCCESS)
 @plugin.thread(False)
-@module.unblockable
+@plugin.unblockable
 @plugin.priority('medium')
 def sasl_success(bot, trigger):
     """End CAP request on successful SASL auth.
@@ -1097,9 +1097,9 @@ def sasl_fail(bot, trigger):
     bot.quit('SASL Auth Failed')
 
 
-@module.event(events.RPL_SASLMECHS)
+@plugin.event(events.RPL_SASLMECHS)
 @plugin.thread(False)
-@module.unblockable
+@plugin.unblockable
 @plugin.priority('low')
 def sasl_mechs(bot, trigger):
     # Presumably we're only here if we said we actually *want* sasl, but still
@@ -1157,11 +1157,11 @@ def _get_sasl_pass_and_mech(bot):
 # Live blocklist editing
 
 
-@module.commands('blocks')
-@module.thread(False)
-@module.unblockable
-@module.priority('low')
-@module.require_admin
+@plugin.commands('blocks')
+@plugin.thread(False)
+@plugin.unblockable
+@plugin.priority('low')
+@plugin.require_admin
 def blocks(bot, trigger):
     """
     Manage Sopel's blocking features.\
@@ -1239,7 +1239,7 @@ def blocks(bot, trigger):
         bot.reply(STRINGS['huh'])
 
 
-@module.event('ACCOUNT')
+@plugin.event('ACCOUNT')
 @plugin.thread(False)
 @plugin.unblockable
 @plugin.priority('medium')
@@ -1255,9 +1255,9 @@ def account_notify(bot, trigger):
     LOGGER.info("Update account for nick %r: %s", trigger.nick, account)
 
 
-@module.event(events.RPL_WHOSPCRPL)
+@plugin.event(events.RPL_WHOSPCRPL)
 @plugin.thread(False)
-@module.unblockable
+@plugin.unblockable
 @plugin.priority('medium')
 def recv_whox(bot, trigger):
     """Track ``WHO`` responses when ``WHOX`` is enabled."""
@@ -1297,12 +1297,12 @@ def _record_who(bot, channel, user, host, nick, account=None, away=None, modes=N
     priv = 0
     if modes:
         mapping = {
-            "+": module.VOICE,
-            "%": module.HALFOP,
-            "@": module.OP,
-            "&": module.ADMIN,
-            "~": module.OWNER,
-            "!": module.OPER,
+            "+": plugin.VOICE,
+            "%": plugin.HALFOP,
+            "@": plugin.OP,
+            "&": plugin.ADMIN,
+            "~": plugin.OWNER,
+            "!": plugin.OPER,
         }
         for c in modes:
             priv = priv | mapping[c]
@@ -1314,9 +1314,9 @@ def _record_who(bot, channel, user, host, nick, account=None, away=None, modes=N
     bot.privileges[channel][nick] = priv
 
 
-@module.event(events.RPL_WHOREPLY)
+@plugin.event(events.RPL_WHOREPLY)
 @plugin.thread(False)
-@module.unblockable
+@plugin.unblockable
 @plugin.priority('medium')
 def recv_who(bot, trigger):
     """Track ``WHO`` responses when ``WHOX`` is not enabled."""
@@ -1326,9 +1326,9 @@ def recv_who(bot, trigger):
     _record_who(bot, channel, user, host, nick, away=away, modes=modes)
 
 
-@module.event('AWAY')
-@module.thread(False)
-@module.unblockable
+@plugin.event('AWAY')
+@plugin.thread(False)
+@plugin.unblockable
 @plugin.priority('medium')
 def track_notify(bot, trigger):
     """Track users going away or coming back."""
@@ -1341,10 +1341,10 @@ def track_notify(bot, trigger):
     LOGGER.info("User %s: %s", state_change, trigger.nick)
 
 
-@module.event('TOPIC')
-@module.event(events.RPL_TOPIC)
-@module.thread(False)
-@module.unblockable
+@plugin.event('TOPIC')
+@plugin.event(events.RPL_TOPIC)
+@plugin.thread(False)
+@plugin.unblockable
 @plugin.priority('medium')
 def track_topic(bot, trigger):
     """Track channels' topics."""
@@ -1358,7 +1358,7 @@ def track_topic(bot, trigger):
     LOGGER.info("Channel's topic updated: %s", channel)
 
 
-@module.rule(r'(?u).*(.+://\S+).*')
+@plugin.rule(r'(?u).*(.+://\S+).*')
 def handle_url_callbacks(bot, trigger):
     """Dispatch callbacks on URLs
 

--- a/test/modules/test_modules_url.py
+++ b/test/modules/test_modules_url.py
@@ -6,7 +6,7 @@ import re
 
 import pytest
 
-from sopel import bot, loader, module, plugin, plugins, trigger
+from sopel import bot, loader, plugin, plugins, trigger
 from sopel.modules import url
 
 
@@ -36,12 +36,12 @@ def mockbot(configfactory):
     url_plugin.setup(sopel)
     url_plugin.register(sopel)
 
-    @module.url(re.escape('https://example.com/') + r'(.+)')
+    @plugin.url(re.escape('https://example.com/') + r'(.+)')
     @plugin.label('handle_urls_https')
     def url_callback_https(bot, trigger, match):
         pass
 
-    @module.url(re.escape('http://example.com/') + r'(.+)')
+    @plugin.url(re.escape('http://example.com/') + r'(.+)')
     @plugin.label('handle_urls_http')
     def url_callback_http(bot, trigger, match):
         pass

--- a/test/plugins/test_plugins_rules.py
+++ b/test/plugins/test_plugins_rules.py
@@ -6,7 +6,7 @@ import re
 
 import pytest
 
-from sopel import bot, loader, module, plugin, trigger
+from sopel import bot, loader, plugin, trigger
 from sopel.plugins import rules
 from sopel.tests import rawlist
 
@@ -815,7 +815,7 @@ def test_rule_execute(mockbot):
 
 def test_rule_from_callable(mockbot):
     # prepare callable
-    @module.rule(r'hello', r'hi', r'hey', r'hello|hi')
+    @plugin.rule(r'hello', r'hi', r'hey', r'hello|hi')
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -856,7 +856,7 @@ def test_rule_from_callable_nick_placeholder(mockbot):
     # note: yes, the $nick variable is super confusing
     # it should probably accept \s* instead of \s+
     # so a pattern like "$nick hello" would be way easier to read
-    @module.rule(r'$nickhello')
+    @plugin.rule(r'$nickhello')
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -893,7 +893,7 @@ def test_rule_from_callable_nick_placeholder(mockbot):
 
 def test_rule_from_callable_nickname_placeholder(mockbot):
     # prepare callable
-    @module.rule(r'$nickname hello')
+    @plugin.rule(r'$nickname hello')
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -984,7 +984,7 @@ def test_rule_from_callable_invalid(mockbot):
 
 def test_rule_from_callable_lazy_invalid(mockbot):
     # prepare callable
-    @module.rule(r'.*')
+    @plugin.rule(r'.*')
     def handler(wrapped, trigger, match=None):
         wrapped.reply('Hi!')
 
@@ -1015,7 +1015,7 @@ def test_rule_from_callable_lazy_invalid_no_regex(mockbot):
 
 def test_kwargs_from_callable(mockbot):
     # prepare callable
-    @module.rule(r'hello', r'hi', r'hey', r'hello|hi')
+    @plugin.rule(r'hello', r'hi', r'hey', r'hello|hi')
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -1054,7 +1054,7 @@ def test_kwargs_from_callable(mockbot):
 
 def test_kwargs_from_callable_label(mockbot):
     # prepare callable
-    @module.rule(r'hello', r'hi', r'hey', r'hello|hi')
+    @plugin.rule(r'hello', r'hi', r'hey', r'hello|hi')
     @plugin.label('hello_rule')
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
@@ -1069,8 +1069,8 @@ def test_kwargs_from_callable_label(mockbot):
 
 def test_kwargs_from_callable_priority(mockbot):
     # prepare callable
-    @module.rule(r'hello', r'hi', r'hey', r'hello|hi')
-    @module.priority(rules.PRIORITY_LOW)
+    @plugin.rule(r'hello', r'hi', r'hey', r'hello|hi')
+    @plugin.priority(rules.PRIORITY_LOW)
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -1084,8 +1084,8 @@ def test_kwargs_from_callable_priority(mockbot):
 
 def test_kwargs_from_callable_event(mockbot):
     # prepare callable
-    @module.rule(r'hello', r'hi', r'hey', r'hello|hi')
-    @module.event('PRIVMSG', 'NOTICE')
+    @plugin.rule(r'hello', r'hi', r'hey', r'hello|hi')
+    @plugin.event('PRIVMSG', 'NOTICE')
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -1097,10 +1097,10 @@ def test_kwargs_from_callable_event(mockbot):
     assert kwargs['events'] == ['PRIVMSG', 'NOTICE']
 
 
-def test_kwargs_from_callable_intent(mockbot):
+def test_kwargs_from_callable_ctcp_intent(mockbot):
     # prepare callable
-    @module.rule(r'hello', r'hi', r'hey', r'hello|hi')
-    @module.intent('ACTION')
+    @plugin.rule(r'hello', r'hi', r'hey', r'hello|hi')
+    @plugin.ctcp('ACTION')
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -1114,8 +1114,8 @@ def test_kwargs_from_callable_intent(mockbot):
 
 def test_kwargs_from_callable_allow_echo(mockbot):
     # prepare callable
-    @module.rule(r'hello', r'hi', r'hey', r'hello|hi')
-    @module.echo
+    @plugin.rule(r'hello', r'hi', r'hey', r'hello|hi')
+    @plugin.echo
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -1129,8 +1129,8 @@ def test_kwargs_from_callable_allow_echo(mockbot):
 
 def test_kwargs_from_callable_threaded(mockbot):
     # prepare callable
-    @module.rule(r'hello', r'hi', r'hey', r'hello|hi')
-    @module.thread(False)
+    @plugin.rule(r'hello', r'hi', r'hey', r'hello|hi')
+    @plugin.thread(False)
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -1144,8 +1144,8 @@ def test_kwargs_from_callable_threaded(mockbot):
 
 def test_kwargs_from_callable_unblockable(mockbot):
     # prepare callable
-    @module.rule(r'hello', r'hi', r'hey', r'hello|hi')
-    @module.unblockable
+    @plugin.rule(r'hello', r'hi', r'hey', r'hello|hi')
+    @plugin.unblockable
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -1159,8 +1159,8 @@ def test_kwargs_from_callable_unblockable(mockbot):
 
 def test_kwargs_from_callable_rate_limit(mockbot):
     # prepare callable
-    @module.rule(r'hello', r'hi', r'hey', r'hello|hi')
-    @module.rate(user=20, channel=30, server=40)
+    @plugin.rule(r'hello', r'hi', r'hey', r'hello|hi')
+    @plugin.rate(user=20, channel=30, server=40)
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -1178,8 +1178,8 @@ def test_kwargs_from_callable_rate_limit(mockbot):
 
 def test_kwargs_from_callable_examples(mockbot):
     # prepare callable
-    @module.rule(r'hello', r'hi', r'hey', r'hello|hi')
-    @module.example('hello')
+    @plugin.rule(r'hello', r'hi', r'hey', r'hello|hi')
+    @plugin.example('hello')
     def handler(wrapped, trigger):
         """This is the doc you are looking for."""
         wrapped.reply('Hi!')
@@ -1211,9 +1211,9 @@ def test_kwargs_from_callable_examples(mockbot):
 
 def test_kwargs_from_callable_examples_test(mockbot):
     # prepare callable
-    @module.rule(r'hello', r'hi', r'hey', r'hello|hi')
-    @module.example('hi', 'Hi!')
-    @module.example('hello', 'Hi!')
+    @plugin.rule(r'hello', r'hi', r'hey', r'hello|hi')
+    @plugin.example('hi', 'Hi!')
+    @plugin.example('hello', 'Hi!')
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -1264,10 +1264,10 @@ def test_kwargs_from_callable_examples_test(mockbot):
 
 def test_kwargs_from_callable_examples_help(mockbot):
     # prepare callable
-    @module.rule(r'hello', r'hi', r'hey', r'hello|hi')
-    @module.example('hi', user_help=True)
-    @module.example('hey', 'Hi!')
-    @module.example('hello', 'Hi!', user_help=True)
+    @plugin.rule(r'hello', r'hi', r'hey', r'hello|hi')
+    @plugin.example('hi', user_help=True)
+    @plugin.example('hey', 'Hi!')
+    @plugin.example('hello', 'Hi!', user_help=True)
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -1329,8 +1329,8 @@ def test_kwargs_from_callable_examples_help(mockbot):
 
 def test_kwargs_from_callable_examples_doc(mockbot):
     # prepare callable
-    @module.rule(r'hello', r'hi', r'hey', r'hello|hi')
-    @module.example('hello')
+    @plugin.rule(r'hello', r'hi', r'hey', r'hello|hi')
+    @plugin.example('hello')
     def handler(wrapped, trigger):
         """This is the doc you are looking for.
 
@@ -1707,7 +1707,7 @@ def test_command_match_subcommand_aliases(mockbot):
 
 def test_command_from_callable(mockbot):
     # prepare callable
-    @module.commands('hello', 'hi', 'hey')
+    @plugin.commands('hello', 'hi', 'hey')
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -1761,7 +1761,7 @@ def test_command_from_callable(mockbot):
 
 def test_command_from_callable_subcommand(mockbot):
     # prepare callable
-    @module.commands('main sub')
+    @plugin.commands('main sub')
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -1789,8 +1789,8 @@ def test_command_from_callable_subcommand(mockbot):
 
 def test_command_from_callable_subcommand_aliases(mockbot):
     # prepare callable
-    @module.commands('main', 'main sub')
-    @module.commands('reverse sub', 'reverse')
+    @plugin.commands('main', 'main sub')
+    @plugin.commands('reverse sub', 'reverse')
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -1847,7 +1847,7 @@ def test_command_from_callable_regex_pattern(mockbot):
     # Command name as regex pattern will be removed in Sopel 8.0
 
     # prepare callable
-    @module.commands('main .*')
+    @plugin.commands('main .*')
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -1875,7 +1875,7 @@ def test_command_from_callable_regex_pattern(mockbot):
 
 def test_command_from_callable_invalid(mockbot):
     # prepare callable
-    @module.rule(r'.*')
+    @plugin.rule(r'.*')
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -2059,7 +2059,7 @@ def test_nick_command_has_alias(mockbot):
 
 def test_nick_command_from_callable_invalid(mockbot):
     # prepare callable
-    @module.rule(r'.*')
+    @plugin.rule(r'.*')
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -2072,7 +2072,7 @@ def test_nick_command_from_callable_invalid(mockbot):
 
 def test_nick_command_from_callable(mockbot):
     # prepare callable
-    @module.nickname_commands('hello', 'hi', 'hey')
+    @plugin.nickname_commands('hello', 'hi', 'hey')
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -2165,7 +2165,7 @@ def test_nick_command_from_callable_regex_pattern(mockbot):
     # Command name as regex pattern will be removed in Sopel 8.0
 
     # prepare callable
-    @module.nickname_commands('do .*')
+    @plugin.nickname_commands('do .*')
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -2288,7 +2288,7 @@ def test_action_command_match_intent(mockbot):
 
 def test_action_command_from_callable_invalid(mockbot):
     # prepare callable
-    @module.rule(r'.*')
+    @plugin.rule(r'.*')
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -2301,7 +2301,7 @@ def test_action_command_from_callable_invalid(mockbot):
 
 def test_action_command_from_callable(mockbot):
     # prepare callable
-    @module.action_commands('hello', 'hi', 'hey')
+    @plugin.action_commands('hello', 'hi', 'hey')
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -2370,7 +2370,7 @@ def test_action_command_from_callable_regex_pattern(mockbot):
     # Command name as regex pattern will be removed in Sopel 8.0
 
     # prepare callable
-    @module.action_commands('do .*')
+    @plugin.action_commands('do .*')
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -2699,7 +2699,7 @@ def test_url_callback_from_callable(mockbot):
     link_3 = 'https://not-example.com/test'
 
     # prepare callable
-    @module.url(re.escape('https://example.com/') + r'(\w+)')
+    @plugin.url(re.escape('https://example.com/') + r'(\w+)')
     def handler(wrapped, trigger, match):
         wrapped.say('Hi!')
         return 'The return value: %s' % match.group(0)
@@ -2780,7 +2780,7 @@ def test_url_callback_from_callable_no_match_parameter(mockbot):
     link = 'https://example.com/test'
 
     # prepare callable
-    @module.url(re.escape('https://example.com/') + r'(\w+)')
+    @plugin.url(re.escape('https://example.com/') + r'(\w+)')
     def handler(wrapped, trigger):
         wrapped.say('Hi!')
         return 'The return value: %s' % trigger.group(0)
@@ -2874,7 +2874,7 @@ def test_url_callback_from_callable_invalid(mockbot):
 
 def test_url_callback_from_callable_lazy_invalid(mockbot):
     # prepare callable
-    @module.url(r'.*')
+    @plugin.url(r'.*')
     def handler(wrapped, trigger, match=None):
         wrapped.reply('Hi!')
 

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -6,7 +6,7 @@ import re
 
 import pytest
 
-from sopel import bot, loader, module, plugin, plugins, trigger
+from sopel import bot, loader, plugin, plugins, trigger
 from sopel.plugins import rules
 from sopel.tests import rawlist
 from sopel.tools import Identifier, SopelMemory
@@ -20,45 +20,45 @@ enable = coretasks
 """
 
 MOCK_MODULE_CONTENT = """# coding=utf-8
-import sopel.module
+from sopel import plugin
 
 
-@sopel.module.commands("do")
+@plugin.commands("do")
 def command_do(bot, trigger):
     pass
 
 
-@sopel.module.nickname_commands("info")
+@plugin.nickname_commands("info")
 def nick_command_info(bot, trigger):
     pass
 
 
-@sopel.module.action_commands("tell")
+@plugin.action_commands("tell")
 def action_command_tell(bot, trigger):
     pass
 
 
-@sopel.module.interval(5)
+@plugin.interval(5)
 def interval5s(bot):
     pass
 
 
-@sopel.module.interval(10)
+@plugin.interval(10)
 def interval10s(bot):
     pass
 
 
-@sopel.module.url(r'(.+\\.)?example\\.com')
+@plugin.url(r'(.+\\.)?example\\.com')
 def example_url(bot):
     pass
 
 
-@sopel.module.rule(r'Hello \\w+')
+@plugin.rule(r'Hello \\w+')
 def rule_hello(bot):
     pass
 
 
-@sopel.module.event('TOPIC')
+@plugin.event('TOPIC')
 def rule_on_topic(bot):
     pass
 
@@ -337,7 +337,7 @@ def test_reload_plugin_unregistered_plugin(tmpconfig):
 def test_register_callables(tmpconfig):
     sopel = bot.Sopel(tmpconfig)
 
-    @module.rule(r'(hi|hello|hey|sup)')
+    @plugin.rule(r'(hi|hello|hey|sup)')
     def rule_hello(bot, trigger):
         pass
 
@@ -361,40 +361,40 @@ def test_register_callables(tmpconfig):
     def rule_search_what(bot, trigger):
         pass
 
-    @module.commands('do')
-    @module.example('.do nothing')
+    @plugin.commands('do')
+    @plugin.example('.do nothing')
     def command_do(bot, trigger):
         """The do command does nothing."""
         pass
 
-    @module.commands('main sub')
-    @module.example('.main sub')
+    @plugin.commands('main sub')
+    @plugin.example('.main sub')
     def command_main_sub(bot, trigger):
         """A command with subcommand sub."""
         pass
 
-    @module.commands('main other')
-    @module.example('.main other')
+    @plugin.commands('main other')
+    @plugin.example('.main other')
     def command_main_other(bot, trigger):
         """A command with subcommand other."""
         pass
 
-    @module.nickname_commands('info')
-    @module.example('$nickname: info about this')
+    @plugin.nickname_commands('info')
+    @plugin.example('$nickname: info about this')
     def nick_command_info(bot, trigger):
         """Ask Sopel to get some info about nothing."""
         pass
 
-    @module.action_commands('tell')
+    @plugin.action_commands('tell')
     def action_command_tell(bot, trigger):
         pass
 
-    @module.commands('mixed')
-    @module.rule('mixing')
+    @plugin.commands('mixed')
+    @plugin.rule('mixing')
     def mixed_rule_command(bot, trigger):
         pass
 
-    @module.event('JOIN')
+    @plugin.event('JOIN')
     @plugin.label('handle_join_event')
     def on_join(bot, trigger):
         pass
@@ -541,12 +541,12 @@ def test_register_callables(tmpconfig):
 def test_register_urls(tmpconfig):
     sopel = bot.Sopel(tmpconfig)
 
-    @module.url(r'https://(\S+)/(.+)?')
+    @plugin.url(r'https://(\S+)/(.+)?')
     @plugin.label('handle_urls_https')
     def url_callback_https(bot, trigger, match):
         pass
 
-    @module.url(r'http://(\S+)/(.+)?')
+    @plugin.url(r'http://(\S+)/(.+)?')
     @plugin.label('handle_urls_http')
     def url_callback_http(bot, trigger, match):
         pass

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -7,37 +7,36 @@ import re
 
 import pytest
 
-from sopel import loader, module, plugins
+from sopel import loader, plugin, plugins
 
 
 MOCK_MODULE_CONTENT = """# coding=utf-8
 import re
 
-import sopel.module
-import sopel.plugin
+from sopel import plugin
 
 
-@sopel.module.commands("first")
+@plugin.commands("first")
 def first_command(bot, trigger):
     pass
 
 
-@sopel.module.commands("second")
+@plugin.commands("second")
 def second_command(bot, trigger):
     pass
 
 
-@sopel.module.interval(5)
+@plugin.interval(5)
 def interval5s(bot):
     pass
 
 
-@sopel.module.interval(10)
+@plugin.interval(10)
 def interval10s(bot):
     pass
 
 
-@sopel.module.url(r'.\\.example\\.com')
+@plugin.url(r'.\\.example\\.com')
 def example_url(bot, trigger, match=None):
     pass
 
@@ -46,27 +45,27 @@ def loader(settings):
     return [re.compile(r'.+\\.example\\.com')]
 
 
-@sopel.plugin.url_lazy(loader)
+@plugin.url_lazy(loader)
 def example_url_lazy(bot, trigger):
     pass
 
 
-@sopel.plugin.rule_lazy(loader)
+@plugin.rule_lazy(loader)
 def example_rule_lazy(bot, trigger):
     pass
 
 
-@sopel.plugin.find_lazy(loader)
+@plugin.find_lazy(loader)
 def example_find_lazy(bot, trigger):
     pass
 
 
-@sopel.plugin.search_lazy(loader)
+@plugin.search_lazy(loader)
 def example_search_lazy(bot, trigger):
     pass
 
 
-@sopel.module.event('TOPIC')
+@plugin.event('TOPIC')
 def on_topic_command(bot):
     pass
 
@@ -79,7 +78,7 @@ def ignored():
     pass
 
 
-@sopel.module.rate(10)
+@plugin.rate(10)
 def ignored_rate():
     pass
 
@@ -650,8 +649,8 @@ def test_clean_callable_events_basestring(tmpconfig, func):
 
 
 def test_clean_callable_example(tmpconfig, func):
-    module.commands('test')(func)
-    module.example('.test hello')(func)
+    plugin.commands('test')(func)
+    plugin.example('.test hello')(func)
 
     loader.clean_callable(func, tmpconfig)
 
@@ -666,7 +665,7 @@ def test_clean_callable_example(tmpconfig, func):
 
 
 def test_clean_callable_example_not_set(tmpconfig, func):
-    module.commands('test')(func)
+    plugin.commands('test')(func)
 
     loader.clean_callable(func, tmpconfig)
 
@@ -681,9 +680,9 @@ def test_clean_callable_example_not_set(tmpconfig, func):
 
 
 def test_clean_callable_example_multi_commands(tmpconfig, func):
-    module.commands('test')(func)
-    module.commands('unit')(func)
-    module.example('.test hello')(func)
+    plugin.commands('test')(func)
+    plugin.commands('unit')(func)
+    plugin.example('.test hello')(func)
 
     loader.clean_callable(func, tmpconfig)
 
@@ -702,9 +701,9 @@ def test_clean_callable_example_multi_commands(tmpconfig, func):
 
 
 def test_clean_callable_example_first_only(tmpconfig, func):
-    module.commands('test')(func)
-    module.example('.test hello')(func)
-    module.example('.test bonjour')(func)
+    plugin.commands('test')(func)
+    plugin.example('.test hello')(func)
+    plugin.example('.test bonjour')(func)
 
     loader.clean_callable(func, tmpconfig)
 
@@ -718,10 +717,10 @@ def test_clean_callable_example_first_only(tmpconfig, func):
 
 
 def test_clean_callable_example_first_only_multi_commands(tmpconfig, func):
-    module.commands('test')(func)
-    module.commands('unit')(func)
-    module.example('.test hello')(func)
-    module.example('.test bonjour')(func)
+    plugin.commands('test')(func)
+    plugin.commands('unit')(func)
+    plugin.example('.test hello')(func)
+    plugin.example('.test bonjour')(func)
 
     loader.clean_callable(func, tmpconfig)
 
@@ -740,8 +739,8 @@ def test_clean_callable_example_first_only_multi_commands(tmpconfig, func):
 
 
 def test_clean_callable_example_user_help(tmpconfig, func):
-    module.commands('test')(func)
-    module.example('.test hello', user_help=True)(func)
+    plugin.commands('test')(func)
+    plugin.example('.test hello', user_help=True)(func)
 
     loader.clean_callable(func, tmpconfig)
 
@@ -755,9 +754,9 @@ def test_clean_callable_example_user_help(tmpconfig, func):
 
 
 def test_clean_callable_example_user_help_multi(tmpconfig, func):
-    module.commands('test')(func)
-    module.example('.test hello', user_help=True)(func)
-    module.example('.test bonjour', user_help=True)(func)
+    plugin.commands('test')(func)
+    plugin.example('.test hello', user_help=True)(func)
+    plugin.example('.test bonjour', user_help=True)(func)
 
     loader.clean_callable(func, tmpconfig)
 
@@ -771,9 +770,9 @@ def test_clean_callable_example_user_help_multi(tmpconfig, func):
 
 
 def test_clean_callable_example_user_help_mixed(tmpconfig, func):
-    module.commands('test')(func)
-    module.example('.test hello')(func)
-    module.example('.test bonjour', user_help=True)(func)
+    plugin.commands('test')(func)
+    plugin.example('.test hello')(func)
+    plugin.example('.test bonjour', user_help=True)(func)
 
     loader.clean_callable(func, tmpconfig)
 
@@ -787,8 +786,8 @@ def test_clean_callable_example_user_help_mixed(tmpconfig, func):
 
 
 def test_clean_callable_example_default_prefix(tmpconfig, func):
-    module.commands('test')(func)
-    module.example('.test hello')(func)
+    plugin.commands('test')(func)
+    plugin.example('.test hello')(func)
 
     tmpconfig.core.help_prefix = '!'
     loader.clean_callable(func, tmpconfig)
@@ -803,8 +802,8 @@ def test_clean_callable_example_default_prefix(tmpconfig, func):
 
 
 def test_clean_callable_example_nickname(tmpconfig, func):
-    module.commands('test')(func)
-    module.example('$nickname: hello')(func)
+    plugin.commands('test')(func)
+    plugin.example('$nickname: hello')(func)
 
     loader.clean_callable(func, tmpconfig)
 
@@ -818,8 +817,8 @@ def test_clean_callable_example_nickname(tmpconfig, func):
 
 
 def test_clean_callable_example_nickname_custom_prefix(tmpconfig, func):
-    module.commands('test')(func)
-    module.example('$nickname: hello')(func)
+    plugin.commands('test')(func)
+    plugin.example('$nickname: hello')(func)
 
     tmpconfig.core.help_prefix = '!'
     loader.clean_callable(func, tmpconfig)

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -11,35 +11,35 @@ from sopel import plugins
 
 
 MOCK_MODULE_CONTENT = """# coding=utf-8
-import sopel.module
+from sopel import plugin
 
 
-@sopel.module.commands("first")
+@plugin.commands("first")
 def first_command(bot, trigger):
     pass
 
 
-@sopel.module.commands("second")
+@plugin.commands("second")
 def second_command(bot, trigger):
     pass
 
 
-@sopel.module.interval(5)
+@plugin.interval(5)
 def interval5s(bot):
     pass
 
 
-@sopel.module.interval(10)
+@plugin.interval(10)
 def interval10s(bot):
     pass
 
 
-@sopel.module.url(r'.\\.example\\.com')
+@plugin.url(r'.\\.example\\.com')
 def example_url(bot):
     pass
 
 
-@sopel.module.event('TOPIC')
+@plugin.event('TOPIC')
 def on_topic_command(bot):
     pass
 

--- a/test/tools/test_tools_jobs.py
+++ b/test/tools/test_tools_jobs.py
@@ -6,7 +6,7 @@ import time
 
 import pytest
 
-from sopel import loader, module, plugin
+from sopel import loader, plugin
 from sopel.tools import jobs
 
 
@@ -200,7 +200,7 @@ def test_job_next_many():
 
 
 def test_job_from_callable(mockconfig):
-    @module.interval(5)
+    @plugin.interval(5)
     @plugin.label('testjob')
     def handler(manager):
         """The job's docstring."""


### PR DESCRIPTION
### Description
Tin. `coretasks` and all tests (except `test_module.py`, for obvious reasons) now use the members of `sopel.plugin` only.

One more step on the road to #1738. This isn't actually part of the task list there, but it still feels good.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
Hopefully will not conflict with #2116, which already uses `plugin` for all its newly added decorator calls.