### PR TITLE
cli: remove legacy mode for run script

### DIFF
--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -471,8 +471,20 @@ def main(argv=None):
 
     :param list argv: command line arguments
     """
-    # Step One: Parse The Command Line
+    # Build parser and handle default command
+    global_options = ['-h', '--help', '-V', '--version']
     parser = build_parser()
+
+    argv = argv or sys.argv[1:]
+    if not argv:
+        # No argument: assume start sub-command
+        argv = ['start']
+
+    elif argv[0].startswith('-') and argv[0] not in global_options:
+        # No sub-command and no global option
+        argv = ['start'] + argv
+
+    # Step One: Parse The Command Line
     opts = parser.parse_args(argv)
 
     # Handle "-V/--version" option
@@ -499,6 +511,7 @@ def main(argv=None):
         return command(opts)
     except KeyError:
         parser.print_usage()
+        return ERR_CODE
     except KeyboardInterrupt:
         print("\n\nInterrupted")
         return ERR_CODE

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -484,7 +484,7 @@ def main(argv=None):
         # No sub-command and no global option
         argv = ['start'] + argv
 
-    # Step One: Parse The Command Line
+    # Parse The Command Line
     opts = parser.parse_args(argv)
 
     # Handle "-V/--version" option
@@ -493,14 +493,10 @@ def main(argv=None):
         return
 
     try:
-        # Step Two: "Do not run as root" checks
-        try:
-            check_not_root()
-        except RuntimeError as err:
-            tools.stderr('%s' % err)
-            return ERR_CODE
+        # Check "Do not run as root"
+        check_not_root()
 
-        # Step Three: Handle command
+        # Select command
         action = getattr(opts, 'action', None)
         command = {
             'start': command_start,
@@ -508,12 +504,17 @@ def main(argv=None):
             'stop': command_stop,
             'restart': command_restart,
         }[action]
+
+        # Run command
         return command(opts)
     except KeyError:
         parser.print_usage()
         return ERR_CODE
     except KeyboardInterrupt:
         print("\n\nInterrupted")
+        return ERR_CODE
+    except RuntimeError as err:
+        tools.stderr(str(err))
         return ERR_CODE
 
 

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -120,88 +120,23 @@ def run(settings, pid_file, daemon=False):
     os._exit(0)
 
 
-def add_legacy_options(parser):
-    """Add legacy options to the argument parser.
-
-    :param parser: argument parser
-    :type parser: :class:`argparse.ArgumentParser`
-    """
-    # TL;DR: option -d/--fork is not deprecated.
-    # When the legacy action is replaced in Sopel 8, 'start' will become the
-    # new default action, with its arguments.
-    # The option -d/--fork is used by both actions (start and legacy),
-    # and it has the same meaning and behavior, therefore it is not deprecated.
-    parser.add_argument("-d", '--fork', action="store_true",
-                        dest="daemonize",
-                        help="Daemonize Sopel.")
-    parser.add_argument("-q", '--quit', action="store_true", dest="quit",
-                        help=(
-                            "Gracefully quit Sopel "
-                            "(deprecated, and will be removed in Sopel 8; "
-                            "use ``sopel stop`` instead)"))
-    parser.add_argument("-k", '--kill', action="store_true", dest="kill",
-                        help=(
-                            "Kill Sopel "
-                            "(deprecated, and will be removed in Sopel 8; "
-                            "use ``sopel stop --kill`` instead)"))
-    parser.add_argument("-r", '--restart', action="store_true", dest="restart",
-                        help=(
-                            "Restart Sopel "
-                            "(deprecated, and will be removed in Sopel 8; "
-                            "use `sopel restart` instead)"))
-    parser.add_argument("-l", '--list', action="store_true",
-                        dest="list_configs",
-                        help=(
-                            "List all config files found"
-                            "(deprecated, and will be removed in Sopel 8; "
-                            "use ``sopel-config list`` instead)"))
-    parser.add_argument('--quiet', action="store_true", dest="quiet",
-                        help="Suppress all output")
-    parser.add_argument('-w', '--configure-all', action='store_true',
-                        dest='wizard',
-                        help=(
-                            "Run the configuration wizard "
-                            "(deprecated, and will be removed in Sopel 8; "
-                            "use `sopel configure` instead)"))
-    parser.add_argument('--configure-modules', action='store_true',
-                        dest='mod_wizard',
-                        help=(
-                            "Run the configuration wizard, but only for the "
-                            "plugin configuration options "
-                            "(deprecated, and will be removed in Sopel 8; "
-                            "use ``sopel configure --plugins`` instead)"))
-    parser.add_argument('-v', action="store_true",
-                        dest='version_legacy',
-                        help=(
-                            "Show version number and exit "
-                            "(deprecated, and will be removed in Sopel 8; "
-                            "use ``-V/--version`` instead)"))
-    parser.add_argument('-V', '--version', action='store_true',
-                        dest='version',
-                        help='Show version number and exit')
-
-
 def build_parser():
     """Build an argument parser for the bot.
 
     :return: the argument parser
     :rtype: :class:`argparse.ArgumentParser`
     """
-    parser = argparse.ArgumentParser(description='Sopel IRC Bot',
-                                     usage='%(prog)s [options]')
-    add_legacy_options(parser)
-    utils.add_common_arguments(parser)
+    parser = argparse.ArgumentParser(description='Sopel IRC Bot')
+
+    parser.add_argument('-V', '--version', action='store_true',
+                        dest='version',
+                        help='Show version number and exit')
 
     subparsers = parser.add_subparsers(
         title='subcommands',
         description='List of Sopel\'s subcommands',
         dest='action',
         metavar='{start,configure,stop,restart}')
-
-    # manage `legacy` subcommand
-    parser_legacy = subparsers.add_parser('legacy')
-    add_legacy_options(parser_legacy)
-    utils.add_common_arguments(parser_legacy)
 
     # manage `start` subcommand
     parser_start = subparsers.add_parser(
@@ -310,19 +245,6 @@ def print_version():
                            sys.version_info.micro)
     print('Sopel %s (running on Python %s)' % (__version__, py_ver))
     print('https://sopel.chat/')
-
-
-def print_config(configdir):
-    """Print list of available configurations from config directory."""
-    configs = utils.enumerate_configs(configdir)
-    print('Config files in %s:' % configdir)
-    configfile = None
-    for configfile in configs:
-        print('\t%s' % configfile)
-    if not configfile:
-        print('\tNone found')
-
-    print('-------------------------')
 
 
 def get_configuration(options):
@@ -544,159 +466,21 @@ def command_restart(opts):
         os.kill(pid, signal.SIGILL)
 
 
-def command_legacy(opts):
-    """Legacy Sopel run script.
-
-    :param opts: parsed arguments
-    :type opts: :class:`argparse.Namespace`
-
-    The ``legacy`` command manages the old-style ``sopel`` command line tool.
-    Most of its features are replaced by the following commands:
-
-    * ``sopel start`` replaces the default behavior (run the bot)
-    * ``sopel stop`` replaces the ``--quit/--kill`` options
-    * ``sopel restart`` replaces the ``--restart`` option
-    * ``sopel configure`` replaces the
-      ``-w/--configure-all/--configure-modules`` options
-
-    The ``-v`` option for "version" is deprecated, ``-V/--version`` should be
-    used instead.
-
-    .. seealso::
-
-       The github issue `#1471`__ tracks various changes requested for future
-       versions of Sopel, some of them related to this legacy command.
-
-       .. __: https://github.com/sopel-irc/sopel/issues/1471
-
-    """
-    # Step One: Handle "No config needed" options
-    if opts.version:
-        print_version()
-        return
-    elif opts.version_legacy:
-        tools.stderr(
-            'WARNING: option -v is deprecated; '
-            'use `sopel -V/--version` instead')
-        print_version()
-        return
-
-    configpath = utils.find_config(opts.configdir, opts.config)
-
-    if opts.wizard:
-        tools.stderr(
-            'WARNING: option -w/--configure-all is deprecated; '
-            'use `sopel configure` instead')
-        utils.wizard(configpath)
-        return
-
-    if opts.mod_wizard:
-        tools.stderr(
-            'WARNING: option --configure-modules is deprecated; '
-            'use `sopel configure --plugins` instead')
-        utils.plugins_wizard(configpath)
-        return
-
-    if opts.list_configs:
-        tools.stderr(
-            'WARNING: option --list is deprecated; '
-            'use `sopel-config list` instead')
-        print_config(opts.configdir)
-        return
-
-    # Step Two: Get the configuration file and prepare to run
-    try:
-        settings = get_configuration(opts)
-    except config.ConfigurationError as e:
-        tools.stderr(e)
-        return ERR_CODE_NO_RESTART
-
-    if settings.core.not_configured:
-        tools.stderr('Bot is not configured, can\'t start')
-        return ERR_CODE_NO_RESTART
-
-    # Step Three: Handle process-lifecycle options and manage the PID file
-    pid_dir = settings.core.pid_dir
-    pid_file_path = get_pid_filename(settings, pid_dir)
-    old_pid = get_running_pid(pid_file_path)
-
-    if old_pid is not None and tools.check_pid(old_pid):
-        if not opts.quit and not opts.kill and not opts.restart:
-            tools.stderr(
-                'There\'s already a Sopel instance running with this config file')
-            tools.stderr(
-                'Try using either the `sopel stop` command or the `sopel restart` command')
-            return ERR_CODE
-        elif opts.kill:
-            tools.stderr(
-                'WARNING: option -k/--kill is deprecated; '
-                'use `sopel stop --kill` instead')
-            tools.stderr('Killing the Sopel')
-            os.kill(old_pid, signal.SIGKILL)
-            return
-        elif opts.quit:
-            tools.stderr(
-                'WARNING: options -q/--quit is deprecated; '
-                'use `sopel stop` instead')
-            tools.stderr('Signaling Sopel to stop gracefully')
-            if hasattr(signal, 'SIGUSR1'):
-                os.kill(old_pid, signal.SIGUSR1)
-            else:
-                # Windows will not generate SIGTERM itself
-                # https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/signal
-                os.kill(old_pid, signal.SIGTERM)
-            return
-        elif opts.restart:
-            tools.stderr(
-                'WARNING: options --restart is deprecated; '
-                'use `sopel restart` instead')
-            tools.stderr('Asking Sopel to restart')
-            if hasattr(signal, 'SIGUSR2'):
-                os.kill(old_pid, signal.SIGUSR2)
-            else:
-                # Windows will not generate SIGILL itself
-                # https://docs.microsoft.com/en-us/cpp/c-runtime-library/reference/signal
-                os.kill(old_pid, signal.SIGILL)
-            return
-    elif opts.kill or opts.quit or opts.restart:
-        tools.stderr('Sopel is not running!')
-        return ERR_CODE
-
-    if opts.daemonize:
-        child_pid = os.fork()
-        if child_pid != 0:
-            return
-    with open(pid_file_path, 'w') as pid_file:
-        pid_file.write(str(os.getpid()))
-
-    # Step Four: Initialize and run Sopel
-    ret = run(settings, pid_file_path)
-    os.unlink(pid_file_path)
-    if ret == -1:
-        os.execv(sys.executable, ['python'] + sys.argv)
-    else:
-        return ret
-
-
 def main(argv=None):
     """Sopel run script entry point.
 
     :param list argv: command line arguments
     """
+    # Step One: Parse The Command Line
+    parser = build_parser()
+    opts = parser.parse_args(argv)
+
+    # Handle "-V/--version" option
+    if opts.version:
+        print_version()
+        return
+
     try:
-        # Step One: Parse The Command Line
-        parser = build_parser()
-
-        # make sure to have an action first (`legacy` by default)
-        # TODO: `start` should be the default in Sopel 8
-        argv = argv or sys.argv[1:]
-        if not argv:
-            argv = ['legacy']
-        elif argv[0].startswith('-') and argv[0] not in ['-h', '--help']:
-            argv = ['legacy'] + argv
-
-        opts = parser.parse_args(argv)
-
         # Step Two: "Do not run as root" checks
         try:
             check_not_root()
@@ -705,15 +489,16 @@ def main(argv=None):
             return ERR_CODE
 
         # Step Three: Handle command
-        action = getattr(opts, 'action', 'legacy')
+        action = getattr(opts, 'action', None)
         command = {
-            'legacy': command_legacy,
             'start': command_start,
             'configure': command_configure,
             'stop': command_stop,
             'restart': command_restart,
-        }.get(action)
+        }[action]
         return command(opts)
+    except KeyError:
+        parser.print_usage()
     except KeyboardInterrupt:
         print("\n\nInterrupted")
         return ERR_CODE

--- a/test/cli/test_cli_run.py
+++ b/test/cli/test_cli_run.py
@@ -53,136 +53,6 @@ def default_empty_config_env(monkeypatch):
     monkeypatch.delenv("SOPEL_CONFIG_DIR", raising=False)
 
 
-def test_build_parser_legacy():
-    """Assert parser's namespace exposes legacy's options (default values)"""
-    parser = build_parser()
-    options = parser.parse_args(['legacy'])
-
-    assert isinstance(options, argparse.Namespace)
-    assert hasattr(options, 'config')
-    assert hasattr(options, 'configdir')
-    assert hasattr(options, 'daemonize')
-    assert hasattr(options, 'quiet')
-    assert hasattr(options, 'quit')
-    assert hasattr(options, 'kill')
-    assert hasattr(options, 'restart')
-    assert hasattr(options, 'version')
-    assert hasattr(options, 'version_legacy')
-    assert hasattr(options, 'wizard')
-    assert hasattr(options, 'mod_wizard')
-    assert hasattr(options, 'list_configs')
-
-    assert options.config == 'default'
-    assert options.configdir == config.DEFAULT_HOMEDIR
-    assert options.daemonize is False
-    assert options.quiet is False
-    assert options.quit is False
-    assert options.kill is False
-    assert options.restart is False
-    assert options.version is False
-    assert options.version_legacy is False
-    assert options.wizard is False
-    assert options.mod_wizard is False
-    assert options.list_configs is False
-
-
-def test_build_parser_legacy_config():
-    parser = build_parser()
-    options = parser.parse_args(['legacy', '-c', 'custom'])
-    assert options.config == 'custom'
-
-    options = parser.parse_args(['legacy', '--config', 'custom'])
-    assert options.config == 'custom'
-
-
-def test_build_parser_legacy_configdir():
-    parser = build_parser()
-
-    options = parser.parse_args(['legacy', '--config-dir', 'custom'])
-    assert options.configdir == 'custom'
-
-
-def test_build_parser_legacy_daemonize():
-    parser = build_parser()
-    options = parser.parse_args(['legacy', '-d'])
-    assert options.daemonize is True
-
-    options = parser.parse_args(['legacy', '--fork'])
-    assert options.daemonize is True
-
-
-def test_build_parser_legacy_quiet():
-    parser = build_parser()
-    options = parser.parse_args(['legacy', '--quiet'])
-    assert options.quiet is True
-
-
-def test_build_parser_legacy_quit():
-    parser = build_parser()
-    options = parser.parse_args(['legacy', '-q'])
-    assert options.quit is True
-
-    options = parser.parse_args(['legacy', '--quit'])
-    assert options.quit is True
-
-
-def test_build_parser_legacy_kill():
-    parser = build_parser()
-    options = parser.parse_args(['legacy', '-k'])
-    assert options.kill is True
-
-    options = parser.parse_args(['legacy', '--kill'])
-    assert options.kill is True
-
-
-def test_build_parser_legacy_restart():
-    parser = build_parser()
-    options = parser.parse_args(['legacy', '-r'])
-    assert options.restart is True
-
-    options = parser.parse_args(['legacy', '--restart'])
-    assert options.restart is True
-
-
-def test_build_parser_legacy_version():
-    parser = build_parser()
-    options = parser.parse_args(['legacy', '-v'])
-    assert options.version is False
-    assert options.version_legacy is True
-
-    options = parser.parse_args(['legacy', '-V'])
-    assert options.version is True
-    assert options.version_legacy is False
-
-    options = parser.parse_args(['legacy', '--version'])
-    assert options.version is True
-    assert options.version_legacy is False
-
-
-def test_build_parser_legacy_wizard():
-    parser = build_parser()
-    options = parser.parse_args(['legacy', '-w'])
-    assert options.wizard is True
-    assert options.mod_wizard is False
-
-    options = parser.parse_args(['legacy', '--configure-all'])
-    assert options.wizard is True
-    assert options.mod_wizard is False
-
-    options = parser.parse_args(['legacy', '--configure-modules'])
-    assert options.wizard is False
-    assert options.mod_wizard is True
-
-
-def test_build_parser_legacy_list_config():
-    parser = build_parser()
-    options = parser.parse_args(['legacy', '-l'])
-    assert options.list_configs is True
-
-    options = parser.parse_args(['legacy', '--list'])
-    assert options.list_configs is True
-
-
 def test_build_parser_start():
     """Assert parser's namespace exposes start's options (default values)"""
     parser = build_parser()
@@ -372,7 +242,7 @@ def test_get_configuration(tmpdir):
     ]))
 
     parser = build_parser()
-    options = parser.parse_args(['legacy', '-c', 'default.cfg'])
+    options = parser.parse_args(['start', '-c', 'default.cfg'])
 
     with cd(working_dir.strpath):
         result = get_configuration(options)


### PR DESCRIPTION
### Description

Fix  #1584 by removing the legacy parser completely, fixing the doc and the help message. Options are no longer available without a subcommands, which is a breaking change. However, it makes everything else better (the doc, the usage, the code etc.) and it's Sopel 8 and it's the right way to do a command line tool.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
