### PR TITLE
plugins: don't search in `~/.sopel/modules` by default any more

### DIFF
--- a/sopel/plugins/__init__.py
+++ b/sopel/plugins/__init__.py
@@ -13,7 +13,6 @@ and only one plugin per unique name, using a specific order:
 
 * extra directories defined in the settings
 * homedir's ``plugins`` directory
-* homedir's ``modules`` directory
 * ``sopel.plugins`` setuptools entry points
 * ``sopel_modules``'s subpackages
 * ``sopel.modules``'s core plugins
@@ -137,21 +136,19 @@ def enumerate_plugins(settings):
 
     .. seealso::
 
-       The find functions used are:
+        The find functions used are:
 
-       * :func:`find_internal_plugins` for internal plugins
-       * :func:`find_sopel_modules_plugins` for ``sopel_modules.*`` plugins
-       * :func:`find_entry_point_plugins` for plugins exposed by setuptools
-         entry points
-       * :func:`find_directory_plugins` for plugins in ``$homedir/modules``,
-         ``$homedir/plugins``, and in extra directories, as defined by
-         ``settings.core.extra``
+        * :func:`find_internal_plugins` for internal plugins
+        * :func:`find_sopel_modules_plugins` for ``sopel_modules.*`` plugins
+        * :func:`find_entry_point_plugins` for plugins exposed by setuptools
+          entry points
+        * :func:`find_directory_plugins` for plugins in ``$homedir/plugins``,
+          and in extra directories as defined by ``settings.core.extra``
 
-    .. versionchanged:: 7.0
+    .. versionchanged:: 8.0
 
-       Previously, plugins were called "modules", so this would load plugins
-       from the ``$homedir/modules`` directory. Now it also loads plugins
-       from the ``$homedir/plugins`` directory.
+        Looks in ``$homedir/plugins`` instead of the ``$homedir/modules``
+        directory, reflecting Sopel's shift away from calling them "modules".
 
     """
     from_internals = find_internal_plugins()
@@ -159,11 +156,10 @@ def enumerate_plugins(settings):
     from_entry_points = find_entry_point_plugins()
     # load from directories
     source_dirs = [
-        os.path.join(settings.homedir, 'modules'),
         os.path.join(settings.homedir, 'plugins'),
     ]
     if settings.core.extra:
-        source_dirs = source_dirs + list(settings.core.extra)
+        source_dirs = source_dirs + settings.core.extra
 
     from_directories = [
         find_directory_plugins(source_dir)
@@ -205,7 +201,7 @@ def get_usable_plugins(settings):
     contains one and only one plugin per unique name, using a specific order:
 
     * extra directories defined in the settings
-    * homedir's ``modules`` directory
+    * homedir's ``plugins`` directory
     * ``sopel.plugins`` setuptools entry points
     * ``sopel_modules``'s subpackages
     * ``sopel.modules``'s core plugins

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -374,7 +374,7 @@ class PyFilePlugin(PyModulePlugin):
     ``__init__.py`` file, and behaves like a :class:`PyModulePlugin`::
 
         >>> from sopel.plugins.handlers import PyFilePlugin
-        >>> plugin = PyFilePlugin('/home/sopel/.sopel/modules/custom.py')
+        >>> plugin = PyFilePlugin('/home/sopel/.sopel/plugins/custom.py')
         >>> plugin.load()
         >>> plugin.name
         'custom'


### PR DESCRIPTION
### Description
Tin. Part of #1738.

Also reindented the touched docstring to follow our current conventions re: block roles (e.g. `.. seealso::`).

Removed unnecessary `list(ListAttribute)` typecast.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches