### PR TITLE
bot: remove `bot.memory['url_callbacks]` and use internal state

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -321,8 +321,6 @@ class Sopel(irc.AbstractBot):
                 try:
                     if plugin.has_setup():
                         plugin.setup(self)
-                        # TODO: remove in Sopel 8
-                        self.__setup_plugins_check_manual_url_callbacks(name)
                     plugin.register(self)
                 except Exception as e:
                     load_error = load_error + 1
@@ -340,29 +338,6 @@ class Sopel(irc.AbstractBot):
                 load_disabled)
         else:
             LOGGER.warning("Warning: Couldn't load any plugins")
-
-    def __setup_plugins_check_manual_url_callbacks(self, name):
-        # check if a plugin modified bot.memory['url_callbacks'] manually
-        # TODO: remove in Sopel 8
-        if 'url_callbacks' not in self.memory:
-            # nothing to check
-            return
-
-        for key, callback in self.memory['url_callbacks'].items():
-            is_checked = getattr(
-                callback, '_sopel_url_callbacks_checked', False)
-            if is_checked:
-                # already checked; move on to next callback
-                continue
-
-            # deprecation warning
-            LOGGER.warning(
-                "Plugin `%s` uses `bot.memory['url_callbacks']`; "
-                'this key is deprecated and will be removed in Sopel 8. '
-                'Use `@url` or `@url_lazy` instead. Callback was: %s',
-                name, callback.__name__)
-            # mark callback as checked
-            setattr(callback, '_sopel_url_callbacks_checked', True)
 
     # post setup
 
@@ -1122,9 +1097,6 @@ class Sopel(irc.AbstractBot):
         if isinstance(pattern, str):
             pattern = re.compile(pattern)
 
-        # Mark the callback as checked: using this method is safe.
-        # TODO: remove in Sopel 8
-        setattr(callback, '_sopel_url_callbacks_checked', True)
         self.memory['url_callbacks'][pattern] = callback
 
     @deprecated(

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -1162,6 +1162,11 @@ class Sopel(irc.AbstractBot):
         except KeyError:
             pass
 
+    @deprecated(
+        reason='Issues with @url decorator have been fixed. Simply use that.',
+        version='8.0',
+        removed_in='9.0',
+    )
     def search_url_callbacks(self, url):
         """Yield callbacks whose regex pattern matches the ``url``.
 
@@ -1181,6 +1186,11 @@ class Sopel(irc.AbstractBot):
 
             Searches for registered callbacks in an internal property instead
             of ``bot.memory['url_callbacks']``.
+
+        .. deprecated:: 8.0
+
+            Made obsolete by fixes to the behavior of
+            :func:`sopel.plugin.url`. Will be removed in Sopel 9.
 
         .. seealso::
 

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -1082,29 +1082,6 @@ def test_unregister_url_callback_no_memory(tmpconfig):
     # no exception implies success
 
 
-# Remove once manual callback management is deprecated (8.0)
-def test_unregister_url_callback_manual(tmpconfig):
-    """Test unregister_url_callback removes a specific callback that was added manually"""
-    test_pattern = r'https://(www\.)?example\.com'
-
-    def url_handler(*args, **kwargs):
-        return None
-
-    sopel = bot.Sopel(tmpconfig, daemon=False)
-    sopel.memory["url_callbacks"] = SopelMemory()
-
-    # register a callback manually
-    sopel.memory["url_callbacks"][re.compile(test_pattern)] = url_handler
-    results = list(sopel.search_url_callbacks("https://www.example.com"))
-    assert results[0][0] == url_handler, "Callback must be present"
-
-    # unregister it
-    sopel.unregister_url_callback(test_pattern, url_handler)
-
-    results = list(sopel.search_url_callbacks("https://www.example.com"))
-    assert not results, "Callback should have been removed"
-
-
 def test_unregister_url_callback_unknown_pattern(tmpconfig):
     """Test unregister_url_callback pass when pattern is unknown."""
     test_pattern = r'https://(www\.)?example\.com'
@@ -1173,3 +1150,22 @@ def test_multiple_url_callback(tmpconfig):
     results = list(sopel.search_url_callbacks('https://example.com'))
     assert len(results) == 1, 'Exactly one handler must remain'
     assert url_handler_global in results[0], 'Wrong remaining handler'
+
+
+# Added for Sopel 8; can be removed in Sopel 9
+def test_manual_url_callback_not_found(tmpconfig):
+    """Test that the bot now ignores manually registered URL callbacks."""
+    # Sopel 8.0 no longer supports `bot.memory['url_callbacks'], and this test
+    # is to make sure that it *really* no longer works.
+    test_pattern = r'https://(www\.)?example\.com'
+
+    def url_handler(*args, **kwargs):
+        return None
+
+    sopel = bot.Sopel(tmpconfig, daemon=False)
+    sopel.memory['url_callbacks'] = SopelMemory()
+
+    # register a callback manually
+    sopel.memory['url_callbacks'][re.compile(test_pattern)] = url_handler
+    results = list(sopel.search_url_callbacks("https://www.example.com"))
+    assert not results, "Manually registered callback must not be found"


### PR DESCRIPTION
### Description
Plugins doing this will receive warnings through the entire remaining lifetime of 7.x (at least several months, perhaps up to a year-ish), and it's high time to push plugin devs away from using anything but the `plugin.url` and `plugin.url_lazy` decorators.

As pointed out in a comment below, also deprecates `bot.search_url_callbacks()` (which should have been deprecated along with its register/unregister siblings).

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - Or rather, we have already tested that the functionality replacing it works as intended.

### Notes
Sopel 9.0 will drop the `(un)register_url_callback` functions, finally ending the era of plugins manually managing their own URL callbacks. That will feel _almost_ as good as dumping Python 2. 😁

This could have been one commit, and I didn't test the intermediate state. Initially I was only going to remove the stuff that said it could be removed in 8.0, then remembered that there was more to that story.