### PR TITLE
formatting: `colors` is now an Enum

### DIFF
--- a/sopel/formatting.py
+++ b/sopel/formatting.py
@@ -7,6 +7,7 @@
 # Licensed under the Eiffel Forum License 2.
 from __future__ import generator_stop
 
+from enum import Enum
 import re
 import string
 
@@ -32,7 +33,7 @@ __all__ = [
     'monospace',
     'reverse',
     'plain',
-    # utility class
+    # utility enum
     'colors',
 ]
 
@@ -123,37 +124,39 @@ PLAIN_PATTERN = '|'.join([
 PLAIN_REGEX = re.compile(PLAIN_PATTERN)
 
 
-# TODO when we can move to 3.3+ completely, make this an Enum.
-class colors:
+class colors(str, Enum):
+    # Mostly aligned with https://modern.ircdocs.horse/formatting.html#colors
+    # which are likely based on mIRC's color names (https://www.mirc.com/colors.html)
     WHITE = '00'
     BLACK = '01'
     BLUE = '02'
-    NAVY = BLUE
     GREEN = '03'
-    RED = '04'
+    LIGHT_RED = '04'
     BROWN = '05'
-    MAROON = BROWN
     PURPLE = '06'
     ORANGE = '07'
-    OLIVE = ORANGE
     YELLOW = '08'
     LIGHT_GREEN = '09'
-    LIME = LIGHT_GREEN
-    TEAL = '10'
+    TEAL = '10'  # TODO: should be called 'CYAN'
     LIGHT_CYAN = '11'
-    CYAN = LIGHT_CYAN
     LIGHT_BLUE = '12'
-    ROYAL = LIGHT_BLUE
     PINK = '13'
-    LIGHT_PURPLE = PINK
-    FUCHSIA = PINK
     GREY = '14'
     LIGHT_GREY = '15'
-    SILVER = LIGHT_GREY
 
     # Create aliases.
+    NAVY = BLUE
+    RED = LIGHT_RED
+    MAROON = BROWN
+    OLIVE = ORANGE  # TODO: held over from antiquity; does anyone actually think this?
+    LIME = LIGHT_GREEN
+    CYAN = LIGHT_CYAN  # TODO: should be what is called 'TEAL' above
+    ROYAL = LIGHT_BLUE
+    LIGHT_PURPLE = PINK
+    FUCHSIA = PINK
     GRAY = GREY
     LIGHT_GRAY = LIGHT_GREY
+    SILVER = LIGHT_GREY
 
 
 def _get_color(color):


### PR DESCRIPTION
### Description
Following up on an old TODO comment, now possible because we no longer support Python 2. Making this an Enum means it's safe against plugins accidentally (or intentionally) overwriting the color values.

This isn't the appropriate time to address such an issue, but the color name 'TEAL' doesn't exist in mIRC's documentation, nor is it listed at the "[horse docs](https://modern.ircdocs.horse/formatting.html#colors)" I also don't know why 'OLIVE' is an alias to 'ORANGE'.

No color names have been changed *yet*, but I did add comments to point out the issue during future improvements.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
#### Compatibility
If a plugin is using the 7.x `formatting.colors` class as documented and intended, no problem. Any code pulling funny business like overriding color names for convenience _will_ have problems, but we're not going to hand-hold people who went s(o)pelunking in the plugin API's innards and messed with stuff. Their code will break, and they'll have to fix it.

#### Future plans
Stuff like 'TEAL' and 'OLIVE' can be deprecated [by creating a custom `EnumMeta` subclass](https://stackoverflow.com/a/62309159/5991) that (in our case) would invoke the `tools.deprecated` machinery similar to how the `ValidatedAttribute` with `parse=bool` [stuff works](https://github.com/sopel-irc/sopel/blob/8ba105881dc5755a519d691ebffeb8e32a1e5484/sopel/config/types.py#L273-L283) in 7.1. However this PR is just to take care of the immediate, easy conversion from a boring, basic class to an Enum. Fancy stuff later!