### PR TITLE
conftest: remove hacks/shims for running tests on Python 3.3

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -11,11 +11,7 @@ def pytest_addoption(parser):
 
 
 def pytest_collection_modifyitems(config, items):
-    # first, make sure things run in order
-    # needed to mitigate some weird quirk of vcrpy on Python 3.3, no idea why
-    items.sort(key=lambda item: (item.fspath or '') + '::' + item.name)
-
-    # rest of this is handling for "offline mode"
+    # handle running tests in "offline mode"
     if not config.getoption('--offline'):
         # nothing to skip
         return
@@ -41,10 +37,3 @@ def vcr_cassette_dir(request):
         # We know it's part of Sopel...
         parts = parts[1:]
     return os.path.join('test', 'vcr', *parts)
-
-
-@pytest.fixture
-def vcr_cassette_path(request, vcr_cassette_name):
-    # pytest-vcr 0.3.0 looks for this fixture name
-    # remove when killing off Python 3.3 support
-    return os.path.join(vcr_cassette_dir(request), vcr_cassette_name)


### PR DESCRIPTION
### Description
Tin. IIRC some of the behavior I'm removing was to work around issues that were only reproducible under Python 3.3 _on Travis CI_ (and not in my local 3.3 env), making them doubly irrelevant now that we switched to GitHub Actions _and_ only support py3.6+.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches