### PR TITLE
plugins.rules.URLCallback: use `yield from` expression

### DIFF
--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -1675,9 +1675,7 @@ class URLCallback(Rule):
                 # skip invalid URLs
                 continue
 
-            # TODO: convert to 'yield from' when dropping Python 2.7
-            for result in self.parse(url):
-                yield result
+            yield from self.parse(url)
 
     def parse(self, text):
         for regex in self._regexes:


### PR DESCRIPTION
### Description
We have dropped support for Python 2, and this eliminates yet another TODO comment left in the code.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches