### PR TITLE
loader: drop compatibility code for old-style Phenny/Jenni modules

### DIFF
--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -101,22 +101,7 @@ def clean_callable(func, config):
     if not hasattr(func, 'event'):
         func.event = ['PRIVMSG']
     else:
-        if isinstance(func.event, (str, bytes)):
-            func.event = [func.event.upper()]
-        else:
-            func.event = [event.upper() for event in func.event]
-
-    # TODO: remove in Sopel 8
-    # Stay compatible with old Phenny/Jenni "modules" (plugins)
-    # that set the attribute directly
-    if hasattr(func, 'rule') and isinstance(func.rule, (str, bytes)):
-        LOGGER.warning(
-            'The `rule` attribute of %s.%s should be a list, not a string; '
-            'this behavior is deprecated in Sopel 7.1 '
-            'and will be removed in Sopel 8. '
-            'To prevent this problem always use `sopel.plugin.rule(%r)`.',
-            func.__module__, func.__name__, func.rule)
-        func.rule = [func.rule]
+        func.event = [event.upper() for event in func.event]
 
     if any(hasattr(func, attr) for attr in ['commands', 'nickname_commands', 'action_commands']):
         if hasattr(func, 'example'):

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -373,18 +373,6 @@ def test_clean_callable_event(tmpconfig, func):
     assert func.global_rate == 0
 
 
-def test_clean_callable_event_string(tmpconfig, func):
-    setattr(func, 'event', 'some')
-    loader.clean_callable(func, tmpconfig)
-
-    assert hasattr(func, 'event')
-    assert func.event == ['SOME']
-
-    # idempotency
-    loader.clean_callable(func, tmpconfig)
-    assert func.event == ['SOME']
-
-
 def test_clean_callable_rule(tmpconfig, func):
     setattr(func, 'rule', [r'abc'])
     loader.clean_callable(func, tmpconfig)
@@ -424,22 +412,6 @@ def test_clean_callable_rule(tmpconfig, func):
     assert func.rate == 0
     assert func.channel_rate == 0
     assert func.global_rate == 0
-
-
-def test_clean_callable_rule_string(tmpconfig, func):
-    setattr(func, 'rule', r'abc')
-    loader.clean_callable(func, tmpconfig)
-
-    assert hasattr(func, 'rule')
-    assert len(func.rule) == 1
-
-    # Test the regex is compiled properly
-    assert func.rule[0] == r'abc'
-
-    # idempotency
-    loader.clean_callable(func, tmpconfig)
-    assert len(func.rule) == 1
-    assert func.rule[0] == r'abc'
 
 
 def test_clean_callable_rule_nick(tmpconfig, func):
@@ -632,20 +604,6 @@ def test_clean_callable_events(tmpconfig, func):
 
     assert hasattr(func, 'event')
     assert func.event == ['TOPIC', 'JOIN', 'NICK']
-
-
-def test_clean_callable_events_basestring(tmpconfig, func):
-    setattr(func, 'event', 'topic')
-    loader.clean_callable(func, tmpconfig)
-
-    assert hasattr(func, 'event')
-    assert func.event == ['TOPIC']
-
-    setattr(func, 'event', 'JOIN')
-    loader.clean_callable(func, tmpconfig)
-
-    assert hasattr(func, 'event')
-    assert func.event == ['JOIN']
 
 
 def test_clean_callable_example(tmpconfig, func):


### PR DESCRIPTION
### Description
Way back, before the `plugin` (or `module`) decorators were a thing, "modules" of the time were written by directly assigning attributes of each callable to add the required properties for the bot's loader.

We don't support that any more. Code like that is probably five or more years old *at minimum*, and should be updated.

Also drops related tests, of course.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
Did I think about raising some kind of warning instead of silently correcting the values as Sopel 7.x and earlier have been doing? Yes. I decided against it, because that would just replace one kind of legacy fallback mode with another. Rip off the band-aid.