### PR TITLE
tools.events: convert to `Enum`

### DIFF
--- a/sopel/tools/_events.py
+++ b/sopel/tools/_events.py
@@ -1,7 +1,9 @@
 from __future__ import generator_stop
 
+from enum import Enum
 
-class events(object):
+
+class events(str, Enum):
     """An enumeration of all the standardized and notable IRC numeric events
 
     This allows you to do, for example, ``@plugin.event(events.RPL_WELCOME)``
@@ -79,7 +81,7 @@ class events(object):
     ERR_NOTREGISTERED = '451'
     ERR_NEEDMOREPARAMS = '461'
     ERR_ALREADYREGISTRED = '462'
-    ERR_ALREADYREGISTERED = '462'  # corrected spelling used in some tutorials
+    ERR_ALREADYREGISTERED = ERR_ALREADYREGISTRED  # corrected spelling used in some tutorials
     ERR_NOPERMFORHOST = '463'
     ERR_PASSWDMISMATCH = '464'
     ERR_YOUREBANNEDCREEP = '465'


### PR DESCRIPTION
### Description
Anyone using these as intended should see no ill effects, but using an `Enum` class will actively thwart plugins that try to do something silly like override a numeric name.

Really, it's the same thing as #2122 but for the numeric events instead.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches