### PR TITLE
pronouns: fetch list from the pronoun.is GitHub repo at start

### DIFF
--- a/sopel/modules/pronouns.py
+++ b/sopel/modules/pronouns.py
@@ -12,12 +12,32 @@ import logging
 import requests
 
 from sopel import plugin
+from sopel.config import types
 
 
 LOGGER = logging.getLogger(__name__)
 
 
+class PronounsSection(types.StaticSection):
+    fetch_complete_list = types.BooleanAttribute('fetch_complete_list', default=True)
+    """Whether to attempt fetching the complete list pronoun.is uses, at bot startup."""
+
+
+def configure(settings):
+    """
+    | name | example | purpose |
+    | ---- | ------- | ------- |
+    | fetch_complete_list | True | Whether to attempt fetching the complete pronoun list from pronoun.is at startup. |
+    """
+    settings.define_section('pronouns', PronounsSection)
+    settings.pronouns.configure_setting(
+        'fetch_complete_list',
+        'Fetch the current pronoun.is list at startup?')
+
+
 def setup(bot):
+    bot.config.define_section('pronouns', PronounsSection)
+
     # Copied from pronoun.is, leaving a *lot* out.
     # If ambiguous, the earlier one will be used.
     # This basic set is hard-coded to guarantee that the ten most(ish) common sets
@@ -34,6 +54,9 @@ def setup(bot):
         'it/it': 'it/it/its/its/itself',
         'ey/em': 'ey/em/eir/eirs/eirself',
     }
+
+    if not bot.config.pronouns.fetch_complete_list:
+        return
 
     # and now try to get the current one
     # who needs an API that might never exist?


### PR DESCRIPTION
### Description
We don't have to wait until the 12th of Never for pronoun.is to have an API. Parsing tab-separated values is easy, and the file is already sorted according to approximate frequency for us according to their readme.

Includes a kill-switch config setting in case the repo ever gets deleted or reorganized, or the file format changes.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
Speaking of something that's over-complicated for what it does (as Exi said on IRC yesterday)… this also finds the shortest unique set of pronouns for each option to use in links. The only outlier cases now are `they/them/their/theirs/themsel(ves|f)`, which won't be abbreviated as `they/.../themsel(ves|f)`. I might or might not find the motivation to fix that.