### PR TITLE
irc: rework parsing of modestrings

### DIFF
--- a/docs/source/irc.rst
+++ b/docs/source/irc.rst
@@ -38,6 +38,13 @@ Backends
     :show-inheritance:
 
 
+Mode Messages
+=============
+
+.. automodule:: sopel.irc.modes
+    :members:
+
+
 ISUPPORT
 ========
 

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -20,6 +20,7 @@ from typing import Optional
 
 from sopel import irc, logger, plugins, tools
 from sopel.db import SopelDB
+from sopel.irc import modes
 import sopel.loader
 from sopel.plugin import NOLIMIT
 from sopel.plugins import jobs as plugin_jobs, rules as plugin_rules
@@ -79,6 +80,9 @@ class Sopel(irc.AbstractBot):
 
         For servers that do not support IRCv3, this will be an empty set.
         """
+
+        self.modeparser = modes.ModeParser()
+        """A mode parser used to parse ``MODE`` messages and modestrings."""
 
         self.channels = tools.SopelIdentifierMemory()
         """A map of the channels that Sopel is in.

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -558,6 +558,9 @@ def _parse_modes(bot, args, clear=False):
                 modes[mode].add(param)
             elif param in modes[mode]:
                 modes[mode].remove(param)
+                # remove mode if empty
+                if not modes[mode]:
+                    modes.pop(mode)
         elif letter == 'B':
             if is_added:
                 modes[mode] = param

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -46,6 +46,19 @@ CORE_QUERYTYPE = '999'
 Other plugins should use a different querytype.
 """
 
+MODE_PREFIX_PRIVILEGES = {
+    "v": plugin.VOICE,
+    "h": plugin.HALFOP,
+    "o": plugin.OP,
+    "a": plugin.ADMIN,
+    "q": plugin.OWNER,
+    "y": plugin.OPER,
+    "Y": plugin.OPER,
+}
+
+MODE_PREFIXES = set(MODE_PREFIX_PRIVILEGES.keys())
+
+
 batched_caps = {}
 
 
@@ -528,23 +541,13 @@ def _parse_modes(bot, args, clear=False):
         LOGGER.debug(
             "The server sent a possibly malformed MODE message: %r", args)
 
-    mapping = {
-        "v": plugin.VOICE,
-        "h": plugin.HALFOP,
-        "o": plugin.OP,
-        "a": plugin.ADMIN,
-        "q": plugin.OWNER,
-        "y": plugin.OPER,
-        "Y": plugin.OPER,
-    }
-
-    privileges = mapping.keys()
+    privileges = MODE_PREFIXES
     if 'PREFIX' in bot.isupport:
-        privileges = bot.isupport.PREFIX.keys()
+        privileges = set(bot.isupport.PREFIX.keys())
 
     modemessage = ircmodes.ModeParser(
         bot.isupport.CHANMODES,
-        privileges=set(privileges),
+        privileges=privileges,
     )
     modeinfo = modemessage.parse_modestring(args[1], tuple(args[2:]))
 
@@ -585,7 +588,7 @@ def _parse_modes(bot, args, clear=False):
         # User privs modes, always have a param
         nick = Identifier(param)
         priv = channel.privileges.get(nick, 0)
-        value = mapping[privilege]
+        value = MODE_PREFIX_PRIVILEGES[privilege]
         if is_added:
             priv = priv | value
         else:

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -546,7 +546,7 @@ def _parse_modes(bot, args, clear=False):
         LOGGER.debug(
             "The server sent a possibly malformed MODE message: %r", args)
 
-    modeinfo = bot.modeparser.parse_modestring(args[1], tuple(args[2:]))
+    modeinfo = bot.modeparser.parse(args[1], tuple(args[2:]))
 
     # set or update channel's modes
     modes = {} if clear else copy.deepcopy(channel.modes)

--- a/sopel/irc/modes.py
+++ b/sopel/irc/modes.py
@@ -121,9 +121,21 @@ class ModeParser:
         'A': tuple('beI'),
         'B': tuple('k'),
         'C': tuple('l'),
-        'D': tuple('Oaimnqpsrt'),
+        'D': tuple('Oimnpsrt'),
     }
-    """Default CHANMODES per :rfc:`2811`."""
+    """Default CHANMODES per :rfc:`2811`.
+
+    .. note::
+
+        Mode ``a`` has been removed from the default list, as it appears
+        to be a relic of the past and is more commonly used as a privilege.
+
+        Mode ``q`` has been removed too, as it is commonly used as a privilege.
+
+        If a server is unhappy with these defaults, they should advertise
+        ``CHANMODES`` and ``PREFIX`` properly.
+
+    """
 
     def __init__(
         self,
@@ -131,18 +143,18 @@ class ModeParser:
         type_params: Dict[str, ParamRequired] = DEFAULT_MODETYPE_PARAM_CONFIG,
         privileges: Set[str] = PRIVILEGES,
     ) -> None:
-        self.chanmodes: Dict[str, Tuple[str, ...]] = chanmodes
+        self.chanmodes: Dict[str, Tuple[str, ...]] = dict(chanmodes)
         """Map of mode types (``str``) to their lists of modes (``tuple``).
 
         This map should come from ``ISUPPORT``, usually through
         :attr:`bot.isupport.CHANMODES <sopel.irc.isupport.ISupport.CHANMODES>`.
         """
-        self.type_params = type_params
+        self.type_params = dict(type_params)
         """Map of mode types (``str``) with their param requirements.
 
         This map defaults to :data:`DEFAULT_MODETYPE_PARAM_CONFIG`.
         """
-        self.privileges = privileges
+        self.privileges = set(privileges)
         """Set of valid user privileges.
 
         This set should come from ``ISUPPORT``, usually through

--- a/sopel/irc/modes.py
+++ b/sopel/irc/modes.py
@@ -8,10 +8,9 @@
 """
 from __future__ import generator_stop
 
-from collections import namedtuple
 import enum
 import logging
-from typing import Dict, Generator, List, Optional, Set, Tuple
+from typing import Dict, Generator, List, NamedTuple, Optional, Set, Tuple
 
 
 LOGGER = logging.getLogger(__name__)
@@ -67,12 +66,42 @@ def _parse_modestring(
         yield (char, is_added)
 
 
-ModeMessage = namedtuple('ModeMessage', [
-    'modes',
-    'privileges',
-    'ignored_modes',
-    'leftover_params',
-])
+class ModeMessage(NamedTuple):
+    """Mode message with modes and privileges."""
+    modes: Tuple[Tuple[str, str, bool, Optional[str]], ...]
+    """Tuple of added and removed modes.
+
+    Each item follows the same structure::
+
+        (type, mode, is_added, param)
+
+    Where ``type`` is the mode type (such as A, B, C, D); ``mode`` is the mode
+    letter; ``is_added`` tells if the mode should be added or removed; and
+    ``param`` is an optional parameter value for that mode only when necessary.
+    """
+    privileges: Tuple[Tuple[str, bool, str], ...]
+    """Tuple of added and removed privileges.
+
+    Each item follows the same structure::
+
+        (privilege, is_added, target)
+
+    Where ``privilege`` is the privilege letter; ``is_added`` tells if the
+    privilege should be added or removed; and ``target`` is the target for that
+    privilege.
+    """
+    ignored_modes: Tuple[Tuple[str, bool], ...]
+    """Ignored modes when they are unknown or there is a missing parameter.
+
+    Each item follows the same structure::
+
+        (mode, is_added)
+
+    Where ``mode`` is the mode or privilege letter and ``is_added`` tells if
+    the mode or privilege wants to be added or removed.
+    """
+    leftover_params: Tuple[str, ...]
+    """Parameters not used by any valid mode or privilege."""
 
 
 class ModeParser:

--- a/sopel/irc/modes.py
+++ b/sopel/irc/modes.py
@@ -1,0 +1,235 @@
+"""Mode management for IRC channels.
+
+.. seealso::
+
+    https://modern.ircdocs.horse/#mode-message
+
+.. versionadded:: 8.0
+"""
+from __future__ import generator_stop
+
+from collections import namedtuple
+import logging
+from typing import Dict, Generator, List, Optional, Set, Tuple
+
+
+LOGGER = logging.getLogger(__name__)
+
+PARAM_ALWAYS = 'always'
+PARAM_ADDED = 'added'
+PARAM_REMOVED = 'removed'
+PARAM_NEVER = 'never'
+DEFAULT_MODETYPE_PARAM_CONFIG = {
+    'A': PARAM_ALWAYS,
+    'B': PARAM_ALWAYS,
+    'C': PARAM_ADDED,
+    'D': PARAM_NEVER,
+}
+"""Default parameter requirements for mode types."""
+
+
+class ModeException(Exception):
+    """Base exception class for mode management."""
+    pass
+
+
+class ModeTypeUnknown(ModeException):
+    """Exception when a mode's type is unknown or cannot be determined."""
+    def __init__(self, mode) -> None:
+        super().__init__('Unknown type for mode %s' % mode)
+
+
+class ModeTypeImproperlyConfigured(ModeException):
+    """Exception when the mode's type management is not configured properly."""
+    def __init__(self, mode: str, letter: str) -> None:
+        message = 'Type {mode} for mode {letter} is not properly configured.'
+        super().__init__(message.format(mode=mode, letter=letter))
+
+
+def _parse_modestring(
+    modestring: str,
+) -> Generator[Tuple[str, bool], None, None]:
+    is_added = True
+    for char in modestring:
+        if char in '+-':
+            is_added = char == '+'
+            continue
+        yield (char, is_added)
+
+
+ModeMessage = namedtuple('ModeMessage', [
+    'modes',
+    'privileges',
+    'ignored_modes',
+    'leftover_params',
+])
+
+
+class ModeParser:
+    """ModeMessage parser for IRC's ``MODE`` messages for channel modes."""
+    PRIVILEGES: Set[str] = {
+        "v",  # VOICE
+        "h",  # HALFOP
+        "o",  # OP
+        "a",  # ADMIN
+        "q",  # OWNER
+        "y",  # OPER
+        "Y",  # OPER
+    }
+    """Set of user privileges used by default."""
+
+    def __init__(
+        self,
+        chanmodes: Dict[str, Tuple[str, ...]],
+        type_params: Dict[str, str] = DEFAULT_MODETYPE_PARAM_CONFIG,
+        privileges: Set[str] = PRIVILEGES,
+    ) -> None:
+        self.chanmodes: Dict[str, Tuple[str, ...]] = chanmodes
+        """Map of mode types (``str``) to their lists of modes (``tuple``).
+
+        This map should come from ``ISUPPORT``, usually through
+        :attr:`bot.isupport.CHANMODES <sopel.irc.isupport.ISupport.CHANMODES>`.
+        """
+        self.type_params = type_params
+        """Map of mode types (``str``) with their param requirements.
+
+        This map defaults to :data:`DEFAULT_MODETYPE_PARAM_CONFIG`.
+        """
+        self.privileges = privileges
+        """Set of valid user privileges.
+
+        This set should come from ``ISUPPORT``, usually through
+        :attr:`bot.isupport.PREFIX <sopel.irc.isupport.ISupport.PREFIX>`.
+
+        If a server doesn't advertise its prefixes for user privileges,
+        :attr:`PRIVILEGES` will be used as a default value.
+        """
+
+    def get_mode_type(self, mode: str) -> str:
+        """Retrieve the type of ``mode``.
+
+        :raise ModeTypeUnknown: if the mode's type cannot be determined
+        :return: the mode's type as defined by :attr:`chanmodes`
+
+        ::
+
+            >>> mm = ModeParser({'A': tuple('beI'), 'B': tuple('k')}, {})
+            >>> mm.get_mode_type('b')
+            'A'
+            >>> mm.get_mode_type('k')
+            'B'
+
+        This method will raise a :exc:`ModeTypeUnknown` if the mode is unknown,
+        including the case where ``mode`` is actually a user privilege such as
+        ``v``.
+        """
+        for letter, modes in self.chanmodes.items():
+            if mode in modes:
+                return letter
+        raise ModeTypeUnknown(mode)
+
+    def get_mode_info(
+        self,
+        mode: str,
+        is_added: bool,
+    ) -> Tuple[Optional[str], bool, bool]:
+        """Retrieve ``mode``'s information when added or removed.
+
+        :raise ModeTypeUnknown: when the mode's type is unknown and isn't a
+                                user privilege
+        :raise ModeTypeImproperlyConfigured: when the mode's type is known but
+                                             there is no information for
+                                             parameters (if and when they are
+                                             required by the mode)
+        :return: a tuple with three values: the mode type, if it requires a
+                 parameter, and if it's a channel mode or a user privilege
+
+        ::
+
+            >>> chanmodes = {'A': tuple('beI'), 'B': tuple('k')}
+            >>> t_params = {'A': PARAM_ALWAYS, 'B': PARAM_ADDED}
+            >>> mm = ModeParser(chanmodes, t_params)
+            >>> mm.get_mode_info('e', False)
+            ('A', True, False)
+            >>> mm.get_mode_info('k', False)
+            ('B', False, False)
+            >>> mm.get_mode_info('v', True)
+            (None, True, True)
+
+        .. note::
+
+            A user privilege ``mode`` doesn't have a type so the first value
+            returned will be ``None`` in that case.
+        """
+        try:
+            letter = self.get_mode_type(mode)
+        except ModeTypeUnknown:
+            if mode in self.privileges:
+                # a user privilege doesn't have a type
+                return None, True, True
+            # not a user privilege: re-raise error
+            raise
+
+        if letter not in self.type_params:
+            # we don't know how to handle this type of mode
+            raise ModeTypeImproperlyConfigured(mode, letter)
+
+        type_param = self.type_params[letter]
+        return letter, not type_param == PARAM_NEVER and (
+            type_param == PARAM_ALWAYS
+            or type_param == PARAM_ADDED and is_added
+            or type_param == PARAM_REMOVED and not is_added
+        ), False
+
+    def parse_modestring(
+        self,
+        modestring: str,
+        params: Tuple[str, ...]
+    ) -> ModeMessage:
+        """Parse a ``modestring`` for a channel with its ``params``.
+
+        :return: the parsed and validated information for that ``modestring``
+        """
+        imodes = iter(_parse_modestring(modestring))
+        iparams = iter(params)
+        modes: List = []
+        privileges: List = []
+        for mode, is_added in imodes:
+            param = None
+            try:
+                letter, required, is_priv = self.get_mode_info(mode, is_added)
+                if required:
+                    try:
+                        param = next(iparams)
+                    except StopIteration:
+                        # Not enough parameters: we have to stop here
+                        return ModeMessage(
+                            tuple(modes),
+                            tuple(privileges),
+                            ((mode, is_added),) + tuple(imodes),
+                            tuple(),
+                        )
+            except ModeException as modeerror:
+                LOGGER.debug(
+                    'Invalid modestring: %r; error: %s',
+                    modestring,
+                    modeerror,
+                )
+                return ModeMessage(
+                    tuple(modes),
+                    tuple(privileges),
+                    ((mode, is_added),) + tuple(imodes),
+                    tuple(iparams),
+                )
+
+            if is_priv:
+                privileges.append((mode, is_added, param))
+            else:
+                modes.append((letter, mode, is_added, param))
+
+        return ModeMessage(
+            tuple(modes),
+            tuple(privileges),
+            tuple(imodes),
+            tuple(iparams),
+        )

--- a/sopel/irc/modes.py
+++ b/sopel/irc/modes.py
@@ -117,9 +117,17 @@ class ModeParser:
     }
     """Set of user privileges used by default."""
 
+    CHANMODES = {
+        'A': tuple('beI'),
+        'B': tuple('k'),
+        'C': tuple('l'),
+        'D': tuple('Oaimnqpsrt'),
+    }
+    """Default CHANMODES per :rfc:`2811`."""
+
     def __init__(
         self,
-        chanmodes: Dict[str, Tuple[str, ...]],
+        chanmodes: Dict[str, Tuple[str, ...]] = CHANMODES,
         type_params: Dict[str, ParamRequired] = DEFAULT_MODETYPE_PARAM_CONFIG,
         privileges: Set[str] = PRIVILEGES,
     ) -> None:

--- a/test/irc/test_irc_modes.py
+++ b/test/irc/test_irc_modes.py
@@ -1,0 +1,627 @@
+from __future__ import generator_stop
+
+import pytest
+
+from sopel.irc.modes import (
+    ModeParser,
+    ModeTypeImproperlyConfigured,
+    ModeTypeUnknown,
+    PARAM_ADDED,
+    PARAM_ALWAYS,
+    PARAM_NEVER,
+    PARAM_REMOVED,
+)
+
+ADDED = True
+REMOVED = False
+REQUIRED = True
+NOT_REQUIRED = False
+PREFIX = True
+NOT_PREFIX = False
+
+
+@pytest.mark.parametrize('mode, letter', (
+    ('b', 'A'),
+    ('c', 'A'),
+    ('e', 'B'),
+    ('f', 'B'),
+    ('g', 'B'),
+))
+def test_modemessage_get_mode_type(mode, letter):
+    modemessage = ModeParser({
+        'A': tuple('bc'),
+        'B': tuple('efg'),
+    }, {})
+
+    assert modemessage.get_mode_type(mode) == letter
+
+
+def test_modemessage_get_mode_type_empty():
+    modemessage = ModeParser({}, {})
+
+    # common mode
+    with pytest.raises(ModeTypeUnknown):
+        modemessage.get_mode_type('b')
+
+    # common privilege
+    with pytest.raises(ModeTypeUnknown):
+        modemessage.get_mode_type('v')
+
+
+def test_modemessage_get_mode_type_unknown():
+    modemessage = ModeParser({
+        'A': tuple('bc'),
+        'B': tuple('efg'),
+    }, {})
+
+    # unknown mode
+    with pytest.raises(ModeTypeUnknown):
+        modemessage.get_mode_type('z')
+
+    # common privilege
+    with pytest.raises(ModeTypeUnknown):
+        modemessage.get_mode_type('v')
+
+
+@pytest.mark.parametrize('mode, is_added, result', (
+    # X: always
+    ('b', ADDED, ('X', REQUIRED, NOT_PREFIX)),
+    ('b', REMOVED, ('X', REQUIRED, NOT_PREFIX)),
+    ('c', ADDED, ('X', REQUIRED, NOT_PREFIX)),
+    ('c', REMOVED, ('X', REQUIRED, NOT_PREFIX)),
+    # Y: added only
+    ('e', ADDED, ('Y', REQUIRED, NOT_PREFIX)),
+    ('e', REMOVED, ('Y', NOT_REQUIRED, NOT_PREFIX)),
+    ('f', ADDED, ('Y', REQUIRED, NOT_PREFIX)),
+    ('f', REMOVED, ('Y', NOT_REQUIRED, NOT_PREFIX)),
+    ('g', ADDED, ('Y', REQUIRED, NOT_PREFIX)),
+    ('g', REMOVED, ('Y', NOT_REQUIRED, NOT_PREFIX)),
+    # Z: removed only
+    ('i', ADDED, ('Z', NOT_REQUIRED, NOT_PREFIX)),
+    ('i', REMOVED, ('Z', REQUIRED, NOT_PREFIX)),
+    ('j', ADDED, ('Z', NOT_REQUIRED, NOT_PREFIX)),
+    ('j', REMOVED, ('Z', REQUIRED, NOT_PREFIX)),
+    # T: never
+    ('k', ADDED, ('T', NOT_REQUIRED, NOT_PREFIX)),
+    ('k', REMOVED, ('T', NOT_REQUIRED, NOT_PREFIX)),
+    ('l', ADDED, ('T', NOT_REQUIRED, NOT_PREFIX)),
+    ('l', REMOVED, ('T', NOT_REQUIRED, NOT_PREFIX)),
+    ('m', ADDED, ('T', NOT_REQUIRED, NOT_PREFIX)),
+    ('m', REMOVED, ('T', NOT_REQUIRED, NOT_PREFIX)),
+    # PREFIX: always
+    ('v', ADDED, (None, REQUIRED, PREFIX)),
+    ('v', REMOVED, (None, REQUIRED, PREFIX)),
+    ('h', ADDED, (None, REQUIRED, PREFIX)),
+    ('h', REMOVED, (None, REQUIRED, PREFIX)),
+    ('o', ADDED, (None, REQUIRED, PREFIX)),
+    ('o', REMOVED, (None, REQUIRED, PREFIX)),
+    ('a', ADDED, (None, REQUIRED, PREFIX)),
+    ('a', REMOVED, (None, REQUIRED, PREFIX)),
+    ('q', ADDED, (None, REQUIRED, PREFIX)),
+    ('q', REMOVED, (None, REQUIRED, PREFIX)),
+    ('y', ADDED, (None, REQUIRED, PREFIX)),
+    ('y', REMOVED, (None, REQUIRED, PREFIX)),
+    ('Y', ADDED, (None, REQUIRED, PREFIX)),
+    ('Y', REMOVED, (None, REQUIRED, PREFIX)),
+))
+def test_modemessage_get_mode_info(mode, is_added, result):
+    modemessage = ModeParser({
+        'X': tuple('bc'),
+        'Y': tuple('efg'),
+        'Z': tuple('ij'),
+        'T': tuple('klm'),
+    }, {
+        'X': PARAM_ALWAYS,
+        'Y': PARAM_ADDED,
+        'Z': PARAM_REMOVED,
+        'T': PARAM_NEVER,
+    })
+
+    assert modemessage.get_mode_info(mode, is_added) == result
+
+
+def test_modemessage_get_mode_info_empty():
+    modemessage = ModeParser(chanmodes={}, type_params={}, privileges=set())
+
+    with pytest.raises(ModeTypeUnknown):
+        modemessage.get_mode_info('b', ADDED)
+
+    with pytest.raises(ModeTypeUnknown):
+        modemessage.get_mode_info('b', REMOVED)
+
+
+@pytest.mark.parametrize('privilege', ('v', 'h', 'a', 'q', 'o', 'y', 'Y'))
+def test_modemessage_get_mode_info_empty_default_privileges(privilege):
+    modemessage = ModeParser(chanmodes={}, type_params={})
+
+    assert modemessage.get_mode_info(privilege, ADDED), (REQUIRED, PREFIX)
+    assert modemessage.get_mode_info(privilege, REMOVED), (REQUIRED, PREFIX)
+
+
+@pytest.mark.parametrize('privilege', ('v', 'h', 'a', 'q', 'o', 'y', 'Y'))
+def test_modemessage_get_mode_info_empty_privileges_config(privilege):
+    modemessage = ModeParser(chanmodes={}, type_params={}, privileges=set())
+
+    with pytest.raises(ModeTypeUnknown):
+        modemessage.get_mode_info(privilege, ADDED)
+
+    with pytest.raises(ModeTypeUnknown):
+        modemessage.get_mode_info(privilege, REMOVED)
+
+
+def test_modemessage_get_mode_info_no_param_config():
+    modemessage = ModeParser({
+        'X': tuple('bc'),
+        'Y': tuple('efg'),
+        'Z': tuple('ij'),
+        'T': tuple('klm'),
+    }, {})
+
+    with pytest.raises(ModeTypeImproperlyConfigured):
+        modemessage.get_mode_info('b', ADDED)
+
+    with pytest.raises(ModeTypeImproperlyConfigured):
+        modemessage.get_mode_info('b', REMOVED)
+
+
+def test_modemessage_get_mode_info_custom_privileges():
+    modemessage = ModeParser(chanmodes={}, type_params={}, privileges=set('b'))
+
+    assert modemessage.get_mode_info('b', ADDED), (REQUIRED, PREFIX)
+    assert modemessage.get_mode_info('b', REMOVED), (REQUIRED, PREFIX)
+
+    with pytest.raises(ModeTypeUnknown):
+        modemessage.get_mode_info('v', ADDED)
+
+    with pytest.raises(ModeTypeUnknown):
+        modemessage.get_mode_info('v', REMOVED)
+
+
+def test_modemessage_parse_modestring_single_mode():
+    modemessage = ModeParser({
+        'X': tuple('bc'),
+        'Y': tuple('efg'),
+        'Z': tuple('ij'),
+        'T': tuple('klm'),
+    }, {
+        'X': PARAM_ALWAYS,
+        'Y': PARAM_ADDED,
+        'Z': PARAM_REMOVED,
+        'T': PARAM_NEVER,
+    })
+
+    # X: always a parameter
+    result = modemessage.parse_modestring('+b', ('Arg1',))
+    assert result.modes == (('X', 'b', ADDED, 'Arg1'),)
+    assert not result.ignored_modes
+    assert not result.privileges
+    assert not result.leftover_params
+
+    result = modemessage.parse_modestring('-b', ('Arg1',))
+    assert result.modes == (('X', 'b', REMOVED, 'Arg1'),)
+    assert not result.ignored_modes
+    assert not result.privileges
+    assert not result.leftover_params
+
+    # Y: parameter when added only
+    result = modemessage.parse_modestring('+e', ('Arg1',))
+    assert result.modes == (('Y', 'e', ADDED, 'Arg1'),)
+    assert not result.ignored_modes
+    assert not result.privileges
+    assert not result.leftover_params
+
+    result = modemessage.parse_modestring('-e', ('Arg1',))
+    assert result.modes == (('Y', 'e', REMOVED, None),)
+    assert not result.ignored_modes
+    assert not result.privileges
+    assert result.leftover_params == ('Arg1',)
+
+    # Z: parameter when removed only
+    result = modemessage.parse_modestring('+i', ('Arg1',))
+    assert result.modes == (('Z', 'i', ADDED, None),)
+    assert not result.ignored_modes
+    assert not result.privileges
+    assert result.leftover_params == ('Arg1',)
+
+    result = modemessage.parse_modestring('-i', ('Arg1',))
+    assert result.modes == (('Z', 'i', REMOVED, 'Arg1'),)
+    assert not result.ignored_modes
+    assert not result.privileges
+    assert not result.leftover_params
+
+    # T: no parameter
+    result = modemessage.parse_modestring('+k', ('Arg1',))
+    assert result.modes == (('T', 'k', ADDED, None),)
+    assert not result.ignored_modes
+    assert not result.privileges
+    assert result.leftover_params == ('Arg1',)
+
+    result = modemessage.parse_modestring('-k', ('Arg1',))
+    assert result.modes == (('T', 'k', REMOVED, None),)
+    assert not result.ignored_modes
+    assert not result.privileges
+    assert result.leftover_params == ('Arg1',)
+
+    # Common privilege
+    result = modemessage.parse_modestring('+v', ('Arg1',))
+    assert not result.modes
+    assert not result.ignored_modes
+    assert result.privileges == (('v', ADDED, 'Arg1'),)
+    assert not result.leftover_params
+
+    result = modemessage.parse_modestring('-v', ('Arg1',))
+    assert not result.modes
+    assert not result.ignored_modes
+    assert result.privileges == (('v', REMOVED, 'Arg1'),)
+    assert not result.leftover_params
+
+
+def test_modemessage_parse_modestring_multi_mode_add_only():
+    modemessage = ModeParser({
+        'X': tuple('bc'),
+        'Y': tuple('efg'),
+        'Z': tuple('ij'),
+        'T': tuple('klm'),
+    }, {
+        'X': PARAM_ALWAYS,
+        'Y': PARAM_ADDED,
+        'Z': PARAM_REMOVED,
+        'T': PARAM_NEVER,
+    })
+
+    # modes only
+    result = modemessage.parse_modestring('+beik', ('Arg1', 'Arg2'))
+    assert result.modes == (
+        ('X', 'b', ADDED, 'Arg1'),
+        ('Y', 'e', ADDED, 'Arg2'),
+        ('Z', 'i', ADDED, None),
+        ('T', 'k', ADDED, None),
+    )
+    assert not result.ignored_modes
+    assert not result.privileges
+    assert not result.leftover_params
+
+    # privileges only
+    result = modemessage.parse_modestring('+vo', ('Arg1', 'Arg2'))
+    assert not result.modes
+    assert not result.ignored_modes
+    assert result.privileges == (
+        ('v', ADDED, 'Arg1'),
+        ('o', ADDED, 'Arg2'),
+    )
+    assert not result.leftover_params
+
+    # modes & privileges
+    result = modemessage.parse_modestring(
+        '+bveoik', ('Arg1', 'Arg2', 'Arg3', 'Arg4'))
+    assert result.modes == (
+        ('X', 'b', ADDED, 'Arg1'),
+        ('Y', 'e', ADDED, 'Arg3'),
+        ('Z', 'i', ADDED, None),
+        ('T', 'k', ADDED, None),
+    )
+    assert not result.ignored_modes
+    assert result.privileges == (
+        ('v', ADDED, 'Arg2'),
+        ('o', ADDED, 'Arg4'),
+    )
+    assert not result.leftover_params
+
+
+def test_modemessage_parse_modestring_multi_mode_remove_only():
+    modemessage = ModeParser({
+        'X': tuple('bc'),
+        'Y': tuple('efg'),
+        'Z': tuple('ij'),
+        'T': tuple('klm'),
+    }, {
+        'X': PARAM_ALWAYS,
+        'Y': PARAM_ADDED,
+        'Z': PARAM_REMOVED,
+        'T': PARAM_NEVER,
+    })
+
+    # modes only
+    result = modemessage.parse_modestring('-beik', ('Arg1', 'Arg2'))
+    assert result.modes == (
+        ('X', 'b', REMOVED, 'Arg1'),
+        ('Y', 'e', REMOVED, None),
+        ('Z', 'i', REMOVED, 'Arg2'),
+        ('T', 'k', REMOVED, None),
+    )
+    assert not result.ignored_modes
+    assert not result.privileges
+    assert not result.leftover_params
+
+    # privileges only
+    result = modemessage.parse_modestring('-vo', ('Arg1', 'Arg2'))
+    assert not result.modes
+    assert not result.ignored_modes
+    assert result.privileges == (
+        ('v', REMOVED, 'Arg1'),
+        ('o', REMOVED, 'Arg2'),
+    )
+    assert not result.leftover_params
+
+    # modes & privileges
+    result = modemessage.parse_modestring(
+        '-bveoik', ('Arg1', 'Arg2', 'Arg3', 'Arg4'))
+    assert result.modes == (
+        ('X', 'b', REMOVED, 'Arg1'),
+        ('Y', 'e', REMOVED, None),
+        ('Z', 'i', REMOVED, 'Arg4'),
+        ('T', 'k', REMOVED, None),
+    )
+    assert not result.ignored_modes
+    assert result.privileges == (
+        ('v', REMOVED, 'Arg2'),
+        ('o', REMOVED, 'Arg3'),
+    )
+    assert not result.leftover_params
+
+
+def test_modemessage_parse_modestring_multi_mode_mixed_add_remove():
+    modemessage = ModeParser({
+        'X': tuple('bc'),
+        'Y': tuple('efg'),
+        'Z': tuple('ij'),
+        'T': tuple('klm'),
+    }, {
+        'X': PARAM_ALWAYS,
+        'Y': PARAM_ADDED,
+        'Z': PARAM_REMOVED,
+        'T': PARAM_NEVER,
+    })
+
+    # added first
+    result = modemessage.parse_modestring(
+        '+bveik-cofjl', ('Arg1', 'Arg2', 'Arg3', 'Arg4', 'Arg5', 'Arg6'))
+    assert result.modes == (
+        ('X', 'b', ADDED, 'Arg1'),
+        ('Y', 'e', ADDED, 'Arg3'),
+        ('Z', 'i', ADDED, None),
+        ('T', 'k', ADDED, None),
+        ('X', 'c', REMOVED, 'Arg4'),
+        ('Y', 'f', REMOVED, None),
+        ('Z', 'j', REMOVED, 'Arg6'),
+        ('T', 'l', REMOVED, None),
+    )
+    assert not result.ignored_modes
+    assert result.privileges == (
+        ('v', ADDED, 'Arg2'),
+        ('o', REMOVED, 'Arg5'),
+    )
+    assert not result.leftover_params
+
+    # removed first
+    result = modemessage.parse_modestring(
+        '-cofjl+bveik', ('Arg1', 'Arg2', 'Arg3', 'Arg4', 'Arg5', 'Arg6'))
+    assert result.modes == (
+        ('X', 'c', REMOVED, 'Arg1'),
+        ('Y', 'f', REMOVED, None),
+        ('Z', 'j', REMOVED, 'Arg3'),
+        ('T', 'l', REMOVED, None),
+        ('X', 'b', ADDED, 'Arg4'),
+        ('Y', 'e', ADDED, 'Arg6'),
+        ('Z', 'i', ADDED, None),
+        ('T', 'k', ADDED, None),
+    )
+    assert not result.ignored_modes
+    assert result.privileges == (
+        ('o', REMOVED, 'Arg2'),
+        ('v', ADDED, 'Arg5'),
+    )
+    assert not result.leftover_params
+
+    # mixed add/remove
+    result = modemessage.parse_modestring(
+        '+bve-cof+ik-jl', ('Arg1', 'Arg2', 'Arg3', 'Arg4', 'Arg5', 'Arg6'))
+    assert result.modes == (
+        ('X', 'b', ADDED, 'Arg1'),
+        ('Y', 'e', ADDED, 'Arg3'),
+        ('X', 'c', REMOVED, 'Arg4'),
+        ('Y', 'f', REMOVED, None),
+        ('Z', 'i', ADDED, None),
+        ('T', 'k', ADDED, None),
+        ('Z', 'j', REMOVED, 'Arg6'),
+        ('T', 'l', REMOVED, None),
+    )
+    assert not result.ignored_modes
+    assert result.privileges == (
+        ('v', ADDED, 'Arg2'),
+        ('o', REMOVED, 'Arg5'),
+    )
+    assert not result.leftover_params
+
+
+def test_modemessage_parse_modestring_leftover_params():
+    modemessage = ModeParser({
+        'X': tuple('bc'),
+        'Y': tuple('efg'),
+        'Z': tuple('ij'),
+        'T': tuple('klm'),
+    }, {
+        'X': PARAM_ALWAYS,
+        'Y': PARAM_ADDED,
+        'Z': PARAM_REMOVED,
+        'T': PARAM_NEVER,
+    })
+
+    # Single mode
+    result = modemessage.parse_modestring(
+        '+b', ('Arg1', 'Arg2'))
+    assert result.modes == (
+        ('X', 'b', ADDED, 'Arg1'),
+    )
+    assert not result.ignored_modes
+    assert not result.privileges
+    assert result.leftover_params == ('Arg2',)
+
+    # Single privilege
+    result = modemessage.parse_modestring(
+        '+v', ('Arg1', 'Arg2'))
+    assert not result.modes
+    assert not result.ignored_modes
+    assert result.privileges == (
+        ('v', ADDED, 'Arg1'),
+    )
+    assert result.leftover_params == ('Arg2',)
+
+    # Multi modes
+    result = modemessage.parse_modestring(
+        '+be-fi+jk-l', ('Arg1', 'Arg2', 'Arg3', 'Arg4'))
+    assert result.modes == (
+        ('X', 'b', ADDED, 'Arg1'),
+        ('Y', 'e', ADDED, 'Arg2'),
+        ('Y', 'f', REMOVED, None),
+        ('Z', 'i', REMOVED, 'Arg3'),
+        ('Z', 'j', ADDED, None),
+        ('T', 'k', ADDED, None),
+        ('T', 'l', REMOVED, None),
+    )
+    assert not result.ignored_modes
+    assert not result.privileges
+    assert result.leftover_params == ('Arg4',)
+
+
+def test_modemessage_parse_modestring_ignored_modes():
+    modemessage = ModeParser({
+        'X': tuple('bc'),
+        'Y': tuple('efg'),
+        'Z': tuple('ij'),
+        'T': tuple('klm'),
+    }, {
+        'X': PARAM_ALWAYS,
+        'Y': PARAM_ADDED,
+        'Z': PARAM_REMOVED,
+        'T': PARAM_NEVER,
+    })
+
+    # Single mode
+    result = modemessage.parse_modestring('+B', ('Arg1',))
+    assert not result.modes
+    assert result.ignored_modes == (('B', ADDED),)
+    assert not result.privileges
+    assert result.leftover_params == ('Arg1',)
+
+    # Multi modes/privileges
+    result = modemessage.parse_modestring(
+        '+bv+B-o', ('Arg1', 'Arg2', 'Arg3'))
+    assert result.modes == (
+        ('X', 'b', ADDED, 'Arg1'),
+    )
+    assert result.ignored_modes == (
+        ('B', ADDED),
+        ('o', REMOVED),
+    )
+    assert result.privileges == (
+        ('v', ADDED, 'Arg2'),
+    )
+    assert result.leftover_params == ('Arg3',)
+
+
+def test_modemessage_parse_modestring_no_params():
+    modemessage = ModeParser({
+        'X': tuple('bc'),
+        'Y': tuple('efg'),
+        'Z': tuple('ij'),
+        'T': tuple('klm'),
+    }, {
+        'X': PARAM_ALWAYS,
+        'Y': PARAM_ADDED,
+        'Z': PARAM_REMOVED,
+        'T': PARAM_NEVER,
+    })
+
+    # Single mode
+    result = modemessage.parse_modestring('+b', tuple())
+    assert not result.modes
+    assert result.ignored_modes == (('b', ADDED),)
+    assert not result.privileges
+    assert not result.leftover_params
+
+    result = modemessage.parse_modestring('-b', tuple())
+    assert not result.modes
+    assert result.ignored_modes == (('b', REMOVED),)
+    assert not result.privileges
+    assert not result.leftover_params
+
+    # Single privilege
+    result = modemessage.parse_modestring('+v', tuple())
+    assert not result.modes
+    assert result.ignored_modes == (('v', ADDED),)
+    assert not result.privileges
+    assert not result.leftover_params
+
+    result = modemessage.parse_modestring('-v', tuple())
+    assert not result.modes
+    assert result.ignored_modes == (('v', REMOVED),)
+    assert not result.privileges
+    assert not result.leftover_params
+
+    # Mixed multi modes/privileges
+    result = modemessage.parse_modestring('+b-v', tuple())
+    assert not result.modes
+    assert result.ignored_modes == (('b', ADDED), ('v', REMOVED),)
+    assert not result.privileges
+    assert not result.leftover_params
+
+
+def test_modemessage_parse_modestring_missing_params():
+    modemessage = ModeParser({
+        'X': tuple('bc'),
+        'Y': tuple('efg'),
+        'Z': tuple('ij'),
+        'T': tuple('klm'),
+    }, {
+        'X': PARAM_ALWAYS,
+        'Y': PARAM_ADDED,
+        'Z': PARAM_REMOVED,
+        'T': PARAM_NEVER,
+    })
+
+    # Modes only
+    result = modemessage.parse_modestring('+bc', ('Arg1',))
+    assert result.modes == (
+        ('X', 'b', ADDED, 'Arg1'),
+    )
+    assert result.ignored_modes == (('c', ADDED),)
+    assert not result.privileges
+    assert not result.leftover_params
+
+    result = modemessage.parse_modestring('-bc', ('Arg1',))
+    assert result.modes == (
+        ('X', 'b', REMOVED, 'Arg1'),
+    )
+    assert result.ignored_modes == (('c', REMOVED),)
+    assert not result.privileges
+    assert not result.leftover_params
+
+    # Prefixes only
+    result = modemessage.parse_modestring('+vo', ('Arg1',))
+    assert not result.modes
+    assert result.ignored_modes == (('o', ADDED),)
+    assert result.privileges == (
+        ('v', ADDED, 'Arg1'),
+    )
+    assert not result.leftover_params
+
+    result = modemessage.parse_modestring('-vo', ('Arg1',))
+    assert not result.modes
+    assert result.ignored_modes == (('o', REMOVED),)
+    assert result.privileges == (
+        ('v', REMOVED, 'Arg1'),
+    )
+    assert not result.leftover_params
+
+    # Mixed modes/privileges
+    result = modemessage.parse_modestring('+bv-co', ('Arg1', 'Arg2', 'Arg3'))
+    assert result.modes == (
+        ('X', 'b', ADDED, 'Arg1'),
+        ('X', 'c', REMOVED, 'Arg3'),
+    )
+    assert result.ignored_modes == (('o', REMOVED),)
+    assert result.privileges == (
+        ('v', ADDED, 'Arg2'),
+    )
+    assert not result.leftover_params

--- a/test/irc/test_irc_modes.py
+++ b/test/irc/test_irc_modes.py
@@ -6,10 +6,7 @@ from sopel.irc.modes import (
     ModeParser,
     ModeTypeImproperlyConfigured,
     ModeTypeUnknown,
-    PARAM_ADDED,
-    PARAM_ALWAYS,
-    PARAM_NEVER,
-    PARAM_REMOVED,
+    ParamRequired,
 )
 
 ADDED = True
@@ -111,10 +108,10 @@ def test_modemessage_get_mode_info(mode, is_added, result):
         'Z': tuple('ij'),
         'T': tuple('klm'),
     }, {
-        'X': PARAM_ALWAYS,
-        'Y': PARAM_ADDED,
-        'Z': PARAM_REMOVED,
-        'T': PARAM_NEVER,
+        'X': ParamRequired.ALWAYS,
+        'Y': ParamRequired.ADDED,
+        'Z': ParamRequired.REMOVED,
+        'T': ParamRequired.NEVER,
     })
 
     assert modemessage.get_mode_info(mode, is_added) == result
@@ -184,10 +181,10 @@ def test_modemessage_parse_modestring_single_mode():
         'Z': tuple('ij'),
         'T': tuple('klm'),
     }, {
-        'X': PARAM_ALWAYS,
-        'Y': PARAM_ADDED,
-        'Z': PARAM_REMOVED,
-        'T': PARAM_NEVER,
+        'X': ParamRequired.ALWAYS,
+        'Y': ParamRequired.ADDED,
+        'Z': ParamRequired.REMOVED,
+        'T': ParamRequired.NEVER,
     })
 
     # X: always a parameter
@@ -263,10 +260,10 @@ def test_modemessage_parse_modestring_multi_mode_add_only():
         'Z': tuple('ij'),
         'T': tuple('klm'),
     }, {
-        'X': PARAM_ALWAYS,
-        'Y': PARAM_ADDED,
-        'Z': PARAM_REMOVED,
-        'T': PARAM_NEVER,
+        'X': ParamRequired.ALWAYS,
+        'Y': ParamRequired.ADDED,
+        'Z': ParamRequired.REMOVED,
+        'T': ParamRequired.NEVER,
     })
 
     # modes only
@@ -315,10 +312,10 @@ def test_modemessage_parse_modestring_multi_mode_remove_only():
         'Z': tuple('ij'),
         'T': tuple('klm'),
     }, {
-        'X': PARAM_ALWAYS,
-        'Y': PARAM_ADDED,
-        'Z': PARAM_REMOVED,
-        'T': PARAM_NEVER,
+        'X': ParamRequired.ALWAYS,
+        'Y': ParamRequired.ADDED,
+        'Z': ParamRequired.REMOVED,
+        'T': ParamRequired.NEVER,
     })
 
     # modes only
@@ -367,10 +364,10 @@ def test_modemessage_parse_modestring_multi_mode_mixed_add_remove():
         'Z': tuple('ij'),
         'T': tuple('klm'),
     }, {
-        'X': PARAM_ALWAYS,
-        'Y': PARAM_ADDED,
-        'Z': PARAM_REMOVED,
-        'T': PARAM_NEVER,
+        'X': ParamRequired.ALWAYS,
+        'Y': ParamRequired.ADDED,
+        'Z': ParamRequired.REMOVED,
+        'T': ParamRequired.NEVER,
     })
 
     # added first
@@ -441,10 +438,10 @@ def test_modemessage_parse_modestring_leftover_params():
         'Z': tuple('ij'),
         'T': tuple('klm'),
     }, {
-        'X': PARAM_ALWAYS,
-        'Y': PARAM_ADDED,
-        'Z': PARAM_REMOVED,
-        'T': PARAM_NEVER,
+        'X': ParamRequired.ALWAYS,
+        'Y': ParamRequired.ADDED,
+        'Z': ParamRequired.REMOVED,
+        'T': ParamRequired.NEVER,
     })
 
     # Single mode
@@ -491,10 +488,10 @@ def test_modemessage_parse_modestring_ignored_modes():
         'Z': tuple('ij'),
         'T': tuple('klm'),
     }, {
-        'X': PARAM_ALWAYS,
-        'Y': PARAM_ADDED,
-        'Z': PARAM_REMOVED,
-        'T': PARAM_NEVER,
+        'X': ParamRequired.ALWAYS,
+        'Y': ParamRequired.ADDED,
+        'Z': ParamRequired.REMOVED,
+        'T': ParamRequired.NEVER,
     })
 
     # Single mode
@@ -527,10 +524,10 @@ def test_modemessage_parse_modestring_no_params():
         'Z': tuple('ij'),
         'T': tuple('klm'),
     }, {
-        'X': PARAM_ALWAYS,
-        'Y': PARAM_ADDED,
-        'Z': PARAM_REMOVED,
-        'T': PARAM_NEVER,
+        'X': ParamRequired.ALWAYS,
+        'Y': ParamRequired.ADDED,
+        'Z': ParamRequired.REMOVED,
+        'T': ParamRequired.NEVER,
     })
 
     # Single mode
@@ -574,10 +571,10 @@ def test_modemessage_parse_modestring_missing_params():
         'Z': tuple('ij'),
         'T': tuple('klm'),
     }, {
-        'X': PARAM_ALWAYS,
-        'Y': PARAM_ADDED,
-        'Z': PARAM_REMOVED,
-        'T': PARAM_NEVER,
+        'X': ParamRequired.ALWAYS,
+        'Y': ParamRequired.ADDED,
+        'Z': ParamRequired.REMOVED,
+        'T': ParamRequired.NEVER,
     })
 
     # Modes only

--- a/test/irc/test_irc_modes.py
+++ b/test/irc/test_irc_modes.py
@@ -174,6 +174,33 @@ def test_modemessage_get_mode_info_custom_privileges():
         modemessage.get_mode_info('v', REMOVED)
 
 
+def test_modemessage_parse_modestring_default():
+    modeparser = ModeParser()
+    result = modeparser.parse_modestring(
+        '+Oaimn-qpsrt+lk-beI' + '+Z',
+        tuple('abcdef'))
+    assert result.modes == (
+        ('D', 'O', ADDED, None),
+        ('D', 'a', ADDED, None),
+        ('D', 'i', ADDED, None),
+        ('D', 'm', ADDED, None),
+        ('D', 'n', ADDED, None),
+        ('D', 'q', REMOVED, None),
+        ('D', 'p', REMOVED, None),
+        ('D', 's', REMOVED, None),
+        ('D', 'r', REMOVED, None),
+        ('D', 't', REMOVED, None),
+        ('C', 'l', ADDED, 'a'),
+        ('B', 'k', ADDED, 'b'),
+        ('A', 'b', REMOVED, 'c'),
+        ('A', 'e', REMOVED, 'd'),
+        ('A', 'I', REMOVED, 'e'),
+    )
+    assert result.ignored_modes == (('Z', ADDED),)
+    assert not result.privileges
+    assert result.leftover_params == ('f',)
+
+
 def test_modemessage_parse_modestring_single_mode():
     modemessage = ModeParser({
         'X': tuple('bc'),

--- a/test/irc/test_irc_modes.py
+++ b/test/irc/test_irc_modes.py
@@ -177,15 +177,13 @@ def test_modemessage_get_mode_info_custom_privileges():
 def test_modemessage_parse_modestring_default():
     modeparser = ModeParser()
     result = modeparser.parse_modestring(
-        '+Oaimn-qpsrt+lk-beI' + '+Z',
+        '+Oimn-psrt+lk-beI' + '+Z',
         tuple('abcdef'))
     assert result.modes == (
         ('D', 'O', ADDED, None),
-        ('D', 'a', ADDED, None),
         ('D', 'i', ADDED, None),
         ('D', 'm', ADDED, None),
         ('D', 'n', ADDED, None),
-        ('D', 'q', REMOVED, None),
         ('D', 'p', REMOVED, None),
         ('D', 's', REMOVED, None),
         ('D', 'r', REMOVED, None),

--- a/test/irc/test_irc_modes.py
+++ b/test/irc/test_irc_modes.py
@@ -7,6 +7,7 @@ from sopel.irc.modes import (
     ModeTypeImproperlyConfigured,
     ModeTypeUnknown,
     ParamRequired,
+    parse_modestring,
 )
 
 ADDED = True
@@ -15,6 +16,19 @@ REQUIRED = True
 NOT_REQUIRED = False
 PREFIX = True
 NOT_PREFIX = False
+
+
+@pytest.mark.parametrize('modestring, result', (
+    ('a', (('a', ADDED),)),
+    ('+a', (('a', ADDED),)),
+    ('-a', (('a', REMOVED),)),
+    ('+a-b', (('a', ADDED), ('b', REMOVED))),
+    ('-a+b', (('a', REMOVED), ('b', ADDED))),
+    ('+ab-cd', (('a', ADDED), ('b', ADDED), ('c', REMOVED), ('d', REMOVED))),
+    ('+a-b+c-d', (('a', ADDED), ('b', REMOVED), ('c', ADDED), ('d', REMOVED))),
+))
+def test_parse_modestring(modestring, result):
+    assert tuple(parse_modestring(modestring)) == result
 
 
 @pytest.mark.parametrize('mode, letter', (

--- a/test/test_coretasks.py
+++ b/test/test_coretasks.py
@@ -64,6 +64,7 @@ def test_bot_mixed_mode_removal(mockbot, ircfactory):
     """
     irc = ircfactory(mockbot)
     irc.bot._isupport = isupport.ISupport(chanmodes=("b", "", "", "m", tuple()))
+    irc.bot.modeparser.chanmodes = irc.bot.isupport.CHANMODES
     irc.channel_joined('#test', ['Uvoice', 'Uop'])
 
     irc.mode_set('#test', '+qao', ['Uvoice', 'Uvoice', 'Uvoice'])
@@ -90,6 +91,7 @@ def test_bot_mixed_mode_types(mockbot, ircfactory):
     """
     irc = ircfactory(mockbot)
     irc.bot._isupport = isupport.ISupport(chanmodes=("be", "", "", "mn", tuple()))
+    irc.bot.modeparser.chanmodes = irc.bot.isupport.CHANMODES
     irc.channel_joined('#test', [
         'Uvoice', 'Uop', 'Uadmin', 'Uvoice2', 'Uop2', 'Uadmin2'])
     irc.mode_set('#test', '+amovn', ['Uadmin', 'Uop', 'Uvoice'])
@@ -113,6 +115,7 @@ def test_bot_unknown_mode(mockbot, ircfactory):
     """Ensure modes not in PREFIX or CHANMODES trigger a WHO."""
     irc = ircfactory(mockbot)
     irc.bot._isupport = isupport.ISupport(chanmodes=("b", "", "", "mnt", tuple()))
+    irc.bot.modeparser.chanmodes = irc.bot.isupport.CHANMODES
     irc.channel_joined("#test", ["Alex", "Bob", "Cheryl"])
     irc.mode_set("#test", "+te", ["Alex"])
 
@@ -126,6 +129,7 @@ def test_bot_unknown_priv_mode(mockbot, ircfactory):
     """Ensure modes in `mapping` but not PREFIX are treated as unknown."""
     irc = ircfactory(mockbot)
     irc.bot._isupport = isupport.ISupport(prefix={"o": "@", "v": "+"})
+    irc.bot.modeparser.privileges = set(irc.bot.isupport.PREFIX.keys())
     irc.channel_joined("#test", ["Alex", "Bob", "Cheryl"])
     irc.mode_set("#test", "+oh", ["Alex", "Bob"])
 
@@ -139,6 +143,7 @@ def test_bot_extra_mode_args(mockbot, ircfactory, caplog):
     """Test warning on extraneous MODE args."""
     irc = ircfactory(mockbot)
     irc.bot._isupport = isupport.ISupport(chanmodes=("b", "k", "l", "mnt", tuple()))
+    irc.bot.modeparser.chanmodes = irc.bot.isupport.CHANMODES
     irc.channel_joined("#test", ["Alex", "Bob", "Cheryl"])
 
     mode_msg = ":Sopel!bot@bot MODE #test +m nonsense"
@@ -161,6 +166,7 @@ def test_handle_rpl_channelmodeis(mockbot, ircfactory):
     ])
     irc = ircfactory(mockbot)
     irc.bot._isupport = isupport.ISupport(chanmodes=("b", "k", "l", "mnt", tuple()))
+    irc.bot.modeparser.chanmodes = irc.bot.isupport.CHANMODES
     irc.channel_joined("#test", ["Alex", "Bob", "Cheryl"])
     mockbot.on_message(rpl_channelmodeis)
 
@@ -174,6 +180,7 @@ def test_handle_rpl_channelmodeis_clear(mockbot, ircfactory):
     """Test RPL_CHANNELMODEIS events clearing previous modes"""
     irc = ircfactory(mockbot)
     irc.bot._isupport = isupport.ISupport(chanmodes=("b", "k", "l", "mnt", tuple()))
+    irc.bot.modeparser.chanmodes = irc.bot.isupport.CHANMODES
     irc.channel_joined("#test", ["Alex", "Bob", "Cheryl"])
 
     rpl_base = ":mercury.libera.chat 324 TestName #test {modes}"


### PR DESCRIPTION
### Description

Following the work on #2098 I was able to refactor that part of the modestring parsing I had in mind since a long time ago. My main goal was to extract the parsing logic, and separate it from the application of new modes & privileges to users.

So now there is a `sopel.irc.modes` module that contains only modestring parsing (with the appropriate tests), and this module is then used in the `coretasks` plugin. There is close to 0 change in behavior, but there is at least two I can remember:

1. it now uses `deepcopy` to get the existing channel modes to prevent any mutability issues
2. before, when something went wrong (unknown mode type), `channel.modes = modes` wasn't done; this is now fixed

No tests on coretasks have been modified, although I used them locally to ensure that 1. it worked as intended, and 2. without breaking changes. And yes, at first, they didn't pass, and I had to fix what was broken in my code. So I'm pretty happy about all this. As said on IRC, this wasn't possible without the work of @half-duplex that relentlessly fixed the modeparsing before.

One last thing: I used type hint on `sopel.irc.modes` and validated it with `mypy`: so far, so good. I might do more of that later. I just hope it works fine with Py3.6 because I know for a fact that type hinting changed in later versions. Further conversation need to happen around Py3.10 too, because that version might not be easy to support while supporting 3.6.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches