### PR TITLE
tools.time: handle aware datetimes too in `format_time()`

### DIFF
--- a/sopel/tools/time.py
+++ b/sopel/tools/time.py
@@ -160,17 +160,20 @@ def format_time(db=None, config=None, zone=None, nick=None, channel=None,
     :type db: :class:`~.db.SopelDB`
     :param config: bot config object (optional)
     :type config: :class:`~.config.Config`
-    :param str zone: name of timezone to use (optional)
+    :param str zone: name of timezone to use for output (optional)
     :param str nick: nick whose time format to use, if set (optional)
     :param str channel: channel whose time format to use, if set (optional)
     :param time: the time value to format (optional)
     :type time: :class:`~datetime.datetime`
 
-    ``time``, if given, should be a naive ``datetime.datetime`` object and will
-    be treated as being in the UTC timezone. If it is not given, the current
-    time will be used. If ``zone`` is given it must be present in the IANA Time
-    Zone Database; ``get_timezone`` can be helpful for this. If ``zone`` is not
-    given, UTC will be assumed.
+    ``time``, if given, should be a ``datetime.datetime`` object, and will be
+    treated as being in the UTC timezone if it is :ref:`naïve
+    <aware-and-naive-objects>`. If ``time`` is not given, the current time
+    will be used.
+
+    If ``zone`` is given it must be present in the IANA Time Zone Database;
+    ``get_timezone`` can be helpful for this. If ``zone`` is not given, UTC
+    will be assumed.
 
     The format for the string is chosen in the following order:
 
@@ -183,6 +186,7 @@ def format_time(db=None, config=None, zone=None, nick=None, channel=None,
     If ``db`` is not given or is not set up, steps 1 and 2 are skipped. If
     ``config`` is not given, step 3 will be skipped.
     """
+    utc = pytz.timezone('UTC')
     tformat = None
     if db:
         if nick:
@@ -192,19 +196,19 @@ def format_time(db=None, config=None, zone=None, nick=None, channel=None,
     if not tformat and config and config.core.default_time_format:
         tformat = config.core.default_time_format
     if not tformat:
-        tformat = '%Y-%m-%d - %T%Z'
+        tformat = '%Y-%m-%d - %T %z'
 
     if not time:
-        time = datetime.datetime.utcnow()
+        time = datetime.datetime.now(tz=utc)
+    elif not time.tzinfo:
+        time = utc.localize(time)
 
     if not zone:
-        return time.strftime(tformat)
+        zone = utc
     else:
-        if not time.tzinfo:
-            utc = pytz.timezone('UTC')
-            time = utc.localize(time)
         zone = pytz.timezone(zone)
-        return time.astimezone(zone).strftime(tformat)
+
+    return time.astimezone(zone).strftime(tformat)
 
 
 def seconds_to_split(seconds):

--- a/test/tools/test_tools_time.py
+++ b/test/tools/test_tools_time.py
@@ -4,6 +4,7 @@ from __future__ import generator_stop
 import datetime
 
 import pytest
+import pytz
 
 from sopel.tools import time
 
@@ -44,6 +45,42 @@ def test_validate_format():
 def test_validate_format_none():
     with pytest.raises(ValueError):
         time.validate_format(None)
+
+
+UTC = pytz.timezone('UTC')
+PARIS = pytz.timezone('Europe/Paris')
+
+TIME_FORMAT_PAIRS = [
+    (
+        # Naïve
+        datetime.datetime(
+            2021, 7, 4, 17, 7, 6,
+            tzinfo=None,
+        ),
+        '2021-07-04 - 17:07:06 +0000',
+    ),
+    (
+        # Aware, UTC
+        datetime.datetime(
+            2021, 7, 4, 17, 7, 6,
+            tzinfo=UTC,
+        ),
+        '2021-07-04 - 17:07:06 +0000',
+    ),
+    (
+        # Aware, non-UTC
+        datetime.datetime(
+            2021, 7, 4, 17, 7, 6,
+            tzinfo=UTC,
+        ).astimezone(PARIS),
+        '2021-07-04 - 17:07:06 +0000',
+    ),
+]
+
+
+@pytest.mark.parametrize('time_arg, result', TIME_FORMAT_PAIRS)
+def test_format_time(time_arg, result):
+    assert time.format_time(time=time_arg) == result
 
 
 def test_seconds_to_human():


### PR DESCRIPTION
### Description
As a side note, the absolute fallback default time format has been changed here to use `%z` (UTC offset) instead of `%Z` (zone name), since the zone name is almost never useful and the offset is actually handy to have in tests. And in the output, too...

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
After faffing around _way_ too much with the tests, I'm not _entirely_ sure any more if their passing actually means anything. Sure, `tools.time.format_time()` seems to do what I expect in an interactive console, but… that's not a unit test.

I don't _think_ this warrants "Breaking Change" treatment since the only user-facing behavior change is the output when _no_ other time format source is passed to `format_time()` and it uses the tweaked default… but opinions may vary. Maybe aware `datetime` objects being legal now should be called out.

See also: https://github.com/sopel-irc/sopel/pull/2099#issuecomment-860932459