### PR TITLE
Expose plugin versions, enable retrieval with `.version`

### DIFF
--- a/sopel/modules/version.py
+++ b/sopel/modules/version.py
@@ -33,13 +33,34 @@ def git_info():
 
 
 @plugin.command('version')
+@plugin.example('.version [plugin_name]')
 @plugin.output_prefix('[version] ')
 def version(bot, trigger):
-    """Display the installed version of Sopel.
+    """Display the installed version of Sopel or a plugin.
 
     Includes the version of Python Sopel is installed on.
     Includes the commit hash if Sopel is installed from source.
     """
+    plugin = trigger.group(3)
+    if plugin and plugin.lower() != "sopel":
+        # Plugin version
+        if not bot.has_plugin(plugin):
+            bot.say("I don't have a plugin named %r loaded." % plugin)
+            return
+
+        meta = bot.get_plugin_meta(plugin)
+        if meta["version"] is None:
+            version = "(unknown)"
+        else:
+            version = "v" + str(meta["version"])
+
+        if meta["source"].startswith("sopel."):
+            version += " (built in)"
+
+        bot.say(plugin + " " + version)
+        return
+
+    # Sopel version
     parts = [
         'Sopel v%s' % release,
         'Python: %s' % platform.python_version()

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -117,6 +117,7 @@ class AbstractPluginHandler(abc.ABC):
         * type: the plugin's type
         * source: the plugin's source
           (filesystem path, python import path, etc.)
+        * version: the plugin's version string if available, otherwise ``None``
         """
         # TODO: change return type to a TypedDict when dropping py3.7
 
@@ -273,6 +274,7 @@ class PyModulePlugin(AbstractPluginHandler):
         * label: see :meth:`~sopel.plugins.handlers.PyModulePlugin.get_label`
         * type: see :attr:`PLUGIN_TYPE`
         * source: the name of the plugin's module
+        * version: the version string of the plugin if available, otherwise ``None``
 
         Example::
 
@@ -281,6 +283,7 @@ class PyModulePlugin(AbstractPluginHandler):
                 'type: 'python-module',
                 'label: 'example plugin',
                 'source': 'sopel_modules.example',
+                'version': '3.1.2',
             }
 
         """
@@ -289,6 +292,7 @@ class PyModulePlugin(AbstractPluginHandler):
             'type': self.PLUGIN_TYPE,
             'name': self.name,
             'source': self.module_name,
+            'version': getattr(self._module, "__version__", None),
         }
 
     def load(self):
@@ -460,6 +464,7 @@ class PyFilePlugin(PyModulePlugin):
                 'type: 'python-file',
                 'label: 'example plugin',
                 'source': '/home/username/.sopel/plugins/example.py',
+                'version': '3.1.2',
             }
 
         """
@@ -563,6 +568,7 @@ class EntryPointPlugin(PyModulePlugin):
                 'type: 'setup-entrypoint',
                 'label: 'example plugin',
                 'source': 'example = my_plugin.example',
+                'version': '3.1.2',
             }
 
         """


### PR DESCRIPTION
### Description
Exposes `plugin._module.__version__` (or `None`) in plugin metadata, and adds `.version plugin_name`.

```irc
<!mal> .version
< Sopel> [version] Sopel v8.0.0.dev0 | Python: 3.9.5 | Commit: blahblah
<!mal> .version coretasks
< Sopel> [version] coretasks v8.0.0.dev0 (built in)
<!mal> .version mypackage
< Sopel> [version] mypackage v9.9.9
<!mal> .version test
< Sopel> [version] test (version unknown)
<!mal> .version fake
< Sopel> [version] I don't have a plugin named 'fake' loaded.
```
This will confuse any daring person with a sopel module named sopel, but that's a risk I'm willing to take.
It does work for individual .py files that contain a `__version__`.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
