### PR TITLE
cli.plugins: keep plugin meta info on loading error

### DIFF
--- a/sopel/cli/plugins.py
+++ b/sopel/cli/plugins.py
@@ -211,12 +211,15 @@ def handle_list(options):
                 else:
                     description['name'] = utils.red(name)
         except Exception as error:
-            label = ('%s' % error) or 'unknown loading exception'
+            description.update(plugin.get_meta_description())
+
+            meta_label = description.get('label') or '(error)'
+            error_label = ('%s' % error) or 'unknown loading exception'
+            label = '%s (error: %s)' % (meta_label, error_label)
             error_status = 'error'
+
             description.update({
-                'label': 'Error: %s' % label,
-                'type': 'unknown',
-                'source': 'unknown',
+                'label': label,
                 'status': error_status,
             })
             if not no_color:
@@ -267,12 +270,15 @@ def handle_show(options):
         description.update(plugin.get_meta_description())
         loaded = True
     except Exception as error:
-        label = ('%s' % error) or 'unknown loading exception'
+        description.update(plugin.get_meta_description())
+
+        meta_label = description.get('label') or '(error)'
+        error_label = ('%s' % error) or 'unknown loading exception'
+        label = '%s (error: %s)' % (meta_label, error_label)
         error_status = 'error'
+
         description.update({
-            'label': 'Error: %s' % label,
-            'type': 'unknown',
-            'source': 'unknown',
+            'label': label,
             'status': error_status,
         })
 


### PR DESCRIPTION
### Description

Fix #2113 

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
