### PR TITLE
irc: add safe_text_length and use abc.ABC for AbstractBot

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -15,6 +15,7 @@ import re
 import signal
 import threading
 import time
+from typing import Optional
 
 from sopel import irc, logger, plugins, tools
 from sopel.db import SopelDB
@@ -186,16 +187,16 @@ class Sopel(irc.AbstractBot):
         )
 
     @property
-    def hostmask(self):
-        """The current hostmask for the bot :class:`sopel.tools.target.User`.
+    def hostmask(self) -> Optional[str]:
+        """The current hostmask for the bot :class:`~sopel.tools.target.User`.
 
-        :return: the bot's current hostmask
-        :rtype: str
-
-        Bot must be connected and in at least one channel.
+        :return: the bot's current hostmask if the bot is connected and in
+                 a least one channel; ``None`` otherwise
+        :rtype: Optional[str]
         """
         if not self.users or self.nick not in self.users:
-            raise KeyError("'hostmask' not available: bot must be connected and in at least one channel.")
+            # bot must be connected and in at least one channel
+            return None
 
         return self.users.get(self.nick).hostmask
 

--- a/test/test_irc.py
+++ b/test/test_irc.py
@@ -4,6 +4,8 @@ from __future__ import generator_stop
 import pytest
 
 from sopel.tests import rawlist
+from sopel.tools import Identifier
+from sopel.tools.target import User
 
 
 TMP_CONFIG = """
@@ -30,6 +32,17 @@ def bot(tmpconfig, botfactory):
 def prefix_length(bot):
     # ':', nick, '!', '~', ident/username, '@', maximum hostname length, <0x20>
     return 1 + len(bot.nick) + 1 + 1 + len(bot.user) + 1 + 63 + 1
+
+
+def test_safe_text_length_hostmask_unknown(bot):
+    assert bot.hostmask is None
+    assert bot.safe_text_length('#channel') == 414
+
+
+def test_safe_text_length(bot):
+    bot.users[Identifier(bot.nick)] = User(bot.nick, bot.user, 'hostname')
+    assert bot.hostmask is not None
+    assert bot.safe_text_length('#channel') == 470
 
 
 def test_on_connect(bot):


### PR DESCRIPTION
### Description

Tin. I was always a bit annoyed by the `say` method that does too much on its own, and I know that @half-duplex wanted a way to know the safe length for an IRC message without having to reinvent the wheel each time. I hope this will help, even if just a little.

Working on this part, I saw that `hostmask` is used but not defined by the abstract class, so I took this opportunity to use `abc.ABC` and the `abc.abstractmethod` decorator.

By doing so, I also replaced the `KeyError` when the hostmask is not defined to return `None` instead. This is a very minor breaking change. I'm not sure anyone is using `bot.hostmask`, and they probably don't use it when the bot is not connected/hasn't join a channel yet.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
