### PR TITLE
sopel: use python3 style class and abc.ABC

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -45,7 +45,7 @@ SIGNALS = QUIT_SIGNALS + RESTART_SIGNALS
 
 class Sopel(irc.AbstractBot):
     def __init__(self, config, daemon=False):
-        super(Sopel, self).__init__(config)
+        super().__init__(config)
         self._daemon = daemon  # Used for iPython. TODO something saner here
         self.wantsrestart = False
         self._running_triggers = []
@@ -1199,7 +1199,7 @@ class Sopel(irc.AbstractBot):
         self.quit(message)
 
 
-class SopelWrapper(object):
+class SopelWrapper:
     """Wrapper around a Sopel instance and a Trigger.
 
     :param sopel: Sopel instance

--- a/sopel/config/__init__.py
+++ b/sopel/config/__init__.py
@@ -86,7 +86,7 @@ class ConfigurationNotFound(ConfigurationError):
     :param str filename: file path that could not be found
     """
     def __init__(self, filename):
-        super(ConfigurationNotFound, self).__init__(None)
+        super().__init__(None)
         self.filename = filename
         """Path to the configuration file that could not be found."""
 
@@ -94,7 +94,7 @@ class ConfigurationNotFound(ConfigurationError):
         return 'Unable to find the configuration file %s' % self.filename
 
 
-class Config(object):
+class Config:
     """The bot's configuration.
 
     :param str filename: the configuration file to load and use to populate this
@@ -279,7 +279,7 @@ class Config(object):
             )
         setattr(self, name, cls_(self, name, validate=validate))
 
-    class ConfigSection(object):
+    class ConfigSection:
         """Represents a section of the config file.
 
         :param str name: name of this section

--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -25,6 +25,7 @@ As an example, if one wanted to define the ``[spam]`` section as having an
 
 from __future__ import generator_stop
 
+import abc
 import getpass
 import os.path
 import re
@@ -113,10 +114,7 @@ class StaticSection:
         setattr(self, name, value)
 
 
-# TODO: Make this a proper abstract class when dropping Python 2 support.
-# Abstract classes are much simpler to deal with once we only need to worry
-# about Python 3.4 or newer. (https://stackoverflow.com/a/13646263/5991)
-class BaseValidated(object):
+class BaseValidated(abc.ABC):
     """The base type for a setting descriptor in a :class:`StaticSection`.
 
     :param str name: the attribute name to use in the config file
@@ -196,18 +194,13 @@ class BaseValidated(object):
 
         return self._parse(value, parent, section)
 
+    @abc.abstractmethod
     def serialize(self, value, *args, **kwargs):
-        """Take some object, and return the string to be saved to the file.
+        """Take some object, and return the string to be saved to the file."""
 
-        Must be implemented in subclasses.
-        """
-        raise NotImplementedError("Serialize method must be implemented in subclass")
-
+    @abc.abstractmethod
     def parse(self, value, *args, **kwargs):
-        """Take a string from the file, and return the appropriate object.
-
-        Must be implemented in subclasses."""
-        raise NotImplementedError("Parse method must be implemented in subclass")
+        """Take a string from the file, and return the appropriate object."""
 
     def __get__(self, instance, owner=None):
         if instance is None:

--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -32,11 +32,11 @@ import re
 from sopel.tools import deprecated, get_input
 
 
-class NO_DEFAULT(object):
+class NO_DEFAULT:
     """A special value to indicate that there should be no default."""
 
 
-class StaticSection(object):
+class StaticSection:
     """A configuration section with parsed and validated settings.
 
     This class is intended to be subclassed and customized with added
@@ -305,8 +305,7 @@ class ValidatedAttribute(BaseValidated):
                  serialize=None,
                  default=None,
                  is_secret=False):
-        super(ValidatedAttribute, self).__init__(
-            name, default=default, is_secret=is_secret)
+        super().__init__(name, default=default, is_secret=is_secret)
 
         if parse == bool:
             parse, serialize = _deprecated_special_bool_handling(serialize)
@@ -334,7 +333,7 @@ class ValidatedAttribute(BaseValidated):
         if self.parse == _parse_boolean:
             prompt += ' (y/n)'
             default = 'y' if default else 'n'
-        return super(ValidatedAttribute, self).configure(prompt, default, parent, section_name)
+        return super().configure(prompt, default, parent, section_name)
 
 
 class BooleanAttribute(BaseValidated):
@@ -347,8 +346,7 @@ class BooleanAttribute(BaseValidated):
     If the ``default`` value is not specified, it will be ``False``.
     """
     def __init__(self, name, default=False):
-        super(BooleanAttribute, self).__init__(
-            name, default=default, is_secret=False)
+        super().__init__(name, default=default, is_secret=False)
 
     def configure(self, prompt, default, parent, section_name):
         """Parse and return a value from user's input.
@@ -417,7 +415,7 @@ class SecretAttribute(ValidatedAttribute):
     otherwise behaves like other any option.
     """
     def __init__(self, name, parse=None, serialize=None, default=None):
-        super(SecretAttribute, self).__init__(
+        super().__init__(
             name,
             parse=parse,
             serialize=serialize,
@@ -498,7 +496,7 @@ class ListAttribute(BaseValidated):
 
     def __init__(self, name, strip=True, default=None):
         default = default or []
-        super(ListAttribute, self).__init__(name, default=default)
+        super().__init__(name, default=default)
         self.strip = strip
 
     def parse(self, value):
@@ -621,7 +619,7 @@ class ChoiceAttribute(BaseValidated):
     :type default: str
     """
     def __init__(self, name, choices, default=None):
-        super(ChoiceAttribute, self).__init__(name, default=default)
+        super().__init__(name, default=default)
         self.choices = choices
 
     def parse(self, value):
@@ -668,7 +666,7 @@ class FilenameAttribute(BaseValidated):
     :type default: str
     """
     def __init__(self, name, relative=True, directory=False, default=None):
-        super(FilenameAttribute, self).__init__(name, default=default)
+        super().__init__(name, default=default)
         self.relative = relative
         self.directory = directory
 

--- a/sopel/db.py
+++ b/sopel/db.py
@@ -81,7 +81,7 @@ class PluginValues(BASE):
     value = Column(String(255))
 
 
-class SopelDB(object):
+class SopelDB:
     """Database object class.
 
     :param config: Sopel's configuration settings

--- a/sopel/irc/abstract_backends.py
+++ b/sopel/irc/abstract_backends.py
@@ -3,10 +3,12 @@
 # Licensed under the Eiffel Forum License 2.
 from __future__ import generator_stop
 
+import abc
+
 from .utils import safe
 
 
-class AbstractIRCBackend(object):
+class AbstractIRCBackend(abc.ABC):
     """Abstract class defining the interface and basic logic of an IRC backend.
 
     :param bot: a Sopel instance
@@ -18,13 +20,14 @@ class AbstractIRCBackend(object):
     def __init__(self, bot):
         self.bot = bot
 
+    @abc.abstractmethod
     def is_connected(self):
         """Tell if the backend is connected or not.
 
         :rtype: bool
         """
-        raise NotImplementedError
 
+    @abc.abstractmethod
     def on_irc_error(self, pretrigger):
         """Action to perform when the server sends an error event.
 
@@ -34,14 +37,13 @@ class AbstractIRCBackend(object):
         On IRC error, if ``bot.hasquit`` is set, the backend should close the
         connection so the bot can quit or reconnect as required.
         """
-        raise NotImplementedError
 
+    @abc.abstractmethod
     def irc_send(self, data):
         """Send an IRC line as raw ``data``.
 
         :param bytes data: raw line to send
         """
-        raise NotImplementedError
 
     def send_command(self, *args, **kwargs):
         """Send a command through the IRC connection.

--- a/sopel/irc/isupport.py
+++ b/sopel/irc/isupport.py
@@ -143,7 +143,7 @@ def parse_parameter(arg):
     return (key, parser(value))
 
 
-class ISupport(object):
+class ISupport:
     """Storage class for IRC's ``ISUPPORT`` feature.
 
     An instance of ``ISupport`` can be used as a read-only dict, to store
@@ -196,7 +196,7 @@ class ISupport(object):
         # make sure you can't set the value of any ISUPPORT attribute yourself
         if name == '_ISupport__isupport':
             # allow to set self.__isupport inside of the class
-            super(ISupport, self).__setattr__(name, value)
+            super().__setattr__(name, value)
         elif name in self.__isupport:
             # reject any modification of __isupport
             raise AttributeError("Can't set value for %r" % name)

--- a/sopel/irc/utils.py
+++ b/sopel/irc/utils.py
@@ -59,7 +59,7 @@ def safe(string):
     return string
 
 
-class CapReq(object):
+class CapReq:
     """Represents a pending CAP REQ request.
 
     :param str prefix: either ``=`` (must be enabled),

--- a/sopel/logger.py
+++ b/sopel/logger.py
@@ -18,7 +18,7 @@ class IrcLoggingHandler(logging.Handler):
     Implementation of a :class:`logging.Handler`.
     """
     def __init__(self, bot, level):
-        super(IrcLoggingHandler, self).__init__(level)
+        super().__init__(level)
         self._bot = bot
         self._channel = bot.settings.core.logging_channel
 
@@ -52,7 +52,7 @@ class ChannelOutputFormatter(logging.Formatter):
     Implementation of a :class:`logging.Formatter`.
     """
     def __init__(self, fmt='[%(filename)s] %(message)s', datefmt=None):
-        super(ChannelOutputFormatter, self).__init__(fmt=fmt, datefmt=datefmt)
+        super().__init__(fmt=fmt, datefmt=datefmt)
 
     def formatException(self, exc_info):
         """Format the exception info as a string for output.

--- a/sopel/modules/admin.py
+++ b/sopel/modules/admin.py
@@ -55,13 +55,13 @@ def setup(bot):
 
 class InvalidSection(Exception):
     def __init__(self, section):
-        super(InvalidSection, self).__init__(self, 'Section [{}] does not exist.'.format(section))
+        super().__init__(self, 'Section [{}] does not exist.'.format(section))
         self.section = section
 
 
 class InvalidSectionOption(Exception):
     def __init__(self, section, option):
-        super(InvalidSectionOption, self).__init__(self, 'Section [{}] does not have option \'{}\'.'.format(section, option))
+        super().__init__(self, 'Section [{}] does not have option \'{}\'.'.format(section, option))
         self.section = section
         self.option = option
 

--- a/sopel/modules/currency.py
+++ b/sopel/modules/currency.py
@@ -86,13 +86,13 @@ def setup(bot):
 class FixerError(Exception):
     """A Fixer.io API Error Exception"""
     def __init__(self, status):
-        super(FixerError, self).__init__("FixerError: {}".format(status))
+        super().__init__("FixerError: {}".format(status))
 
 
 class UnsupportedCurrencyError(Exception):
     """A currency is currently not supported by the API"""
     def __init__(self, currency):
-        super(UnsupportedCurrencyError, self).__init__(currency)
+        super().__init__(currency)
 
 
 def build_reply(amount, base, target, out_string):

--- a/sopel/modules/remind.py
+++ b/sopel/modules/remind.py
@@ -288,7 +288,7 @@ REGEX_AT = re.compile(
 )
 
 
-class TimeReminder(object):
+class TimeReminder:
     """Time reminder for the ``at`` command"""
     def __init__(self,
                  hour,

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -1258,7 +1258,7 @@ def url_lazy(*loaders):
     return decorator
 
 
-class example(object):
+class example:
     """Decorate a function with an example, and optionally test output.
 
     :param str msg: the example command (required; see below)

--- a/sopel/plugins/exceptions.py
+++ b/sopel/plugins/exceptions.py
@@ -14,7 +14,7 @@ class PluginNotRegistered(PluginError):
     def __init__(self, name):
         message = 'Plugin "%s" not registered' % name
         self.plugin_name = name
-        super(PluginNotRegistered, self).__init__(message)
+        super().__init__(message)
 
 
 class PluginSettingsError(PluginError):

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -43,6 +43,7 @@ away from the rest of the application.
 # Licensed under the Eiffel Forum License 2.
 from __future__ import generator_stop
 
+import abc
 import imp
 import importlib
 import inspect
@@ -60,7 +61,7 @@ except AttributeError:
     reload = imp.reload
 
 
-class AbstractPluginHandler(object):
+class AbstractPluginHandler(abc.ABC):
     """Base class for plugin handlers.
 
     This abstract class defines the interface Sopel uses to
@@ -75,23 +76,25 @@ class AbstractPluginHandler(object):
     (commands, jobs, etc.), configuring it, and running any required actions
     on shutdown (either upon exiting Sopel or unloading that plugin).
     """
+
+    @abc.abstractmethod
     def load(self):
         """Load the plugin.
 
         This method must be called first, in order to setup, register, shutdown,
         or configure the plugin later.
         """
-        raise NotImplementedError
 
+    @abc.abstractmethod
     def reload(self):
         """Reload the plugin.
 
         This method can be called once the plugin is already loaded. It will
         take care of reloading the plugin from its source.
         """
-        raise NotImplementedError
 
-    def get_label(self):
+    @abc.abstractmethod
+    def get_label(self) -> str:
         """Retrieve a display label for the plugin.
 
         :return: a human readable label for display purpose
@@ -99,9 +102,9 @@ class AbstractPluginHandler(object):
 
         This method should, at least, return ``<module_name> plugin``.
         """
-        raise NotImplementedError
 
-    def get_meta_description(self):
+    @abc.abstractmethod
+    def get_meta_description(self) -> dict:
         """Retrieve a meta description for the plugin.
 
         :return: meta description information
@@ -115,9 +118,10 @@ class AbstractPluginHandler(object):
         * source: the plugin's source
           (filesystem path, python import path, etc.)
         """
-        raise NotImplementedError
+        # TODO: change return type to a TypedDict when dropping py3.7
 
-    def is_loaded(self):
+    @abc.abstractmethod
+    def is_loaded(self) -> bool:
         """Tell if the plugin is loaded or not.
 
         :return: ``True`` if the plugin is loaded, ``False`` otherwise
@@ -126,57 +130,57 @@ class AbstractPluginHandler(object):
         This must return ``True`` if the :meth:`load` method has been called
         with success.
         """
-        raise NotImplementedError
 
+    @abc.abstractmethod
     def setup(self, bot):
         """Run the plugin's setup action.
 
         :param bot: instance of Sopel
         :type bot: :class:`sopel.bot.Sopel`
         """
-        raise NotImplementedError
 
-    def has_setup(self):
+    @abc.abstractmethod
+    def has_setup(self) -> bool:
         """Tell if the plugin has a setup action.
 
         :return: ``True`` if the plugin has a setup, ``False`` otherwise
         :rtype: bool
         """
-        raise NotImplementedError
 
+    @abc.abstractmethod
     def register(self, bot):
         """Register the plugin with the ``bot``.
 
         :param bot: instance of Sopel
         :type bot: :class:`sopel.bot.Sopel`
         """
-        raise NotImplementedError
 
+    @abc.abstractmethod
     def unregister(self, bot):
         """Unregister the plugin from the ``bot``.
 
         :param bot: instance of Sopel
         :type bot: :class:`sopel.bot.Sopel`
         """
-        raise NotImplementedError
 
+    @abc.abstractmethod
     def shutdown(self, bot):
         """Run the plugin's shutdown action.
 
         :param bot: instance of Sopel
         :type bot: :class:`sopel.bot.Sopel`
         """
-        raise NotImplementedError
 
-    def has_shutdown(self):
+    @abc.abstractmethod
+    def has_shutdown(self) -> bool:
         """Tell if the plugin has a shutdown action.
 
         :return: ``True`` if the plugin has a ``shutdown`` action, ``False``
                  otherwise
         :rtype: bool
         """
-        raise NotImplementedError
 
+    @abc.abstractmethod
     def configure(self, settings):
         """Configure Sopel's ``settings`` for this plugin.
 
@@ -185,16 +189,15 @@ class AbstractPluginHandler(object):
 
         This method will be called by Sopel's configuration wizard.
         """
-        raise NotImplementedError
 
-    def has_configure(self):
+    @abc.abstractmethod
+    def has_configure(self) -> bool:
         """Tell if the plugin has a configure action.
 
         :return: ``True`` if the plugin has a ``configure`` action, ``False``
                  otherwise
         :rtype: bool
         """
-        raise NotImplementedError
 
 
 class PyModulePlugin(AbstractPluginHandler):

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -412,7 +412,7 @@ class PyFilePlugin(PyModulePlugin):
         self.path = filename
         self.module_type = module_type
 
-        super(PyFilePlugin, self).__init__(name)
+        super().__init__(name)
 
     def _load(self):
         # The current implementation uses `imp.load_module` to perform the
@@ -460,7 +460,7 @@ class PyFilePlugin(PyModulePlugin):
             }
 
         """
-        data = super(PyFilePlugin, self).get_meta_description()
+        data = super().get_meta_description()
         data.update({
             'source': self.path,
         })
@@ -540,7 +540,7 @@ class EntryPointPlugin(PyModulePlugin):
 
     def __init__(self, entry_point):
         self.entry_point = entry_point
-        super(EntryPointPlugin, self).__init__(entry_point.name)
+        super().__init__(entry_point.name)
 
     def load(self):
         self._module = self.entry_point.load()
@@ -563,7 +563,7 @@ class EntryPointPlugin(PyModulePlugin):
             }
 
         """
-        data = super(EntryPointPlugin, self).get_meta_description()
+        data = super().get_meta_description()
         data.update({
             'source': str(self.entry_point),
         })

--- a/sopel/plugins/jobs.py
+++ b/sopel/plugins/jobs.py
@@ -50,7 +50,7 @@ class Scheduler(jobs.Scheduler):
 
     """
     def __init__(self, manager):
-        super(Scheduler, self).__init__(manager)
+        super().__init__(manager)
         self._jobs = tools.SopelMemoryWithDefault(list)
 
     def register(self, job):

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -141,7 +141,7 @@ def _clean_callable_examples(examples):
     )
 
 
-class Manager(object):
+class Manager:
     """Manager of plugin rules.
 
     This manager stores plugin rules and can then provide the matching rules
@@ -1053,7 +1053,7 @@ class Rule(AbstractRule):
         return exit_code
 
 
-class NamedRuleMixin(object):
+class NamedRuleMixin:
     """Mixin for named rules.
 
     A named rule is invoked by using a specific word, and is usually known
@@ -1186,7 +1186,7 @@ class Command(NamedRuleMixin, Rule):
                  help_prefix=COMMAND_DEFAULT_HELP_PREFIX,
                  aliases=None,
                  **kwargs):
-        super(Command, self).__init__([], **kwargs)
+        super().__init__([], **kwargs)
         self._name = name
         self._prefix = prefix
         self._help_prefix = help_prefix
@@ -1309,7 +1309,7 @@ class NickCommand(NamedRuleMixin, Rule):
         return cls(**kwargs)
 
     def __init__(self, nick, name, nick_aliases=None, aliases=None, **kwargs):
-        super(NickCommand, self).__init__([], **kwargs)
+        super().__init__([], **kwargs)
         self._nick = nick
         self._name = name
         self._nick_aliases = (tuple(nick_aliases)
@@ -1424,7 +1424,7 @@ class ActionCommand(NamedRuleMixin, Rule):
         return cls(**kwargs)
 
     def __init__(self, name, aliases=None, **kwargs):
-        super(ActionCommand, self).__init__([], **kwargs)
+        super().__init__([], **kwargs)
         self._name = name
         self._aliases = tuple(aliases) if aliases is not None else tuple()
         self._regexes = (self.get_rule_regex(),)
@@ -1639,7 +1639,7 @@ class URLCallback(Rule):
                  regexes,
                  schemes=None,
                  **kwargs):
-        super(URLCallback, self).__init__(regexes, **kwargs)
+        super().__init__(regexes, **kwargs)
         # prevent mutability of registered schemes
         self._schemes = tuple(schemes or URL_DEFAULT_SCHEMES)
 

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -24,7 +24,7 @@ import itertools
 import logging
 import re
 import threading
-from typing import Type, TypeVar
+from typing import Generator, Iterable, Type, TypeVar
 from urllib.parse import urlparse
 
 
@@ -596,7 +596,7 @@ class AbstractRule(abc.ABC):
         """
 
     @abc.abstractmethod
-    def match(self, bot, pretrigger):
+    def match(self, bot, pretrigger) -> Iterable:
         """Match a pretrigger according to the rule.
 
         :param bot: Sopel instance
@@ -678,7 +678,7 @@ class AbstractRule(abc.ABC):
         """
 
     @abc.abstractmethod
-    def parse(self, text):
+    def parse(self, text) -> Generator:
         """Parse ``text`` and yield matches.
 
         :param str text: text to parse by the rule

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -16,7 +16,7 @@
 # Licensed under the Eiffel Forum License 2.
 from __future__ import generator_stop
 
-
+import abc
 import datetime
 import functools
 import inspect
@@ -24,6 +24,7 @@ import itertools
 import logging
 import re
 import threading
+from typing import Type, TypeVar
 from urllib.parse import urlparse
 
 
@@ -43,6 +44,7 @@ __all__ = [
     'URLCallback',
 ]
 
+TypedRule = TypeVar('TypedRule', bound='AbstractRule')
 
 LOGGER = logging.getLogger(__name__)
 
@@ -443,7 +445,7 @@ class Manager:
         )
 
 
-class AbstractRule(object):
+class AbstractRule(abc.ABC):
     """Abstract definition of a plugin's rule.
 
     Any rule class must be an implementation of this abstract class, as it
@@ -463,7 +465,8 @@ class AbstractRule(object):
 
     """
     @classmethod
-    def from_callable(cls, settings, handler):
+    @abc.abstractclassmethod
+    def from_callable(cls: Type[TypedRule], settings, handler) -> TypedRule:
         """Instantiate a rule object from ``settings`` and ``handler``.
 
         :param settings: Sopel's settings
@@ -482,7 +485,6 @@ class AbstractRule(object):
         through the filter of the
         :func:`loader's clean<sopel.loader.clean_callable>` function.
         """
-        raise NotImplementedError
 
     @property
     def priority_scale(self):
@@ -499,7 +501,8 @@ class AbstractRule(object):
             PRIORITY_SCALES[PRIORITY_MEDIUM]
         )
 
-    def get_plugin_name(self):
+    @abc.abstractmethod
+    def get_plugin_name(self) -> str:
         """Get the rule's plugin name.
 
         :rtype: str
@@ -508,9 +511,9 @@ class AbstractRule(object):
         register, unregister, and manipulate the rule based on its plugin,
         which is referenced by its name.
         """
-        raise NotImplementedError
 
-    def get_rule_label(self):
+    @abc.abstractmethod
+    def get_rule_label(self) -> str:
         """Get the rule's label.
 
         :rtype: str
@@ -520,9 +523,9 @@ class AbstractRule(object):
         to select, register, unregister, and manipulate the rule based on its
         own label. Note that the label has no effect on the rule's execution.
         """
-        raise NotImplementedError
 
-    def get_usages(self):
+    @abc.abstractmethod
+    def get_usages(self) -> tuple:
         """Get the rule's usage examples.
 
         :rtype: tuple
@@ -530,9 +533,9 @@ class AbstractRule(object):
         A rule can have usage examples, i.e. a list of examples showing how
         the rule can be used, or in what context it can be triggered.
         """
-        raise NotImplementedError
 
-    def get_test_parameters(self):
+    @abc.abstractmethod
+    def get_test_parameters(self) -> tuple:
         """Get parameters for automated tests.
 
         :rtype: tuple
@@ -550,9 +553,9 @@ class AbstractRule(object):
             :meth:`sopel.plugin.example` for more about test parameters.
 
         """
-        raise NotImplementedError
 
-    def get_doc(self):
+    @abc.abstractmethod
+    def get_doc(self) -> str:
         """Get the rule's documentation.
 
         :rtype: str
@@ -561,9 +564,9 @@ class AbstractRule(object):
         on IRC upon asking for help about this rule. The equivalent of Python
         docstrings, but for IRC rules.
         """
-        raise NotImplementedError
 
-    def get_priority(self):
+    @abc.abstractmethod
+    def get_priority(self) -> str:
         """Get the rule's priority.
 
         :rtype: str
@@ -579,9 +582,9 @@ class AbstractRule(object):
             by priority.
 
         """
-        raise NotImplementedError
 
-    def get_output_prefix(self):
+    @abc.abstractmethod
+    def get_output_prefix(self) -> str:
         """Get the rule's output prefix.
 
         :rtype: str
@@ -591,8 +594,8 @@ class AbstractRule(object):
             See the :class:`sopel.bot.SopelWrapper` class for more information
             on how the output prefix can be used.
         """
-        raise NotImplementedError
 
+    @abc.abstractmethod
     def match(self, bot, pretrigger):
         """Match a pretrigger according to the rule.
 
@@ -605,76 +608,76 @@ class AbstractRule(object):
 
         .. __: https://docs.python.org/3.6/library/re.html#match-objects
         """
-        raise NotImplementedError
 
-    def match_event(self, event):
+    @abc.abstractmethod
+    def match_event(self, event) -> bool:
         """Tell if the rule matches this ``event``.
 
         :param str event: potential matching event
         :return: ``True`` when ``event`` matches the rule, ``False`` otherwise
         :rtype: bool
         """
-        raise NotImplementedError
 
-    def match_intent(self, intent):
+    @abc.abstractmethod
+    def match_intent(self, intent) -> bool:
         """Tell if the rule matches this ``intent``.
 
         :param str intent: potential matching intent
         :return: ``True`` when ``intent`` matches the rule, ``False`` otherwise
         :rtype: bool
         """
-        raise NotImplementedError
 
-    def allow_echo(self):
+    @abc.abstractmethod
+    def allow_echo(self) -> bool:
         """Tell if the rule should match echo messages.
 
         :return: ``True`` when the rule allows echo messages,
                  ``False`` otherwise
         :rtype: bool
         """
-        raise NotImplementedError
 
-    def is_threaded(self):
+    @abc.abstractmethod
+    def is_threaded(self) -> bool:
         """Tell if the rule's execution should be in a thread.
 
         :return: ``True`` if the execution should be in a thread,
                  ``False`` otherwise
         :rtype: bool
         """
-        raise NotImplementedError
 
-    def is_unblockable(self):
+    @abc.abstractmethod
+    def is_unblockable(self) -> bool:
         """Tell if the rule is unblockable.
 
         :return: ``True`` when the rule is unblockable, ``False`` otherwise
         :rtype: bool
         """
-        raise NotImplementedError
 
-    def is_rate_limited(self, nick):
+    @abc.abstractmethod
+    def is_rate_limited(self, nick) -> bool:
         """Tell when the rule reached the ``nick``'s rate limit.
 
         :return: ``True`` when the rule reached the limit, ``False`` otherwise
         :rtype: bool
         """
-        raise NotImplementedError
 
-    def is_channel_rate_limited(self, channel):
+    @abc.abstractmethod
+    def is_channel_rate_limited(self, channel) -> bool:
         """Tell when the rule reached the ``channel``'s rate limit.
 
         :return: ``True`` when the rule reached the limit, ``False`` otherwise
         :rtype: bool
         """
-        raise NotImplementedError
 
-    def is_global_rate_limited(self):
+    @abc.abstractmethod
+    def is_global_rate_limited(self) -> bool:
         """Tell when the rule reached the server's rate limit.
 
         :return: ``True`` when the rule reached the limit, ``False`` otherwise
         :rtype: bool
         """
-        raise NotImplementedError
 
+    @abc.abstractmethod
     def parse(self, text):
         """Parse ``text`` and yield matches.
 
@@ -684,8 +687,8 @@ class AbstractRule(object):
 
         .. __: https://docs.python.org/3.6/library/re.html#match-objects
         """
-        raise NotImplementedError
 
+    @abc.abstractmethod
     def execute(self, bot, trigger):
         """Execute the triggered rule.
 
@@ -696,7 +699,6 @@ class AbstractRule(object):
 
         This is the method called by the bot when a rule matches a ``trigger``.
         """
-        raise NotImplementedError
 
 
 class Rule(AbstractRule):

--- a/sopel/tests/factories.py
+++ b/sopel/tests/factories.py
@@ -10,7 +10,7 @@ from sopel import bot, config, plugins, trigger
 from .mocks import MockIRCBackend, MockIRCServer, MockUser
 
 
-class BotFactory(object):
+class BotFactory:
     """Factory to create bot.
 
     .. seealso::
@@ -62,7 +62,7 @@ class BotFactory(object):
         return obj
 
 
-class ConfigFactory(object):
+class ConfigFactory:
     """Factory to create settings.
 
     .. seealso::
@@ -79,7 +79,7 @@ class ConfigFactory(object):
         return config.Config(tmpfile.strpath)
 
 
-class TriggerFactory(object):
+class TriggerFactory:
     """Factory to create trigger.
 
     .. seealso::
@@ -99,7 +99,7 @@ class TriggerFactory(object):
             re.match(pattern or r'.*', raw))
 
 
-class IRCFactory(object):
+class IRCFactory:
     """Factory to create mock IRC server.
 
     .. seealso::
@@ -111,7 +111,7 @@ class IRCFactory(object):
         return MockIRCServer(mockbot, join_threads)
 
 
-class UserFactory(object):
+class UserFactory:
     """Factory to create mock user.
 
     .. seealso::

--- a/sopel/tests/mocks.py
+++ b/sopel/tests/mocks.py
@@ -76,6 +76,10 @@ class MockIRCBackend(AbstractIRCBackend):
         self.message_sent = []
         return sent
 
+    def on_irc_error(self, pretrigger):
+        # implement abstract method
+        pass
+
 
 class MockIRCServer:
     """Fake IRC Server that can send messages to a test bot.

--- a/sopel/tests/mocks.py
+++ b/sopel/tests/mocks.py
@@ -39,7 +39,7 @@ class MockIRCBackend(AbstractIRCBackend):
 
     """
     def __init__(self, *args, **kwargs):
-        super(MockIRCBackend, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.message_sent = []
         """List of raw messages sent by the bot.
 
@@ -77,7 +77,7 @@ class MockIRCBackend(AbstractIRCBackend):
         return sent
 
 
-class MockIRCServer(object):
+class MockIRCServer:
     """Fake IRC Server that can send messages to a test bot.
 
     :param bot: test bot instance to send messages to
@@ -347,7 +347,7 @@ class MockIRCServer(object):
                 t.join()
 
 
-class MockUser(object):
+class MockUser:
     """Fake user that can generate messages to send to a bot.
 
     :param str nick: nickname

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -378,7 +378,7 @@ class Identifier(str):
         return self and not self.startswith(_channel_prefixes)
 
 
-class OutputRedirect(object):
+class OutputRedirect:
     """Redirect the output to the terminal and a log file.
 
     A simplified object used to write to both the terminal and a log file.
@@ -609,13 +609,13 @@ class SopelIdentifierMemory(SopelMemory):
     .. versionadded:: 7.1
     """
     def __getitem__(self, key):
-        return super(SopelIdentifierMemory, self).__getitem__(Identifier(key))
+        return super().__getitem__(Identifier(key))
 
     def __contains__(self, key):
-        return super(SopelIdentifierMemory, self).__contains__(Identifier(key))
+        return super().__contains__(Identifier(key))
 
     def __setitem__(self, key, value):
-        super(SopelIdentifierMemory, self).__setitem__(Identifier(key), value)
+        super().__setitem__(Identifier(key), value)
 
 
 def chain_loaders(*lazy_loaders):

--- a/sopel/tools/jobs.py
+++ b/sopel/tools/jobs.py
@@ -193,7 +193,7 @@ class Scheduler(threading.Thread):
             self.manager.on_job_error(self, job, error)
 
 
-class Job(object):
+class Job:
     """Holds information about when a function should be called next.
 
     :param intervals: set of intervals; each is a number of seconds between

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -7,7 +7,7 @@ from sopel.tools import Identifier
 
 
 @functools.total_ordering
-class User(object):
+class User:
     """A representation of a user Sopel is aware of.
 
     :param nick: the user's nickname
@@ -53,7 +53,7 @@ class User(object):
 
 
 @functools.total_ordering
-class Channel(object):
+class Channel:
     """A representation of a channel Sopel is in.
 
     :param name: the channel name

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -14,7 +14,7 @@ __all__ = [
 ]
 
 
-class PreTrigger(object):
+class PreTrigger:
     """A parsed raw message from the server.
 
     :param str own_nick: the bot's own IRC nickname

--- a/test/irc/test_irc_abstract_backends.py
+++ b/test/irc/test_irc_abstract_backends.py
@@ -2,7 +2,6 @@
 from __future__ import generator_stop
 
 
-from sopel.irc.abstract_backends import AbstractIRCBackend
 from sopel.tests.mocks import MockIRCBackend
 
 
@@ -15,7 +14,7 @@ class BotCollector:
 
 
 def test_prepare_command():
-    backend = AbstractIRCBackend(BotCollector())
+    backend = MockIRCBackend(BotCollector())
 
     result = backend.prepare_command('INFO')
     assert result == 'INFO\r\n'
@@ -25,7 +24,7 @@ def test_prepare_command():
 
 
 def test_prepare_command_text():
-    backend = AbstractIRCBackend(BotCollector())
+    backend = MockIRCBackend(BotCollector())
 
     result = backend.prepare_command('PRIVMSG', '#sopel', text='Hello world!')
     assert result == 'PRIVMSG #sopel :Hello world!\r\n'
@@ -38,7 +37,7 @@ def test_prepare_command_text():
 
 
 def test_prepare_command_text_too_long():
-    backend = AbstractIRCBackend(BotCollector())
+    backend = MockIRCBackend(BotCollector())
 
     max_length = 510 - len('PRIVMSG #sopel :')
     text = '-' * (max_length + 1)  # going above max length by one


### PR DESCRIPTION
### Description

In Python 2, there was 2 styles:

* `class ClassName:`
* `class ClassName(object)`

And they behaved differently, and using `super()` is different too. However, in Python3, both are equivalent to doing the second style, and we can use `super()` directly. I remember having to work with Py2.4 compatible code in my career, and this "new style class" stuff was... a pure nightmare. I'm just glad we can get rid of this.

Also, there is now `abc.ABC` that allows to describe an abstract class as being abstract. This is interesting because it doesn't require to add `raise NotImplementedError` anymore: a few decorators and it's all good!

One last thing: I added few type hint here and there, and I had fun with `TypeVar`. It's looking good!

Note: I think I want a "housekeeping" or "cleaning code" label or something. :grin: 

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
