### PR TITLE
pronouns: add `.clearpronouns` command

### DIFF
--- a/sopel/modules/pronouns.py
+++ b/sopel/modules/pronouns.py
@@ -120,3 +120,11 @@ def set_pronouns(bot, trigger):
     bot.reply(
         "Thanks for telling me! I'll remember you use {}.{}".format(pronouns, disambig)
     )
+    
+    
+@plugin.command('clearpronouns')
+def unset_pronouns(bot, trigger):
+        bot.db.delete_nick_value(trigger.nick, 'pronouns')   
+        bot.reply(
+            "I'll forget your pronouns."
+        )


### PR DESCRIPTION
Closes #2137

### Description
Adds a `.clearpronouns` command to make the bot forget one's pronouns. 

I added a short reply. I can change it if it doesn't seem appropriate. 

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [ ] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [ ] I have tested the functionality of the things this change touches
