### PR TITLE
wikipedia: log a warning if `lang_per_channel` is used for a channel

### DIFF
--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -8,6 +8,7 @@ https://sopel.chat
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import logging
 import re
 
 from requests import get
@@ -21,6 +22,7 @@ try:  # TODO: Remove fallback when dropping py2
 except ImportError:
     from HTMLParser import HTMLParser
 
+LOGGER = logging.getLogger(__name__)
 REDIRECT = re.compile(r'^REDIRECT (.*)')
 PLUGIN_OUTPUT_PREFIX = '[wikipedia] '
 
@@ -127,6 +129,11 @@ def choose_lang(bot, trigger):
         customlang = re.search('(' + trigger.sender + r'):(\w+)',
                                bot.config.wikipedia.lang_per_channel)
         if customlang is not None:
+            LOGGER.warning(
+                'Language for %s loaded from the deprecated config setting, '
+                'wikipedia.lang_per_channel',
+                trigger.sender,
+            )
             return customlang.group(2)
 
     return bot.config.wikipedia.default_lang


### PR DESCRIPTION
### Description
If a channel's language setting is loaded from the deprecated `wikipedia.lang_per_channel` config value, Sopel will log a warning:

```
[2021-07-03 01:37:59,890] sopel.modules.wikipedia WARNING  - Language for #dgw loaded from the deprecated
config setting, wikipedia.lang_per_channel
```

Targeted to 7.1.x branch for v7.1.2. Should have been done in #1916.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - flake8 doesn't pass because I have the newer version we use on `master`, but should pass in 7.1.x CI
- [x] I have tested the functionality of the things this change touches