### PR TITLE
tools.events: add `RPL_WHOISBOT` from Bot Mode spec

### DIFF
--- a/sopel/tools/_events.py
+++ b/sopel/tools/_events.py
@@ -31,6 +31,8 @@ class events(object):
     RPL_STARTTLS = '670'
     ERR_STARTTLS = '691'
     # ## 3.2
+    # Bot Mode
+    RPL_WHOISBOT = '335'
     # Metadata
     RPL_WHOISKEYVALUE = '760'
     RPL_KEYVALUE = '761'


### PR DESCRIPTION
### Description
See https://ircv3.net/specs/extensions/bot-mode#the-rpl_whoisbot-335-numeric

The reply format is not yet formally specified (PR ref in commit message), but since we're just enumerating things for plugin authors' convenience instead of actually handling the reply, that doesn't matter.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches