### PR TITLE
config.types: remove deprecated `ConfigSection.get_list()` method

### DIFF
--- a/sopel/config/__init__.py
+++ b/sopel/config/__init__.py
@@ -312,29 +312,6 @@ class Config(object):
                 value = ','.join(value)
             self._parent.parser.set(self._name, name, value)
 
-        @tools.deprecated(
-            'No longer used; replaced by a dedicated ListAttribute type.'
-            '7.0', '8.0')
-        def get_list(self, name):
-            """Legacy way of getting a list from a config value.
-
-            :param str name: name of the attribute to fetch and interpret as a list
-            :return: the value of ``name`` as a list
-            :rtype: list
-
-            .. deprecated:: 7.0
-                Use :class:`~.types.ListAttribute` when storing a list value.
-                This legacy method will be removed in Sopel 8.0.
-            """
-            value = getattr(self, name)
-            if not value:
-                return []
-            if isinstance(value, str):
-                value = value.split(',')
-                # Keep the split value, so we don't have to keep doing this
-                setattr(self, name, value)
-            return value
-
     def __getattr__(self, name):
         if name in self.parser.sections():
             items = self.parser.items(name)


### PR DESCRIPTION
### Description
Tin. According to the changelog, this should have been (98a55599a5f82bfd49a59f5364283e6eb5e04618) removed in 6.0? But since it wasn't, we went through a deprecation cycle after marking it with the `deprecated` decorator in 7.0, just to be safe.

Technically it should have been documented as deprecated in 6.0, but oh well. That's water under the bridge now.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - Didn't actually bother to run `make test` since the _only_ remaining references to this method are in its definition and the changelog. It was left untested, whoops.
- [x] I have tested the functionality of the things this change touches