### PR TITLE
irc.utils: remove deprecated `CapReq.module` property

### DIFF
--- a/sopel/irc/utils.py
+++ b/sopel/irc/utils.py
@@ -7,8 +7,6 @@ import collections
 
 from dns import rdtypes, resolver
 
-from sopel.tools import deprecated
-
 
 MYINFO_ARGS = ['client', 'servername', 'version']
 
@@ -93,15 +91,6 @@ class CapReq(object):
         self.arg = arg
         self.failure = failure or nop
         self.success = success or nop
-
-    @property
-    @deprecated(
-        reason='use the `plugin` property instead',
-        version='7.1',
-        removed_in='8.0',
-    )
-    def module(self):
-        return self.plugin
 
 
 class MyInfo(collections.namedtuple('MyInfo', MYINFO_ARGS)):


### PR DESCRIPTION
### Description
Tin. We've reached the documented `removed_in` point for this obsolete prop.

Another thing that's not listed at #1738 but is still technically part of that initiative.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - Again, no test code references this, so I'm leaning on CI to run that against 4 Python versions faster than I can run it against even just one.
- [x] I have tested the functionality of the things this change touches