### PR TITLE
invite: handle expected possible exception

### DIFF
--- a/sopel/modules/invite.py
+++ b/sopel/modules/invite.py
@@ -76,4 +76,7 @@ def invite(bot, trigger):
                 .format(bot.config.core.help_prefix))
         channel = trigger.sender
 
-    invite_handler(bot, trigger.nick, user, channel)
+    try:
+        invite_handler(bot, trigger.nick, user, channel)
+    except ValueError as err:
+        bot.reply('%s' % err)


### PR DESCRIPTION
### Description
Avoids "Unknown error" output to IRC and exception traceback log dump.

Before:
```irc
<grym> .invite hasn't been doing what i need >.> 
<Sopel> Unexpected error (Target channel name must not be a nick.) from grym at 2021-07-05
         15:49:16.901922. Message was: .invite hasn't been doing what i need >.> 
```

After:
```irc
<dgw> .invite hasn't been doing what i need >.>
<SopelTest> dgw: Target channel name must not be a nick.
```

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches