### PR TITLE
pronouns: add `.clearpronouns` command

### DIFF
--- a/sopel/modules/pronouns.py
+++ b/sopel/modules/pronouns.py
@@ -120,3 +120,10 @@ def set_pronouns(bot, trigger):
     bot.reply(
         "Thanks for telling me! I'll remember you use {}.{}".format(pronouns, disambig)
     )
+
+
+@plugin.command('clearpronouns')
+def unset_pronouns(bot, trigger):
+    """Clear pronouns for the given user."""
+    bot.db.delete_nick_value(trigger.nick, 'pronouns')
+    bot.reply("Okay, I'll forget your pronouns.")


### PR DESCRIPTION
### Description

Adds the ability to clear one's pronouns. 

Closes #2137

~~`make qa` reports a bunch of issues but unrelated to my change.~~ @dgw edit: It's because the checks were run on py2, which is no longer supported.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
