### PR TITLE
Revert "bot: deprecate `search_url_callbacks()` method"

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -1150,11 +1150,6 @@ class Sopel(irc.AbstractBot):
         except KeyError:
             pass
 
-    @deprecated(
-        reason='Issues with @url decorator have been fixed. Simply use that.',
-        version='8.0',
-        removed_in='9.0',
-    )
     def search_url_callbacks(self, url):
         """Yield callbacks whose regex pattern matches the ``url``.
 


### PR DESCRIPTION
This reverts commit 3986227c4971e68530ae07113426187e95967046.

```
 <+Exirel> 
Because Sopel still uses `search_url_callbacks`, and have to.
14:01:55 <RhinosF1> 
it does
14:02:21 <+Exirel> 
Yup. So yeah, we need to find a better solution than that.
14:04:19 <RhinosF1> 
I can hack beta if anything needs testing
14:07:20 <+Exirel> 
I think we should not trigger a warning on `search_url_callbacks` in 8.0, make it a no-op in 9.0, and remove it in 10.0.
```

### Description
Revert 3986227c4971e68530ae07113426187e95967046.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
