### PR TITLE
wikipedia: skip messagebox template contents

### DIFF
--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -29,6 +29,7 @@ class WikiParser(HTMLParser):
         self.section_name = section_name
 
         self.citations = False
+        self.messagebox = False
         self.span_depth = 0
         self.div_depth = 0
 
@@ -49,13 +50,34 @@ class WikiParser(HTMLParser):
                     if attr[0] == 'class' and 'edit' in attr[1]:
                         self.span_depth += 1
 
-        elif tag == 'div':  # We want to skip thumbnail text and the inexplicable table of contents, and as such also need to track div depth
+        elif tag == 'div':
+            # We want to skip thumbnail text and the inexplicable table of contents,
+            # and as such also need to track div depth
             if self.div_depth:
                 self.div_depth += 1
             else:
                 for attr in attrs:
                     if attr[0] == 'class' and ('thumb' in attr[1] or attr[1] == 'toc'):
                         self.div_depth += 1
+
+        elif tag == 'table':
+            # Message box templates are what we want to ignore here
+            for attr in attrs:
+                if (
+                    attr[0] == 'class'
+                    and any(classname in attr[1].lower() for classname in [
+                        # Most of list from https://en.wikipedia.org/wiki/Template:Mbox_templates_see_also
+                        'ambox',  # messageboxes on article pages
+                        'cmbox',  # messageboxes on category pages
+                        'imbox',  # messageboxes on file (image) pages
+                        'tmbox',  # messageboxes on talk pages
+                        'fmbox',  # header and footer messageboxes
+                        'ombox',  # messageboxes on other types of page
+                        'mbox',  # for messageboxes that are used in different namespaces and change their presentation accordingly
+                        'dmbox',  # for disambiguation messageboxes
+                    ])
+                ):
+                    self.messagebox = True
 
         elif tag == 'ol':
             for attr in attrs:
@@ -71,9 +93,11 @@ class WikiParser(HTMLParser):
             self.span_depth -= 1
         if self.div_depth and tag == 'div':
             self.div_depth -= 1
+        if self.messagebox and tag == 'table':
+            self.messagebox = False
 
     def handle_data(self, data):
-        if self.consume and not any([self.citations, self.span_depth, self.div_depth]):
+        if self.consume and not any([self.citations, self.messagebox, self.span_depth, self.div_depth]):
             if not (self.is_header and data == self.section_name):  # Skip the initial header info only
                 self.result += data
 


### PR DESCRIPTION
### Description
It took me literally ten minutes to write and test this, albeit not _that_ thoroughly. Should fix #2158, though the reason I opened that issue is I thought it would take more effort/time…

#### Demo

```
<Sopel 7.1.2> [wikipedia] Gurmukhi - Letters | "This article contains IPA phonetic symbols. Without proper
              rendering support, you may see question marks, boxes, or other symbols instead of Unicode
              characters. For an introductory guide on IPA symbols, see Help:IPA. The Gurmukhī alphabet contains
              thirty-five base letters (akkhara, plural akkharā̃), traditionally arranged in seven rows of five
              letters each. The first three letters, or mātarā vāhak ("vowel carrier"), […]"
<This PR> [wikipedia] Gurmukhi - Letters | "The Gurmukhī alphabet contains thirty-five base letters (akkhara,
          plural akkharā̃), traditionally arranged in seven rows of five letters each. The first three letters, or
          mātarā vāhak ("vowel carrier"), are distinct because they form the basis for vowels and are not
          consonants, or vianjan, like the remaining letters are, and except for the second letter aiṛā are never
          used on their own; see § […]"
```

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches