### PR TITLE
translate: handle failure/error better in `.mangle`

### DIFF
--- a/sopel/modules/translate.py
+++ b/sopel/modules/translate.py
@@ -230,9 +230,11 @@ def mangle(bot, trigger):
     """Repeatedly translate the input until it makes absolutely no sense."""
     long_lang_list = ['fr', 'de', 'es', 'it', 'no', 'he', 'la', 'ja', 'cy', 'ar', 'yi', 'zh', 'nl', 'ru', 'fi', 'hi', 'af', 'jw', 'mr', 'ceb', 'cs', 'ga', 'sv', 'eo', 'el', 'ms', 'lv']
     lang_list = []
+
     for __ in range(0, 8):
         lang_list = get_random_lang(long_lang_list, lang_list)
     random.shuffle(lang_list)
+
     if trigger.group(2) is None:
         try:
             phrase = (bot.memory['mangle_lines'][trigger.sender], '')
@@ -241,9 +243,11 @@ def mangle(bot, trigger):
             return
     else:
         phrase = (trigger.group(2).strip(), '')
+
     if phrase[0] == '':
         bot.reply("What do you want me to mangle?")
         return
+
     for lang in lang_list:
         backup = phrase
         try:
@@ -263,6 +267,12 @@ def mangle(bot, trigger):
         if not phrase:
             phrase = backup
             break
+
+    if phrase[0] is None:
+        # translate() returns (None, None) if an error happens,
+        # usually because the bot has exceeded a rate limit
+        bot.reply("Translation rate limit reached. Try again later.")
+        return
 
     bot.say(phrase[0])
 


### PR DESCRIPTION
### Description
Should resolve #2021 by outputting a friendly error instead of what has become an "Unexpected error" involving concatenating `NoneType` to `str` thanks to the output-prefix consistency pass we did in 7.1.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
The logic in this plugin could do with a refactor, especially making `translate()` raise an exception instead of returning garbage. But I'm not up for that tonight, and it wouldn't be appropriate to do that for a 7.1.x bugfix release anyway.