### PR TITLE
config.types: silence `parse==bool` warning until 8.0

### DIFF
--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -273,6 +273,7 @@ def _serialize_boolean(value):
 @deprecated(
     reason='Use BooleanAttribute instead of ValidatedAttribute with parse=bool',
     version='7.1',
+    warning_in='8.0',
     removed_in='9.0',
     stack_frame=-2,
 )


### PR DESCRIPTION
### Description
Turns out *a lot* of plugins use `ValidatedAttribute(..., parse=bool)`, and this is hardly a breaking change. It makes the most sense to tie this warning to a major version, rather than forcing plugin authors to require a minimum minor release of Sopel.

There's no technical reason to change this. It's a philosophical choice that came up for me when reviewing other plugins that make use of bools in their config sections. This warning just isn't useful immediately after deprecation; plugin authors can adopt the new type voluntarily, but Sopel doesn't need to force it in 7.x. Migrating to this new type can be part of the 8.0 migration guide, as a new major release of Sopel _would_ be a natural point to bump plugin requirements. (That goes double for anyone using our cookiecutter template, since it pins `sopel>=current_major,<next_major` by default.)

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
No, I don't know why I left this line out of #2044. It absolutely makes sense given the planned removal isn't until 9.0, but there's no defense for me. I just forgot. 😅