### PR TITLE
announce: make `_chunks()` helper safe against more input types

### DIFF
--- a/sopel/modules/announce.py
+++ b/sopel/modules/announce.py
@@ -17,10 +17,18 @@ def _chunks(items, size):
     :param items: the collection of items to chunk
     :type items: :term:`iterable`
     :param int size: the size of each chunk
+    :return: a :term:`generator` of chunks
+    :rtype: :term:`generator` of :class:`tuple`
     """
+    # Need to convert non-subscriptable types like `dict_keys` objects
+    try:
+        items[0]
+    except TypeError:
+        items = tuple(items)
+
     # from https://stackoverflow.com/a/312464/5991 with modified names for readability
     for delim in range(0, len(items), size):
-        yield items[delim:delim + size]
+        yield tuple(items[delim:delim + size])
 
 
 @plugin.command('announce')

--- a/sopel/modules/announce.py
+++ b/sopel/modules/announce.py
@@ -8,6 +8,8 @@ https://sopel.chat
 """
 from __future__ import generator_stop
 
+import itertools
+
 from sopel import plugin
 
 
@@ -20,15 +22,15 @@ def _chunks(items, size):
     :return: a :term:`generator` of chunks
     :rtype: :term:`generator` of :class:`tuple`
     """
-    # Need to convert non-subscriptable types like `dict_keys` objects
-    try:
-        items[0]
-    except TypeError:
-        items = tuple(items)
-
-    # from https://stackoverflow.com/a/312464/5991 with modified names for readability
-    for delim in range(0, len(items), size):
-        yield tuple(items[delim:delim + size])
+    # This approach is safer than slicing with non-subscriptable types,
+    # for example `dict_keys` objects
+    iterator = iter(items)
+    # TODO: Simplify to assignment expression (`while cond := expr`)
+    # when dropping Python 3.7
+    chunk = tuple(itertools.islice(iterator, size))
+    while chunk:
+        yield chunk
+        chunk = tuple(itertools.islice(iterator, size))
 
 
 @plugin.command('announce')

--- a/test/modules/test_modules_announce.py
+++ b/test/modules/test_modules_announce.py
@@ -1,0 +1,32 @@
+"""Tests for Sopel's ``announce`` plugin"""
+from __future__ import generator_stop
+
+from sopel.modules import announce
+
+
+def test_chunks():
+    """Test the `_chunks` helper for functionality and compatibility."""
+    # list input
+    items = ['list', 'of', 'items', 'to', 'chunk']
+    r = list(announce._chunks(items, 2))
+
+    assert len(r) == 3
+    assert r[0] == tuple(items[:2])
+    assert r[1] == tuple(items[2:4])
+    assert r[2] == tuple(items[4:])
+
+    # tuple input
+    items = ('tuple', 'of', 'items')
+    r = list(announce._chunks(items, 3))
+
+    assert len(r) == 1
+    assert r[0] == items
+
+    # dict keys input
+    keys = {'one': True, 'two': True, 'three': True}.keys()
+    items = list(keys)
+    r = list(announce._chunks(keys, 1))
+
+    assert len(r) == 3
+    for idx in range(len(items)):
+        assert r[idx] == (items[idx],)


### PR DESCRIPTION
### Description
Fixes #2165.

Python 3 `dict.keys()` returns a `dict_keys` object, which is not subscriptable unlike the return value in py2.

Also made the generator return a consistent type (always tuple), and updated the documentation (not that it's actually used anywhere by Sphinx). Added a test, too, because let's (try to) not have this plugin bite us again.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - I ran both the new test and `make quality` on both py3(.8) and py2(.7), and the patch _should_ be clean against both. Since this can't be a straight cherry-pick back to `7.1.x` due to the new test file needing different headers, I have pre-prepped an `announce-py2-backport` branch for myself with the appropriate code style.
- [x] I have tested the functionality of the things this change touches