### PR TITLE
module: import-time deprecation warning

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -19,7 +19,7 @@ import time
 from sopel import irc, logger, plugins, tools
 from sopel.db import SopelDB
 import sopel.loader
-from sopel.module import NOLIMIT
+from sopel.plugin import NOLIMIT
 from sopel.plugins import jobs as plugin_jobs, rules as plugin_rules
 from sopel.tools import deprecated, Identifier
 import sopel.tools.jobs

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -40,8 +40,23 @@ from sopel.plugin import (  # noqa
     url,
     VOICE,
 )
+from sopel.tools import deprecated
 
 
+deprecated(
+    'sopel.module has been replaced by sopel.plugin',
+    version='8.0',
+    removed_in='9.0',
+    func=lambda *args: ...,
+)()
+
+
+@deprecated(
+    '`@intent` is replaced by `sopel.plugin.ctcp`',
+    version='7.1',
+    removed_in='9.0',
+    warning_in='8.0',
+)
 def intent(*intent_list):
     """Decorate a callable to trigger on intent messages.
 


### PR DESCRIPTION
### Description

Tick one more box off #1738 by adding a deprecation warning at import time.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
