### PR TITLE
requirements: pin requests on py3.3 to fix install/build

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,9 @@ geoip2>=4.0,<5.0; python_version >= '3.6'
 # transitive dependency of geoip2; v2 dropped py2.7 & py3 < 3.6
 maxminddb<2.0; python_version < '3.6'
 ipaddress<2.0; python_version < '3.3'
-requests>=2.0.0,<3.0.0
+requests>=2.0.0,<3.0.0; python_version != '3.3'
+# py3.3 doesn't work with the chardet/charset-normalizer detection added in 2.26
+requests>=2.0.0,<2.26; python_version == '3.3'
 # transitive dependency of requests
 # 2.0 will drop EOL Python 2.7 & 3.5, just like Sopel 8 plans to
 urllib3<1.27; python_version != '3.3' and python_version != '3.4'


### PR DESCRIPTION
requests 2.26 switched from chardet to charset-normalizer on py3, and that seems to be [broken on py3.3](https://app.travis-ci.com/github/sopel-irc/sopel/builds/234445467) specifically. It installs, but requests throws an error on loading anyway for some reason. Easiest solution is just to pin the requests version, since especially on py3.3 we don't care about any of the new stuff.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches