### PR TITLE
Update to check for proper UTF8 on Windows

### DIFF
--- a/sopel/__init__.py
+++ b/sopel/__init__.py
@@ -34,7 +34,7 @@ __all__ = [
 ]
 
 loc = locale.getlocale()
-if not loc[1] or 'UTF-8' not in loc[1]:
+if not loc[1] or ('UTF-8' not in loc[1] and 'utf8' not in loc[1]):
     print('WARNING!!! You are running with a non-UTF8 locale environment '
           'variable (e.g. LC_ALL is set to "C"), which makes Python 3 do '
           'stupid things. If you get strange errors, please set it to '


### PR DESCRIPTION
The locale.getlocale() check currently looks for "UTF-8" only, however on windows with powershell and UTF8 enabled the return value is "utf8" so this check still fails.

### Description
Fixes #2173

### Checklist
- [X] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [X] I can and do license this contribution under the EFLv2
- [X] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [X] I have tested the functionality of the things this change touches
