### PR TITLE
docs: remove `test_tools` from "Testing tools" page

### DIFF
--- a/docs/source/tests.rst
+++ b/docs/source/tests.rst
@@ -28,9 +28,3 @@ Mocks
 
 .. automodule:: sopel.tests.mocks
    :members:
-
-Old testing tools
-=================
-
-.. automodule:: sopel.test_tools
-   :members:


### PR DESCRIPTION
### Description
The `test_tools` submodule was removed in #2139, but the docs weren't updated. Yes, it was my fault.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - (Checked by rote: No code changes)
- [x] I have tested the functionality of the things this change touches