### PR TITLE
docs: explicitly select both light and dark Pygments styles

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -105,7 +105,8 @@ exclude_patterns = []
 #show_authors = False
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = 'friendly'
+pygments_dark_style = 'monokai'
 
 # A list of ignored prefixes for module index sorting.
 #modindex_common_prefix = []


### PR DESCRIPTION
### Description
In the dark color scheme particularly, the default Pygments style ("native") has some weird choices in places like imports (underlined names), and bland colors.

Having the styles selected explicitly in the docs' `conf.py` also means we aren't subject to surprise default-value changes from Furo.

### Notes

I'm not _dead_ set on these choices. They're just the best-looking _to me_, out of the options I tested (about 60-70% of the available styles) at https://pygments.org/demo/. Got a suggestion that looks better? I'm all eyes.

In particular, I'd _love_ a more colorful style for light mode to match the choice I made in dark mode, but the light-mode styles that do use significant amounts of color are generally quite muted. The few that choose bolder colors come off as garish to me, or even unreadable (light cyan on white, for example—no thanks).

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - (No code changes.)
- [x] I have tested the functionality of the things this change touches
  - See comparisons below.

### Comparisons

**Light mode**

![sphinx vs. friendly](https://user-images.githubusercontent.com/164140/131203584-2c790599-4b95-4f77-8586-726e844206f4.png)

**Dark mode**

![native vs. monokai](https://user-images.githubusercontent.com/164140/131203599-327d6dad-6981-4b16-abe2-5cb8206f834b.png)