### PR TITLE
sopel: type hint and basic setup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,12 @@
 .PHONY: qa
 qa: quality test coverages
 
-.PHONY: quality
+.PHONY: quality mypy
 quality:
 	./checkstyle.sh
+
+mypy:
+	mypy sopel
 
 .PHONY: test test_norecord test_novcr vcr_rerecord
 test:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,17 +4,17 @@ flake8-coding
 flake8-future-import
 flake8-import-order
 furo==2021.6.24b37  # Sphinx theme
-pytest
-pytest-vcr
-requests-mock
+pytest~=6.2.5
+pytest-vcr~=1.0.2
+requests-mock~=1.9.3
 sphinx>=4,<5
 # specify exact autoprogram version because the new (in 2021) maintainer
 # showed that they will indeed make major changes in patch versions
 sphinxcontrib-autoprogram==0.1.7
 vcrpy<3.0.0
 # type check
-mypy
-sqlalchemy[mypy]
-types-pkg-resources
+mypy>=0.920,<1
+sqlalchemy[mypy]>=1.4,<1.5
+types-pkg-resources~=0.1.3
 types-pytz
-types-requests
+types-requests>=2,<3

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,11 +4,17 @@ flake8-coding
 flake8-future-import
 flake8-import-order
 furo==2021.6.24b37  # Sphinx theme
-pytest>=4.6,<4.7
-pytest-vcr==1.0.2
-requests-mock==1.9.1
+pytest
+pytest-vcr
+requests-mock
 sphinx>=4,<5
 # specify exact autoprogram version because the new (in 2021) maintainer
 # showed that they will indeed make major changes in patch versions
 sphinxcontrib-autoprogram==0.1.7
 vcrpy<3.0.0
+# type check
+mypy
+sqlalchemy[mypy]
+types-pkg-resources
+types-pytz
+types-requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ praw>=4.0.0,<6.0.0
 geoip2>=4.0,<5.0
 requests>=2.0.0,<3.0.0
 dnspython<3.0
-sqlalchemy<1.4
+sqlalchemy>=1.4,<1.5

--- a/setup.cfg
+++ b/setup.cfg
@@ -62,3 +62,6 @@ exclude =
     contrib/*,
     conftest.py
 no-accept-encodings = True
+
+[mypy]
+plugins = sqlalchemy.ext.mypy.plugin

--- a/setup.cfg
+++ b/setup.cfg
@@ -65,3 +65,4 @@ no-accept-encodings = True
 
 [mypy]
 plugins = sqlalchemy.ext.mypy.plugin
+show_error_codes = True

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -778,12 +778,14 @@ class Sopel(irc.AbstractBot):
         self,
         pretrigger: PreTrigger,
     ) -> Union[Tuple[bool, bool], Tuple[None, None]]:
-        if self.settings.core.nick_blocks or self.settings.core.host_blocks:
-            nick_blocked = self._nick_blocked(pretrigger.nick)
-            host_blocked = self._host_blocked(pretrigger.host)
-        else:
+        if not (
+            self.settings.core.nick_blocks
+            or self.settings.core.host_blocks
+        ):
             return (None, None)
 
+        nick_blocked = self._nick_blocked(pretrigger.nick)
+        host_blocked = self._host_blocked(pretrigger.host)
         return (nick_blocked, host_blocked)
 
     def dispatch(self, pretrigger: PreTrigger) -> None:

--- a/sopel/modules/bugzilla.py
+++ b/sopel/modules/bugzilla.py
@@ -11,7 +11,7 @@ import logging
 import re
 
 import requests
-import xmltodict
+import xmltodict  # type: ignore
 
 from sopel import plugin, plugins
 from sopel.config import types

--- a/sopel/modules/bugzilla.py
+++ b/sopel/modules/bugzilla.py
@@ -11,7 +11,7 @@ import logging
 import re
 
 import requests
-import xmltodict  # type: ignore
+import xmltodict  # type: ignore[import]
 
 from sopel import plugin, plugins
 from sopel.config import types

--- a/sopel/modules/currency.py
+++ b/sopel/modules/currency.py
@@ -11,6 +11,7 @@ from __future__ import generator_stop
 import logging
 import re
 import time
+from typing import Dict
 
 import requests
 
@@ -35,7 +36,7 @@ LOGGER = logging.getLogger(__name__)
 UNSUPPORTED_CURRENCY = "Sorry, {} isn't currently supported."
 UNRECOGNIZED_INPUT = "Sorry, I didn't understand the input."
 
-rates = {}
+rates: Dict[str, float] = {}
 rates_updated = 0.0
 
 

--- a/sopel/modules/meetbot.py
+++ b/sopel/modules/meetbot.py
@@ -14,6 +14,7 @@ import os
 import re
 from string import punctuation, whitespace
 import time
+from typing import Dict
 
 from sopel import formatting, plugin, tools
 from sopel.config import types
@@ -62,7 +63,7 @@ def setup(bot):
     bot.config.define_section("meetbot", MeetbotSection)
 
 
-meetings_dict = collections.defaultdict(dict)  # Saves metadata about currently running meetings
+meetings_dict: Dict[str, dict] = collections.defaultdict(dict)  # Saves metadata about currently running meetings
 """
 meetings_dict is a 2D dict.
 

--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -13,8 +13,8 @@ import datetime as dt
 import html
 import re
 
-import praw  # type: ignore
-import prawcore  # type: ignore
+import praw  # type: ignore[import]
+import prawcore  # type: ignore[import]
 import requests
 
 from sopel import plugin

--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -13,8 +13,8 @@ import datetime as dt
 import html
 import re
 
-import praw
-import prawcore
+import praw  # type: ignore
+import prawcore  # type: ignore
 import requests
 
 from sopel import plugin

--- a/sopel/modules/remind.py
+++ b/sopel/modules/remind.py
@@ -368,10 +368,6 @@ class TimeReminder:
             ]
         )
 
-    # Mutable objects probably shouldn't be made hashable
-    # https://docs.python.org/3/reference/datamodel.html#object.__hash__
-    __hash__ = None
-
     def get_duration(self, today=None):
         """Get the duration between the reminder and ``today``
 

--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -11,7 +11,7 @@ from __future__ import generator_stop
 import re
 
 import requests
-import xmltodict
+import xmltodict  # type: ignore
 
 from sopel import plugin
 from sopel.tools import web

--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -11,7 +11,7 @@ from __future__ import generator_stop
 import re
 
 import requests
-import xmltodict  # type: ignore
+import xmltodict  # type: ignore[import]
 
 from sopel import plugin
 from sopel.tools import web

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -17,7 +17,7 @@ from urllib.parse import urlparse
 
 import dns.resolver
 import requests
-from urllib3.exceptions import LocationValueError
+from urllib3.exceptions import LocationValueError  # type: ignore
 
 from sopel import plugin, tools
 from sopel.config import types

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -17,7 +17,7 @@ from urllib.parse import urlparse
 
 import dns.resolver
 import requests
-from urllib3.exceptions import LocationValueError  # type: ignore
+from urllib3.exceptions import LocationValueError  # type: ignore[import]
 
 from sopel import plugin, tools
 from sopel.config import types

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -289,7 +289,7 @@ def find(*patterns: typing.Union[str, typing.Pattern]) -> typing.Callable:
     return add_attribute
 
 
-def find_lazy(*loaders) -> typing.Callable:
+def find_lazy(*loaders: typing.Callable) -> typing.Callable:
     """Decorate a callable as a find rule with lazy loading.
 
     :param loaders: one or more functions to generate a list of **compiled**
@@ -395,7 +395,7 @@ def search(*patterns: typing.Union[str, typing.Pattern]) -> typing.Callable:
     return add_attribute
 
 
-def search_lazy(*loaders) -> typing.Callable:
+def search_lazy(*loaders: typing.Callable) -> typing.Callable:
     """Decorate a callable as a search rule with lazy loading.
 
     :param loaders: one or more functions to generate a list of **compiled**
@@ -481,7 +481,7 @@ def echo(
     return add_attribute
 
 
-def command(*command_list) -> typing.Callable:
+def command(*command_list: str) -> typing.Callable:
     """Decorate a function to set one or more commands that should trigger it.
 
     :param str command_list: one or more command name(s) to match
@@ -578,7 +578,7 @@ commands = command
 """Alias to :func:`command`."""
 
 
-def nickname_command(*command_list) -> typing.Callable:
+def nickname_command(*command_list: str) -> typing.Callable:
     """Decorate a function to trigger on lines starting with "$nickname: command".
 
     :param str command_list: one or more command name(s) to match
@@ -628,7 +628,7 @@ nickname_commands = nickname_command
 """Alias to :func:`nickname_command`."""
 
 
-def action_command(*command_list) -> typing.Callable:
+def action_command(*command_list: str) -> typing.Callable:
     """Decorate a function to trigger on CTCP ACTION lines.
 
     :param str command_list: one or more command name(s) to match
@@ -718,7 +718,7 @@ def priority(value: str) -> typing.Callable:
     return add_attribute
 
 
-def event(*event_list) -> typing.Callable:
+def event(*event_list: str) -> typing.Callable:
     """Decorate a function to be triggered on specific IRC events.
 
     :param str event_list: one or more event name(s) on which to trigger
@@ -748,7 +748,7 @@ def event(*event_list) -> typing.Callable:
 
 def ctcp(
     function: typing.Any = None,
-    *command_list,
+    *command_list: str,
 ) -> typing.Union[typing.Any, typing.Callable]:
     """Decorate a callable to trigger on CTCP commands (mostly, ``ACTION``).
 
@@ -1118,7 +1118,7 @@ def require_bot_privilege(
     return actual_decorator
 
 
-def url(*url_rules) -> typing.Callable:
+def url(*url_rules: str) -> typing.Callable:
     """Decorate a function to handle URLs.
 
     :param str url_rules: one or more regex pattern(s) to match URLs
@@ -1177,7 +1177,7 @@ def url(*url_rules) -> typing.Callable:
     return actual_decorator
 
 
-def url_lazy(*loaders) -> typing.Callable:
+def url_lazy(*loaders: typing.Callable) -> typing.Callable:
     """Decorate a function to handle URL, using lazy-loading for its regex.
 
     :param loaders: one or more functions to generate a list of **compiled**

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -11,6 +11,8 @@ from __future__ import generator_stop
 
 import functools
 import re
+import typing
+
 
 # import and expose privileges as shortcut
 from sopel.privileges import ADMIN, HALFOP, OP, OPER, OWNER, VOICE
@@ -66,7 +68,7 @@ for example, to allow a user to retry a failed command immediately.
 """
 
 
-def unblockable(function):
+def unblockable(function: typing.Any) -> typing.Any:
     """Decorate a function to exempt it from the ignore/blocks system.
 
     For example, this can be used to ensure that important events such as
@@ -90,7 +92,7 @@ def unblockable(function):
     return function
 
 
-def interval(*intervals):
+def interval(*intervals: typing.Union[int, float]) -> typing.Callable:
     """Decorate a function to be called by the bot every *n* seconds.
 
     :param int intervals: one or more duration(s), in seconds
@@ -129,7 +131,7 @@ def interval(*intervals):
     return add_attribute
 
 
-def rule(*patterns):
+def rule(*patterns: typing.Union[str, typing.Pattern]) -> typing.Callable:
     """Decorate a function to be called when a line matches the given pattern.
 
     :param str patterns: one or more regular expression(s)
@@ -184,7 +186,7 @@ def rule(*patterns):
     return add_attribute
 
 
-def rule_lazy(*loaders):
+def rule_lazy(*loaders: typing.Callable) -> typing.Callable:
     """Decorate a callable as a rule with lazy loading.
 
     :param loaders: one or more functions to generate a list of **compiled**
@@ -232,7 +234,7 @@ def rule_lazy(*loaders):
     return decorator
 
 
-def find(*patterns):
+def find(*patterns: typing.Union[str, typing.Pattern]) -> typing.Callable:
     """Decorate a function to be called for each time a pattern is found in a line.
 
     :param str patterns: one or more regular expression(s)
@@ -287,7 +289,7 @@ def find(*patterns):
     return add_attribute
 
 
-def find_lazy(*loaders):
+def find_lazy(*loaders) -> typing.Callable:
     """Decorate a callable as a find rule with lazy loading.
 
     :param loaders: one or more functions to generate a list of **compiled**
@@ -335,7 +337,7 @@ def find_lazy(*loaders):
     return decorator
 
 
-def search(*patterns):
+def search(*patterns: typing.Union[str, typing.Pattern]) -> typing.Callable:
     """Decorate a function to be called when a pattern matches anywhere in a line.
 
     :param str patterns: one or more regular expression(s)
@@ -393,7 +395,7 @@ def search(*patterns):
     return add_attribute
 
 
-def search_lazy(*loaders):
+def search_lazy(*loaders) -> typing.Callable:
     """Decorate a callable as a search rule with lazy loading.
 
     :param loaders: one or more functions to generate a list of **compiled**
@@ -441,7 +443,7 @@ def search_lazy(*loaders):
     return decorator
 
 
-def thread(value):
+def thread(value: bool) -> typing.Callable:
     """Decorate a function to specify if it should be run in a separate thread.
 
     :param bool value: if ``True``, the function is called in a separate thread;
@@ -461,7 +463,9 @@ def thread(value):
     return add_attribute
 
 
-def echo(function=None):
+def echo(
+    function: typing.Optional[typing.Any] = None,
+) -> typing.Union[typing.Any, typing.Callable]:
     """Decorate a function to specify that it should receive echo messages.
 
     This decorator can be used to listen in on the messages that Sopel is
@@ -477,7 +481,7 @@ def echo(function=None):
     return add_attribute
 
 
-def command(*command_list):
+def command(*command_list) -> typing.Callable:
     """Decorate a function to set one or more commands that should trigger it.
 
     :param str command_list: one or more command name(s) to match
@@ -574,7 +578,7 @@ commands = command
 """Alias to :func:`command`."""
 
 
-def nickname_command(*command_list):
+def nickname_command(*command_list) -> typing.Callable:
     """Decorate a function to trigger on lines starting with "$nickname: command".
 
     :param str command_list: one or more command name(s) to match
@@ -624,7 +628,7 @@ nickname_commands = nickname_command
 """Alias to :func:`nickname_command`."""
 
 
-def action_command(*command_list):
+def action_command(*command_list) -> typing.Callable:
     """Decorate a function to trigger on CTCP ACTION lines.
 
     :param str command_list: one or more command name(s) to match
@@ -673,7 +677,7 @@ action_commands = action_command
 """Alias to :func:`action_command`."""
 
 
-def label(value):
+def label(value: str) -> typing.Callable:
     """Decorate a function to add a rule label.
 
     :param str value: a label for the rule
@@ -699,7 +703,7 @@ def label(value):
     return add_attribute
 
 
-def priority(value):
+def priority(value: str) -> typing.Callable:
     """Decorate a function to be executed with higher or lower priority.
 
     :param str value: one of ``high``, ``medium``, or ``low``;
@@ -714,7 +718,7 @@ def priority(value):
     return add_attribute
 
 
-def event(*event_list):
+def event(*event_list) -> typing.Callable:
     """Decorate a function to be triggered on specific IRC events.
 
     :param str event_list: one or more event name(s) on which to trigger
@@ -742,7 +746,10 @@ def event(*event_list):
     return add_attribute
 
 
-def ctcp(function=None, *command_list):
+def ctcp(
+    function: typing.Any = None,
+    *command_list,
+) -> typing.Union[typing.Any, typing.Callable]:
     """Decorate a callable to trigger on CTCP commands (mostly, ``ACTION``).
 
     :param str command_list: one or more CTCP command(s) on which to trigger
@@ -783,7 +790,7 @@ def ctcp(function=None, *command_list):
     return add_attribute
 
 
-def rate(user=0, channel=0, server=0):
+def rate(user: int = 0, channel: int = 0, server: int = 0) -> typing.Callable:
     """Decorate a function to be rate-limited.
 
     :param int user: seconds between permitted calls of this function by the
@@ -812,7 +819,10 @@ def rate(user=0, channel=0, server=0):
     return add_attribute
 
 
-def require_privmsg(message=None, reply=False):
+def require_privmsg(
+    message: typing.Union[typing.Callable, typing.Optional[str]] = None,
+    reply: bool = False,
+) -> typing.Callable:
     """Decorate a function to only be triggerable from a private message.
 
     :param str message: optional message said if triggered in a channel
@@ -847,7 +857,10 @@ def require_privmsg(message=None, reply=False):
     return actual_decorator
 
 
-def require_chanmsg(message=None, reply=False):
+def require_chanmsg(
+    message: typing.Union[typing.Callable, typing.Optional[str]] = None,
+    reply: bool = False,
+) -> typing.Callable:
     """Decorate a function to only be triggerable from a channel message.
 
     :param str message: optional message said if triggered in private message
@@ -892,7 +905,10 @@ def require_chanmsg(message=None, reply=False):
     return actual_decorator
 
 
-def require_account(message=None, reply=False):  # lgtm [py/similar-function]
+def require_account(
+    message: typing.Union[typing.Callable, typing.Optional[str]] = None,
+    reply: bool = False,
+) -> typing.Callable:  # lgtm [py/similar-function]
     """Decorate a function to require services/NickServ authentication.
 
     :param str message: optional message to say if a user without
@@ -938,7 +954,11 @@ def require_account(message=None, reply=False):  # lgtm [py/similar-function]
     return actual_decorator
 
 
-def require_privilege(level, message=None, reply=False):
+def require_privilege(
+    level: int,
+    message: typing.Optional[str] = None,
+    reply: bool = False,
+) -> typing.Callable:
     """Decorate a function to require at least the given channel permission.
 
     :param int level: required privilege level to use this command
@@ -978,7 +998,10 @@ def require_privilege(level, message=None, reply=False):
     return actual_decorator
 
 
-def require_admin(message=None, reply=False):  # lgtm [py/similar-function]
+def require_admin(
+    message: typing.Union[typing.Callable, typing.Optional[str]] = None,
+    reply: bool = False,
+) -> typing.Callable:  # lgtm [py/similar-function]
     """Decorate a function to require the triggering user to be a bot admin.
 
     :param str message: optional message said to non-admin user
@@ -1014,7 +1037,10 @@ def require_admin(message=None, reply=False):  # lgtm [py/similar-function]
     return actual_decorator
 
 
-def require_owner(message=None, reply=False):  # lgtm [py/similar-function]
+def require_owner(
+    message: typing.Union[typing.Callable, typing.Optional[str]] = None,
+    reply: bool = False,
+) -> typing.Callable:  # lgtm [py/similar-function]
     """Decorate a function to require the triggering user to be the bot owner.
 
     :param str message: optional message said to non-owner user
@@ -1049,7 +1075,11 @@ def require_owner(message=None, reply=False):  # lgtm [py/similar-function]
     return actual_decorator
 
 
-def require_bot_privilege(level, message=None, reply=False):
+def require_bot_privilege(
+    level: int,
+    message: typing.Optional[str] = None,
+    reply: bool = False,
+) -> typing.Callable:
     """Decorate a function to require a minimum channel privilege for the bot.
 
     :param int level: minimum channel privilege the bot needs for this function
@@ -1088,7 +1118,7 @@ def require_bot_privilege(level, message=None, reply=False):
     return actual_decorator
 
 
-def url(*url_rules):
+def url(*url_rules) -> typing.Callable:
     """Decorate a function to handle URLs.
 
     :param str url_rules: one or more regex pattern(s) to match URLs
@@ -1147,7 +1177,7 @@ def url(*url_rules):
     return actual_decorator
 
 
-def url_lazy(*loaders):
+def url_lazy(*loaders) -> typing.Callable:
     """Decorate a function to handle URL, using lazy-loading for its regex.
 
     :param loaders: one or more functions to generate a list of **compiled**
@@ -1344,7 +1374,7 @@ class example:
         return func
 
 
-def output_prefix(prefix):
+def output_prefix(prefix: str) -> typing.Callable:
     """Decorate a function to add a prefix on its output.
 
     :param str prefix: the prefix to add (must include trailing whitespace if

--- a/sopel/plugins/__init__.py
+++ b/sopel/plugins/__init__.py
@@ -83,7 +83,7 @@ def find_sopel_modules_plugins():
     responsible to load such plugins.
     """
     try:
-        import sopel_modules  # type: ignore
+        import sopel_modules  # type: ignore[import]
     except ImportError:
         return
 

--- a/sopel/plugins/__init__.py
+++ b/sopel/plugins/__init__.py
@@ -83,7 +83,7 @@ def find_sopel_modules_plugins():
     responsible to load such plugins.
     """
     try:
-        import sopel_modules
+        import sopel_modules  # type: ignore
     except ImportError:
         return
 


### PR DESCRIPTION
### Description

I wanted to add type annotation, and make sure they actually work, i.e. that mypy could validate them. So I installed it, ran it, and... got a load of errors. So tried to fix them, one by one.

Some are easy to fix: for sqlalchemy or pytest, all I had to do was to upgrade the dependency. Given that we are now Py3.6+ only, it was fairly easy and shouldn't be a problem. At least I hope it won't. At least, the test suite is still running fine on my end (Py3.8), and I'm doing this PR to check how it behave on the CI too. If it doesn't work, I'll see what I can do!

Some are trivial to fix: install a type library:

* types-pkg-resources
* types-pytz
* types-requests

Some errors are more complicated, and some are limitation of what is available in Py3.6 (compared to what you can do with 3.8 and 3.9). I don't want to use a backport library yet, because I want to make sure that the very basic typing work properly, one step at a time.

That's also why I didn't put mypy with the `make qa` command: I really like mypy, but I'd like to wait a bit before we enforce it for everyone. Making sure Sopel works is more important to me than having proper type annotations.

So yeah, it's a first step, and this PR is mostly to put the tools in place and see if we can move forward with it. I hope none of the new dependency will be a problem.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
