### PR TITLE
db: remove unused local `drivername` in sqlite code path

### DIFF
--- a/sopel/db.py
+++ b/sopel/db.py
@@ -116,7 +116,6 @@ class SopelDB:
             self.type = self.url.drivername.split('+', 1)[0]
         elif config.core.db_type == 'sqlite':
             self.type = 'sqlite'
-            drivername = config.core.db_driver or 'sqlite'
             path = config.core.db_filename
             if path is None:
                 path = os.path.join(config.core.homedir, config.basename + '.db')


### PR DESCRIPTION
### Description
Resolves [an alert](https://lgtm.com/projects/g/sopel-irc/sopel/snapshot/ecf4f1db80a7be5af44438e152aa3dfcf0d39818/files/sopel/db.py?sort=name&dir=ASC&mode=heatmap#L119) flagged by LGTM.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches