### PR TITLE
coretasks: correctly abort SASL PLAIN on invalid server reply

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -1059,14 +1059,17 @@ def auth_proceed(bot, trigger):
     sasl_username = sasl_username or bot.nick
 
     if mech == 'PLAIN':
-        if trigger.args[0] != '+':
-            # not an expected response from the server; abort SASL
-            token = '*'
-        else:
+        if trigger.args[0] == '+':
             sasl_token = _make_sasl_plain_token(sasl_username, sasl_password)
             LOGGER.info("Sending SASL Auth token.")
             send_authenticate(bot, sasl_token)
-        return
+            return
+        else:
+            # Not an expected response from the server
+            # Send `authenticate-abort` command
+            # See https://ircv3.net/specs/extensions/sasl-3.1#the-authenticate-command
+            bot.write(('AUTHENTICATE', '*'))
+            return
 
     # TODO: Implement SCRAM challenges
 


### PR DESCRIPTION
### Description
Originally [flagged as](https://lgtm.com/projects/g/sopel-irc/sopel/snapshot/ecf4f1db80a7be5af44438e152aa3dfcf0d39818/files/sopel/coretasks.py?sort=name&dir=ASC&mode=heatmap#L1064) an unused local variable by LGTM, but turned out to be a real bug.

Could be worth cutting a 7.1.5 release.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches