### PR TITLE
Add LGTM config file and explicitly set Python version

### DIFF
--- a/lgtm.yml
+++ b/lgtm.yml
@@ -1,0 +1,4 @@
+extraction:
+  python:
+    python_setup:
+      version: "3"


### PR DESCRIPTION
### Description
For whatever reason, when LGTM extracts code from this project, its `interpretConfig` tool (a Java JAR, the source for which I can't find) generates an effective config that tells the analysis to use Python 2 despite all of our tooling having been updated to drop it.

It would be nice to get rid of the false positive alerts we have about py2 stuff, so in the absence of any tooling (that I can find) to track down why LGTM infers the wrong Python version... Let's just set it.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - No code changes
- [ ] I have tested the functionality of the things this change touches
  - The only way to _truly_ test this is to let LGTM analyze the code after merge, I believe. We've seen in the past that e.g. excluding alerts with inline comments won't take effect for PR builds, and the config file probably also behaves that way.