### PR TITLE
contrib: escape instance name in systemd template

### DIFF
--- a/contrib/sopel@.service
+++ b/contrib/sopel@.service
@@ -7,8 +7,8 @@ DefaultInstance=sopel
 [Service]
 Type=simple
 User=sopel
-PIDFile=/run/sopel/sopel-%i.pid
-ExecStart=/usr/bin/sopel -c /etc/sopel/%i.cfg
+PIDFile=/run/sopel/sopel-%I.pid
+ExecStart=/usr/bin/sopel -c /etc/sopel/%I.cfg
 Restart=on-failure
 RestartPreventExitStatus=2
 RestartSec=30


### PR DESCRIPTION
### Description
Using `%I` instead of `%i` escapes filename-unsafe characters like '/'. @Exirel linked a quick systemd guide in our IRC channel earlier, and that led me to look and see what our contrib'd service unit file was using.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - No code changes.
- [x] I have tested the functionality of the things this change touches
  - Well, not _technically_, but it's a minor tweak that will affect only new service units that users create from this template after merge; existing service units won't change unless explicitly edited.

### Notes
No version milestone, as this isn't part of the release package.