### PR TITLE
travis: remove expired DST Root CA X3 cert on trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,18 @@ install:
   - pip install --upgrade "setuptools<=39.2.0; python_version < '3.9'"
   - pip install --upgrade -r requirements.txt -r dev-requirements.txt
   - python setup.py develop
+before_script:
+  # deal with Let's Encrypt's ISRG Root CA X1 being cross-signed by an expired root
+  # only needed on trusty - mark the bad cert disabled in conf, update ca-certificates
+  # bundle, then tell python-requests to use the system bundle instead of certifi's
+  # (as of 2021-10-05, certifi still stubbornly bundles the expired root;
+  # see https://github.com/certifi/python-certifi/pull/162
+  # and https://bugzilla.mozilla.org/show_bug.cgi?id=1733560 for updates)
+  - if [ "$TRAVIS_DIST" == "trusty" ]; then
+      sudo sed -re 's#^(mozilla/DST_Root_CA_X3.crt)$#!\1#' -i /etc/ca-certificates.conf;
+      sudo update-ca-certificates;
+      export REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt;
+    fi
 script:
   - make travis
 env:


### PR DESCRIPTION
### Description
Forcibly remove the expired `mozilla/DST_Root_CA_X3.crt` file and update CA certificate bundle, only on Trusty distro (used for Python 3.3 tests). Also ignore certifi trust store on trusty+py3.3, since certifi maintainers are stubborn (see comments in diff).

Thanks to @half-duplex for helping with the monkey-patch step!

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - Painstakingly: both myself and @half-duplex ran tests in local VMs, and I pushed promising solutions to a `travis-` prefixed test branch to see how they performed on the real thing.
  - If this PR build fails despite all of our advance testing, I might actually cry.

### Notes
Blocks #2190, which can't pass its CI tests until this is fixed.

Considering an alternative approach that replaces the `cp` with an environment variable (`REQUESTS_CA_BUNDLE`).