### PR TITLE
bot: use `optionxform()`-ed setting names for existence check

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -9,6 +9,7 @@ from __future__ import generator_stop
 
 from ast import literal_eval
 from datetime import datetime
+import inspect
 import itertools
 import logging
 import re
@@ -352,8 +353,13 @@ class Sopel(irc.AbstractBot):
         """
         settings = self.settings
         for section_name, section in settings.get_defined_sections():
+            defined_options = {
+                settings.parser.optionxform(opt)
+                for opt, _ in inspect.getmembers(section)
+                if not opt.startswith('_')
+            }
             for option_name in settings.parser.options(section_name):
-                if not hasattr(section, option_name):
+                if option_name not in defined_options:
                     LOGGER.warning(
                         "Config option `%s.%s` is not defined by its section "
                         "and may not be recognized by Sopel.",


### PR DESCRIPTION
### Description
This makes the "setting is defined in section" check case-insensitive, which matches the parsing behavior of `RawConfigParser`.

The `ip` plugin has a `GeoIP_db_path` setting that will erroneously warn users who set it using `sopel-plugins configure`, because the parser writes out its normalized names (in this case, `geoip_db_path`) and then the previous check using `hasattr()` wouldn't find the normalized name.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - `GeoIP_db_path`, `geoip_db_path`, and `i_dont_exist` settings under the `[ip]` section all behaved as expected (respectively: silent, silent, warning).

### Notes
Trivial to backport onto 7.1.x (I've already test-cherry-picked the commit locally; no conflicts), so might as well include it in the upcoming maintenance release we already plan to make.

A nicer future solution could be overriding `StaticSection.__getattr__()` to just always be case insensitive—but such a big change wouldn't fly in a maintenance release.