### PR TITLE
plugin: add missing ' to command's docstring

### DIFF
--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -581,7 +581,7 @@ def command(*command_list):
 
     Another option is to declare command with subcommands only, like this::
 
-        @command('main sub1)
+        @command('main sub1')
             # this command will be triggered on .main sub1
 
         @command('main sub2')


### PR DESCRIPTION
### Description
Tin. I noticed a typo while working on something else (which isn't yet solved, but that's another story).

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - If `make qa` didn't catch the typo, it's not going to complain about the correction. 😜
- [x] I have tested the functionality of the things this change touches

### Notes
If we have another 7.1.x release, this is worth including, but I'm not starting a new milestone just for this.