### PR TITLE
bot: add plugins property

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -16,7 +16,8 @@ import re
 import signal
 import threading
 import time
-from typing import Optional
+from types import MappingProxyType
+from typing import Mapping, Optional
 
 from sopel import irc, logger, plugins, tools
 from sopel.db import SopelDB
@@ -188,6 +189,14 @@ class Sopel(irc.AbstractBot):
             return None
 
         return self.users.get(self.nick).hostmask
+
+    @property
+    def plugins(self) -> Mapping[str, plugins.handlers.AbstractPluginHandler]:
+        """A dict of the bot's currently loaded plugins.
+
+        :return: an immutable map of plugin name to plugin object
+        """
+        return MappingProxyType(self._plugins)
 
     def has_channel_privilege(self, channel, privilege):
         """Tell if the bot has a ``privilege`` level or above in a ``channel``.


### PR DESCRIPTION
### Description
Create `bot.plugins` as suggested by @Exirel on IRC. Uses a property and a MappingProxyType to make bot.plugins and bot.plugins[*] immutable. Needed for cleanliness in #2133

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
