### PR TITLE
isupport: maintain PREFIX ordering

### DIFF
--- a/sopel/irc/isupport.py
+++ b/sopel/irc/isupport.py
@@ -13,9 +13,11 @@ When a server wants to advertise its features and settings, it can use the
 # Licensed under the Eiffel Forum License 2.
 from __future__ import generator_stop
 
+from collections import OrderedDict
 import functools
 import itertools
 import re
+from typing import Dict
 
 
 def _optional(parser, default=None):
@@ -97,7 +99,7 @@ def _parse_prefix(value):
     if len(modes) != len(prefixes):
         raise ValueError('Mode list does not match for PREFIX: %r' % value)
 
-    return tuple(sorted(zip(modes, prefixes)))
+    return tuple(zip(modes, prefixes))
 
 
 ISUPPORT_PARSERS = {
@@ -328,7 +330,7 @@ class ISupport:
         return dict(self['MAXLIST'])
 
     @property
-    def PREFIX(self):
+    def PREFIX(self) -> Dict[str, str]:
         """Expose ``PREFIX`` as a dict, if advertised by the server.
 
         This exposes information about the modes and nick prefixes used for
@@ -343,6 +345,8 @@ class ISupport:
                 'v': '+',
             }
 
+        Entries are in order of descending privilege.
+
         This attribute is not available if the server does not provide the
         right information, and accessing it will raise an
         :exc:`AttributeError`.
@@ -355,7 +359,10 @@ class ISupport:
         if 'PREFIX' not in self:
             raise AttributeError('PREFIX')
 
-        return dict(self['PREFIX'])
+        # This can use a normal dict once we drop python 3.6, as 3.7 promises
+        # `dict` maintains insertion order. Since `OrderedDict` subclasses
+        # `dict`, we'll not promise to always return the former.
+        return OrderedDict(self['PREFIX'])
 
     @property
     def TARGMAX(self):

--- a/test/irc/test_irc_isupport.py
+++ b/test/irc/test_irc_isupport.py
@@ -1,6 +1,8 @@
 """Tests for core ``sopel.irc.isupport``"""
 from __future__ import generator_stop
 
+from collections import OrderedDict
+
 import pytest
 
 from sopel.irc import isupport
@@ -498,6 +500,29 @@ def test_parse_parameter_prefix_invalid_format():
 
     with pytest.raises(ValueError):
         isupport.parse_parameter('PREFIX=(o)@+')
+
+
+def test_parse_parameter_prefix_order_parser():
+    """Ensure PREFIX order is maintained through parser.
+
+    https://modern.ircdocs.horse/#prefix-parameter
+    """
+    key, value = isupport.parse_parameter('PREFIX=(qov)~@+')
+
+    assert value == (('q', '~'), ('o', '@'), ('v', '+'))
+
+
+def test_parse_parameter_prefix_order_property():
+    """Ensure PREFIX order is maintained in property."""
+    instance = isupport.ISupport()
+
+    key, value = isupport.parse_parameter('PREFIX=(qov)~@+')
+    new = instance.apply(
+        prefix=value,
+    )
+
+    assert new.PREFIX == OrderedDict((('q', '~'), ('o', '@'), ('v', '+')))
+    assert tuple(new.PREFIX.keys()) == ('q', 'o', 'v')
 
 
 def test_parse_parameter_targmax():


### PR DESCRIPTION
### Description
Fixes #2198 by no longer sorting PREFIX entries and returning an OrderedDict.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
