### PR TITLE
wikipedia: handle mobile links

### DIFF
--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -252,7 +252,7 @@ def mw_section(server, query, section):
 
 
 # Matches a wikipedia page (excluding spaces and #, but not /File: links), with a separate optional field for the section
-@plugin.url(r'https?:\/\/([a-z]+\.wikipedia\.org)\/wiki\/((?!File\:)[^ #]+)#?([^ ]*)')
+@plugin.url(r'https?:\/\/([a-z]+(?:\.m)?\.wikipedia\.org)\/wiki\/((?!File\:)[^ #]+)#?([^ ]*)')
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def mw_info(bot, trigger, match=None):
     """Retrieves and outputs a snippet of the linked page."""


### PR DESCRIPTION
### Description
```irc
< xnaas> TIL the Wikipedia plugin doesn't activate for mobile links
< xnaas> just standard url plugin output
< xnaas> rip in pieces
```

Previous:
```irc
< mal> https://en.m.wikipedia.org/wiki/1989_(Taylor_Swift_album)
< Sopel> [url] 1989 (Taylor Swift album) - Wikipedia | en.m.wikipedia.org
```
New (matches non-mobile behavior):
```irc
< mal> https://en.m.wikipedia.org/wiki/1989_(Taylor_Swift_album)
< Sopel> [wikipedia] 1989 (Taylor Swift album) | "1989 is the fifth studio album by American singer-songwriter Taylor Swift. It was released on October 27, 2014, by Big Machine Records. Following the release of her genre-spanning fourth studio album Red (2012), noted for pop hooks and electronic elements, the media questioned the validity of Swift's status as a country artist. Inspired by 1980s synth-pop to create a record that shifted her sound and image […]"
```

This does leave server="{lang}.m.wikipedia.org" for `say_snippet()`/etc, but the api seems to behave the same on both.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
