### PR TITLE
reddit: fix shortlinks

### DIFF
--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -32,7 +32,7 @@ post_or_comment_url = (
     r'/r/\S+?/comments/(?P<submission>[\w-]+)'
     r'(?:/?(?:[\w%]+/(?P<comment>[\w-]+))?)'
 )
-short_post_url = r'https?://redd\.it/([\w-]+)'
+short_post_url = r'https?://(redd\.it|reddit\.com)/(?P<submission>[\w-]+)'
 user_url = r'%s/u(?:ser)?/([\w-]+)' % domain
 image_url = r'https?://i\.redd\.it/\S+'
 video_url = r'https?://v\.redd\.it/([\w-]+)'
@@ -122,13 +122,13 @@ def video_info(bot, trigger, match):
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def post_or_comment_info(bot, trigger, match):
     match = match or trigger
-    comment = match.group('comment')
+    groups = match.groupdict()
 
-    if comment:
-        say_comment_info(bot, trigger, comment)
+    if groups.get("comment"):
+        say_comment_info(bot, trigger, groups["comment"])
         return
 
-    say_post_info(bot, trigger, match.group('submission'))
+    say_post_info(bot, trigger, groups["submission"])
 
 
 @plugin.url(gallery_url)


### PR DESCRIPTION
### Description
reddit.py doesn't correctly handle redd.it shortlinks (anymore), and doesn't handle reddit.com shortlinks at all.

```irc
< xnaas> https://redd.it/qhoy7z
<+Sopel> Unexpected error (no such group) from xnaas at 2021-10-29 15:15:13.406136. Message was: https://redd.it/qhoy7z
```

This makes the "comment" group optional, and adds the "submission" group name and reddit.com domain to the shortlink regex.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
