### PR TITLE
web: use `html.unescape()` when available (Python 3.4+)

### DIFF
--- a/sopel/tools/web.py
+++ b/sopel/tools/web.py
@@ -34,6 +34,11 @@ else:
     unichr = chr
     unicode = str
 
+try:
+    import html as HTMLLib
+except ImportError:
+    HTMLLib = None
+
 __all__ = [
     'USER_AGENT',
     'DEFAULT_HEADERS',
@@ -121,6 +126,16 @@ def decode(html):
     :param str html: the HTML page or snippet to process
     :return str: ``html`` with all entity references replaced
     """
+    if HTMLLib is not None:
+        # Python's stdlib has our back in 3.4+
+        # TODO: This should be the only implementation in Sopel 8
+        try:
+            return HTMLLib.unescape(html)
+        except AttributeError:
+            # Must be py3.3; fall through to our half-assed version.
+            pass
+
+    # Not on py3.4+ yet? Then you get to deal with the jankiness.
     return r_entity.sub(entity, html)
 
 


### PR DESCRIPTION
### Description
Fixes #2203 on Python 3.4+ hosts. Anything older, well, we're not going to ship a reimplementation of Python's `html.unescape()` function (and everything else that actually makes it work) in a patch release when we've already dropped support for those Python versions on master. This bug just isn't a showstopper. It's not worth that.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - Well, locally `make quality` raises E741 on a variable name in `sopel/modules/help.py`, but that's nothing to do with this patch and it's not going to be an issue on the older version of flake8 configured for use on 7.1.x.
- [x] I have tested the functionality of the things this change touches
  - Proof that the kind of link in #2203 works now:
    ```
    <dgw> https://matrix.to/#/#element-community-testing:matrix.org
    <SopelTest> [url] You're invited to talk on Matrix | matrix.to
    ```