### PR TITLE
tools, tools.web: rework `web.decode()` to use modern stdlib

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -4,10 +4,6 @@ Additional API features
 Sopel includes a number of additional functions that are useful for various
 common IRC tasks.
 
-Note that ``sopel.web`` was deprecated in 6.2.0, and is not included in this
-documentation; it will be removed completely in Sopel 8. Plugins should use
-`requests <https://github.com/psf/requests>`_ directly.
-
 sopel.tools
 -----------
 

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -29,7 +29,6 @@ from pkg_resources import parse_version
 from sopel import __version__
 
 from ._events import events  # NOQA
-from . import time, web  # NOQA
 
 
 # Kept for backward compatibility
@@ -197,6 +196,13 @@ def deprecated(
         return func(*args, **kwargs)
 
     return deprecated_func
+
+
+# This has to be *after* the definition of `deprecated()` or we
+# get "AttributeError: partially initialized module 'sopel.tools' has no
+# attribute 'deprecated' (most likely due to a circular import)" when trying
+# to use the decorator in submodules.
+from . import time, web  # NOQA
 
 
 @deprecated('Shim for Python 2 cross-compatibility, no longer needed. '

--- a/sopel/tools/web.py
+++ b/sopel/tools/web.py
@@ -18,12 +18,13 @@ applications, APIs, or websites in your plugins.
 
 from __future__ import generator_stop
 
+import html
 from html.entities import name2codepoint
 import re
 import urllib
 from urllib.parse import urlparse, urlunparse
 
-from sopel import __version__
+from sopel import __version__, tools
 
 
 __all__ = [
@@ -85,9 +86,17 @@ Use it like this::
 
 
 r_entity = re.compile(r'&([^;\s]+);')
-"""Regular expression to match HTML entities."""
+"""Regular expression to match HTML entities.
+
+Will be removed in Sopel 9, along with :func:`entity`.
+"""
 
 
+@tools.deprecated(
+    version='8.0',
+    removed_in='9.0',
+    reason="No longer needed now that Python 3.4+ has `html.unescape()`",
+)
 def entity(match):
     """Convert an entity reference to the appropriate character.
 
@@ -96,6 +105,12 @@ def entity(match):
     :return str: the Unicode character corresponding to the given ``match``
         string, or a fallback representation if the reference cannot be
         resolved to a character
+
+    .. deprecated:: 8.0
+
+        Will be removed in Sopel 9. Use :func:`decode` directly or migrate to
+        Python's standard-library equivalent, :func:`html.unescape`.
+
     """
     value = match.group(1).lower()
     if value.startswith('#x'):
@@ -107,13 +122,20 @@ def entity(match):
     return '[' + value + ']'
 
 
-def decode(html):
+def decode(text):
     """Decode HTML entities into Unicode text.
 
-    :param str html: the HTML page or snippet to process
-    :return str: ``html`` with all entity references replaced
+    :param str text: the HTML page or snippet to process
+    :return str: ``text`` with all entity references replaced
+
+    .. versionchanged:: 8.0
+
+        Renamed ``html`` parameter to ``text``. (Python gained a standard
+        library module named :mod:`html` in version 3.4.)
+
     """
-    return r_entity.sub(entity, html)
+    # TODO deprecated?
+    return html.unescape(text)
 
 
 def quote(string, safe='/'):

--- a/sopel/tools/web.py
+++ b/sopel/tools/web.py
@@ -3,11 +3,6 @@ The ``tools.web`` package contains utility functions for interaction with web
 applications, APIs, or websites in your plugins.
 
 .. versionadded:: 7.0
-
-.. note::
-    Some parts of this module will remain accessible through ``sopel.web`` as
-    well until its final removal in Sopel 8. This is for backward
-    compatibility only; please update old code as soon as possible.
 """
 # Copyright © 2008, Sean B. Palmer, inamidst.com
 # Copyright © 2009, Michael Yanovich <yanovich.1@osu.edu>

--- a/sopel/tools/web.py
+++ b/sopel/tools/web.py
@@ -83,7 +83,9 @@ Use it like this::
 r_entity = re.compile(r'&([^;\s]+);')
 """Regular expression to match HTML entities.
 
-Will be removed in Sopel 9, along with :func:`entity`.
+.. deprecated:: 8.0
+
+    Will be removed in Sopel 9, along with :func:`entity`.
 """
 
 


### PR DESCRIPTION
### Description
This fixes #2203 for 8.0. (The patch for 7.1.6 is a separate PR against the maintenance branch, #2204.)

Python 3.4 added the `html.unescape()` function to its standard library, and current versions of Python have MUCH better HTML-entity-replacement implementations than ours. Let's just use the included batteries.

This patch deprecates `tools.web.entity()` and the associated constant `r_entity`. `tools.web.decode()` no longer uses them, and in fact should probably be considered for deprecation itself. (Not done yet; deciding that will come separately, along with its siblings' TODO comments.)

Note that the import of `web` in `tools/__init__.py` had to be moved below the definition of `tools.deprecated()` to avoid causing a circular dependency error. Might as well do it now, since we'll probably mark more stuff in `tools.web` as deprecated during Sopel 8's dev cycle.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches