### PR TITLE
reddit: fix matching twice for reddit.com without www.

### DIFF
--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -32,7 +32,7 @@ post_or_comment_url = (
     r'/r/\S+?/comments/(?P<submission>[\w-]+)'
     r'(?:/?(?:[\w%]+/(?P<comment>[\w-]+))?)'
 )
-short_post_url = r'https?://(redd\.it|reddit\.com)/(?P<submission>[\w-]+)'
+short_post_url = r'https?://(redd\.it|reddit\.com)/(?P<submission>[\w-]+)/?$'
 user_url = r'%s/u(?:ser)?/([\w-]+)' % domain
 image_url = r'https?://i\.redd\.it/\S+'
 video_url = r'https?://v\.redd\.it/([\w-]+)'

--- a/test/modules/test_modules_reddit.py
+++ b/test/modules/test_modules_reddit.py
@@ -1,0 +1,76 @@
+"""Tests for Sopel's ``reddit`` plugin"""
+from __future__ import generator_stop
+
+import pytest
+
+from sopel.trigger import PreTrigger
+
+
+TMP_CONFIG = """
+[core]
+owner = Admin
+nick = Sopel
+enable =
+    reddit
+host = irc.libera.chat
+"""
+
+
+@pytest.fixture
+def bot(botfactory, configfactory):
+    settings = configfactory('default.ini', TMP_CONFIG)
+    return botfactory.preloaded(settings, ['reddit'])
+
+
+MATCHING_URLS = (
+    # URLs the reddit plugin is expected to handle
+    # Should match ONCE each, no more, no less
+    'https://redd.it/123456',
+    'https://redd.it/123456/',
+    'https://reddit.com/123456',
+    'https://reddit.com/123456/',
+    'https://reddit.com/r/subname',
+    'https://reddit.com/r/subname/',
+    'https://www.reddit.com/r/subname',
+    'https://www.reddit.com/r/subname/',
+    'https://reddit.com/r/subname/comments/123456',
+    'https://reddit.com/r/subname/comments/123456/',
+    'https://reddit.com/r/subname/comments/123456?param=value',
+    'https://reddit.com/r/subname/comments/123456/?param=value',
+    'https://www.reddit.com/r/subname/comments/123456',
+    'https://www.reddit.com/r/subname/comments/123456/',
+    'https://reddit.com/r/subname/comments/123456/post_title_slug/234567',
+    'https://reddit.com/r/subname/comments/123456/post_title_slug/234567/',
+    'https://www.reddit.com/r/subname/comments/123456/post_title_slug/234567',
+    'https://www.reddit.com/r/subname/comments/123456/post_title_slug/234567/',
+    'https://reddit.com/r/subname/comments/123456/post_title_slug/234567/?context=1337',
+    'https://www.reddit.com/r/subname/comments/123456/post_title_slug/234567/?context=1337',
+)
+
+
+NON_MATCHING_URLS = (
+    # we don't allow for query parameters on subreddit links (yet?)
+    'https://reddit.com/r/subname?param=value',
+    'https://reddit.com/r/subname/?param=value',
+    'https://www.reddit.com/r/subname?param=value',
+    'https://www.reddit.com/r/subname/?param=value',
+    # "shortlink" style allegedly seen in the wild, but not currently recognized
+    'https://reddit.com/comments/123456',
+    'https://reddit.com/comments/123456/',
+)
+
+
+@pytest.mark.parametrize('link', MATCHING_URLS)
+def test_url_matching(link, bot):
+    line = PreTrigger(bot.nick, ':User!user@irc.libera.chat PRIVMSG #channel {}'.format(link))
+    matches = bot.rules.get_triggered_rules(bot, line)
+
+    assert len([match for match in matches if match[0].get_plugin_name() == 'reddit']) == 1
+
+
+@pytest.mark.parametrize('link', NON_MATCHING_URLS)
+def test_url_non_matching(link, bot):
+    line = PreTrigger(bot.nick, ':User!user@irc.libera.chat PRIVMSG #channel {}'.format(link))
+    matches = bot.rules.get_triggered_rules(bot, line)
+
+    assert len([match for match in matches if match[0].get_plugin_name() == 'reddit']) == 0


### PR DESCRIPTION
### Description
Addresses a regression introduced by #2202 (itself a regression fix, ironically), which added `reddit.com` to the `short_post_url` pattern and made it possible for a post or comment URL to match BOTH that and `post_or_comment_url`.

Since URLs match individually, and not as part of the line, all we need to make sure a shortlink really is one is to ensure that the link ends after the submission ID and optional trailing slash.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - Better than the author of #2202 did, no doubt.
  - This does not absolve me of failing to throw a battery of tests at the change myself. Past experience should have taught all of us by now that messing with `reddit.py`'s URL matching invites madness.

### Notes
To the PR template's question: This does not resolve any GitHub issues, because @xnaas doesn't "submit GitHub issues while naked in bed" and reported the bug on IRC instead.