### PR TITLE
reddit: add flair text to link/submission output

### DIFF
--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -143,9 +143,13 @@ def say_post_info(bot, trigger, id_, show_link=True, show_comments_link=False):
         s = bot.memory['reddit_praw'].submission(id=id_)
 
         message = (
-            '{title} {link}{nsfw} | {points} {points_text} ({percent}) | '
-            '{comments} {comments_text} | Posted by {author} | '
+            '{title}{flair} {link}{nsfw} | {points} {points_text} ({percent}) '
+            '| {comments} {comments_text} | Posted by {author} | '
             'Created at {created}{comments_link}')
+
+        flair = ''
+        if s.link_flair_text:
+            flair = " ('{}' flair)".format(s.link_flair_text)
 
         subreddit = s.subreddit.display_name
         if not show_link:
@@ -205,9 +209,10 @@ def say_post_info(bot, trigger, id_, show_link=True, show_comments_link=False):
 
         title = html.unescape(s.title)
         message = message.format(
-            title=title, link=link, nsfw=nsfw, points=s.score, points_text=points_text,
-            percent=percent, comments=s.num_comments, comments_text=comments_text,
-            author=author, created=created, comments_link=comments_link)
+            title=title, flair=flair, link=link, nsfw=nsfw, points=s.score,
+            points_text=points_text, percent=percent, comments=s.num_comments,
+            comments_text=comments_text, author=author, created=created,
+            comments_link=comments_link)
 
         bot.say(message)
     except prawcore.exceptions.NotFound:


### PR DESCRIPTION
### Description
Displays the link flair, if present, after the submission title.

I found this stale branch because it interfered with tab-completion for #2208. Rebase incoming; just wanted to open the PR first so the original history will be preserved.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
~~Not checking the test/QA boxes yet, since I last touched this code nearly a year ago. CI will take care of checking that QA passes (once I rebase), and testing the behavior will have to happen after all that settles.~~ CI passed; live test worked as expected.

### Output comparison
```
# v7.1.6
<Sopel> [reddit] How many of you are big travelers but still go with a cash back set up? (self.CreditCards) | 20 points
        (84.0%) | 8 comments | Posted by OpossomMyPossom | Created at Sunday, December 05, 2021 20:44:43 -0600

# This patch
<SopelTest> [reddit] How many of you are big travelers but still go with a cash back set up? ('Discussion' flair)
            (self.CreditCards) | 20 points (89.0%) | 8 comments | Posted by OpossomMyPossom | Created at Sunday,
            December 05, 2021 20:44:43 (CST)
```