### PR TITLE
cli: fix legacy parser options for Py3.9.8 (Sopel 7.1.x)

### DIFF
--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -118,7 +118,7 @@ def run(settings, pid_file, daemon=False):
     os._exit(0)
 
 
-def add_legacy_options(parser):
+def add_legacy_options(parser, prefix=''):
     """Add legacy options to the argument parser.
 
     :param parser: argument parser
@@ -130,52 +130,56 @@ def add_legacy_options(parser):
     # The option -d/--fork is used by both actions (start and legacy),
     # and it has the same meaning and behavior, therefore it is not deprecated.
     parser.add_argument("-d", '--fork', action="store_true",
-                        dest="daemonize",
+                        dest="%sdaemonize" % prefix,
                         help="Daemonize Sopel.")
-    parser.add_argument("-q", '--quit', action="store_true", dest="quit",
+    parser.add_argument("-q", '--quit', action="store_true",
+                        dest="%squit" % prefix,
                         help=(
                             "Gracefully quit Sopel "
                             "(deprecated, and will be removed in Sopel 8; "
                             "use ``sopel stop`` instead)"))
-    parser.add_argument("-k", '--kill', action="store_true", dest="kill",
+    parser.add_argument("-k", '--kill', action="store_true",
+                        dest="%skill" % prefix,
                         help=(
                             "Kill Sopel "
                             "(deprecated, and will be removed in Sopel 8; "
                             "use ``sopel stop --kill`` instead)"))
-    parser.add_argument("-r", '--restart', action="store_true", dest="restart",
+    parser.add_argument("-r", '--restart', action="store_true",
+                        dest="%srestart" % prefix,
                         help=(
                             "Restart Sopel "
                             "(deprecated, and will be removed in Sopel 8; "
                             "use `sopel restart` instead)"))
     parser.add_argument("-l", '--list', action="store_true",
-                        dest="list_configs",
+                        dest="%slist_configs" % prefix,
                         help=(
                             "List all config files found"
                             "(deprecated, and will be removed in Sopel 8; "
                             "use ``sopel-config list`` instead)"))
-    parser.add_argument('--quiet', action="store_true", dest="quiet",
+    parser.add_argument('--quiet', action="store_true",
+                        dest="%squiet" % prefix,
                         help="Suppress all output")
     parser.add_argument('-w', '--configure-all', action='store_true',
-                        dest='wizard',
+                        dest='%swizard' % prefix,
                         help=(
                             "Run the configuration wizard "
                             "(deprecated, and will be removed in Sopel 8; "
                             "use `sopel configure` instead)"))
     parser.add_argument('--configure-modules', action='store_true',
-                        dest='mod_wizard',
+                        dest='%smod_wizard' % prefix,
                         help=(
                             "Run the configuration wizard, but only for the "
                             "plugin configuration options "
                             "(deprecated, and will be removed in Sopel 8; "
                             "use ``sopel configure --plugins`` instead)"))
     parser.add_argument('-v', action="store_true",
-                        dest='version_legacy',
+                        dest='%sversion_legacy' % prefix,
                         help=(
                             "Show version number and exit "
                             "(deprecated, and will be removed in Sopel 8; "
                             "use ``-V/--version`` instead)"))
     parser.add_argument('-V', '--version', action='store_true',
-                        dest='version',
+                        dest='%sversion' % prefix,
                         help='Show version number and exit')
 
 
@@ -187,7 +191,12 @@ def build_parser():
     """
     parser = argparse.ArgumentParser(description='Sopel IRC Bot',
                                      usage='%(prog)s [options]')
-    add_legacy_options(parser)
+    # prefix default_ to prevent shadowing subparser legacy options
+    # this is to support Python 3.9.8 which, for some reason, decided to "fix"
+    # a "bug" that introduce a breaking change between two patch version
+    # of Python. The hack works because these legacy options are not actually
+    # used by the subparser, they are used to "trick" user help only.
+    add_legacy_options(parser, 'default_')
     utils.add_common_arguments(parser)
 
     subparsers = parser.add_subparsers(


### PR DESCRIPTION
### Description

The hack adds a prefix to the "dest" of the legacy options added to the main parser. It works because these options are not actually used by the legacy subparser: they exists only to trick the help message into something usable by end-users. It's rather ugly, but at this point we already know that the "legacy" subparser trick is ugly.

We are only fixing the issue introduced by Python 3.9.8 that "fixed" something in argparse that broke our use-case. Let's not delve into that for now.

Should fix #2210 

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
  * In theory that fixes the issue for Python 3.9.8 but I'll let Travis or Github Action ensure that
