### PR TITLE
cli: fix legacy parser options for Py3.9.8 (Sopel 8.x)

### DIFF
--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -120,7 +120,7 @@ def run(settings, pid_file, daemon=False):
     os._exit(0)
 
 
-def add_legacy_options(parser):
+def add_legacy_options(parser, prefix=''):
     """Add legacy options to the argument parser.
 
     :param parser: argument parser
@@ -132,52 +132,56 @@ def add_legacy_options(parser):
     # The option -d/--fork is used by both actions (start and legacy),
     # and it has the same meaning and behavior, therefore it is not deprecated.
     parser.add_argument("-d", '--fork', action="store_true",
-                        dest="daemonize",
+                        dest="%sdaemonize" % prefix,
                         help="Daemonize Sopel.")
-    parser.add_argument("-q", '--quit', action="store_true", dest="quit",
+    parser.add_argument("-q", '--quit', action="store_true",
+                        dest="%squit" % prefix,
                         help=(
                             "Gracefully quit Sopel "
                             "(deprecated, and will be removed in Sopel 8; "
                             "use ``sopel stop`` instead)"))
-    parser.add_argument("-k", '--kill', action="store_true", dest="kill",
+    parser.add_argument("-k", '--kill', action="store_true",
+                        dest="%skill" % prefix,
                         help=(
                             "Kill Sopel "
                             "(deprecated, and will be removed in Sopel 8; "
                             "use ``sopel stop --kill`` instead)"))
-    parser.add_argument("-r", '--restart', action="store_true", dest="restart",
+    parser.add_argument("-r", '--restart', action="store_true",
+                        dest="%srestart" % prefix,
                         help=(
                             "Restart Sopel "
                             "(deprecated, and will be removed in Sopel 8; "
                             "use `sopel restart` instead)"))
     parser.add_argument("-l", '--list', action="store_true",
-                        dest="list_configs",
+                        dest="%slist_configs" % prefix,
                         help=(
                             "List all config files found"
                             "(deprecated, and will be removed in Sopel 8; "
                             "use ``sopel-config list`` instead)"))
-    parser.add_argument('--quiet', action="store_true", dest="quiet",
+    parser.add_argument('--quiet', action="store_true",
+                        dest="%squiet" % prefix,
                         help="Suppress all output")
     parser.add_argument('-w', '--configure-all', action='store_true',
-                        dest='wizard',
+                        dest='%swizard' % prefix,
                         help=(
                             "Run the configuration wizard "
                             "(deprecated, and will be removed in Sopel 8; "
                             "use `sopel configure` instead)"))
     parser.add_argument('--configure-modules', action='store_true',
-                        dest='mod_wizard',
+                        dest='%smod_wizard' % prefix,
                         help=(
                             "Run the configuration wizard, but only for the "
                             "plugin configuration options "
                             "(deprecated, and will be removed in Sopel 8; "
                             "use ``sopel configure --plugins`` instead)"))
     parser.add_argument('-v', action="store_true",
-                        dest='version_legacy',
+                        dest='%sversion_legacy' % prefix,
                         help=(
                             "Show version number and exit "
                             "(deprecated, and will be removed in Sopel 8; "
                             "use ``-V/--version`` instead)"))
     parser.add_argument('-V', '--version', action='store_true',
-                        dest='version',
+                        dest='%sversion' % prefix,
                         help='Show version number and exit')
 
 
@@ -189,7 +193,12 @@ def build_parser():
     """
     parser = argparse.ArgumentParser(description='Sopel IRC Bot',
                                      usage='%(prog)s [options]')
-    add_legacy_options(parser)
+    # prefix default_ to prevent shadowing subparser legacy options
+    # this is to support Python 3.9.8 which, for some reason, decided to "fix"
+    # a "bug" that introduce a breaking change between two patch version
+    # of Python. The hack works because these legacy options are not actually
+    # used by the subparser, they are used to "trick" user help only.
+    add_legacy_options(parser, 'default_')
     utils.add_common_arguments(parser)
 
     subparsers = parser.add_subparsers(

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -199,7 +199,7 @@ def build_parser():
     # of Python. The hack works because these legacy options are not actually
     # used by the subparser, they are used to "trick" user help only.
     add_legacy_options(parser, 'default_')
-    utils.add_common_arguments(parser)
+    utils.add_common_arguments(parser, 'default_')
 
     subparsers = parser.add_subparsers(
         title='subcommands',

--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -240,11 +240,13 @@ def find_config(config_dir, name, extension='.cfg'):
     return os.path.join(config_dir, name)
 
 
-def add_common_arguments(parser):
+def add_common_arguments(parser, prefix=''):
     """Add common and configuration-related arguments to a ``parser``.
 
     :param parser: Argument parser (or subparser)
     :type parser: argparse.ArgumentParser
+    :param str prefix: Destination prefix to prevent conflict in argparse
+                       namespaces for Python 3.9.8
 
     This function adds the common arguments for Sopel's command line tools.
     It adds the following arguments:
@@ -276,7 +278,7 @@ def add_common_arguments(parser):
         '-c', '--config',
         default=os.environ.get('SOPEL_CONFIG') or 'default',
         metavar='filename',
-        dest='config',
+        dest='%sconfig' % prefix,
         help=inspect.cleandoc("""
             Use a specific configuration file.
             A config name can be given and the configuration file will be
@@ -289,7 +291,7 @@ def add_common_arguments(parser):
     parser.add_argument(
         '--config-dir',
         default=os.environ.get('SOPEL_CONFIG_DIR') or config.DEFAULT_HOMEDIR,
-        dest='configdir',
+        dest='%sconfigdir' % prefix,
         help=inspect.cleandoc("""
             Look for configuration files in this directory.
             By default, Sopel will search in ``~/.sopel``.


### PR DESCRIPTION
### Description

Same as #2211 but for the current development version (8.x). I hope Github Action will pass!

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
