### PR TITLE
plugins: execute TODO that was waiting for end of py2 support

### DIFF
--- a/sopel/plugins/__init__.py
+++ b/sopel/plugins/__init__.py
@@ -222,9 +222,6 @@ def get_usable_plugins(settings):
         (plugin.name, (plugin, is_enabled))
         for plugin, is_enabled in enumerate_plugins(settings))
     # reset coretasks's position at the end of the loading queue
-    # Python 2's OrderedDict does not have a `move_to_end` method
-    # TODO: replace by plugins_info.move_to_end('coretasks') for Python 3
-    core_info = plugins_info.pop('coretasks')
-    plugins_info['coretasks'] = core_info
+    plugins_info.move_to_end('coretasks')
 
     return plugins_info


### PR DESCRIPTION
### Description
We can use `collections.OrderedDict.move_to_end()` now.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
Yes, I know CI is going to fail pending resolution of #2210. Hoping the revert will happen soon and Python 3.9.x will get the "expedited release" that a maintainer requested at the Python bug tracker.