### PR TITLE
wiktionary: allow for multi-line etymologies

### DIFF
--- a/sopel/modules/wiktionary.py
+++ b/sopel/modules/wiktionary.py
@@ -49,7 +49,7 @@ def text(html):
     text = text.replace('(intransitive', '(intr.')
     text = text.replace('(transitive', '(trans.')
     text = web.decode(text)
-    return text
+    return text.strip()
 
 
 def wikt(word):
@@ -73,9 +73,13 @@ def wikt(word):
 
         if not is_new_mode:
             if (mode == 'etymology') and ('<p>' in line):
-                etymology = text(line)
+                if etymology is not None:
+                    # multi-line etymologies do exist (e.g. see "mayhem")
+                    etymology += ' ' + text(line)
+                else:
+                    etymology = text(line)
             # 'id="' can occur in definition lines <li> when <sup> tag is used for references;
-            # make sure those are not excluded (see e.g., abecedarian).
+            # make sure those are not excluded (e.g. see "abecedarian").
             elif ('id="' in line) and ('<li>' not in line):
                 mode = None
             elif (mode is not None) and ('<li>' in line):


### PR DESCRIPTION
### Description
Multi-paragraph etymologies no longer get truncated to only the _last_ line.

If the concatenated etymology is too long to fit in an IRC line, it's safely truncated by the existing logic to handle overly long output.

This patch definitely makes me want to give wiktionary the same kind of makeover that wikipedia got a while back. Which is to say: a proper parser-based implementation instead of...whatever you call this.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches