### PR TITLE
coretasks: alert owner if nick in `RPL_WELCOME` does not match config

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -252,6 +252,29 @@ def startup(bot, trigger):
     if bot.connection_registered:
         return
 
+    # nick shenanigans are serious business, but fortunately RPL_WELCOME
+    # includes the actual nick used by the server after truncation, removal
+    # of invalid characters, etc. so we can check for such shenanigans
+    if trigger.event == events.RPL_WELCOME:
+        if bot.nick != trigger.args[0]:
+            # setting modes below is just one of the things that won't work
+            # as expected if the conditions for running this block are met
+            privmsg = (
+                "Hi, I'm your bot, %s. The IRC server didn't assign me the "
+                "nick you configured. This can cause problems for me, and "
+                "make me do weird things. You'll probably want to stop me, "
+                "figure out why my nick isn't acceptable, and fix that before "
+                "starting me again." % bot.nick
+            )
+            debug_msg = (
+                "RPL_WELCOME indicated the server did not accept the bot's "
+                "configured nickname. Requested '%s'; got '%s'. This can "
+                "cause unexpected behavior. Please modify the configuration "
+                "and restart the bot." % (bot.nick, trigger.args[0])
+            )
+            LOGGER.critical(debug_msg)
+            bot.say(privmsg, bot.config.core.owner)
+
     # set flag
     bot.connection_registered = True
 


### PR DESCRIPTION
### Description
Inspired by a recent PR to the "horse docs" site (ircdocs/modern-irc#146), which adds a paragraph about this.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### New log output
The result of "test[ing] the functionality of the things this change touches".

<details>
<summary>stdout/logging</summary>

```
...
[2021-11-27 20:43:25,272] sopel.coretasks      INFO     - End of client capability negotiation requests.
[2021-11-27 20:43:25,307] sopel.coretasks      CRITICAL - RPL_WELCOME indicated the server did not accept the bot's
                                                          configured nickname. Requested
                                                          'ThisIsAVeryLongNickThatRizonWillTruncateBecauseItsLongerThan30Characters';
                                                          got 'ThisIsAVeryLongNickThatRizonWi'. This can cause unexpected
                                                          behavior. Please modify the configuration and restart the bot.
[2021-11-27 20:43:25,310] sopel.coretasks      INFO     - Joining 1 channels (with JOIN throttle OFF); this may take a moment.
...
```

</details>

<details>
<summary>raw log</summary>

```
...
2021-11-27 20:43:25,307 <<      ':irc.sxci.net 001 ThisIsAVeryLongNickThatRizonWi :Welcome to the Rizon Internet Relay Chat Network ThisIsAVeryLongNickThatRizonWi\r\n'
2021-11-27 20:43:25,309 >>      "PRIVMSG dgw :Hi, I'm your bot, ThisIsAVeryLongNickThatRizonWillTruncateBecauseItsLongerThan30Characters. The IRC server didn't assign me the nick you configured. This can cause problems for me, and make me do weird things. You'll probably want to stop me, figure out why my nick isn't acceptable, and fix that before starting me again.\r\n"
2021-11-27 20:43:25,310 >>      'MODE ThisIsAVeryLongNickThatRizonWillTruncateBecauseItsLongerThan30Characters +B\r\n'
...
```

</details>