### PR TITLE
url: bump user-agent

### DIFF
--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -28,7 +28,7 @@ LOGGER = logging.getLogger(__name__)
 USER_AGENT = (
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
     'AppleWebKit/537.36 (KHTML, like Gecko) '
-    'Chrome/78.0.3904.108 Safari/537.36'
+    'Chrome/96.0.4664.45 Safari/537.36'
 )
 DEFAULT_HEADERS = {
     'User-Agent': USER_AGENT,

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -28,7 +28,7 @@ LOGGER = logging.getLogger(__name__)
 USER_AGENT = (
     'Mozilla/5.0 (Windows NT 10.0; Win64; x64) '
     'AppleWebKit/537.36 (KHTML, like Gecko) '
-    'Chrome/96.0.4664.45 Safari/537.36'
+    'Chrome/98.0.4758.102 Safari/537.36'
 )
 DEFAULT_HEADERS = {
     'User-Agent': USER_AGENT,


### PR DESCRIPTION
### Description

Update the user-agent string to Chrome 96, the 2nd most popular UA listed on
https://techblog.willshouse.com/2012/01/03/most-common-user-agents/

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
    - [x] I skimmed it, anyway.
- [x] I can and do license this contribution under the EFLv2
- [ ] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [ ] I have tested the functionality of the things this change touches
