### PR TITLE
plugins.rules: fix conflicting attributes in base classes

### DIFF
--- a/docs/source/plugin/internals.rst
+++ b/docs/source/plugin/internals.rst
@@ -51,6 +51,6 @@ sopel.plugins.rules
       :members:
       :undoc-members:
 
-   .. autoclass:: NamedRuleMixin
+   .. autoclass:: AbstractNamedRule
       :members:
       :undoc-members:


### PR DESCRIPTION
### Description

One PR, two issues:

* LGTM issues that are better fixed than ignored
* ~Type hint warning for documentation~
* Update documentation to replace the mixin by the abstract named rule class
* Fix a deprecated usage of an abstract method decorator in Rule

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
