### PR TITLE
adminchannel: fix unmatchable caret in regex

### DIFF
--- a/sopel/modules/adminchannel.py
+++ b/sopel/modules/adminchannel.py
@@ -133,7 +133,7 @@ def configureHostMask(mask):
     if m is not None:
         return '*!%s@%s' % (m.group(1), m.group(2))
 
-    m = re.match('^([^!@]+)!(^[!@]+)@?$', mask)
+    m = re.match('^([^!@]+)!([^!@]+)@?$', mask)
     if m is not None:
         return '%s!%s@*' % (m.group(1), m.group(2))
 


### PR DESCRIPTION
### Description
`configureHostMask` has had an unmatchable caret in one of its regular expressions since 2014. The fix for master/8.0 will be more like a minor refactor; this is just a patch to fix the obvious bug for stable.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
Merging to `backports-7.1.7`, which is where I've been staging all of the backported patches that were originally merged to `master`. Doing it this way (instead of sending this to `7.1.x`) lets me avoid an annoying rebase later.