### PR TITLE
adminchannel: fix, simplify, and comment hostmask utility function

### DIFF
--- a/sopel/modules/adminchannel.py
+++ b/sopel/modules/adminchannel.py
@@ -144,8 +144,8 @@ def configureHostMask(mask):
     if re.match(r'^[^!@\s]+![^!@\s]+@[^!@\s]+$', mask) is not None:
         return mask
 
-    # invalid format... empty-string is used as a sentinel value
-    return ''
+    # not a shortcut nor a valid hostmask
+    raise ValueError('Invalid hostmask format or unsupported shorthand')
 
 
 @plugin.require_chanmsg
@@ -170,9 +170,12 @@ def ban(bot, trigger):
             return
         channel = opt
         banmask = text[2]
-    banmask = configureHostMask(banmask)
-    if banmask == '':
+
+    try:
+        banmask = configureHostMask(banmask)
+    except ValueError:
         return
+
     bot.write(['MODE', channel, '+b', banmask])
 
 
@@ -197,9 +200,12 @@ def unban(bot, trigger):
             return
         channel = opt
         banmask = text[2]
-    banmask = configureHostMask(banmask)
-    if banmask == '':
+
+    try:
+        banmask = configureHostMask(banmask)
+    except ValueError:
         return
+
     bot.write(['MODE', channel, '-b', banmask])
 
 
@@ -224,9 +230,12 @@ def quiet(bot, trigger):
             return
         quietmask = text[2]
         channel = opt
-    quietmask = configureHostMask(quietmask)
-    if quietmask == '':
+
+    try:
+        quietmask = configureHostMask(quietmask)
+    except ValueError:
         return
+
     bot.write(['MODE', channel, '+q', quietmask])
 
 
@@ -251,9 +260,12 @@ def unquiet(bot, trigger):
             return
         quietmask = text[2]
         channel = opt
-    quietmask = configureHostMask(quietmask)
-    if quietmask == '':
+
+    try:
+        quietmask = configureHostMask(quietmask)
+    except ValueError:
         return
+
     bot.write(['MODE', channel, '-q', quietmask])
 
 
@@ -285,9 +297,12 @@ def kickban(bot, trigger):
         mask = text[3]
         reasonidx = 4
     reason = ' '.join(text[reasonidx:])
-    mask = configureHostMask(mask)
-    if mask == '':
+
+    try:
+        mask = configureHostMask(mask)
+    except ValueError:
         return
+
     bot.write(['MODE', channel, '+b', mask])
     bot.kick(nick, channel, reason)
 

--- a/sopel/modules/adminchannel.py
+++ b/sopel/modules/adminchannel.py
@@ -118,25 +118,27 @@ def kick(bot, trigger):
 
 def configureHostMask(mask):
     # shortcut for nick!*@*
-    if re.match('^[^.@!/]+$', mask) is not None:
+    if re.match(r'^[^.@!/\s]+$', mask) is not None:
         return '%s!*@*' % mask
 
-    # shortcut for *!*@host (only works for hosts containing dot)
-    if re.match('^[^@!]+$', mask) is not None:
+    # shortcut for *!*@host
+    # won't work for local names w/o dot, but does support cloaks/with/slashes
+    if re.match(r'^[^@!\s]+$', mask) is not None:
         return '*!*@%s' % mask
 
-    # shortcut for *!user@* (must give 'user@' as input)
-    m = re.match('^([^!@]+)@$', mask)
+    # shortcut for *!user@*
+    # requires trailing @ to be recognized as a username instead of a nick
+    m = re.match(r'^([^!@\s]+)@$', mask)
     if m is not None:
         return '*!%s@*' % m.group(1)
 
     # shortcut for *!user@host
-    m = re.match('^([^!@]+)@([^@!]+)$', mask)
+    m = re.match(r'^([^!@\s]+)@([^@!\s]+)$', mask)
     if m is not None:
         return '*!%s@%s' % (m.group(1), m.group(2))
 
     # shortcut for nick!user@*
-    m = re.match('^([^!@]+)!([^!@]+)@?$', mask)
+    m = re.match(r'^([^!@\s]+)!([^!@\s]+)@?$', mask)
     if m is not None:
         return '%s!%s@*' % (m.group(1), m.group(2))
 

--- a/sopel/modules/adminchannel.py
+++ b/sopel/modules/adminchannel.py
@@ -117,27 +117,34 @@ def kick(bot, trigger):
 
 
 def configureHostMask(mask):
-    if mask == '*!*@*':
-        return mask
+    # shortcut for nick!*@*
     if re.match('^[^.@!/]+$', mask) is not None:
         return '%s!*@*' % mask
+
+    # shortcut for *!*@host (only works for hosts containing dot)
     if re.match('^[^@!]+$', mask) is not None:
         return '*!*@%s' % mask
 
+    # shortcut for *!user@* (must give 'user@' as input)
     m = re.match('^([^!@]+)@$', mask)
     if m is not None:
         return '*!%s@*' % m.group(1)
 
+    # shortcut for *!user@host
     m = re.match('^([^!@]+)@([^@!]+)$', mask)
     if m is not None:
         return '*!%s@%s' % (m.group(1), m.group(2))
 
-    m = re.match('^([^!@]+)!(^[!@]+)@?$', mask)
+    # shortcut for nick!user@*
+    m = re.match('^([^!@]+)!([^!@]+)@?$', mask)
     if m is not None:
         return '%s!%s@*' % (m.group(1), m.group(2))
 
-    if re.match(r'^\S+[!]\S+[@]\S+$', mask) is not None:
+    # not a shortcut; validate full NUH format
+    if re.match(r'^[^!@\s]+![^!@\s]+@[^!@\s]+$', mask) is not None:
         return mask
+
+    # invalid format... empty-string is used as a sentinel value
     return ''
 
 

--- a/test/modules/test_modules_adminchannel.py
+++ b/test/modules/test_modules_adminchannel.py
@@ -1,0 +1,43 @@
+"""Tests for Sopel's ``adminchannel`` plugin"""
+from __future__ import generator_stop
+
+import pytest
+
+from sopel.modules import adminchannel
+
+
+VALID_INPUTS = (
+    ('justanick', 'justanick!*@*'),
+    ('just-a.host', '*!*@just-a.host'),
+    ('justauser@', '*!justauser@*'),
+    ('someuser@just-a.host', '*!someuser@just-a.host'),
+    ('someuser@dotlesshost', '*!someuser@dotlesshost'),
+    ('somenick!someuser', 'somenick!someuser@*'),
+    ('somenick!someuser@', 'somenick!someuser@*'),
+    ('somenick!someuser@', 'somenick!someuser@*'),
+    ('full!host@mask', 'full!host@mask'),
+    ('full!mask@host.with.dots', 'full!mask@host.with.dots'),
+    ('libera/style/cloak', '*!*@libera/style/cloak'),
+)
+
+INVALID_INPUTS = (
+    'mask with whitespace',
+    'cloak/with whitespace',
+    'nick!auser@something with whitespace',
+    'nick with spaces!user@host',
+    'nick!user with spaces@host',
+    'two!user!names@host',
+    'two!user@host@names',
+)
+
+
+@pytest.mark.parametrize('raw, checked', VALID_INPUTS)
+def test_configureHostMask(raw, checked):
+    """Test the `configureHostMask` helper for functionality and compatibility."""
+    assert adminchannel.configureHostMask(raw) == checked
+
+
+@pytest.mark.parametrize('raw', INVALID_INPUTS)
+def test_configureHostMask_invalid(raw):
+    with pytest.raises(ValueError):
+        adminchannel.configureHostMask(raw)


### PR DESCRIPTION
### Description
The "Big boy" version of #2221.

This is perhaps the most roundabout way to resolve a single LGTM alert in Sopel's history, but it improves a lot of stuff about the `adminchannel` plugin's `configureHostMask` helper function:

- Fix a broken regex (unmatchable caret, the thing LGTM complained about)
- Reduce the number of distinct cases
- Add comments explaining what each case is supposed to do
- Use exceptions to alert the caller about invalid input instead of a weak sentinel value of `''` (empty string)
- Add test cases to make sure that everything behaves as expected

Notably, adding tests also picked out a couple of edge cases that weren't handled, which I then also fixed.

The "Big boy" version of #2221.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - Well yes, that's what the new file under `test/` is for.