### PR TITLE
docs: fix warnings in `plugins.rules`

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -11,4 +11,6 @@ sphinx>=4,<5
 # specify exact autoprogram version because the new (in 2021) maintainer
 # showed that they will indeed make major changes in patch versions
 sphinxcontrib-autoprogram==0.1.7
+# necessary for things like plugins.rules.TypedRule (a TypeVar) to work properly
+sphinx_autodoc_typehints==1.12.0
 vcrpy<3.0.0

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -29,6 +29,7 @@ from sopel import __version__
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'sphinx_autodoc_typehints',
     'sphinx.ext.autosectionlabel',
     'sphinx.ext.intersphinx',
     'sphinxcontrib.autoprogram',

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -465,7 +465,7 @@ class AbstractRule(abc.ABC):
 
     """
     @classmethod
-    @abc.abstractclassmethod
+    @abc.abstractmethod
     def from_callable(cls: Type[TypedRule], settings, handler) -> TypedRule:
         """Instantiate a rule object from ``settings`` and ``handler``.
 

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -734,7 +734,8 @@ class Rule(AbstractRule):
 
         This classmethod takes the ``handler``'s attributes to generate a map
         of keyword arguments for the class. This can be used by the
-        :meth:`from_callable` classmethod to instantiate a new rule object.
+        classmethod :meth:`~AbstractRule.from_callable` to instantiate a new
+        rule object.
 
         The expected attributes are the ones set by decorators from the
         :mod:`sopel.plugin` module.
@@ -818,12 +819,12 @@ class Rule(AbstractRule):
         :return: an instance of this class created from the ``handler``
         :rtype: :class:`AbstractRule`
 
-        Similar to the :meth:`from_callable` classmethod, it requires a rule
-        handler decorated with :mod:`sopel.plugin`'s decorators.
+        Similar to the :meth:`~AbstractRule.from_callable` classmethod, it
+        requires a rule handler decorated with :mod:`sopel.plugin`'s decorators.
 
-        Unlike the :meth:`from_callable` classmethod, the regexes are not
-        already attached to the handler: its loader functions will be used to
-        get the rule's regexes. See the :func:`sopel.plugin.rule_lazy`
+        Unlike the :meth:`~AbstractRule.from_callable` classmethod, the regexes
+        are not already attached to the handler: its loader functions will be
+        used to get the rule's regexes. See the :func:`sopel.plugin.rule_lazy`
         decorator for more information about the handler and the loaders'
         signatures.
 
@@ -1572,9 +1573,9 @@ class URLCallback(Rule):
         trigger with a third parameter: the ``match`` parameter.
 
         To use this class with an existing URL callback handler, the
-        :meth:`from_callable` classmethod **must** be used: it will wrap the
-        handler to work as intended. In that case, the ``trigger`` and the
-        ``match`` arguments will be the same when the rule executes.
+        :meth:`~AbstractRule.from_callable` classmethod **must** be used: it
+        will wrap the handler to work as intended. In that case, the ``trigger``
+        and the ``match`` arguments will be the same when the rule executes.
 
         This behavior makes the ``match`` parameter obsolete, which will be
         removed in Sopel 9.
@@ -1622,13 +1623,15 @@ class URLCallback(Rule):
         :return: an instance of this class created from the ``handler``
         :rtype: :class:`AbstractRule`
 
-        Similar to the :meth:`from_callable` classmethod, it requires a rule
-        handlers decorated with :mod:`sopel.plugin`'s decorators.
+        Similar to the :meth:`~AbstractRule.from_callable` classmethod, it
+        requires a rule handlers decorated with :mod:`sopel.plugin`'s
+        decorators.
 
-        Unlike the :meth:`from_callable` classmethod, the regexes are not
-        already attached to the handler: its loader functions will be used to
-        get the rule's regexes. See the :func:`sopel.plugin.url_lazy` decorator
-        for more information about the handler and the loaders' signatures.
+        Unlike the :meth:`~AbstractRule.from_callable` classmethod, the regexes
+        are not already attached to the handler: its loader functions will be
+        used to get the rule's regexes. See the :func:`sopel.plugin.url_lazy`
+        decorator for more information about the handler and the loaders'
+        signatures.
 
         .. seealso::
 


### PR DESCRIPTION
### Description
This set of changes resolves a number of warnings generated by Sphinx when building the `plugin/internals.rst` page, all of which came from docstrings in `plugins/rules.py`.

Of the 7 fixed warnings, 6 affect visible content (broken inline method references that will now resolve and render as links).

### Comparison

<details>
<summary>Before (7 warnings)</summary>

```bash
dgw@P-body:~/github/sopel$ make cleandoc
make -C docs clean
make[1]: Entering directory '/home/dgw/github/sopel/docs'
rm -rf build/*
make[1]: Leaving directory '/home/dgw/github/sopel/docs'
make -C docs html
make[1]: Entering directory '/home/dgw/github/sopel/docs'
sphinx-build -b html -d build/doctrees   source build/html
Running Sphinx v4.2.0
making output directory... done
loading intersphinx inventory from https://docs.python.org/3/objects.inv...
loading intersphinx inventory from https://docs.sqlalchemy.org/en/13/objects.inv...
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 20 source files that are out of date
updating environment: [new config] 20 added, 0 changed, 0 removed
Deprecated since 8.0, will be removed in 9.0: sopel.module has been replaced by sopel.plugin
  File "/home/dgw/github/sopel/sopel/module.py", line 46, in <module>
    deprecated(
reading sources... [100%] trigger
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] trigger
/home/dgw/github/sopel/sopel/plugins/rules.py:docstring of sopel.plugins.rules.AbstractRule.from_callable:: WARNING: py:class reference target not found: sopel.plugins.rules.TypedRule
/home/dgw/github/sopel/sopel/plugins/rules.py:docstring of sopel.plugins.rules.Rule.from_callable_lazy:10: WARNING: py:meth reference target not found: from_callable
/home/dgw/github/sopel/sopel/plugins/rules.py:docstring of sopel.plugins.rules.Rule.from_callable_lazy:13: WARNING: py:meth reference target not found: from_callable
/home/dgw/github/sopel/sopel/plugins/rules.py:docstring of sopel.plugins.rules.Rule.kwargs_from_callable:7: WARNING: py:meth reference target not found: from_callable
/home/dgw/github/sopel/sopel/plugins/rules.py:docstring of sopel.plugins.rules.URLCallback:27: WARNING: py:meth reference target not found: from_callable
/home/dgw/github/sopel/sopel/plugins/rules.py:docstring of sopel.plugins.rules.URLCallback.from_callable_lazy:10: WARNING: py:meth reference target not found: from_callable
/home/dgw/github/sopel/sopel/plugins/rules.py:docstring of sopel.plugins.rules.URLCallback.from_callable_lazy:13: WARNING: py:meth reference target not found: from_callable
generating indices... genindex py-modindex done
writing additional pages... search done
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded, 7 warnings.

The HTML pages are in build/html.

Build finished. The HTML pages are in build/html.
make[1]: Leaving directory '/home/dgw/github/sopel/docs'
```

</details>
<details>
<summary>After (0 warnings)</summary>

```bash
dgw@P-body:~/github/sopel$ make cleandoc
make -C docs clean
make[1]: Entering directory '/home/dgw/github/sopel/docs'
rm -rf build/*
make[1]: Leaving directory '/home/dgw/github/sopel/docs'
make -C docs html
make[1]: Entering directory '/home/dgw/github/sopel/docs'
sphinx-build -b html -d build/doctrees   source build/html
Running Sphinx v4.2.0
making output directory... done
loading intersphinx inventory from https://docs.python.org/3/objects.inv...
loading intersphinx inventory from https://docs.sqlalchemy.org/en/13/objects.inv...
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 20 source files that are out of date
updating environment: [new config] 20 added, 0 changed, 0 removed
Deprecated since 8.0, will be removed in 9.0: sopel.module has been replaced by sopel.plugin
  File "/home/dgw/github/sopel/sopel/module.py", line 46, in <module>
    deprecated(
reading sources... [100%] trigger
looking for now-outdated files... none found
pickling environment... done
checking consistency... done
preparing documents... done
writing output... [100%] trigger
generating indices... genindex py-modindex done
writing additional pages... search done
copying static files... done
copying extra files... done
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in build/html.

Build finished. The HTML pages are in build/html.
make[1]: Leaving directory '/home/dgw/github/sopel/docs'
```

</details>

```diff
 checking consistency... done
 preparing documents... done
 writing output... [100%] trigger
-/home/dgw/github/sopel/sopel/plugins/rules.py:docstring of sopel.plugins.rules.AbstractRule.from_callable:: WARNING: py:class reference target not found: sopel.plugins.rules.TypedRule
-/home/dgw/github/sopel/sopel/plugins/rules.py:docstring of sopel.plugins.rules.Rule.from_callable_lazy:10: WARNING: py:meth reference target not found: from_callable
-/home/dgw/github/sopel/sopel/plugins/rules.py:docstring of sopel.plugins.rules.Rule.from_callable_lazy:13: WARNING: py:meth reference target not found: from_callable
-/home/dgw/github/sopel/sopel/plugins/rules.py:docstring of sopel.plugins.rules.Rule.kwargs_from_callable:7: WARNING: py:meth reference target not found: from_callable
-/home/dgw/github/sopel/sopel/plugins/rules.py:docstring of sopel.plugins.rules.URLCallback:27: WARNING: py:meth reference target not found: from_callable
-/home/dgw/github/sopel/sopel/plugins/rules.py:docstring of sopel.plugins.rules.URLCallback.from_callable_lazy:10: WARNING: py:meth reference target not found: from_callable
-/home/dgw/github/sopel/sopel/plugins/rules.py:docstring of sopel.plugins.rules.URLCallback.from_callable_lazy:13: WARNING: py:meth reference target not found: from_callable
 generating indices... genindex py-modindex done
 writing additional pages... search done
 copying static files... done
 copying extra files... done
 dumping search index in English (code: en)... done
 dumping object inventory... done
-build succeeded, 7 warnings.
+build succeeded.

 The HTML pages are in build/html.
```

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches