### PR TITLE
db: add `forget_channel()` and `forget_plugin()` methods

### DIFF
--- a/sopel/db.py
+++ b/sopel/db.py
@@ -724,6 +724,28 @@ class SopelDB:
         finally:
             self.ssession.remove()
 
+    def forget_channel(self, channel):
+        """Remove all of a channel's stored values.
+
+        :param str channel: the name of the channel for which to delete values
+        :raise ~sqlalchemy.exc.SQLAlchemyError: if there is a database error
+
+        .. important::
+
+            This is a Nuclear Option. Be *very* sure that you want to do it.
+
+        """
+        channel = self.get_channel_slug(channel)
+        session = self.ssession()
+        try:
+            session.query(ChannelValues).filter(ChannelValues.channel == channel).delete()
+            session.commit()
+        except SQLAlchemyError:
+            session.rollback()
+            raise
+        finally:
+            self.ssession.remove()
+
     # PLUGIN FUNCTIONS
 
     def set_plugin_value(self, plugin, key, value):
@@ -836,6 +858,28 @@ class SopelDB:
             elif default is not None:
                 result = default
             return _deserialize(result)
+        except SQLAlchemyError:
+            session.rollback()
+            raise
+        finally:
+            self.ssession.remove()
+
+    def forget_plugin(self, plugin):
+        """Remove all of a plugin's stored values.
+
+        :param str plugin: the name of the plugin for which to delete values
+        :raise ~sqlalchemy.exc.SQLAlchemyError: if there is a database error
+
+        .. important::
+
+            This is a Nuclear Option. Be *very* sure that you want to do it.
+
+        """
+        plugin = plugin.lower()
+        session = self.ssession()
+        try:
+            session.query(PluginValues).filter(PluginValues.plugin == plugin).delete()
+            session.commit()
         except SQLAlchemyError:
             session.rollback()
             raise

--- a/sopel/db.py
+++ b/sopel/db.py
@@ -12,7 +12,7 @@ from sqlalchemy.exc import OperationalError, SQLAlchemyError
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker
 
-from sopel.tools import Identifier
+from sopel.tools import deprecated, Identifier
 
 
 LOGGER = logging.getLogger(__name__)
@@ -273,7 +273,7 @@ class SopelDB:
 
             Alias/group management functions: :meth:`alias_nick`,
             :meth:`unalias_nick`, :meth:`merge_nick_groups`, and
-            :meth:`delete_nick_group`.
+            :meth:`forget_nick_group`.
 
         """
         session = self.ssession()
@@ -476,7 +476,7 @@ class SopelDB:
 
         .. seealso::
 
-            To delete an entire group, use :meth:`delete_nick_group`.
+            To delete an entire group, use :meth:`forget_nick_group`.
 
             To *add* an alias for a nick, use :meth:`alias_nick`.
 
@@ -498,7 +498,7 @@ class SopelDB:
         finally:
             self.ssession.remove()
 
-    def delete_nick_group(self, nick):
+    def forget_nick_group(self, nick):
         """Remove a nickname, all of its aliases, and all of its stored values.
 
         :param str nick: one of the nicknames in the group to be deleted
@@ -522,6 +522,14 @@ class SopelDB:
             raise
         finally:
             self.ssession.remove()
+
+    @deprecated(
+        version='8.0',
+        removed_in='9.0',
+        reason="Renamed to `forget_nick_group`",
+    )
+    def delete_nick_group(self, nick):  # pragma: nocover
+        self.forget_nick_group(nick)
 
     def merge_nick_groups(self, first_nick, second_nick):
         """Merge two nick groups.

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -183,7 +183,7 @@ def test_unalias_nick(db):
     session.close()
 
 
-def test_delete_nick_group(db):
+def test_forget_nick_group(db):
     session = db.ssession()
     aliases = ['Embolalia', 'Embo']
     nick_id = 42
@@ -195,7 +195,7 @@ def test_delete_nick_group(db):
     db.set_nick_value(aliases[0], 'foo', 'bar')
     db.set_nick_value(aliases[1], 'spam', 'eggs')
 
-    db.delete_nick_group(aliases[0])
+    db.forget_nick_group(aliases[0])
 
     # Nothing else has created values, so we know the tables are empty
     nicks = session.query(Nicknames).all()

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -266,6 +266,16 @@ def test_get_channel_value(db):
     session.close()
 
 
+def test_forget_channel(db):
+    db.set_channel_value('#testchan', 'wasd', 'uldr')
+    db.set_channel_value('#testchan', 'asdf', 'hjkl')
+    assert db.get_channel_value('#testchan', 'wasd') == 'uldr'
+    assert db.get_channel_value('#testchan', 'asdf') == 'hjkl'
+    db.forget_channel('#testchan')
+    assert db.get_channel_value('#testchan', 'wasd') is None
+    assert db.get_channel_value('#testchan', 'asdf') is None
+
+
 def test_get_channel_value_default(db):
     assert db.get_channel_value("TestChan", "DoesntExist") is None
     assert db.get_channel_value("TestChan", "DoesntExist", "MyDefault") == "MyDefault"
@@ -325,3 +335,13 @@ def test_delete_plugin_value(db):
     assert db.get_plugin_value('plugin', 'wasd') == 'uldr'
     db.delete_plugin_value('plugin', 'wasd')
     assert db.get_plugin_value('plugin', 'wasd') is None
+
+
+def test_forget_plugin(db):
+    db.set_plugin_value('plugin', 'wasd', 'uldr')
+    db.set_plugin_value('plugin', 'asdf', 'hjkl')
+    assert db.get_plugin_value('plugin', 'wasd') == 'uldr'
+    assert db.get_plugin_value('plugin', 'asdf') == 'hjkl'
+    db.forget_plugin('plugin')
+    assert db.get_plugin_value('plugin', 'wasd') is None
+    assert db.get_plugin_value('plugin', 'asdf') is None


### PR DESCRIPTION
### Description
Tin, really. Up to now it's been possible to delete a _user_ (nick group) from the database, but not possible to forget about a channel or plugin without manually writing SQL for `db.execute()`. Seemed like deletion of value groupings should be as parallel as possible, just like management of individual values is between the three types.

I see these as most useful for cleaning up channels that the bot is leaving permanently, or for plugin authors to add graceful "uninstall preparation" features to clean up whatever detritus the plugin has left in the database.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
There's a deprecation & rename in here too, moving `delete_nick_group()` to `forget_nick_group()`, but I kept it in a separate commit so it's easy to drop if that seems like a bad idea to the rest of y'all.

I'm continuing to try and think of other useful cases that aren't covered by the existing database functions. Might follow up with methods to delete a given key from all nicks/channels. That also applies to the "I'm about to uninstall a plugin forever" situation.