### PR TITLE
sopel: drop support for Python 3.6 and require 3.7+

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.6
           - 3.7
           - 3.8
           - 3.9

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ First, either clone the repository with ``git clone
 git://github.com/sopel-irc/sopel.git`` or download a tarball `from GitHub
 <https://github.com/sopel-irc/sopel/releases/latest>`_.
 
-Note: Sopel requires Python 3.6+ to run.
+Note: Sopel requires Python 3.7+ to run.
 
 In the source directory (whether cloned or from the tarball) run ``pip install
 -e .``. You can then run ``sopel`` to configure and start the bot.

--- a/pytest_run.py
+++ b/pytest_run.py
@@ -10,7 +10,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 if __name__ == "__main__":
     import sys

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,14 +16,13 @@ classifiers =
     License :: Eiffel Forum License (EFL)
     License :: OSI Approved :: Eiffel Forum License
     Operating System :: POSIX :: Linux
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Topic :: Communications :: Chat :: Internet Relay Chat
 
 [options]
-python_requires = >=3.6, <4
+python_requires = >=3.7, <4
 packages = find:
 zip_safe = false
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,12 +49,10 @@ ignore =
     # These are forbidding certain __future__ imports. The future-import plugin
     # has errors both for having and not having them; we want to have these until
     # Sopel no longer supports Python versions that require them.
-    FI55,
+    FI58,
     # These would require future imports that are not needed any more on Sopel's
-    # oldest supported Python version (3.6).
-    FI10,FI11,FI12,FI13,FI14,FI16,FI17,
-    # Ignore "annotations" future import, since it's not available before 3.7
-    FI18
+    # oldest supported Python version (3.7).
+    FI10,FI11,FI12,FI13,FI14,FI15,FI16,FI17,
 exclude =
     docs/*,
     env/*,

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python
-from __future__ import generator_stop
+from __future__ import annotations
 
 import sys
 

--- a/setup.py
+++ b/setup.py
@@ -33,15 +33,15 @@ else:
 
 # We check Python's version ourselves in case someone installed Sopel on an
 # old version of pip (<9.0.0), which doesn't know about `python_requires`.
-if sys.version_info < (3, 6):
-    # Maybe not the best way to do this, but this question is tiring.
-    raise ImportError('Sopel requires Python 3.6+.')
-
-# Py3.6 EOL: https://www.python.org/dev/peps/pep-0494/#lifespan
 if sys.version_info < (3, 7):
+    # Maybe not the best way to do this, but this question is tiring.
+    raise ImportError('Sopel requires Python 3.7+.')
+
+# Py3.7 EOL: https://www.python.org/dev/peps/pep-0537/#and-beyond-schedule
+if sys.version_info < (3, 8):
     # TODO check this warning before releasing Sopel 8.0
     print(
-        'Warning: Python 3.6 will reach end of life by the end of 2021 '
+        'Warning: Python 3.7 will reach end of life by June 2022 '
         'and will receive no further updates. '
         'Sopel 9.0 will drop support for it.',
         file=sys.stderr,

--- a/sopel.py
+++ b/sopel.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-from __future__ import generator_stop
+from __future__ import annotations
 
 import sys
 

--- a/sopel/__init__.py
+++ b/sopel/__init__.py
@@ -9,7 +9,7 @@
 #
 # Licensed under the Eiffel Forum License 2.
 
-from __future__ import generator_stop
+from __future__ import annotations
 
 from collections import namedtuple
 import locale

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -5,7 +5,7 @@
 #
 # Licensed under the Eiffel Forum License 2.
 
-from __future__ import generator_stop
+from __future__ import annotations
 
 from ast import literal_eval
 from datetime import datetime

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -1157,8 +1157,8 @@ class Sopel(irc.AbstractBot):
             The Python documentation for the `re.search`__ function and
             the `match object`__.
 
-        .. __: https://docs.python.org/3.6/library/re.html#re.search
-        .. __: https://docs.python.org/3.6/library/re.html#match-objects
+        .. __: https://docs.python.org/3.7/library/re.html#re.search
+        .. __: https://docs.python.org/3.7/library/re.html#match-objects
 
         """
         for regex, function in self._url_callbacks.items():

--- a/sopel/cli/__init__.py
+++ b/sopel/cli/__init__.py
@@ -1,4 +1,4 @@
-from __future__ import generator_stop
+from __future__ import annotations
 
 # Shortcut imports
 from .utils import (  # noqa

--- a/sopel/cli/config.py
+++ b/sopel/cli/config.py
@@ -1,5 +1,5 @@
 """Sopel Config Command Line Interface (CLI): ``sopel-config``"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import argparse
 import os

--- a/sopel/cli/plugins.py
+++ b/sopel/cli/plugins.py
@@ -1,5 +1,5 @@
 """Sopel Plugins Command Line Interface (CLI): ``sopel-plugins``"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import argparse
 import inspect

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import argparse
 import logging

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -22,15 +22,15 @@ from . import utils
 # This is in case someone somehow manages to install Sopel on an old version
 # of pip (<9.0.0), which doesn't know about `python_requires`, or tries to run
 # from source on an unsupported version of Python.
-if sys.version_info < (3, 6):
-    tools.stderr('Error: Sopel requires Python 3.6+.')
+if sys.version_info < (3, 7):
+    tools.stderr('Error: Sopel requires Python 3.7+.')
     sys.exit(1)
 
-# Py3.6 EOL: https://www.python.org/dev/peps/pep-0494/#lifespan
-if sys.version_info < (3, 7):
+# Py3.7 EOL: https://www.python.org/dev/peps/pep-0537/#and-beyond-schedule
+if sys.version_info < (3, 8):
     # TODO check this warning before releasing Sopel 8.0
     print(
-        'Warning: Python 3.6 will reach end of life by the end of 2021 '
+        'Warning: Python 3.7 will reach end of life by June 2022 '
         'and will receive no further updates. '
         'Sopel 9.0 will drop support for it.',
         file=sys.stderr,

--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -1,4 +1,4 @@
-from __future__ import generator_stop
+from __future__ import annotations
 
 import inspect
 import logging

--- a/sopel/config/__init__.py
+++ b/sopel/config/__init__.py
@@ -47,7 +47,7 @@ the :class:`Config` object is instantiated; it uses
 # Copyright © 2012, Elad Alfassa <elad@fedoraproject.org>
 # Licensed under the Eiffel Forum License 2.
 
-from __future__ import generator_stop
+from __future__ import annotations
 
 import configparser
 import os

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -1,4 +1,4 @@
-from __future__ import generator_stop
+from __future__ import annotations
 
 import os.path
 

--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -23,7 +23,7 @@ As an example, if one wanted to define the ``[spam]`` section as having an
     ValueError: ListAttribute value must be a list.
 """
 
-from __future__ import generator_stop
+from __future__ import annotations
 
 import abc
 import getpass

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -20,7 +20,7 @@ dispatch function in :class:`sopel.bot.Sopel` and making it easier to maintain.
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import generator_stop
+from __future__ import annotations
 
 import base64
 import collections

--- a/sopel/db.py
+++ b/sopel/db.py
@@ -1,4 +1,4 @@
-from __future__ import generator_stop
+from __future__ import annotations
 
 import errno
 import json

--- a/sopel/formatting.py
+++ b/sopel/formatting.py
@@ -5,7 +5,7 @@
 # Copyright 2014, Elsie Powell, embolalia.com
 # Copyright 2019, dgw, technobabbl.es
 # Licensed under the Eiffel Forum License 2.
-from __future__ import generator_stop
+from __future__ import annotations
 
 from enum import Enum
 import re

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -22,7 +22,7 @@ who should worry about :class:`sopel.bot.Sopel` only.
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import generator_stop
+from __future__ import annotations
 
 import abc
 from datetime import datetime

--- a/sopel/irc/abstract_backends.py
+++ b/sopel/irc/abstract_backends.py
@@ -1,7 +1,7 @@
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import generator_stop
+from __future__ import annotations
 
 import abc
 

--- a/sopel/irc/backends.py
+++ b/sopel/irc/backends.py
@@ -3,7 +3,7 @@
 # Licensed under the Eiffel Forum License 2.
 # When working on core IRC protocol related features, consult protocol
 # documentation at http://www.irchelp.org/irchelp/rfc/
-from __future__ import generator_stop
+from __future__ import annotations
 
 import asynchat
 import asyncore

--- a/sopel/irc/isupport.py
+++ b/sopel/irc/isupport.py
@@ -11,7 +11,7 @@ When a server wants to advertise its features and settings, it can use the
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import generator_stop
+from __future__ import annotations
 
 from collections import OrderedDict
 import functools

--- a/sopel/irc/modes.py
+++ b/sopel/irc/modes.py
@@ -23,7 +23,7 @@ than how Sopel knows about them.
 
 .. versionadded:: 8.0
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import enum
 import logging

--- a/sopel/irc/utils.py
+++ b/sopel/irc/utils.py
@@ -1,7 +1,7 @@
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import generator_stop
+from __future__ import annotations
 
 from typing import NamedTuple
 

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -9,7 +9,7 @@
     Do **not** build your plugin based on what is here, you do **not** need to.
 
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import inspect
 import logging

--- a/sopel/logger.py
+++ b/sopel/logger.py
@@ -1,4 +1,4 @@
-from __future__ import generator_stop
+from __future__ import annotations
 
 import logging
 from logging.config import dictConfig

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -5,7 +5,7 @@
     Use :mod:`sopel.plugin` instead. This will be removed in Sopel 9.
 
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 # Import everything from sopel.plugin at the time of replacement.
 # Everything new from this point on must *not* leak here.

--- a/sopel/modules/__init__.py
+++ b/sopel/modules/__init__.py
@@ -1,1 +1,1 @@
-from __future__ import generator_stop
+from __future__ import annotations

--- a/sopel/modules/admin.py
+++ b/sopel/modules/admin.py
@@ -9,7 +9,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import logging
 

--- a/sopel/modules/adminchannel.py
+++ b/sopel/modules/adminchannel.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import re
 

--- a/sopel/modules/announce.py
+++ b/sopel/modules/announce.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import itertools
 

--- a/sopel/modules/bugzilla.py
+++ b/sopel/modules/bugzilla.py
@@ -5,7 +5,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import logging
 import re

--- a/sopel/modules/calc.py
+++ b/sopel/modules/calc.py
@@ -5,7 +5,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 from sopel import plugin
 from sopel.tools.calculation import eval_equation

--- a/sopel/modules/choose.py
+++ b/sopel/modules/choose.py
@@ -8,7 +8,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import random
 import unicodedata

--- a/sopel/modules/clock.py
+++ b/sopel/modules/clock.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 from sopel import plugin, tools
 from sopel.tools.time import (

--- a/sopel/modules/countdown.py
+++ b/sopel/modules/countdown.py
@@ -5,7 +5,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import datetime
 

--- a/sopel/modules/currency.py
+++ b/sopel/modules/currency.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import logging
 import re

--- a/sopel/modules/dice.py
+++ b/sopel/modules/dice.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import operator
 import random

--- a/sopel/modules/emoticons.py
+++ b/sopel/modules/emoticons.py
@@ -5,7 +5,7 @@ Licensed under the Eiffel Forum License 2
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 from sopel import plugin
 

--- a/sopel/modules/find.py
+++ b/sopel/modules/find.py
@@ -11,7 +11,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 from collections import deque
 import re

--- a/sopel/modules/find_updates.py
+++ b/sopel/modules/find_updates.py
@@ -8,7 +8,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import json
 

--- a/sopel/modules/find_updates.py
+++ b/sopel/modules/find_updates.py
@@ -10,6 +10,8 @@ https://sopel.chat
 """
 from __future__ import generator_stop
 
+import json
+
 import requests
 
 from sopel import (
@@ -64,8 +66,7 @@ def check_version(bot):
     try:
         if success:
             info = r.json()
-    except ValueError:
-        # TODO: use JSONDecodeError when dropping Pythons < 3.5
+    except json.JSONDecodeError:
         _check_failed(bot)
         success = False
 

--- a/sopel/modules/help.py
+++ b/sopel/modules/help.py
@@ -9,7 +9,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import collections
 import logging

--- a/sopel/modules/invite.py
+++ b/sopel/modules/invite.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 from sopel import plugin, tools
 

--- a/sopel/modules/ip.py
+++ b/sopel/modules/ip.py
@@ -7,7 +7,7 @@ Licensed under the Eiffel Forum License 2.
 https://sopel.chat
 """
 
-from __future__ import generator_stop
+from __future__ import annotations
 
 import logging
 import os

--- a/sopel/modules/isup.py
+++ b/sopel/modules/isup.py
@@ -5,7 +5,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import requests
 

--- a/sopel/modules/lmgtfy.py
+++ b/sopel/modules/lmgtfy.py
@@ -5,7 +5,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat/
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 from urllib.parse import urlencode
 

--- a/sopel/modules/meetbot.py
+++ b/sopel/modules/meetbot.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import codecs
 import collections

--- a/sopel/modules/ping.py
+++ b/sopel/modules/ping.py
@@ -4,7 +4,7 @@ Copyright 2008 (?), Sean B. Palmer, inamidst.com
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import random
 

--- a/sopel/modules/pronouns.py
+++ b/sopel/modules/pronouns.py
@@ -5,7 +5,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 from sopel import plugin
 

--- a/sopel/modules/py.py
+++ b/sopel/modules/py.py
@@ -5,7 +5,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 from requests import get
 

--- a/sopel/modules/rand.py
+++ b/sopel/modules/rand.py
@@ -5,7 +5,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import random
 import sys

--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -7,7 +7,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import datetime as dt
 import html

--- a/sopel/modules/reload.py
+++ b/sopel/modules/reload.py
@@ -5,7 +5,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import logging
 import subprocess

--- a/sopel/modules/remind.py
+++ b/sopel/modules/remind.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import collections
 from datetime import datetime

--- a/sopel/modules/safety.py
+++ b/sopel/modules/safety.py
@@ -5,7 +5,7 @@ Licensed under the Eiffel Forum License 2.
 
 This plugin uses virustotal.com
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import json
 import logging

--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import re
 

--- a/sopel/modules/seen.py
+++ b/sopel/modules/seen.py
@@ -7,7 +7,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import datetime
 import time

--- a/sopel/modules/tell.py
+++ b/sopel/modules/tell.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 from collections import defaultdict
 import io  # don't use `codecs` for loading the DB; it will split lines on some IRC formatting

--- a/sopel/modules/tld.py
+++ b/sopel/modules/tld.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 from datetime import datetime
 from encodings import idna

--- a/sopel/modules/translate.py
+++ b/sopel/modules/translate.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import json
 import logging

--- a/sopel/modules/unicode_info.py
+++ b/sopel/modules/unicode_info.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import unicodedata
 

--- a/sopel/modules/units.py
+++ b/sopel/modules/units.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import re
 

--- a/sopel/modules/uptime.py
+++ b/sopel/modules/uptime.py
@@ -5,7 +5,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import datetime
 

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -8,7 +8,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import ipaddress
 import logging

--- a/sopel/modules/version.py
+++ b/sopel/modules/version.py
@@ -6,7 +6,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import datetime
 import os

--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -5,7 +5,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 from html.parser import HTMLParser
 import re

--- a/sopel/modules/wiktionary.py
+++ b/sopel/modules/wiktionary.py
@@ -5,7 +5,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import re
 

--- a/sopel/modules/xkcd.py
+++ b/sopel/modules/xkcd.py
@@ -7,7 +7,7 @@ Licensed under the Eiffel Forum License 2.
 
 https://sopel.chat
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import random
 import re

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -7,7 +7,7 @@
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 # Licensed under the Eiffel Forum License 2.
 
-from __future__ import generator_stop
+from __future__ import annotations
 
 import functools
 import re

--- a/sopel/plugins/__init__.py
+++ b/sopel/plugins/__init__.py
@@ -26,7 +26,7 @@ exist for each type of plugin.
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import generator_stop
+from __future__ import annotations
 
 import collections
 import imp

--- a/sopel/plugins/exceptions.py
+++ b/sopel/plugins/exceptions.py
@@ -2,7 +2,7 @@
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import generator_stop
+from __future__ import annotations
 
 
 class PluginError(Exception):

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -41,7 +41,7 @@ away from the rest of the application.
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import generator_stop
+from __future__ import annotations
 
 import abc
 import imp

--- a/sopel/plugins/jobs.py
+++ b/sopel/plugins/jobs.py
@@ -14,7 +14,7 @@
 # Copyright 2020, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import generator_stop
+from __future__ import annotations
 
 import itertools
 import logging

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -14,7 +14,7 @@
 # Copyright 2020, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import generator_stop
+from __future__ import annotations
 
 import abc
 import datetime

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -606,7 +606,7 @@ class AbstractRule(abc.ABC):
 
         This method must return a list of `match objects`__.
 
-        .. __: https://docs.python.org/3.6/library/re.html#match-objects
+        .. __: https://docs.python.org/3.7/library/re.html#match-objects
         """
 
     @abc.abstractmethod
@@ -685,7 +685,7 @@ class AbstractRule(abc.ABC):
         :return: yield a list of match object
         :rtype: generator of `re.match`__
 
-        .. __: https://docs.python.org/3.6/library/re.html#match-objects
+        .. __: https://docs.python.org/3.7/library/re.html#match-objects
         """
 
     @abc.abstractmethod

--- a/sopel/privileges.py
+++ b/sopel/privileges.py
@@ -53,7 +53,7 @@ This allows to use comparators and bitwise operators to compare privileges::
 
 In that case, ``priv`` contains both VOICE and OP privileges, but not HALFOP.
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 
 VOICE = 1

--- a/sopel/tests/__init__.py
+++ b/sopel/tests/__init__.py
@@ -2,7 +2,7 @@
 
 .. versionadded:: 7.0
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 
 def rawlist(*args):

--- a/sopel/tests/factories.py
+++ b/sopel/tests/factories.py
@@ -2,7 +2,7 @@
 
 .. versionadded:: 7.0
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import re
 

--- a/sopel/tests/mocks.py
+++ b/sopel/tests/mocks.py
@@ -2,7 +2,7 @@
 
 .. versionadded:: 7.0
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 
 from sopel.irc.abstract_backends import AbstractIRCBackend

--- a/sopel/tests/pytest_plugin.py
+++ b/sopel/tests/pytest_plugin.py
@@ -2,7 +2,7 @@
 
 .. versionadded:: 7.0
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import re
 import sys

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -11,7 +11,7 @@
 
 # https://sopel.chat
 
-from __future__ import generator_stop
+from __future__ import annotations
 
 import codecs
 from collections import defaultdict

--- a/sopel/tools/_events.py
+++ b/sopel/tools/_events.py
@@ -1,4 +1,4 @@
-from __future__ import generator_stop
+from __future__ import annotations
 
 from enum import Enum
 

--- a/sopel/tools/calculation.py
+++ b/sopel/tools/calculation.py
@@ -1,5 +1,5 @@
 """Tools to help safely do calculations from user input"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import ast
 import numbers

--- a/sopel/tools/jobs.py
+++ b/sopel/tools/jobs.py
@@ -11,7 +11,7 @@
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-from __future__ import generator_stop
+from __future__ import annotations
 
 import inspect
 import logging

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -1,4 +1,4 @@
-from __future__ import generator_stop
+from __future__ import annotations
 
 import functools
 

--- a/sopel/tools/time.py
+++ b/sopel/tools/time.py
@@ -1,5 +1,5 @@
 """Tools for getting and displaying the time."""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import datetime
 

--- a/sopel/tools/web.py
+++ b/sopel/tools/web.py
@@ -11,7 +11,7 @@ applications, APIs, or websites in your plugins.
 # Copyright © 2019, dgw, technobabbl.es
 # Licensed under the Eiffel Forum License 2.
 
-from __future__ import generator_stop
+from __future__ import annotations
 
 import html
 from html.entities import name2codepoint

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -1,5 +1,5 @@
 """Triggers are how Sopel tells callables about their runtime context."""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import datetime
 import re

--- a/test/cli/test_cli_run.py
+++ b/test/cli/test_cli_run.py
@@ -1,5 +1,5 @@
 """Tests for command handling"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import argparse
 from contextlib import contextmanager

--- a/test/cli/test_cli_utils.py
+++ b/test/cli/test_cli_utils.py
@@ -1,5 +1,5 @@
 """Tests for sopel.cli.utils"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import argparse
 from contextlib import contextmanager

--- a/test/config/test_config_types.py
+++ b/test/config/test_config_types.py
@@ -1,4 +1,4 @@
-from __future__ import generator_stop
+from __future__ import annotations
 
 import os
 

--- a/test/irc/test_irc_abstract_backends.py
+++ b/test/irc/test_irc_abstract_backends.py
@@ -1,5 +1,5 @@
 """Tests for core ``sopel.irc.backends``"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 
 from sopel.tests.mocks import MockIRCBackend

--- a/test/irc/test_irc_isupport.py
+++ b/test/irc/test_irc_isupport.py
@@ -1,5 +1,5 @@
 """Tests for core ``sopel.irc.isupport``"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 from collections import OrderedDict
 

--- a/test/irc/test_irc_modes.py
+++ b/test/irc/test_irc_modes.py
@@ -1,4 +1,4 @@
-from __future__ import generator_stop
+from __future__ import annotations
 
 import pytest
 

--- a/test/irc/test_irc_utils.py
+++ b/test/irc/test_irc_utils.py
@@ -1,5 +1,5 @@
 """Tests for core ``sopel.irc.utils``"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import pytest
 

--- a/test/modules/test_modules_adminchannel.py
+++ b/test/modules/test_modules_adminchannel.py
@@ -1,5 +1,5 @@
 """Tests for Sopel's ``adminchannel`` plugin"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import pytest
 

--- a/test/modules/test_modules_announce.py
+++ b/test/modules/test_modules_announce.py
@@ -1,5 +1,5 @@
 """Tests for Sopel's ``announce`` plugin"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 from sopel.modules import announce
 

--- a/test/modules/test_modules_choose.py
+++ b/test/modules/test_modules_choose.py
@@ -1,5 +1,5 @@
 """Tests for Sopel's ``choose`` plugin"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import pytest
 

--- a/test/modules/test_modules_find_updates.py
+++ b/test/modules/test_modules_find_updates.py
@@ -1,5 +1,5 @@
 """Tests for Sopel's ``find_updates`` plugin"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import pytest
 import requests.exceptions

--- a/test/modules/test_modules_isup.py
+++ b/test/modules/test_modules_isup.py
@@ -1,5 +1,5 @@
 """Tests for Sopel's ``isup`` plugin"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import pytest
 import requests.exceptions

--- a/test/modules/test_modules_reddit.py
+++ b/test/modules/test_modules_reddit.py
@@ -1,5 +1,5 @@
 """Tests for Sopel's ``reddit`` plugin"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import pytest
 

--- a/test/modules/test_modules_remind.py
+++ b/test/modules/test_modules_remind.py
@@ -1,5 +1,5 @@
 """Tests for Sopel's ``remind`` plugin"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 from datetime import datetime
 import os

--- a/test/modules/test_modules_tell.py
+++ b/test/modules/test_modules_tell.py
@@ -1,5 +1,5 @@
 """Tests for Sopel's ``tell`` plugin"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import datetime
 import io

--- a/test/modules/test_modules_url.py
+++ b/test/modules/test_modules_url.py
@@ -1,5 +1,5 @@
 """Tests for Sopel's ``url`` plugin"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import re
 

--- a/test/plugins/test_plugins_handlers.py
+++ b/test/plugins/test_plugins_handlers.py
@@ -1,5 +1,5 @@
 """Tests for the ``sopel.plugins.handlers`` module."""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import os
 import sys

--- a/test/plugins/test_plugins_rules.py
+++ b/test/plugins/test_plugins_rules.py
@@ -1,5 +1,5 @@
 """Tests for the ``sopel.plugins.rules`` module."""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import re
 

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -1,5 +1,5 @@
 """Tests for core ``sopel.bot`` module"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 from datetime import datetime, timezone
 import re
@@ -19,7 +19,7 @@ nick = TestBot
 enable = coretasks
 """
 
-MOCK_MODULE_CONTENT = """from __future__ import generator_stop
+MOCK_MODULE_CONTENT = """from __future__ import annotations
 from sopel import plugin
 
 

--- a/test/test_config.py
+++ b/test/test_config.py
@@ -1,4 +1,4 @@
-from __future__ import generator_stop
+from __future__ import annotations
 
 import os
 

--- a/test/test_coretasks.py
+++ b/test/test_coretasks.py
@@ -1,5 +1,5 @@
 """coretasks.py tests"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 from datetime import datetime, timezone
 

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -3,7 +3,7 @@
 TODO: Most of these tests assume functionality tested in other tests. This is
 enough to get everything working (and is better than nothing), but best
 practice would probably be not to do that."""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import json
 import os

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -1,5 +1,5 @@
 """Tests for message formatting"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import pytest
 

--- a/test/test_irc.py
+++ b/test/test_irc.py
@@ -1,5 +1,5 @@
 """Tests for core ``sopel.irc``"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import pytest
 

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -1,5 +1,5 @@
 """Tests for the ``sopel.loader`` module."""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import inspect
 import re
@@ -9,7 +9,7 @@ import pytest
 from sopel import loader, plugin, plugins
 
 
-MOCK_MODULE_CONTENT = """from __future__ import generator_stop
+MOCK_MODULE_CONTENT = """from __future__ import annotations
 import re
 
 from sopel import plugin

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -6,7 +6,7 @@
     compatible up to Sopel 9, when it will be removed.
 
 """
-from __future__ import generator_stop
+from __future__ import annotations
 
 import pytest
 

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -1,5 +1,5 @@
 """Tests for sopel.plugin decorators"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 from sopel import plugin
 from sopel.tests import rawlist

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -1,5 +1,5 @@
 """Test for the ``sopel.plugins`` module."""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import sys
 
@@ -9,7 +9,7 @@ import pytest
 from sopel import plugins
 
 
-MOCK_MODULE_CONTENT = """from __future__ import generator_stop
+MOCK_MODULE_CONTENT = """from __future__ import annotations
 from sopel import plugin
 
 

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -1,5 +1,5 @@
 """Tests sopel.tools"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import re
 

--- a/test/test_trigger.py
+++ b/test/test_trigger.py
@@ -1,5 +1,5 @@
 """Tests for message parsing"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import datetime
 import re

--- a/test/tests/test_tests_mocks.py
+++ b/test/tests/test_tests_mocks.py
@@ -1,5 +1,5 @@
 """Tests for ``sopel.tests.mocks`` module"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 from sopel.tests.mocks import MockIRCBackend
 

--- a/test/tools/test_tools_jobs.py
+++ b/test/tools/test_tools_jobs.py
@@ -1,5 +1,5 @@
 """Tests for Job Scheduler"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import time
 

--- a/test/tools/test_tools_target.py
+++ b/test/tools/test_tools_target.py
@@ -1,5 +1,5 @@
 """Tests for targets: Channel & User"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 from sopel import plugin
 from sopel.tools import Identifier, target

--- a/test/tools/test_tools_time.py
+++ b/test/tools/test_tools_time.py
@@ -1,5 +1,5 @@
 """Tools for getting and displaying the time."""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import datetime
 

--- a/test/tools/test_tools_web.py
+++ b/test/tools/test_tools_web.py
@@ -1,5 +1,5 @@
 """Tests Sopel's web tools"""
-from __future__ import generator_stop
+from __future__ import annotations
 
 import pytest
 


### PR DESCRIPTION
### Description

Tin. Python 3.6 died yesterday. I checked the warning for 3.6, they were written for Sopel 8, so we can either keep 3.6 or drop it now. Either way, this is not a big change, unlike Python 2.

I haven't modified the usage of `OrderedDict`, because there are slight difference between `dict` and `OrderedDict` in particular when considering equality. 

I haven't check the "future" import either, hence the "draft" status for now.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
