### PR TITLE
tools: deprecate more Python 2-like shims

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -9,6 +9,7 @@ sopel.tools
 
 .. automodule:: sopel.tools
    :members:
+   :exclude-members: iteritems, iterkeys, itervalues, raw_input
    :private-members: Identifier._lower, Identifier._lower_swapped
 
 sopel.tools.web

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -31,13 +31,6 @@ from sopel import __version__
 from ._events import events  # NOQA
 
 
-# Kept for backward compatibility
-# TODO: consider removing that
-raw_input = input
-iteritems = dict.items
-itervalues = dict.values
-iterkeys = dict.keys
-
 _channel_prefixes = ('#', '&', '+', '!')
 
 # Can be implementation-dependent
@@ -203,6 +196,29 @@ def deprecated(
 # attribute 'deprecated' (most likely due to a circular import)" when trying
 # to use the decorator in submodules.
 from . import time, web  # NOQA
+
+
+# Long kept for Python compatibility, but it's time we let these go.
+raw_input = deprecated(  # pragma: no cover
+    'Use the `input` function directly.',
+    version='8.0',
+    removed_in='8.1',
+    func=input)
+iteritems = deprecated(  # pragma: no cover
+    "Use the dict object's `.items()` method directly.",
+    version='8.0',
+    removed_in='8.1',
+    func=dict.items)
+itervalues = deprecated(  # pragma: no cover
+    "Use the dict object's `.values()` method directly.",
+    version='8.0',
+    removed_in='8.1',
+    func=dict.values)
+iterkeys = deprecated(  # pragma: no cover
+    "Use the dict object's `.keys()` method directly.",
+    version='8.0',
+    removed_in='8.1',
+    func=dict.keys)
 
 
 @deprecated('Shim for Python 2 cross-compatibility, no longer needed. '


### PR DESCRIPTION
### Description
These four functions were for backward compatibility, as they all stand in for features removed in Python 3. Sopel no longer supports Python 2, and it's long past time for plugin authors to use the correct Python 3 functions instead of these.

Honestly, no one should be using these any more in almost-2022. Think of the deprecation warning(s) as a wake-up call to modernize your code!

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
Excluded the now-deprecated module members from coverage reporting, in an attempt to keep our coverage percentage focused only on code we intend to keep. Also excluded these members from the docs. Compare [deploy preview](https://deploy-preview-2228--sopel-unstable-docs.netlify.app/api.html#sopel.tools.get_sendable_message) to [current unstable](https://unstable.docs.sopel.chat/api.html#sopel.tools.iteritems).