### PR TITLE
irc: implement CASEMAPPING parameter for ISUPPORT

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -17,7 +17,6 @@ sopel.tools.identifiers
 
 .. automodule:: sopel.tools.identifiers
    :members:
-   :private-members: Identifier._lower, Identifier._lower_swapped
 
 
 sopel.tools.web

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -10,7 +10,15 @@ sopel.tools
 .. automodule:: sopel.tools
    :members:
    :exclude-members: iteritems, iterkeys, itervalues, raw_input
+
+
+sopel.tools.identifiers
+-----------------------
+
+.. automodule:: sopel.tools.identifiers
+   :members:
    :private-members: Identifier._lower, Identifier._lower_swapped
+
 
 sopel.tools.web
 ---------------

--- a/docs/source/plugin/bot.rst
+++ b/docs/source/plugin/bot.rst
@@ -23,7 +23,8 @@ second argument::
 
     bot.say('The bot is now talking!', '#private-channel')
 
-Instead of a string, you can use an instance of :class:`sopel.tools.Identifier`.
+Instead of a string, you can use an instance of
+:class:`~sopel.tools.identifiers.Identifier`.
 
 If you want to reply to a user in a private message, you can use the trigger's
 :attr:`~sopel.trigger.Trigger.nick` attribute as destination::
@@ -261,8 +262,8 @@ which provides the following information:
            if not trigger.sender.is_nick():
                # this trigger is from a channel
 
-       See :meth:`Identifier.is_nick() <sopel.tools.Identifier.is_nick>` for
-       more information.
+       See :meth:`Identifier.is_nick() <sopel.tools.identifiers.Identifier.is_nick>`
+       for more information.
 
 Getting users in a channel
 --------------------------

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -84,17 +84,18 @@ class Sopel(irc.AbstractBot):
         self.channels = tools.SopelIdentifierMemory()
         """A map of the channels that Sopel is in.
 
-        The keys are :class:`sopel.tools.Identifier`\\s of the channel names,
-        and map to :class:`sopel.tools.target.Channel` objects which contain
-        the users in the channel and their permissions.
+        The keys are :class:`~sopel.tools.identifiers.Identifier`\\s of the
+        channel names, and map to :class:`~sopel.tools.target.Channel` objects
+        which contain the users in the channel and their permissions.
         """
 
         self.users = tools.SopelIdentifierMemory()
         """A map of the users that Sopel is aware of.
 
-        The keys are :class:`sopel.tools.Identifier`\\s of the nicknames, and
-        map to :class:`sopel.tools.target.User` instances. In order for Sopel
-        to be aware of a user, it must share at least one mutual channel.
+        The keys are :class:`~sopel.tools.identifiers.Identifier`\\s of the
+        nicknames, and map to :class:`~sopel.tools.target.User` instances. In
+        order for Sopel to be aware of a user, it must share at least one
+        mutual channel.
         """
 
         self.db = db.SopelDB(config)
@@ -212,9 +213,10 @@ class Sopel(irc.AbstractBot):
             >>> bot.has_channel_privilege('#chan', plugin.VOICE)
             True
 
-        The ``channel`` argument can be either a :class:`str` or a
-        :class:`sopel.tools.Identifier`, as long as Sopel joined said channel.
-        If the channel is unknown, a :exc:`ValueError` will be raised.
+        The ``channel`` argument can be either a :class:`str` or an
+        :class:`~sopel.tools.identifiers.Identifier`, as long as Sopel joined
+        said channel. If the channel is unknown, a :exc:`ValueError` will be
+        raised.
         """
         if channel not in self.channels:
             raise ValueError('Unknown channel %s' % channel)

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, Iterable, Mapping, Optional, Tuple, Union
 from sopel import db, irc, logger, plugin, plugins, tools
 from sopel.irc import modes
 from sopel.plugins import jobs as plugin_jobs, rules as plugin_rules
-from sopel.tools import deprecated, Identifier, jobs as tools_jobs
+from sopel.tools import deprecated, jobs as tools_jobs
 from sopel.trigger import PreTrigger, Trigger
 
 
@@ -989,7 +989,7 @@ class Sopel(irc.AbstractBot):
             if not bad_nick:
                 continue
             if (re.match(bad_nick + '$', nick, re.IGNORECASE) or
-                    Identifier(bad_nick) == nick):
+                    self.make_identifier(bad_nick) == nick):
                 return True
         return False
 

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -102,7 +102,7 @@ class Sopel(irc.AbstractBot):
         mutual channel.
         """
 
-        self.db = db.SopelDB(config)
+        self.db = db.SopelDB(config, identifier_factory=self.make_identifier)
         """The bot's database, as a :class:`sopel.db.SopelDB` instance."""
 
         self.memory = tools.SopelMemory()

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -81,7 +81,9 @@ class Sopel(irc.AbstractBot):
         self.modeparser = modes.ModeParser()
         """A mode parser used to parse ``MODE`` messages and modestrings."""
 
-        self.channels = tools.SopelIdentifierMemory()
+        self.channels = tools.SopelIdentifierMemory(
+            identifier_factory=self.make_identifier,
+        )
         """A map of the channels that Sopel is in.
 
         The keys are :class:`~sopel.tools.identifiers.Identifier`\\s of the
@@ -89,7 +91,9 @@ class Sopel(irc.AbstractBot):
         which contain the users in the channel and their permissions.
         """
 
-        self.users = tools.SopelIdentifierMemory()
+        self.users = tools.SopelIdentifierMemory(
+            identifier_factory=self.make_identifier,
+        )
         """A map of the users that Sopel is aware of.
 
         The keys are :class:`~sopel.tools.identifiers.Identifier`\\s of the

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -880,7 +880,7 @@ class CoreSection(StaticSection):
     :default: ``Sopel: https://sopel.chat/``
     """
 
-    nick = ValidatedAttribute('nick', Identifier, default=Identifier('Sopel'))
+    nick = ValidatedAttribute('nick', default='Sopel')
     """The nickname for the bot.
 
     :default: ``Sopel``

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -143,7 +143,7 @@ def auth_after_register(bot):
 
     # nickserv-based auth method needs to check for current nick
     if auth_method == 'nickserv':
-        if bot.nick != bot.settings.core.nick:
+        if bot.nick != bot.make_identifier(bot.settings.core.nick):
             LOGGER.warning("Sending nickserv GHOST command.")
             bot.say(
                 'GHOST %s %s' % (bot.settings.core.nick, auth_password),
@@ -844,7 +844,8 @@ def track_quit(bot, trigger):
 
     LOGGER.info("User quit: %s", trigger.nick)
 
-    if trigger.nick == bot.settings.core.nick and trigger.nick != bot.nick:
+    configured_nick = bot.make_identifier(bot.settings.core.nick)
+    if trigger.nick == configured_nick and trigger.nick != bot.nick:
         # old nick is now available, let's change nick again
         bot.change_current_nick(bot.settings.core.nick)
         auth_after_register(bot)

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -484,7 +484,10 @@ def handle_names(bot, trigger):
         return
     channel = bot.make_identifier(channels.group(1))
     if channel not in bot.channels:
-        bot.channels[channel] = target.Channel(channel)
+        bot.channels[channel] = target.Channel(
+            channel,
+            identifier_factory=bot.make_identifier,
+        )
 
     # This could probably be made flexible in the future, but I don't think
     # it'd be worth it.
@@ -795,7 +798,10 @@ def track_join(bot, trigger):
 
     # is it a new channel?
     if channel not in bot.channels:
-        bot.channels[channel] = target.Channel(channel)
+        bot.channels[channel] = target.Channel(
+            channel,
+            identifier_factory=bot.make_identifier,
+        )
 
     # did *we* just join?
     if trigger.nick == bot.nick:
@@ -1386,7 +1392,11 @@ def _record_who(bot, channel, user, host, nick, account=None, away=None, modes=N
         for c in modes:
             priv = priv | mapping[c]
     if channel not in bot.channels:
-        bot.channels[channel] = target.Channel(channel)
+        bot.channels[channel] = target.Channel(
+            channel,
+            identifier_factory=bot.make_identifier,
+        )
+
     bot.channels[channel].add_user(usr, privs=priv)
 
 

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -347,6 +347,7 @@ def handle_isupport(bot, trigger):
     botmode_support = 'BOT' in bot.isupport
     namesx_support = 'NAMESX' in bot.isupport
     uhnames_support = 'UHNAMES' in bot.isupport
+    casemapping_support = 'CASEMAPPING' in bot.isupport
 
     # parse ISUPPORT message from server
     parameters = {}
@@ -366,6 +367,11 @@ def handle_isupport(bot, trigger):
 
     if 'PREFIX' in bot.isupport:
         bot.modeparser.privileges = set(bot.isupport.PREFIX.keys())
+
+    # was CASEMAPPING support status updated?
+    if not casemapping_support and 'CASEMAPPING' in bot.isupport:
+        # Re-create the bot's nick with the proper identifier+casemapping
+        bot.rebuild_nick()
 
     # was BOT mode support status updated?
     if not botmode_support and 'BOT' in bot.isupport:

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -126,14 +126,11 @@ class AbstractBot(abc.ABC):
 
     def make_identifier(self, name: str) -> identifiers.Identifier:
         """Instantiate an Identifier using the bot's context."""
-        casemapping = identifiers.rfc1459_lower
-
-        if 'CASEMAPPING' in self.isupport:
-            casemapping = {
-                'ascii': identifiers.ascii_lower,
-                'rfc1459': identifiers.rfc1459_lower,
-                'rfc1459-strict': identifiers.rfc1459_strict_lower,
-            }.get(self.isupport['CASEMAPPING'], casemapping)
+        casemapping = {
+            'ascii': identifiers.ascii_lower,
+            'rfc1459': identifiers.rfc1459_lower,
+            'rfc1459-strict': identifiers.rfc1459_strict_lower,
+        }.get(self.isupport.get('CASEMAPPING'), identifiers.rfc1459_lower)
 
         return identifiers.Identifier(name, casemapping=casemapping)
 

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -47,7 +47,7 @@ class AbstractBot(abc.ABC):
     """Abstract definition of Sopel's interface."""
     def __init__(self, settings):
         # private properties: access as read-only properties
-        self._nick = tools.Identifier(settings.core.nick)
+        self._nick = self.make_identifier(settings.core.nick)
         self._user = settings.core.user
         self._name = settings.core.name
         self._isupport = ISupport()
@@ -122,6 +122,11 @@ class AbstractBot(abc.ABC):
         """Bot's hostmask."""
 
     # Utility
+
+    def make_identifier(self, name: str) -> tools.Identifier:
+        """Instantiate an Identifier using the bot's context."""
+        # TODO: have a way to tell the Identifier which CASEMAPPING to use
+        return tools.Identifier(name)
 
     def safe_text_length(self, recipient: str) -> int:
         """Estimate a safe text length for an IRC message.
@@ -335,7 +340,7 @@ class AbstractBot(abc.ABC):
 
         :param str new_nick: new nick to be used by the bot
         """
-        self._nick = tools.Identifier(new_nick)
+        self._nick = self.make_identifier(new_nick)
         LOGGER.debug('Sending nick "%s"', self.nick)
         self.backend.send_nick(self.nick)
 
@@ -670,7 +675,7 @@ class AbstractBot(abc.ABC):
         flood_penalty_ratio = self.settings.core.flood_penalty_ratio
 
         with self.sending:
-            recipient_id = tools.Identifier(recipient)
+            recipient_id = self.make_identifier(recipient)
             recipient_stack = self.stack.setdefault(recipient_id, {
                 'messages': [],
                 'flood_left': flood_burst_lines,

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -259,6 +259,7 @@ class AbstractBot(abc.ABC):
             self.nick,
             message,
             url_schemes=self.settings.core.auto_url_schemes,
+            identifier_factory=self.make_identifier,
         )
         if all(cap not in self.enabled_capabilities for cap in ['account-tag', 'extended-join']):
             pretrigger.tags.pop('account', None)
@@ -304,6 +305,7 @@ class AbstractBot(abc.ABC):
                 self.nick,
                 ":{0}!{1}@{2} {3}".format(self.nick, self.user, host, raw),
                 url_schemes=self.settings.core.auto_url_schemes,
+                identifier_factory=self.make_identifier,
             )
             self.dispatch(pretrigger)
 

--- a/sopel/modules/adminchannel.py
+++ b/sopel/modules/adminchannel.py
@@ -112,7 +112,7 @@ def kick(bot, trigger):
         channel = opt
         reasonidx = 3
     reason = ' '.join(text[reasonidx:])
-    if nick != bot.config.core.nick:
+    if nick != bot.make_identifier(bot.config.core.nick):
         bot.kick(nick, channel, reason)
 
 

--- a/sopel/modules/adminchannel.py
+++ b/sopel/modules/adminchannel.py
@@ -10,7 +10,7 @@ from __future__ import generator_stop
 
 import re
 
-from sopel import formatting, plugin, tools
+from sopel import formatting, plugin
 
 
 ERROR_MESSAGE_NOT_OP = "I'm not a channel operator!"
@@ -101,7 +101,7 @@ def kick(bot, trigger):
     argc = len(text)
     if argc < 2:
         return
-    opt = tools.Identifier(text[1])
+    opt = bot.make_identifier(text[1])
     nick = opt
     channel = trigger.sender
     reasonidx = 2
@@ -164,7 +164,7 @@ def ban(bot, trigger):
     argc = len(text)
     if argc < 2:
         return
-    opt = tools.Identifier(text[1])
+    opt = bot.make_identifier(text[1])
     banmask = opt
     channel = trigger.sender
     if not opt.is_nick():
@@ -194,7 +194,7 @@ def unban(bot, trigger):
     argc = len(text)
     if argc < 2:
         return
-    opt = tools.Identifier(text[1])
+    opt = bot.make_identifier(text[1])
     banmask = opt
     channel = trigger.sender
     if not opt.is_nick():
@@ -224,7 +224,7 @@ def quiet(bot, trigger):
     argc = len(text)
     if argc < 2:
         return
-    opt = tools.Identifier(text[1])
+    opt = bot.make_identifier(text[1])
     quietmask = opt
     channel = trigger.sender
     if not opt.is_nick():
@@ -254,7 +254,7 @@ def unquiet(bot, trigger):
     argc = len(text)
     if argc < 2:
         return
-    opt = tools.Identifier(text[1])
+    opt = bot.make_identifier(text[1])
     quietmask = opt
     channel = trigger.sender
     if not opt.is_nick():
@@ -286,7 +286,7 @@ def kickban(bot, trigger):
     argc = len(text)
     if argc < 4:
         return
-    opt = tools.Identifier(text[1])
+    opt = bot.make_identifier(text[1])
     nick = opt
     mask = text[2]
     channel = trigger.sender

--- a/sopel/modules/clock.py
+++ b/sopel/modules/clock.py
@@ -8,7 +8,7 @@ https://sopel.chat
 """
 from __future__ import generator_stop
 
-from sopel import plugin, tools
+from sopel import plugin
 from sopel.tools.time import (
     format_time,
     get_channel_timezone,
@@ -60,7 +60,7 @@ def f_time(bot, trigger):
         # guess if the argument is a nick, a channel, or a timezone
         zone = None
         argument = argument.strip()
-        channel_or_nick = tools.Identifier(argument)
+        channel_or_nick = bot.make_identifier(argument)
 
         # first, try to get nick or channel's timezone
         help_prefix = bot.config.core.help_prefix

--- a/sopel/modules/find.py
+++ b/sopel/modules/find.py
@@ -23,7 +23,9 @@ from sopel.tools import SopelIdentifierMemory
 
 def setup(bot):
     if 'find_lines' not in bot.memory:
-        bot.memory['find_lines'] = SopelIdentifierMemory()
+        bot.memory['find_lines'] = SopelIdentifierMemory(
+            identifier_factory=bot.make_identifier,
+        )
 
 
 def shutdown(bot):
@@ -42,7 +44,9 @@ def collectlines(bot, trigger):
     """Create a temporary log of what people say"""
     # Add a log for the channel and nick, if there isn't already one
     if trigger.sender not in bot.memory['find_lines']:
-        bot.memory['find_lines'][trigger.sender] = SopelIdentifierMemory()
+        bot.memory['find_lines'][trigger.sender] = SopelIdentifierMemory(
+            identifier_factory=bot.make_identifier,
+        )
     if trigger.nick not in bot.memory['find_lines'][trigger.sender]:
         bot.memory['find_lines'][trigger.sender][trigger.nick] = deque(maxlen=10)
 

--- a/sopel/modules/find.py
+++ b/sopel/modules/find.py
@@ -18,7 +18,7 @@ import re
 
 from sopel import plugin
 from sopel.formatting import bold
-from sopel.tools import Identifier, SopelIdentifierMemory
+from sopel.tools import SopelIdentifierMemory
 
 
 def setup(bot):
@@ -102,7 +102,7 @@ def quit_cleanup(bot, trigger):
 @plugin.unblockable
 def kick_cleanup(bot, trigger):
     """Clean up cached data when a user is kicked from a channel."""
-    nick = Identifier(trigger.args[1])
+    nick = bot.make_identifier(trigger.args[1])
     if nick == bot.nick:
         # We got kicked! Nuke the whole channel.
         _cleanup_channel(bot, trigger.sender)
@@ -153,7 +153,7 @@ def findandreplace(bot, trigger):
         return
 
     # Correcting other person vs self.
-    rnick = Identifier(trigger.group('nick') or trigger.nick)
+    rnick = bot.make_identifier(trigger.group('nick') or trigger.nick)
 
     # only do something if there is conversation to work with
     history = bot.memory['find_lines'].get(trigger.sender, {}).get(rnick, None)

--- a/sopel/modules/invite.py
+++ b/sopel/modules/invite.py
@@ -8,7 +8,7 @@ https://sopel.chat
 """
 from __future__ import generator_stop
 
-from sopel import plugin, tools
+from sopel import plugin
 
 
 MIN_PRIV = plugin.HALFOP
@@ -16,9 +16,9 @@ MIN_PRIV = plugin.HALFOP
 
 def invite_handler(bot, sender, user, channel):
     """Common control logic for invite commands received from anywhere."""
-    sender = tools.Identifier(sender)
-    user = tools.Identifier(user)
-    channel = tools.Identifier(channel)
+    sender = bot.make_identifier(sender)
+    user = bot.make_identifier(user)
+    channel = bot.make_identifier(channel)
 
     # Sanity checks, in case someone reuses this function from outside the plugin
     if not sender.is_nick():

--- a/sopel/modules/meetbot.py
+++ b/sopel/modules/meetbot.py
@@ -524,7 +524,7 @@ def take_comment(bot, trigger):
         return
 
     target, message = trigger.group(2).split(None, 1)
-    target = tools.Identifier(target)
+    target = bot.make_identifier(target)
     if not is_meeting_running(target):
         bot.say("There is no active meeting in that channel.")
     else:

--- a/sopel/modules/seen.py
+++ b/sopel/modules/seen.py
@@ -12,7 +12,7 @@ from __future__ import generator_stop
 import datetime
 import time
 
-from sopel import plugin, tools
+from sopel import plugin
 from sopel.tools.time import seconds_to_human
 
 
@@ -44,7 +44,7 @@ def seen(bot, trigger):
     delta = seconds_to_human((trigger.time - saw).total_seconds())
 
     msg = "I last saw " + nick
-    if tools.Identifier(channel) == trigger.sender:
+    if bot.make_identifier(channel) == trigger.sender:
         if action:
             msg += " in here {since}, doing: {nick} {action}".format(
                 since=delta,

--- a/sopel/modules/tell.py
+++ b/sopel/modules/tell.py
@@ -16,7 +16,7 @@ import threading
 import time
 import unicodedata
 
-from sopel import formatting, plugin, tools
+from sopel import formatting, plugin
 from sopel.config import types
 from sopel.tools.time import format_time, get_timezone
 
@@ -186,7 +186,7 @@ def f_remind(bot, trigger):
         bot.reply("%s %s what?" % (verb, tellee))
         return
 
-    tellee = tools.Identifier(tellee)
+    tellee = bot.make_identifier(tellee)
 
     if not os.path.exists(bot.tell_filename):
         return
@@ -202,7 +202,7 @@ def f_remind(bot, trigger):
         bot.reply("I'm here now; you can %s me whatever you want!" % verb)
         return
 
-    if tellee not in (tools.Identifier(teller), bot.nick, 'me'):
+    if tellee not in (bot.make_identifier(teller), bot.nick, 'me'):
         tz = get_timezone(bot.db, bot.config, None, tellee)
         timenow = format_time(bot.db, bot.config, tz, tellee)
         with bot.memory['tell_lock']:
@@ -215,7 +215,7 @@ def f_remind(bot, trigger):
 
         response = "I'll pass that on when %s is around." % tellee
         bot.reply(response)
-    elif tools.Identifier(teller) == tellee:
+    elif bot.make_identifier(teller) == tellee:
         bot.reply('You can %s yourself that.' % verb)
     else:
         bot.reply("Hey, I'm not as stupid as Monty you know!")

--- a/sopel/modules/translate.py
+++ b/sopel/modules/translate.py
@@ -24,7 +24,9 @@ PLUGIN_OUTPUT_PREFIX = '[translate] '
 
 def setup(bot):
     if 'mangle_lines' not in bot.memory:
-        bot.memory['mangle_lines'] = tools.SopelIdentifierMemory()
+        bot.memory['mangle_lines'] = tools.SopelIdentifierMemory(
+            identifier_factory=bot.make_identifier,
+        )
 
 
 def shutdown(bot):

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -130,7 +130,9 @@ def setup(bot):
 
     # Ensure last_seen_url is in memory
     if 'last_seen_url' not in bot.memory:
-        bot.memory['last_seen_url'] = tools.SopelIdentifierMemory()
+        bot.memory['last_seen_url'] = tools.SopelIdentifierMemory(
+            identifier_factory=bot.make_identifier,
+        )
 
     # Initialize shortened_urls as a dict if it doesn't exist.
     if 'shortened_urls' not in bot.memory:

--- a/sopel/tests/factories.py
+++ b/sopel/tests/factories.py
@@ -5,6 +5,7 @@
 from __future__ import generator_stop
 
 import re
+from typing import Iterable, Optional
 
 from sopel import bot, config, plugins, trigger
 from .mocks import MockIRCBackend, MockIRCServer, MockUser
@@ -18,7 +19,11 @@ class BotFactory:
         The :func:`~sopel.tests.pytest_plugin.botfactory` fixture can be used
         to instantiate this factory.
     """
-    def preloaded(self, settings, preloads=None):
+    def preloaded(
+        self,
+        settings: config.Config,
+        preloads: Optional[Iterable[str]] = None,
+    ) -> bot.Sopel:
         """Create a bot and preload its plugins.
 
         :param settings: Sopel's configuration for testing purposes
@@ -56,7 +61,7 @@ class BotFactory:
 
         return mockbot
 
-    def __call__(self, settings):
+    def __call__(self, settings: config.Config) -> bot.Sopel:
         obj = bot.Sopel(settings, daemon=False)
         obj.backend = MockIRCBackend(obj)
         return obj
@@ -73,7 +78,7 @@ class ConfigFactory:
     def __init__(self, tmpdir):
         self.tmpdir = tmpdir
 
-    def __call__(self, name, data):
+    def __call__(self, name: str, data: str) -> config.Config:
         tmpfile = self.tmpdir.join(name)
         tmpfile.write(data)
         return config.Config(tmpfile.strpath)
@@ -87,16 +92,34 @@ class TriggerFactory:
         The :func:`~sopel.tests.pytest_plugin.triggerfactory` fixture can be
         used to instantiate this factory.
     """
-    def wrapper(self, mockbot, raw, pattern=None):
+    def wrapper(
+        self,
+        mockbot: bot.Sopel,
+        raw: str,
+        pattern: Optional[str] = None,
+    ) -> bot.SopelWrapper:
         trigger = self(mockbot, raw, pattern=pattern)
         return bot.SopelWrapper(mockbot, trigger)
 
-    def __call__(self, mockbot, raw, pattern=None):
+    def __call__(
+        self,
+        mockbot: bot.Sopel,
+        raw: str,
+        pattern: Optional[str] = None,
+    ) -> trigger.Trigger:
+        match = re.match(pattern or r'.*', raw)
+        if match is None:
+            raise ValueError(
+                'Cannot create a Trigger without a matching pattern')
+
         url_schemes = mockbot.settings.core.auto_url_schemes
-        return trigger.Trigger(
-            mockbot.settings,
-            trigger.PreTrigger(mockbot.nick, raw, url_schemes=url_schemes),
-            re.match(pattern or r'.*', raw))
+        pretrigger = trigger.PreTrigger(
+            mockbot.nick,
+            raw,
+            url_schemes=url_schemes,
+            identifier_factory=mockbot.make_identifier,
+        )
+        return trigger.Trigger(mockbot.settings, pretrigger, match)
 
 
 class IRCFactory:
@@ -107,7 +130,11 @@ class IRCFactory:
         The :func:`~sopel.tests.pytest_plugin.ircfactory` fixture can be used
         to create this factory.
     """
-    def __call__(self, mockbot, join_threads=True):
+    def __call__(
+        self,
+        mockbot: bot.Sopel,
+        join_threads: bool = True,
+    ) -> MockIRCServer:
         return MockIRCServer(mockbot, join_threads)
 
 
@@ -119,5 +146,10 @@ class UserFactory:
         The :func:`~sopel.tests.pytest_plugin.userfactory` fixture can be used
         to create this factory.
     """
-    def __call__(self, nick=None, user=None, host=None):
+    def __call__(
+        self,
+        nick: Optional[str] = None,
+        user: Optional[str] = None,
+        host: Optional[str] = None,
+    ) -> MockUser:
         return MockUser(nick, user, host)

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -23,6 +23,7 @@ import re
 import sys
 import threading
 import traceback
+from typing import Callable
 
 from pkg_resources import parse_version
 
@@ -31,6 +32,8 @@ from sopel import __version__
 from ._events import events  # NOQA
 from .identifiers import Identifier
 
+
+IdentifierFactory = Callable[[str], Identifier]
 
 # Can be implementation-dependent
 _regex_type = type(re.compile(''))
@@ -508,14 +511,22 @@ class SopelIdentifierMemory(SopelMemory):
 
     .. versionadded:: 7.1
     """
+    def __init__(
+        self,
+        *args,
+        identifier_factory: IdentifierFactory = Identifier,
+    ) -> None:
+        super().__init__(*args)
+        self.make_identifier = identifier_factory
+
     def __getitem__(self, key):
-        return super().__getitem__(Identifier(key))
+        return super().__getitem__(self.make_identifier(key))
 
     def __contains__(self, key):
-        return super().__contains__(Identifier(key))
+        return super().__contains__(self.make_identifier(key))
 
     def __setitem__(self, key, value):
-        super().__setitem__(Identifier(key), value)
+        super().__setitem__(self.make_identifier(key), value)
 
 
 def chain_loaders(*lazy_loaders):

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -501,15 +501,33 @@ class SopelIdentifierMemory(SopelMemory):
     with both ``Identifier`` and :class:`str` objects, taking advantage of the
     case-insensitive behavior of ``Identifier``.
 
+    As it works with :class:`~.identifiers.Identifier`, it accepts an
+    identifier factory. This factory usually comes from a bot instance (see
+    :meth:`bot.make_identifier()<sopel.irc.AbstractBot.make_identifier>`), like
+    in the example of a plugin setup function::
+
+        def setup(bot):
+            bot.memory['my_plugin_storage'] = SopelIdentifierMemory(
+                identifier_factory=bot.make_identifier,
+            )
+
     .. note::
 
-        Internally, it will try to do ``key = tools.Identifier(key)``, which
-        will raise an exception if it cannot instantiate the key properly::
+        Internally, it will try to do ``key = self.make_identifier(key)``,
+        which will raise an exception if it cannot instantiate the key
+        properly::
 
             >>> memory[1] = 'error'
-            AttributeError: 'int' object has no attribute 'lower'
+            AttributeError: 'int' object has no attribute 'translate'
 
     .. versionadded:: 7.1
+
+    .. versionchanged:: 8.0
+
+        The parameter ``identifier_factory`` has been added to properly
+        transform ``str`` into :class:`~.identifiers.Identifier`. This factory
+        is stored and accessible through :attr:`make_identifier`.
+
     """
     def __init__(
         self,
@@ -518,6 +536,7 @@ class SopelIdentifierMemory(SopelMemory):
     ) -> None:
         super().__init__(*args)
         self.make_identifier = identifier_factory
+        """A factory to transform keys into identifiers."""
 
     def __getitem__(self, key):
         return super().__getitem__(self.make_identifier(key))

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -482,7 +482,7 @@ class SopelIdentifierMemory(SopelMemory):
     """Special Sopel memory that stores ``Identifier`` as key.
 
     This is a convenient subclass of :class:`SopelMemory` that always casts its
-    keys as instances of :class:`Identifier`::
+    keys as instances of :class:`~.identifiers.Identifier`::
 
         >>> from sopel import tools
         >>> memory = tools.SopelIdentifierMemory()

--- a/sopel/tools/identifiers.py
+++ b/sopel/tools/identifiers.py
@@ -7,9 +7,10 @@ identifiers must be processed to be compared properly. This process depends on
 which RFC and how that RFC is implemented by the server: IRC being an old
 protocol, different RFCs have differents version of that process:
 
-* :rfc:`1549#section-2.2`: ASCII characters, and ``[]\\`` are mapped to ``{}|``
-* :rfc:`2812#section-2.2`: same as in the previous RFC, adding ``~`` mapped to
-  ``^``
+* :rfc:`RFC 1459 § 2.2<1459#section-2.2>`: ASCII characters, and ``[]\\`` are
+  mapped to ``{}|``
+* :rfc:`RFC 2812 § 2.2<2812#section-2.2>`: same as in the previous RFC, adding
+  ``~`` mapped to ``^``
 
 Then when ISUPPORT was added, the `CASEMAPPING parameter`__ was defined so the
 server can say which process to apply:
@@ -63,7 +64,7 @@ def rfc1459_lower(text: str) -> str:
     """Lower ``text`` according to :rfc:`2812`.
 
     Similar to :func:`rfc1459_strict_lower`, but also maps ``~`` to ``^``, as
-    per :rfc:`2812#section-2.2`:
+    per :rfc:`RFC 2812 § 2.2<2812#section-2.2>`:
 
         Because of IRC's Scandinavian origin, the characters ``{}|^`` are
         considered to be the lower case equivalents of the characters
@@ -83,7 +84,7 @@ def rfc1459_lower(text: str) -> str:
 def rfc1459_strict_lower(text: str) -> str:
     """Lower ``text`` according to :rfc:`1459` (strict version).
 
-    As per :rfc:`1459#section-2.2`:
+    As per :rfc:`RFC 1459 § 2.2<1459#section-2.2>`:
 
         Because of IRC's scandanavian origin, the characters ``{}|`` are
         considered to be the lower case equivalents of the characters ``[]\\``.
@@ -108,7 +109,8 @@ class Identifier(str):
 
     This case insensitivity uses the provided ``casemapping`` function,
     following the rules for the `CASEMAPPING parameter`__ from ISUPPORT. By
-    default, it uses :func:`rfc1459_lower`, following :rfc:`2812#section-2.2`.
+    default, it uses :func:`rfc1459_lower`, following
+    :rfc:`RFC 2812 § 2.2<2812#section-2.2>`.
 
     .. note::
 
@@ -153,7 +155,8 @@ class Identifier(str):
 
         .. versionchanged:: 8.0
 
-            Now use the :attr:`casemapping` function to lower the identifier.
+            Now uses the :attr:`casemapping` function to lower the identifier.
+
         """
         return self.casemapping(self)
 
@@ -201,6 +204,7 @@ class Identifier(str):
 
             This method was added to ensure migration of improperly lowercased
             data: it reverts the data back to the previous lowercase rules.
+
         """
         # The tilde replacement isn't needed for identifiers, but is for
         # channels, which may be useful at some point in the future.

--- a/sopel/tools/identifiers.py
+++ b/sopel/tools/identifiers.py
@@ -1,0 +1,168 @@
+"""Identifier tools to represent IRC names (nick or channel)."""
+from __future__ import annotations
+
+import string
+
+
+ASCII_TABLE = str.maketrans(string.ascii_uppercase, string.ascii_lowercase)
+RFC1459_TABLE = str.maketrans(
+    string.ascii_uppercase + '[]\\~',
+    string.ascii_lowercase + '{}|^',
+)
+RFC1459_STRICT_TABLE = str.maketrans(
+    string.ascii_uppercase + '[]\\',
+    string.ascii_lowercase + '{}|',
+)
+
+
+def ascii_lower(text: str) -> str:
+    """Lower ``text`` according to the ASCII CASEMAPPING"""
+    return text.translate(ASCII_TABLE)
+
+
+def rfc1459_lower(text: str) -> str:
+    """Lower ``text`` according to :rfc:`1459` (with ``~`` mapped to ``^``).
+
+    Similar to :func:`rfc1459_strict_lower`, but also maps ``~`` to
+    ``^`` as defined for the ``rfc1459`` value of the
+    `CASEMAPPING parameter`__.
+
+    .. __: https://modern.ircdocs.horse/index.html#casemapping-parameter
+    """
+    return text.translate(RFC1459_TABLE)
+
+
+def rfc1459_strict_lower(text: str) -> str:
+    """Lower ``text`` according to :rfc:`1459` (strict version).
+
+    As per `section 2.2`__:
+
+        Because of IRC's scandanavian origin, the characters ``{}|`` are
+        considered to be the lower case equivalents of the characters ``[]\\``.
+
+    .. __: https://datatracker.ietf.org/doc/html/rfc1459#section-2.2
+    """
+    return text.translate(RFC1459_STRICT_TABLE)
+
+
+_channel_prefixes = ('#', '&', '+', '!')
+
+
+class Identifier(str):
+    """A ``str`` subclass which acts appropriately for IRC identifiers.
+
+    When used as normal ``str`` objects, case will be preserved.
+    However, when comparing two Identifier objects, or comparing an Identifier
+    object with a ``str`` object, the comparison will be case insensitive.
+    This case insensitivity includes the case convention conventions regarding
+    ``[]``, ``{}``, ``|``, ``\\``, ``^`` and ``~`` described in RFC 2812.
+    """
+    def __init__(self, identifier) -> None:
+        super().__init__()
+        # According to RFC2812, identifiers have to be in the ASCII range.
+        # However, I think it's best to let the IRCd determine that, and we'll
+        # just assume unicode. It won't hurt anything, and is more internally
+        # consistent. And who knows, maybe there's another use case for this
+        # weird case convention.
+        self._lowered = Identifier._lower(identifier)
+
+    def lower(self):
+        """Get the RFC 2812-compliant lowercase version of this identifier.
+
+        :return: RFC 2812-compliant lowercase version of the
+                 :py:class:`Identifier` instance
+        :rtype: str
+        """
+        return self._lowered
+
+    @staticmethod
+    def _lower(identifier: str):
+        """Convert an identifier to lowercase per RFC 2812.
+
+        :param str identifier: the identifier (nickname or channel) to convert
+        :return: RFC 2812-compliant lowercase version of ``identifier``
+        :rtype: str
+        """
+        if isinstance(identifier, Identifier):
+            return identifier._lowered
+        # The tilde replacement isn't needed for identifiers, but is for
+        # channels, which may be useful at some point in the future.
+        low = identifier.lower().replace('[', '{').replace(']', '}')
+        low = low.replace('\\', '|').replace('~', '^')
+        return rfc1459_lower(identifier)
+
+    @staticmethod
+    def _lower_swapped(identifier: str):
+        """Backward-compatible version of :meth:`_lower`.
+
+        :param str identifier: the identifier (nickname or channel) to convert
+        :return: RFC 2812-non-compliant lowercase version of ``identifier``
+        :rtype: str
+
+        This is what the old :meth:`_lower` function did before Sopel 7.0. It maps
+        ``{}``, ``[]``, ``|``, ``\\``, ``^``, and ``~`` incorrectly.
+
+        You shouldn't use this unless you need to migrate stored values from the
+        previous, incorrect "lowercase" representation to the correct one.
+        """
+        # The tilde replacement isn't needed for identifiers, but is for
+        # channels, which may be useful at some point in the future.
+        low = identifier.lower().replace('{', '[').replace('}', ']')
+        low = low.replace('|', '\\').replace('^', '~')
+        return low
+
+    def __repr__(self):
+        return "%s(%r)" % (
+            self.__class__.__name__,
+            self.__str__()
+        )
+
+    def __hash__(self):
+        return self._lowered.__hash__()
+
+    def __lt__(self, other):
+        if isinstance(other, str):
+            other = Identifier._lower(other)
+        return str.__lt__(self._lowered, other)
+
+    def __le__(self, other):
+        if isinstance(other, str):
+            other = Identifier._lower(other)
+        return str.__le__(self._lowered, other)
+
+    def __gt__(self, other):
+        if isinstance(other, str):
+            other = Identifier._lower(other)
+        return str.__gt__(self._lowered, other)
+
+    def __ge__(self, other):
+        if isinstance(other, str):
+            other = Identifier._lower(other)
+        return str.__ge__(self._lowered, other)
+
+    def __eq__(self, other):
+        if isinstance(other, str):
+            other = Identifier._lower(other)
+        return str.__eq__(self._lowered, other)
+
+    def __ne__(self, other):
+        return not (self == other)
+
+    def is_nick(self) -> bool:
+        """Check if the Identifier is a nickname (i.e. not a channel)
+
+        :return: ``True`` if this :py:class:`Identifier` is a nickname;
+                 ``False`` if it appears to be a channel
+
+        ::
+
+            >>> from sopel import tools
+            >>> ident = tools.Identifier('Sopel')
+            >>> ident.is_nick()
+            True
+            >>> ident = tools.Identifier('#sopel')
+            >>> ident.is_nick()
+            False
+
+        """
+        return bool(self) and not self.startswith(_channel_prefixes)

--- a/sopel/tools/identifiers.py
+++ b/sopel/tools/identifiers.py
@@ -1,4 +1,37 @@
-"""Identifier tools to represent IRC names (nick or channel)."""
+"""Identifier tools to represent IRC names (nick or channel).
+
+Nick and channel are defined by their names, which are "identifiers": their
+names are used to differentiate users from each others, channels from each
+others. To ensure that two channels or two users are the same, their
+identifiers must be processed to be compared properly. This process depends on
+which RFC and how that RFC is implemented by the server: IRC being an old
+protocol, different RFCs have differents version of that process:
+
+* :rfc:`1549#section-2.2`: ASCII characters, and ``[]\\`` are mapped to ``{}|``
+* :rfc:`2812#section-2.2`: same as in the previous RFC, adding ``~`` mapped to
+  ``^``
+
+Then when ISUPPORT was added, the `CASEMAPPING parameter`__ was defined so the
+server can say which process to apply:
+
+* ``ascii``: only ``[A-Z]`` must be mapped to ``[a-z]`` (implemented by
+  :func:`ascii_lower`)
+* ``rfc1459``: follow :rfc:`2812`; because of how it was implemented in most
+  server (implemented by :func:`rfc1459_lower`)
+* A strict version of :rfc:`1459` also exist but it is not recommended
+  (implemented by :func:`rfc1459_strict_lower`)
+
+As a result, the :class:`Identifier` class requires a casemapping function,
+which should be provided by the :class:`bot<sopel.bot.Sopel>`.
+
+.. seealso::
+
+    The bot's :class:`make_identifier<sopel.bot.Sopel.make_identifier>` method
+    should be used to instantiate an :class:`Identifier` to honor the
+    ``CASEMAPPING`` parameter.
+
+.. __: https://modern.ircdocs.horse/index.html#casemapping-parameter
+"""
 from __future__ import annotations
 
 import string
@@ -18,16 +51,29 @@ RFC1459_STRICT_TABLE = str.maketrans(
 
 
 def ascii_lower(text: str) -> str:
-    """Lower ``text`` according to the ASCII CASEMAPPING"""
+    """Lower ``text`` according to the ``ascii`` value of ``CASEMAPPING``.
+
+    In that version, only ``[A-Z]`` are to be mapped to their lowercase
+    equivalent (``[a-z]``). Non-ASCII characters are kept unmodified.
+    """
     return text.translate(ASCII_TABLE)
 
 
 def rfc1459_lower(text: str) -> str:
-    """Lower ``text`` according to :rfc:`1459` (with ``~`` mapped to ``^``).
+    """Lower ``text`` according to :rfc:`2812`.
 
-    Similar to :func:`rfc1459_strict_lower`, but also maps ``~`` to
-    ``^`` as defined for the ``rfc1459`` value of the
-    `CASEMAPPING parameter`__.
+    Similar to :func:`rfc1459_strict_lower`, but also maps ``~`` to ``^``, as
+    per :rfc:`2812#section-2.2`:
+
+        Because of IRC's Scandinavian origin, the characters ``{}|^`` are
+        considered to be the lower case equivalents of the characters
+        ``[]\\~``, respectively.
+
+    .. note::
+
+        This is an implementation of the `CASEMAPPING parameter`__ for the
+        value ``rfc1459``, which doesn't use :rfc:`1459` but its updated version
+        :rfc:`2812`.
 
     .. __: https://modern.ircdocs.horse/index.html#casemapping-parameter
     """
@@ -37,12 +83,11 @@ def rfc1459_lower(text: str) -> str:
 def rfc1459_strict_lower(text: str) -> str:
     """Lower ``text`` according to :rfc:`1459` (strict version).
 
-    As per `section 2.2`__:
+    As per :rfc:`1459#section-2.2`:
 
         Because of IRC's scandanavian origin, the characters ``{}|`` are
         considered to be the lower case equivalents of the characters ``[]\\``.
 
-    .. __: https://datatracker.ietf.org/doc/html/rfc1459#section-2.2
     """
     return text.translate(RFC1459_STRICT_TABLE)
 
@@ -53,14 +98,37 @@ _channel_prefixes = ('#', '&', '+', '!')
 class Identifier(str):
     """A ``str`` subclass which acts appropriately for IRC identifiers.
 
+    :param str identifier: IRC identifier
+    :param casemapping: a casemapping function (optional keyword argument)
+    :type casemapping: Callable[[:class:`str`], :class:`str`]
+
     When used as normal ``str`` objects, case will be preserved.
     However, when comparing two Identifier objects, or comparing an Identifier
     object with a ``str`` object, the comparison will be case insensitive.
-    This case insensitivity includes the case convention conventions regarding
-    ``[]``, ``{}``, ``|``, ``\\``, ``^`` and ``~`` described in RFC 2812.
+
+    This case insensitivity uses the provided ``casemapping`` function,
+    following the rules for the `CASEMAPPING parameter`__ from ISUPPORT. By
+    default, it uses :func:`rfc1459_lower`, following :rfc:`2812#section-2.2`.
+
+    .. note::
+
+        To instantiate an ``Identifier`` with the appropriate ``casemapping``
+        function, it is best to rely on
+        :meth:`bot.make_identifier<sopel.irc.AbstractBot.make_identifier>`.
+
+    .. versionchanged:: 8.0
+
+        The ``casemapping`` parameter has been added.
+
+    .. __: https://modern.ircdocs.horse/index.html#casemapping-parameter
     """
-    def __new__(cls, *args, **kwargs) -> 'Identifier':
-        return str.__new__(cls, *args)
+    def __new__(
+        cls,
+        identifier: str,
+        *,
+        casemapping: Casemapping = rfc1459_lower,
+    ) -> 'Identifier':
+        return str.__new__(cls, identifier)
 
     def __init__(
         self,
@@ -73,22 +141,41 @@ class Identifier(str):
         """Casemapping function to lower the identifier."""
         self._lowered = self.casemapping(identifier)
 
-    def lower(self):
-        """Get the RFC 2812-compliant lowercase version of this identifier.
+    def lower(self) -> str:
+        """Get the IRC-compliant lowercase version of this identifier.
 
-        :return: RFC 2812-compliant lowercase version of the
-                 :py:class:`Identifier` instance
-        :rtype: str
+        :return: IRC-compliant lowercase version used for case-insensitive
+                 comparisons
+
+        The behavior of this method depends on the identifier's casemapping
+        function, which should be selected based on the ``CASEMAPPING``
+        parameter from ``ISUPPORT``.
+
+        .. versionchanged:: 8.0
+
+            Now use the :attr:`casemapping` function to lower the identifier.
         """
         return self.casemapping(self)
 
     @staticmethod
     def _lower(identifier: str):
-        """Convert an identifier to lowercase per RFC 2812.
+        """Convert an identifier to lowercase per :rfc:`2812`.
 
         :param str identifier: the identifier (nickname or channel) to convert
         :return: RFC 2812-compliant lowercase version of ``identifier``
         :rtype: str
+
+        :meta public:
+
+        .. versionchanged:: 8.0
+
+            Previously, this would lower all non-ASCII characters. It now uses
+            a strict implementation of the ``CASEMAPPING`` parameter. This is
+            now equivalent to call :func:`rfc1459_lower`.
+
+            If the ``identifier`` is an instance of :class:`Identifier`, this
+            will call that identifier's :meth:`lower` method instead.
+
         """
         if isinstance(identifier, Identifier):
             return identifier.lower()
@@ -98,19 +185,27 @@ class Identifier(str):
     def _lower_swapped(identifier: str):
         """Backward-compatible version of :meth:`_lower`.
 
-        :param str identifier: the identifier (nickname or channel) to convert
+        :param identifier: the identifier (nickname or channel) to convert
         :return: RFC 2812-non-compliant lowercase version of ``identifier``
         :rtype: str
 
-        This is what the old :meth:`_lower` function did before Sopel 7.0. It maps
-        ``{}``, ``[]``, ``|``, ``\\``, ``^``, and ``~`` incorrectly.
+        This is what the old :meth:`_lower` function did before Sopel 7.0. It
+        maps ``{}``, ``[]``, ``|``, ``\\``, ``^``, and ``~`` incorrectly.
 
-        You shouldn't use this unless you need to migrate stored values from the
-        previous, incorrect "lowercase" representation to the correct one.
+        You shouldn't use this unless you need to migrate stored values from
+        the previous, incorrect "lowercase" representation to the correct one.
+
+        :meta public:
+
+        .. versionadded: 7.0
+
+            This method was added to ensure migration of improperly lowercased
+            data: it reverts the data back to the previous lowercase rules.
         """
         # The tilde replacement isn't needed for identifiers, but is for
         # channels, which may be useful at some point in the future.
-        low = identifier.lower().replace('{', '[').replace('}', ']')
+        # Always convert to str, to prevent using custom casemapping
+        low = str(identifier).lower().replace('{', '[').replace('}', ']')
         low = low.replace('|', '\\').replace('^', '~')
         return low
 

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -1,9 +1,14 @@
 from __future__ import generator_stop
 
+from datetime import datetime
 import functools
+from typing import Any, Callable, Dict, Optional, Set, Union
 
 from sopel import privileges
-from sopel.tools import Identifier
+from sopel.tools import identifiers
+
+
+IdentifierFactory = Callable[[str], identifiers.Identifier]
 
 
 @functools.total_ordering
@@ -19,15 +24,20 @@ class User:
         'nick', 'user', 'host', 'channels', 'account', 'away',
     )
 
-    def __init__(self, nick, user, host):
-        assert isinstance(nick, Identifier)
+    def __init__(
+        self,
+        nick: identifiers.Identifier,
+        user: Optional[str],
+        host: Optional[str],
+    ) -> None:
+        assert isinstance(nick, identifiers.Identifier)
         self.nick = nick
         """The user's nickname."""
         self.user = user
         """The user's local username."""
         self.host = host
         """The user's hostname."""
-        self.channels = {}
+        self.channels: Dict[identifiers.Identifier, 'Channel'] = {}
         """The channels the user is in.
 
         This maps channel name :class:`~sopel.tools.identifiers.Identifier`\\s
@@ -45,12 +55,12 @@ class User:
                                                        self.host))
     """The user's full hostmask."""
 
-    def __eq__(self, other):
+    def __eq__(self, other: Any) -> bool:
         if not isinstance(other, User):
             return NotImplemented
         return self.nick == other.nick
 
-    def __lt__(self, other):
+    def __lt__(self, other: Any) -> bool:
         if not isinstance(other, User):
             return NotImplemented
         return self.nick < other.nick
@@ -62,32 +72,45 @@ class Channel:
 
     :param name: the channel name
     :type name: :class:`~sopel.tools.identifiers.Identifier`
+    :param identifier_factory: A factory to create
+                               :class:`~sopel.tools.identifiers.Identifier`\\s
     """
     __slots__ = (
-        'name', 'users', 'privileges', 'topic', 'modes', 'last_who', 'join_time',
+        'name',
+        'users',
+        'privileges',
+        'topic',
+        'modes',
+        'last_who',
+        'join_time',
+        'make_identifier',
     )
 
-    def __init__(self, name):
-        assert isinstance(name, Identifier)
+    def __init__(
+        self,
+        name: identifiers.Identifier,
+        identifier_factory: IdentifierFactory = identifiers.Identifier,
+    ) -> None:
+        assert isinstance(name, identifiers.Identifier)
         self.name = name
         """The name of the channel."""
-        self.users = {}
+        self.users: Dict[identifiers.Identifier, User] = {}
         """The users in the channel.
 
         This maps nickname :class:`~sopel.tools.identifiers.Identifier`\\s to
         :class:`User` objects.
         """
-        self.privileges = {}
+        self.privileges: Dict[identifiers.Identifier, int] = {}
         """The permissions of the users in the channel.
 
         This maps nickname :class:`~sopel.tools.identifiers.Identifier`\\s to
         bitwise integer values. This can be compared to appropriate constants
-        from :mod:`sopel.plugin`.
+        from :mod:`sopel.privileges`.
         """
         self.topic = ''
         """The topic of the channel."""
 
-        self.modes = {}
+        self.modes: Dict[str, Union[Set, str, bool]] = {}
         """The channel's modes.
 
         For type A modes (nick/address list), the value is a set. For type B
@@ -100,21 +123,28 @@ class Channel:
             does not automatically populate all modes and lists.
         """
 
-        self.last_who = None
+        self.last_who: Optional[datetime] = None
         """The last time a WHO was requested for the channel."""
 
-        self.join_time = None
+        self.join_time: Optional[datetime] = None
         """The time the server acknowledged our JOIN message.
 
         Based on server-reported time if the ``server-time`` IRCv3 capability
         is available, otherwise the time Sopel received it.
         """
 
-    def clear_user(self, nick):
+        self.make_identifier: IdentifierFactory = identifier_factory
+        """Factory to create :class:`~sopel.tools.identifiers.Identifier`.
+
+        ``Identifier`` is used for :class:`User`'s nick, and the channel
+        needs to translate nicks from string to ``Identifier`` when
+        manipulating data associated to a user by its nickname.
+        """
+
+    def clear_user(self, nick: identifiers.Identifier) -> None:
         """Remove ``nick`` from this channel.
 
         :param nick: the nickname of the user to remove
-        :type nick: :class:`~sopel.tools.identifiers.Identifier`
 
         Called after a user leaves the channel via PART, KICK, QUIT, etc.
         """
@@ -123,13 +153,12 @@ class Channel:
         if user is not None:
             user.channels.pop(self.name, None)
 
-    def add_user(self, user, privs=0):
+    def add_user(self, user: User, privs: int = 0) -> None:
         """Add ``user`` to this channel.
 
         :param user: the new user to add
-        :type user: :class:`User`
-        :param int privs: privilege bitmask (see constants in
-                          :mod:`sopel.plugin`)
+        :param privs: privilege bitmask (see constants in
+                      :mod:`sopel.privileges`)
 
         Called when a new user JOINs the channel.
         """
@@ -138,12 +167,11 @@ class Channel:
         self.privileges[user.nick] = privs or 0
         user.channels[self.name] = self
 
-    def has_privilege(self, nick, privilege):
+    def has_privilege(self, nick: str, privilege: int) -> bool:
         """Tell if a user has a ``privilege`` level or above in this channel.
 
-        :param str nick: a user's nick in this channel
-        :param int privilege: privilege level to check
-        :rtype: bool
+        :param nick: a user's nick in this channel
+        :param privilege: privilege level to check
 
         This method checks the user's privilege level in this channel, i.e. if
         it has this level or higher privileges::
@@ -153,8 +181,8 @@ class Channel:
             True
 
         The ``nick`` argument can be either a :class:`str` or a
-        :class:`sopel.tools.identifiers.Identifier`. If the user is not in this channel,
-        it will be considered as not having any privilege.
+        :class:`sopel.tools.identifiers.Identifier`. If the user is not in this
+        channel, it will be considered as not having any privilege.
 
         .. seealso::
 
@@ -169,13 +197,12 @@ class Channel:
             on the presence of standard modes: ``+v`` (voice) and ``+o`` (op).
 
         """
-        return self.privileges.get(Identifier(nick), 0) >= privilege
+        return self.privileges.get(self.make_identifier(nick), 0) >= privilege
 
-    def is_oper(self, nick):
+    def is_oper(self, nick: str) -> bool:
         """Tell if a user has the OPER (operator) privilege level.
 
-        :param str nick: a user's nick in this channel
-        :rtype: bool
+        :param nick: a user's nick in this channel
 
         Unlike :meth:`has_privilege`, this method checks if the user has been
         explicitly granted the OPER privilege level::
@@ -201,13 +228,13 @@ class Channel:
             sensibly if only ``+v`` (voice) and ``+o`` (op) modes exist.
 
         """
-        return self.privileges.get(Identifier(nick), 0) & privileges.OPER
+        nick_id = self.make_identifier(nick)
+        return bool(self.privileges.get(nick_id, 0) & privileges.OPER)
 
-    def is_owner(self, nick):
+    def is_owner(self, nick: str) -> bool:
         """Tell if a user has the OWNER privilege level.
 
-        :param str nick: a user's nick in this channel
-        :rtype: bool
+        :param nick: a user's nick in this channel
 
         Unlike :meth:`has_privilege`, this method checks if the user has been
         explicitly granted the OWNER privilege level::
@@ -233,13 +260,13 @@ class Channel:
             sensibly if only ``+v`` (voice) and ``+o`` (op) modes exist.
 
         """
-        return self.privileges.get(Identifier(nick), 0) & privileges.OWNER
+        nick_id = self.make_identifier(nick)
+        return bool(self.privileges.get(nick_id, 0) & privileges.OWNER)
 
-    def is_admin(self, nick):
+    def is_admin(self, nick: str) -> bool:
         """Tell if a user has the ADMIN privilege level.
 
-        :param str nick: a user's nick in this channel
-        :rtype: bool
+        :param nick: a user's nick in this channel
 
         Unlike :meth:`has_privilege`, this method checks if the user has been
         explicitly granted the ADMIN privilege level::
@@ -265,13 +292,13 @@ class Channel:
             sensibly if only ``+v`` (voice) and ``+o`` (op) modes exist.
 
         """
-        return self.privileges.get(Identifier(nick), 0) & privileges.ADMIN
+        nick_id = self.make_identifier(nick)
+        return bool(self.privileges.get(nick_id, 0) & privileges.ADMIN)
 
-    def is_op(self, nick):
+    def is_op(self, nick: str) -> bool:
         """Tell if a user has the OP privilege level.
 
-        :param str nick: a user's nick in this channel
-        :rtype: bool
+        :param nick: a user's nick in this channel
 
         Unlike :meth:`has_privilege`, this method checks if the user has been
         explicitly granted the OP privilege level::
@@ -291,13 +318,13 @@ class Channel:
             True
 
         """
-        return self.privileges.get(Identifier(nick), 0) & privileges.OP
+        nick_id = self.make_identifier(nick)
+        return bool(self.privileges.get(nick_id, 0) & privileges.OP)
 
-    def is_halfop(self, nick):
+    def is_halfop(self, nick: str) -> bool:
         """Tell if a user has the HALFOP privilege level.
 
-        :param str nick: a user's nick in this channel
-        :rtype: bool
+        :param nick: a user's nick in this channel
 
         Unlike :meth:`has_privilege`, this method checks if the user has been
         explicitly granted the HALFOP privilege level::
@@ -323,13 +350,13 @@ class Channel:
             sensibly if only ``+v`` (voice) and ``+o`` (op) modes exist.
 
         """
-        return self.privileges.get(Identifier(nick), 0) & privileges.HALFOP
+        nick_id = self.make_identifier(nick)
+        return bool(self.privileges.get(nick_id, 0) & privileges.HALFOP)
 
-    def is_voiced(self, nick):
+    def is_voiced(self, nick: str) -> bool:
         """Tell if a user has the VOICE privilege level.
 
-        :param str nick: a user's nick in this channel
-        :rtype: bool
+        :param nick: a user's nick in this channel
 
         Unlike :meth:`has_privilege`, this method checks if the user has been
         explicitly granted the VOICE privilege level::
@@ -350,17 +377,20 @@ class Channel:
             True
 
         """
-        return self.privileges.get(Identifier(nick), 0) & privileges.VOICE
+        nick_id = self.make_identifier(nick)
+        return bool(self.privileges.get(nick_id, 0) & privileges.VOICE)
 
-    def rename_user(self, old, new):
+    def rename_user(
+        self,
+        old: identifiers.Identifier,
+        new: identifiers.Identifier,
+    ):
         """Rename a user.
 
         :param old: the user's old nickname
-        :type old: :class:`~sopel.tools.identifiers.Identifier`
         :param new: the user's new nickname
-        :type new: :class:`~sopel.tools.identifiers.Identifier`
 
-        Called on NICK events.
+        Called on ``NICK`` events.
         """
         if old in self.users:
             self.users[new] = self.users.pop(old)

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -11,7 +11,7 @@ class User:
     """A representation of a user Sopel is aware of.
 
     :param nick: the user's nickname
-    :type nick: :class:`~.tools.Identifier`
+    :type nick: :class:`sopel.tools.identifiers.Identifier`
     :param str user: the user's local username ("user" in `user@host.name`)
     :param str host: the user's hostname ("host.name" in `user@host.name`)
     """
@@ -30,8 +30,8 @@ class User:
         self.channels = {}
         """The channels the user is in.
 
-        This maps channel name :class:`~sopel.tools.Identifier`\\s to
-        :class:`Channel` objects.
+        This maps channel name :class:`~sopel.tools.identifiers.Identifier`\\s
+        to :class:`Channel` objects.
         """
         self.account = None
         """The IRC services account of the user.
@@ -61,7 +61,7 @@ class Channel:
     """A representation of a channel Sopel is in.
 
     :param name: the channel name
-    :type name: :class:`~.tools.Identifier`
+    :type name: :class:`~sopel.tools.identifiers.Identifier`
     """
     __slots__ = (
         'name', 'users', 'privileges', 'topic', 'modes', 'last_who', 'join_time',
@@ -74,15 +74,15 @@ class Channel:
         self.users = {}
         """The users in the channel.
 
-        This maps nickname :class:`~sopel.tools.Identifier`\\s to :class:`User`
-        objects.
+        This maps nickname :class:`~sopel.tools.identifiers.Identifier`\\s to
+        :class:`User` objects.
         """
         self.privileges = {}
         """The permissions of the users in the channel.
 
-        This maps nickname :class:`~sopel.tools.Identifier`\\s to bitwise
-        integer values. This can be compared to appropriate constants from
-        :mod:`sopel.plugin`.
+        This maps nickname :class:`~sopel.tools.identifiers.Identifier`\\s to
+        bitwise integer values. This can be compared to appropriate constants
+        from :mod:`sopel.plugin`.
         """
         self.topic = ''
         """The topic of the channel."""
@@ -114,7 +114,7 @@ class Channel:
         """Remove ``nick`` from this channel.
 
         :param nick: the nickname of the user to remove
-        :type nick: :class:`~.tools.Identifier`
+        :type nick: :class:`~sopel.tools.identifiers.Identifier`
 
         Called after a user leaves the channel via PART, KICK, QUIT, etc.
         """
@@ -153,7 +153,7 @@ class Channel:
             True
 
         The ``nick`` argument can be either a :class:`str` or a
-        :class:`sopel.tools.Identifier`. If the user is not in this channel,
+        :class:`sopel.tools.identifiers.Identifier`. If the user is not in this channel,
         it will be considered as not having any privilege.
 
         .. seealso::
@@ -356,9 +356,9 @@ class Channel:
         """Rename a user.
 
         :param old: the user's old nickname
-        :type old: :class:`~.tools.Identifier`
+        :type old: :class:`~sopel.tools.identifiers.Identifier`
         :param new: the user's new nickname
-        :type new: :class:`~.tools.Identifier`
+        :type new: :class:`~sopel.tools.identifiers.Identifier`
 
         Called on NICK events.
         """

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -228,8 +228,8 @@ class Channel:
             sensibly if only ``+v`` (voice) and ``+o`` (op) modes exist.
 
         """
-        nick_id = self.make_identifier(nick)
-        return bool(self.privileges.get(nick_id, 0) & privileges.OPER)
+        identifier = self.make_identifier(nick)
+        return bool(self.privileges.get(identifier, 0) & privileges.OPER)
 
     def is_owner(self, nick: str) -> bool:
         """Tell if a user has the OWNER privilege level.
@@ -260,8 +260,8 @@ class Channel:
             sensibly if only ``+v`` (voice) and ``+o`` (op) modes exist.
 
         """
-        nick_id = self.make_identifier(nick)
-        return bool(self.privileges.get(nick_id, 0) & privileges.OWNER)
+        identifier = self.make_identifier(nick)
+        return bool(self.privileges.get(identifier, 0) & privileges.OWNER)
 
     def is_admin(self, nick: str) -> bool:
         """Tell if a user has the ADMIN privilege level.
@@ -292,8 +292,8 @@ class Channel:
             sensibly if only ``+v`` (voice) and ``+o`` (op) modes exist.
 
         """
-        nick_id = self.make_identifier(nick)
-        return bool(self.privileges.get(nick_id, 0) & privileges.ADMIN)
+        identifier = self.make_identifier(nick)
+        return bool(self.privileges.get(identifier, 0) & privileges.ADMIN)
 
     def is_op(self, nick: str) -> bool:
         """Tell if a user has the OP privilege level.
@@ -318,8 +318,8 @@ class Channel:
             True
 
         """
-        nick_id = self.make_identifier(nick)
-        return bool(self.privileges.get(nick_id, 0) & privileges.OP)
+        identifier = self.make_identifier(nick)
+        return bool(self.privileges.get(identifier, 0) & privileges.OP)
 
     def is_halfop(self, nick: str) -> bool:
         """Tell if a user has the HALFOP privilege level.
@@ -350,8 +350,8 @@ class Channel:
             sensibly if only ``+v`` (voice) and ``+o`` (op) modes exist.
 
         """
-        nick_id = self.make_identifier(nick)
-        return bool(self.privileges.get(nick_id, 0) & privileges.HALFOP)
+        identifier = self.make_identifier(nick)
+        return bool(self.privileges.get(identifier, 0) & privileges.HALFOP)
 
     def is_voiced(self, nick: str) -> bool:
         """Tell if a user has the VOICE privilege level.
@@ -377,8 +377,8 @@ class Channel:
             True
 
         """
-        nick_id = self.make_identifier(nick)
-        return bool(self.privileges.get(nick_id, 0) & privileges.VOICE)
+        identifier = self.make_identifier(nick)
+        return bool(self.privileges.get(identifier, 0) & privileges.VOICE)
 
     def rename_user(
         self,

--- a/sopel/tools/time.py
+++ b/sopel/tools/time.py
@@ -67,7 +67,7 @@ def get_nick_timezone(db, nick):
     :param db: Bot's database handler (usually ``bot.db``)
     :type db: :class:`~sopel.db.SopelDB`
     :param nick: IRC nickname
-    :type nick: :class:`~sopel.tools.Identifier`
+    :type nick: :class:`~sopel.tools.identifiers.Identifier`
     :return: the timezone associated with the ``nick``
 
     If a timezone cannot be found for ``nick``, or if it is invalid, ``None``
@@ -85,7 +85,7 @@ def get_channel_timezone(db, channel):
     :param db: Bot's database handler (usually ``bot.db``)
     :type db: :class:`~sopel.db.SopelDB`
     :param channel: IRC channel name
-    :type channel: :class:`~sopel.tools.Identifier`
+    :type channel: :class:`~sopel.tools.identifiers.Identifier`
     :return: the timezone associated with the ``channel``
 
     If a timezone cannot be found for ``channel``, or if it is invalid,

--- a/sopel/tools/time.py
+++ b/sopel/tools/time.py
@@ -141,8 +141,7 @@ def get_timezone(db=None, config=None, zone=None, nick=None, channel=None):
     if zone:
         tz = _check(zone)
         if not tz:
-            tz = _check(
-                db.get_nick_or_channel_value(zone, 'timezone'))
+            tz = _check(db.get_nick_or_channel_value(zone, 'timezone'))
     if not tz and nick:
         tz = _check(db.get_nick_value(nick, 'timezone'))
     if not tz and channel:

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -230,13 +230,13 @@ class Trigger(str):
     sender = property(lambda self: self._pretrigger.sender)
     """Where the message arrived from.
 
-    :type: :class:`~.tools.Identifier`
+    :type: :class:`~sopel.tools.identifiers.Identifier`
 
     This will be a channel name for "regular" (channel) messages, or the nick
     that sent a private message.
 
     You can check if the trigger comes from a channel or a nick with its
-    :meth:`~sopel.tools.Identifier.is_nick` method::
+    :meth:`~sopel.tools.identifiers.Identifier.is_nick` method::
 
         if trigger.sender.is_nick():
             # message sent from a private message
@@ -280,7 +280,7 @@ class Trigger(str):
     nick = property(lambda self: self._pretrigger.nick)
     """The nickname who sent the message.
 
-    :type: :class:`~.tools.Identifier`
+    :type: :class:`~sopel.tools.identifiers.Identifier`
     """
     host = property(lambda self: self._pretrigger.host)
     """The hostname of the person who sent the message.

--- a/test/test_coretasks.py
+++ b/test/test_coretasks.py
@@ -315,6 +315,26 @@ def test_handle_isupport(mockbot):
     assert 'CNOTICE' in mockbot.isupport
 
 
+def test_handle_isupport_casemapping(mockbot):
+    # Set bot's nick to something that needs casemapping
+    mockbot.settings.core.nick = 'Test[a]'
+    mockbot._nick = mockbot.make_identifier(mockbot.settings.core.nick)
+
+    # check default behavior (`rfc1459` casemapping)
+    assert mockbot.nick.lower() == 'test{a}'
+    assert str(mockbot.nick) == 'Test[a]'
+
+    # now the bot "connects" to a server using `CASEMAPPING=ascii`
+    mockbot.on_message(
+        ':irc.example.com 005 Sopel '
+        'CHANTYPES=# EXCEPTS INVEX CHANMODES=eIbq,k,flj,CFLMPQScgimnprstz '
+        'CHANLIMIT=#:120 PREFIX=(ov)@+ MAXLIST=bqeI:100 MODES=4 '
+        'NETWORK=example STATUSMSG=@+ CALLERID=g CASEMAPPING=ascii '
+        ':are supported by this server')
+
+    assert mockbot.nick.lower() == 'test[a]'
+
+
 @pytest.mark.parametrize('modes', ['', 'Rw'])
 def test_handle_isupport_bot_mode(mockbot, modes):
     mockbot.config.core.modes = modes

--- a/test/tools/test_tools_identifiers.py
+++ b/test/tools/test_tools_identifiers.py
@@ -1,0 +1,126 @@
+"""Tests for IRC Identifier"""
+from __future__ import annotations
+
+import pytest
+
+from sopel.tools import identifiers
+
+
+@pytest.mark.parametrize('name, slug', (
+    ('abcd', 'abcd'),
+    ('ABCD', 'abcd'),
+    ('abc[]d', 'abc[]d'),
+    ('abc\\d', 'abc\\d'),
+    ('abc~d', 'abc~d'),
+    ('[A]B\\C~D', '[a]b\\c~d'),
+    ('ÙNÏÇÔDÉ', 'ÙnÏÇÔdÉ'),
+))
+def test_ascii_lower(name: str, slug: str):
+    assert identifiers.ascii_lower(name) == slug
+
+
+@pytest.mark.parametrize('name, slug', (
+    ('abcd', 'abcd'),
+    ('ABCD', 'abcd'),
+    ('abc[]d', 'abc{}d'),
+    ('abc\\d', 'abc|d'),
+    ('abc~d', 'abc^d'),
+    ('[A]B\\C~D', '{a}b|c^d'),
+    ('ÙNÏÇÔDÉ', 'ÙnÏÇÔdÉ'),
+))
+def test_rfc1459_lower(name: str, slug: str):
+    assert identifiers.rfc1459_lower(name) == slug
+
+
+@pytest.mark.parametrize('name, slug', (
+    ('abcd', 'abcd'),
+    ('ABCD', 'abcd'),
+    ('abc[]d', 'abc{}d'),
+    ('abc\\d', 'abc|d'),
+    ('abc~d', 'abc~d'),
+    ('[A]B\\C~D', '{a}b|c~d'),
+    ('ÙNÏÇÔDÉ', 'ÙnÏÇÔdÉ'),
+))
+def test_rfc1459_strict_lower(name: str, slug: str):
+    assert identifiers.rfc1459_strict_lower(name) == slug
+
+
+def test_identifier_repr():
+    assert "Identifier('ABCD[]')" == '%r' % identifiers.Identifier('ABCD[]')
+
+
+@pytest.mark.parametrize('name, slug, gt, lt', (
+    ('abcd', 'abcd', 'abcde', 'abc'),
+    ('ABCD', 'abcd', 'ABCDE', 'abc'),
+    ('abc[]d', 'abc{}d', 'abc[]de', 'abc{}'),
+    ('abc\\d', 'abc|d', 'abc\\de', 'abc|'),
+    ('abc~d', 'abc^d', 'abc~de', 'abc^'),
+    ('[A]B\\C~D', '{a}b|c^d', '[A]B\\C~DE', '{a}b|c^'),
+))
+def test_identifier_default_casemapping(name, slug, gt, lt):
+    identifier = identifiers.Identifier(name)
+    assert slug == identifier.lower()
+    assert hash(slug) == hash(identifier)
+
+    # eq
+    assert identifier == slug
+    assert identifier == name
+    assert identifier == identifiers.Identifier(slug)
+    assert identifier == identifiers.Identifier(name)
+
+    # not eq
+    assert identifier != slug + 'f'
+    assert identifier != name + 'f'
+    assert identifier != identifiers.Identifier(slug + 'f')
+    assert identifier != identifiers.Identifier(name + 'f')
+
+    # gt(e)
+    assert identifier >= slug
+    assert identifier >= name
+    assert identifier >= lt
+    assert identifier > lt
+    assert identifier >= identifiers.Identifier(lt)
+    assert identifier > identifiers.Identifier(lt)
+
+    # lt(e)
+    assert identifier <= slug
+    assert identifier <= name
+    assert identifier <= gt
+    assert identifier < gt
+    assert identifier <= identifiers.Identifier(gt)
+    assert identifier < identifiers.Identifier(gt)
+
+
+@pytest.mark.parametrize('wrong_type', (
+    None, 0, 10, 3.14, object()
+))
+def test_identifier_compare_invalid(wrong_type):
+    identifier = identifiers.Identifier('xnaas')
+
+    # you can compare equality (or lack thereof)
+    assert not (identifier == wrong_type)
+    assert identifier != wrong_type
+
+    with pytest.raises(TypeError):
+        identifier >= wrong_type
+
+    with pytest.raises(TypeError):
+        identifier > wrong_type
+
+    with pytest.raises(TypeError):
+        identifier <= wrong_type
+
+    with pytest.raises(TypeError):
+        identifier < wrong_type
+
+
+def test_identifier_is_nick():
+    assert identifiers.Identifier('Exirel').is_nick()
+
+
+def test_identifier_is_nick_channel():
+    assert not identifiers.Identifier('#exirel').is_nick()
+
+
+def test_identifier_is_nick_empty():
+    assert not identifiers.Identifier('').is_nick()


### PR DESCRIPTION
### Description

This PR contains various changes with the end goal to use the server's casemapping instead of the hardcoded one. Sadly, this includes breaking changes.

#### Non-breaking changes

* The bot has a new method `make_identifier`: it uses the `CASEMAPPING` parameter from isupport to select the appropriate casemapping function (from `sopel.tools.identifiers`)
* The `Identifier` class has several changes:
  * `Identifier` now lives its best life in `sopel.tools.identifiers`, mostly to prevent cyclic import errors. This comes with some more documentation.
  * `Identifier` doesn't override `str.__new__` anymore, I figured out a way to use `__init__` instead, and it works fine.
  * `Identifier` has a new argument: `casemapping`. It's a callable that **must** take one parameter (a string) and return a string.
  * The default value of `casemapping` is `rfc1459_lower`, making this argument optional (at the moment).
  * `self.casemapping` is now used in place of `Identifier._lower` to get a lowercase version of the identifier string
* Classes that create `Identifier` have a new argument: It's a callable that **must** take one parameter (a string) and return an instance of `Identifier` with properly configured casemapping.
  * `User` and `Channel` (both from `sopel.tools.target`)
  * `PreTrigger| (from `sopel.trigger`)
  * `SopelDB` (from `sopel.db`)
  * `SopelIdentifierMemory` (from `sopel.tools`)
* The new argument is used to instantiate `Identifier` when necessary
* `coretasks` and other modules are now using `bot.make_identifier` when they need an `Identifier`
* All method from `SopelDB` now accept a `str` (some used to accept `Identifier` only) since it can always convert them into an `Identifier` when necessary
* Various type hint here and there because why not

#### Breaking changes

* `Identifier._lower` doesn't lower all character as it used to do, now it uses the `rfc1459_lower` function which lowercase only [A-Z] characters. In theory, this is not a breaking change because IRC identifiers shouldn't accept non-ASCII characters anyway. However, in the case of IRC server supporting Unicode identifiers (for nicknames and/or channels), this is a breaking change. A solution to that would be to implement rfc7613 (PRECIS) as suggested by https://modern.ircdocs.horse/index.html#casemapping-parameter
* `core.nick` is now a `str` and not an `Identifier` anymore, meaning that any plugin using that config option will need to transform it into an `Identifier`; this is considered a breaking change, even tho it shouldn't be a problem considering that most Identifier-related operations are through objects that already convert `str` into `Identifier` when necessary

#### Going further

The next steps would be:

* to merge #2232
* to implement a PRECIS profile for casemapping—I think it would even work on current ascii-only identifier, making Sopel UTF-8 ready before servers can be
* to move memory classes into their own submodule
* and probably to move other things outside of `sopel/tools/__init__.py`
* to implement dynamic chantype for identifiers

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
