### PR TITLE
sopel: move deprecated() to sopel.lifecycle

### DIFF
--- a/docs/source/lifecycle.rst
+++ b/docs/source/lifecycle.rst
@@ -1,0 +1,31 @@
+====================
+Lifecycle Management
+====================
+
+As Sopel grows and evolves, sometimes it needs to say goodbye to obsolete code
+and replace it. The solution can be new (and hopefully better) code, switching
+to an external library, or maybe putting the feature into an external plugin.
+
+In any case, Sopel will always try to mark as deprecated what will be removed,
+indicating when it was deprecated, and when it should be removed. The goal is
+to help Sopel developers and plugin authors understand what must be done to
+adapt their code to a future version of Sopel::
+
+    Deprecated since 8.0, will be removed in 9.0: sopel.module has been
+    replaced by sopel.plugin
+      File "/home/exirel/dev/sopel/sopel/module.py", line 46, in <module>
+        deprecated(
+
+This example above shows a deprecation warning for the ``sopel.module`` module
+that is deprecated: it shows when it was deprecated (Sopel 8.0), when it will
+be removed (Sopel 9.0), and how to fix that warning (use :mod:`sopel.plugin`).
+
+Although this feature is primarily for use by Sopel developers, plugin authors
+can also take advantage of it with the :func:`sopel.lifecycle.deprecated`
+function documented below.
+
+sopel.lifecycle
+===============
+
+.. automodule:: sopel.lifecycle
+   :members:

--- a/docs/source/package.rst
+++ b/docs/source/package.rst
@@ -1,4 +1,4 @@
-
+=================
 Sopel Package API
 =================
 
@@ -11,3 +11,4 @@ Sopel Package API
     db
     api
     irc
+    lifecycle

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -21,8 +21,9 @@ from typing import Any, Dict, Iterable, Mapping, Optional, Tuple, Union
 
 from sopel import db, irc, logger, plugin, plugins, tools
 from sopel.irc import modes
+from sopel.lifecycle import deprecated
 from sopel.plugins import jobs as plugin_jobs, rules as plugin_rules
-from sopel.tools import deprecated, jobs as tools_jobs
+from sopel.tools import jobs as tools_jobs
 from sopel.trigger import PreTrigger, Trigger
 
 

--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -30,7 +30,8 @@ import getpass
 import os.path
 import re
 
-from sopel.tools import deprecated, get_input
+from sopel.lifecycle import deprecated
+from sopel.tools import get_input
 
 
 class NO_DEFAULT:

--- a/sopel/db.py
+++ b/sopel/db.py
@@ -13,7 +13,7 @@ from sqlalchemy.exc import OperationalError, SQLAlchemyError
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker
 
-from sopel.tools import deprecated
+from sopel.lifecycle import deprecated
 from sopel.tools.identifiers import Identifier
 
 

--- a/sopel/lifecycle.py
+++ b/sopel/lifecycle.py
@@ -1,0 +1,180 @@
+"""Deprecation module for Sopel developers and plugin authors.
+
+.. versionadded:: 8.0
+
+    Previously in :mod:`sopel.tools`, the :func:`deprecated` function has been
+    moved to this newly created module, as it can be used in every part of the
+    Sopel codebase, including :mod:`sopel.tools` itself.
+
+"""
+from __future__ import annotations
+
+import functools
+import inspect
+import logging
+import traceback
+from typing import Callable, Optional
+
+from pkg_resources import parse_version
+
+from sopel import __version__
+
+
+def deprecated(
+    reason: Optional[str] = None,
+    version: Optional[str] = None,
+    removed_in: Optional[str] = None,
+    warning_in: Optional[str] = None,
+    stack_frame: int = -1,
+    func: Optional[Callable] = None,
+):
+    """Decorator to mark deprecated functions in Sopel's API
+
+    :param reason: optional text added to the deprecation warning
+    :param version: optional version number when the decorated function
+                    is deprecated
+    :param removed_in: optional version number when the deprecated function
+                       will be removed
+    :param warning_in: optional version number when the decorated function
+                       should start emitting a warning when called
+    :param stack_frame: optional stack frame to output; defaults to
+                        ``-1``; should almost always be negative
+    :param func: deprecated function
+    :return: a callable that depends on how the decorator is called; either
+             the decorated function, or a decorator with the appropriate
+             parameters
+
+    Any time the decorated ``func`` is called, a deprecation warning will be
+    logged, with the last frame of the traceback. The optional ``warning_in``
+    argument suppresses the warning on Sopel versions older than that, allowing
+    for multi-stage deprecation timelines.
+
+    The decorator can be used with or without arguments::
+
+        from sopel.lifecycle import deprecated
+
+        @deprecated
+        def func1():
+            print('func 1')
+
+        @deprecated()
+        def func2():
+            print('func 2')
+
+        @deprecated(reason='obsolete', version='7.0', removed_in='8.0')
+        def func3():
+            print('func 3')
+
+    which will output the following in a console::
+
+        >>> func1()
+        Deprecated: func1
+        File "<stdin>", line 1, in <module>
+        func 1
+        >>> func2()
+        Deprecated: func2
+        File "<stdin>", line 1, in <module>
+        func 2
+        >>> func3()
+        Deprecated since 7.0, will be removed in 8.0: obsolete
+        File "<stdin>", line 1, in <module>
+        func 3
+
+    The ``stack_frame`` argument can be used to choose which stack frame is
+    logged along with the message text. By default, this decorator logs the
+    most recent stack frame (the last entry in the list, ``-1``), corresponding
+    to where the decorated function itself was called. However, in certain
+    cases such as deprecating conditional behavior within an object
+    constructor, it can be useful to show a less recent stack frame instead.
+
+    .. note::
+
+        This decorator can be also used on callables that are not functions,
+        such as classes and callable objects.
+
+    .. versionadded:: 7.0
+        Parameters ``reason``, ``version``, and ``removed_in``.
+
+    .. versionadded:: 7.1
+        The ``warning_in`` and ``stack_frame`` parameters.
+
+    .. versionchanged:: 8.0
+        Moved out of :mod:`sopel.tools` to resolve circular dependency issues.
+
+    """
+    if not any([reason, version, removed_in, warning_in, func]):
+        # common usage: @deprecated()
+        return deprecated
+
+    if callable(reason):
+        # common usage: @deprecated
+        return deprecated(func=reason)
+
+    if func is None:
+        # common usage: @deprecated(message, version, removed_in)
+        def decorator(func):
+            return deprecated(
+                reason, version, removed_in, warning_in, stack_frame, func)
+        return decorator
+
+    # now, we have everything we need to have:
+    # - message is not a callable (could be None)
+    # - func is not None
+    # - version and removed_in can be None but that's OK
+    # so now we can return the actual decorated function
+
+    message = reason or getattr(func, '__name__', '<anonymous-function>')
+
+    template = 'Deprecated: {message}'
+    if version and removed_in:
+        template = (
+            'Deprecated since {version}, '
+            'will be removed in {removed_in}: '
+            '{message}')
+    elif version:
+        template = 'Deprecated since {version}: {message}'
+    elif removed_in:
+        template = 'Deprecated, will be removed in {removed_in}: {message}'
+
+    text = template.format(
+        message=message, version=version, removed_in=removed_in)
+
+    @functools.wraps(func)
+    def deprecated_func(*args, **kwargs):
+        if not (warning_in and
+                parse_version(warning_in) >= parse_version(__version__)):
+            original_frame = inspect.stack()[-stack_frame]
+            mod = inspect.getmodule(original_frame[0])
+            module_name = None
+            if mod:
+                module_name = mod.__name__
+            if module_name:
+                if module_name.startswith('sopel.'):
+                    # core, or core plugin
+                    logger = logging.getLogger(module_name)
+                else:
+                    # probably a plugin; try to handle most cases sanely
+                    if module_name.startswith('sopel_modules.'):
+                        # namespace package plugins have a prefix, obviously
+                        # they will use Sopel's namespace; other won't
+                        module_name = module_name.replace(
+                            'sopel_modules.',
+                            'sopel.externals.',
+                            1,
+                        )
+                    logger = logging.getLogger(module_name)
+            else:
+                # don't know the module/plugin name, but we want to make sure
+                # the log line is still output, so just get *something*
+                logger = logging.getLogger(__name__)
+
+            # Format only the desired stack frame
+            trace = traceback.extract_stack()
+            trace_frame = traceback.format_list(trace[:-1])[stack_frame][:-1]
+
+            # Warn the user
+            logger.warning(text + "\n" + trace_frame)
+
+        return func(*args, **kwargs)
+
+    return deprecated_func

--- a/sopel/logger.py
+++ b/sopel/logger.py
@@ -5,6 +5,7 @@ from logging.config import dictConfig
 import os
 
 from sopel import tools
+from sopel.lifecycle import deprecated
 
 
 class IrcLoggingHandler(logging.Handler):
@@ -155,7 +156,7 @@ def setup_logging(settings):
     dictConfig(logging_config)
 
 
-@tools.deprecated(
+@deprecated(
     reason='use sopel.tools.get_logger instead',
     version='7.0',
     warning_in='8.0',

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -7,6 +7,7 @@
 """
 from __future__ import annotations
 
+from sopel.lifecycle import deprecated
 # Import everything from sopel.plugin at the time of replacement.
 # Everything new from this point on must *not* leak here.
 # Therefore, don't add anything to this import list. Ever.
@@ -40,7 +41,6 @@ from sopel.plugin import (  # noqa
     url,
     VOICE,
 )
-from sopel.tools import deprecated
 
 
 deprecated(

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -15,189 +15,23 @@ from __future__ import annotations
 
 import codecs
 from collections import defaultdict
-import functools
-import inspect
 import logging
 import os
 import re
 import sys
 import threading
-import traceback
 from typing import Callable
 
-from pkg_resources import parse_version
-
-from sopel import __version__
-
+from sopel.lifecycle import deprecated  # Don't delete; maintains backward compatibility with pre-8.0 API
 from ._events import events  # NOQA
 from .identifiers import Identifier
+from . import time, web  # NOQA
 
 
 IdentifierFactory = Callable[[str], Identifier]
 
 # Can be implementation-dependent
 _regex_type = type(re.compile(''))
-
-
-def deprecated(
-    reason=None,
-    version=None,
-    removed_in=None,
-    warning_in=None,
-    stack_frame=-1,
-    func=None,
-):
-    """Decorator to mark deprecated functions in Sopel's API
-
-    :param str reason: optional text added to the deprecation warning
-    :param str version: optional version number when the decorated function
-                        is deprecated
-    :param str removed_in: optional version number when the deprecated function
-                           will be removed
-    :param str warning_in: optional version number when the decorated function
-                           should start emitting a warning when called
-    :param int stack_frame: optional stack frame to output; defaults to
-                            ``-1``; should almost always be negative
-    :param callable func: deprecated function
-    :return: a callable that depends on how the decorator is called; either
-             the decorated function, or a decorator with the appropriate
-             parameters
-
-    Any time the decorated ``func`` is called, a deprecation warning will be
-    printed to ``sys.stderr``, with the last frame of the traceback. The
-    optional ``warning_in`` argument suppresses the warning on Sopel versions
-    older than that, allowing for multi-stage deprecation timelines.
-
-    The decorator can be used with or without arguments::
-
-        from sopel import tools
-
-        @tools.deprecated
-        def func1():
-            print('func 1')
-
-        @tools.deprecated()
-        def func2():
-            print('func 2')
-
-        @tools.deprecated(reason='obsolete', version='7.0', removed_in='8.0')
-        def func3():
-            print('func 3')
-
-    which will output the following in a console::
-
-        >>> func1()
-        Deprecated: func1
-        File "<stdin>", line 1, in <module>
-        func 1
-        >>> func2()
-        Deprecated: func2
-        File "<stdin>", line 1, in <module>
-        func 2
-        >>> func3()
-        Deprecated since 7.0, will be removed in 8.0: obsolete
-        File "<stdin>", line 1, in <module>
-        func 3
-
-    The ``stack_frame`` argument can be used to choose which stack frame is
-    printed along with the message text. By default, this decorator prints the
-    most recent stack frame (the last entry in the list, ``-1``),
-    corresponding to where the decorated function itself was called. However,
-    in certain cases such as deprecating conditional behavior within an object
-    constructor, it can be useful to show a less recent stack frame instead.
-
-    .. note::
-
-        There is nothing that prevents this decorator to be used on a class's
-        method, or on any existing callable.
-
-    .. versionadded:: 7.0
-        Parameters ``reason``, ``version``, and ``removed_in``.
-
-    .. versionadded:: 7.1
-        The ``warning_in`` and ``stack_frame`` parameters.
-
-    """
-    if not any([reason, version, removed_in, warning_in, func]):
-        # common usage: @deprecated()
-        return deprecated
-
-    if callable(reason):
-        # common usage: @deprecated
-        return deprecated(func=reason)
-
-    if func is None:
-        # common usage: @deprecated(message, version, removed_in)
-        def decorator(func):
-            return deprecated(
-                reason, version, removed_in, warning_in, stack_frame, func)
-        return decorator
-
-    # now, we have everything we need to have:
-    # - message is not a callable (could be None)
-    # - func is not None
-    # - version and removed_in can be None but that's OK
-    # so now we can return the actual decorated function
-
-    message = reason or getattr(func, '__name__', '<anonymous-function>')
-
-    template = 'Deprecated: {message}'
-    if version and removed_in:
-        template = (
-            'Deprecated since {version}, '
-            'will be removed in {removed_in}: '
-            '{message}')
-    elif version:
-        template = 'Deprecated since {version}: {message}'
-    elif removed_in:
-        template = 'Deprecated, will be removed in {removed_in}: {message}'
-
-    text = template.format(
-        message=message, version=version, removed_in=removed_in)
-
-    @functools.wraps(func)
-    def deprecated_func(*args, **kwargs):
-        if not (warning_in and
-                parse_version(warning_in) >= parse_version(__version__)):
-            original_frame = inspect.stack()[-stack_frame]
-            mod = inspect.getmodule(original_frame[0])
-            module_name = None
-            if mod:
-                module_name = mod.__name__
-            if module_name:
-                if module_name.startswith('sopel.'):
-                    # core, or core plugin
-                    logger = logging.getLogger(module_name)
-                else:
-                    # probably a plugin; use Sopel's public API for getting the
-                    # logger for a plugin
-                    if module_name.startswith('sopel_modules.'):
-                        # namespace package plugins have a prefix, obviously
-                        # TODO: use str.removeprefix() when we drop Python<3.9
-                        module_name = module_name.replace('sopel_modules.', '', 1)
-                    logger = get_logger(module_name)
-            else:
-                # don't know the module/plugin name, but we want to make sure
-                # the log line is still output, so just get *something*
-                logger = logging.getLogger(__name__)
-
-            # Format only the desired stack frame
-            trace = traceback.extract_stack()
-            trace_frame = traceback.format_list(trace[:-1])[stack_frame][:-1]
-
-            # Warn the user
-            logger.warning(text + "\n" + trace_frame)
-
-        return func(*args, **kwargs)
-
-    return deprecated_func
-
-
-# This has to be *after* the definition of `deprecated()` or we
-# get "AttributeError: partially initialized module 'sopel.tools' has no
-# attribute 'deprecated' (most likely due to a circular import)" when trying
-# to use the decorator in submodules.
-from . import time, web  # NOQA
 
 
 # Long kept for Python compatibility, but it's time we let these go.

--- a/sopel/tools/web.py
+++ b/sopel/tools/web.py
@@ -19,7 +19,8 @@ import re
 import urllib
 from urllib.parse import urlparse, urlunparse
 
-from sopel import __version__, tools
+from sopel import __version__
+from sopel.lifecycle import deprecated
 
 
 __all__ = [
@@ -89,7 +90,7 @@ r_entity = re.compile(r'&([^;\s]+);')
 """
 
 
-@tools.deprecated(
+@deprecated(
     version='8.0',
     removed_in='9.0',
     reason="No longer needed now that Python 3.4+ has `html.unescape()`",


### PR DESCRIPTION
### Description

The `deprecated()` function is used everywhere, whenever we need to deprecate something. Sometimes, that somethings is right where this function is defined: in `sopel.tools`, causing cyclic import errors.

In an effort to reduce cyclic import errors, and to organize the code a bit better (mostly by removing everything from `sopel/tools/__init__.py`), this function is moved to its own sopel's submodule: `sopel.lifecycle`.

Documentation has been updated accordingly, and every part of Sopel that used `sopel.tools.deprecated` is now using `sopel.lifecycle.deprecated`.

In order to prevent yet another cyclic import error, `deprecated` no longer uses `sopel.tools.get_logger` to get the logger for an external plugins (that isn't using the namespace), but tries to mimic its behavior for namespace plugins only.

**Edit**: After discussion, I moved from `sopel.deprecated` to `sopel.lifecycle`. This module can be used, in the **future** to manage more version & lifecycle related things. But for now, I'd rather see this merged than trying to do too much and be frustrated because I've other things in mind that are blocked by this change.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
