### PR TITLE
tools.target: use slots for Channel and User types

### DIFF
--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -15,6 +15,10 @@ class User:
     :param str user: the user's local username ("user" in `user@host.name`)
     :param str host: the user's hostname ("host.name" in `user@host.name`)
     """
+    __slots__ = (
+        'nick', 'user', 'host', 'channels', 'account', 'away',
+    )
+
     def __init__(self, nick, user, host):
         assert isinstance(nick, Identifier)
         self.nick = nick
@@ -59,6 +63,10 @@ class Channel:
     :param name: the channel name
     :type name: :class:`~.tools.Identifier`
     """
+    __slots__ = (
+        'name', 'users', 'privileges', 'topic', 'modes', 'last_who', 'join_time',
+    )
+
     def __init__(self, name):
         assert isinstance(name, Identifier)
         self.name = name


### PR DESCRIPTION
### Description
Tin, really. Python has [this feature](https://docs.python.org/3.9/reference/datamodel.html?highlight=__slots__#slots) where you can tell it to store instance attributes in a "slot", and using it can make small objects more time- and space-efficient by eliminating the need to look up attributes in the instance's `__dict__`.

This can save some significant memory when Sopel is in many and/or large channels. For example, without this patch (in bytes):

- Size of empty channel: 1200
- Size of channel with 100 users: 84560
- Size of channel with 1000 users: 817944

And with this patch (also in bytes):

- Size of empty channel: 680
- Size of channel with 100 users: 72608
- Size of channel with 1000 users: 705304

An empty channel is reduced by nearly half, and channels with some significant user count can be reduced by some 10-15%.

I have not checked the impact of this patch on execution time, but would be glad to do so if requested.

### Notes
These values were calculated using [`Pympler.asizeof`](https://pympler.readthedocs.io/en/latest/asizeof.html#asizeof) (basically a recursive version of `sys.getsizeof`) in a simple test script:

```python
from sopel.tools import Identifier, target
from pympler.asizeof import asizeof

c = target.Channel(Identifier('#Sopel'))

print('Size of empty channel:', asizeof(c))

for n in range(1, 100):
    name = 'user{}'.format(n)
    c.add_user(
        target.User(
            Identifier(name)
            name,
            'some.example.org'
        )
    )

print('Size of channel with 100 users:', asizeof(c))

for n in range(101, 1000):
    name = 'user{}'.format(n)
    c.add_user(
        target.User(
            Identifier(name),
            name,
            'some.example.org'
        )
    )

print('Size of channel with 1000 users:', asizeof(c))
```

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - flake8 flags some errors in my `target_sizes.py` test script, which I didn't bother to make PEP8-compliant.
- [x] I have tested the functionality of the things this change touches