### PR TITLE
db, test: do not create nick ID by default

### DIFF
--- a/sopel/db.py
+++ b/sopel/db.py
@@ -403,7 +403,6 @@ class SopelDB:
 
         :param str nick: the nickname whose values to modify
         :param str key: the name of the value to delete
-        :raise ValueError: if the ``nick`` does not exist
         :raise ~sqlalchemy.exc.SQLAlchemyError: if there is a database error
 
         .. seealso::
@@ -550,8 +549,6 @@ class SopelDB:
 
         :param str first_nick: one nick in the first group to merge
         :param str second_nick: one nick in the second group to merge
-        :raise ValueError: if either ``first_nick`` or ``second_nick`` does
-                           not exist in the database
         :raise ~sqlalchemy.exc.SQLAlchemyError: if there is a database error
 
         Takes two nicks, which may or may not be registered. Unregistered nicks
@@ -567,8 +564,8 @@ class SopelDB:
         Plugins which define their own tables relying on the nick table will
         need to handle their own merging separately.
         """
-        first_id = self.get_nick_id(Identifier(first_nick))
-        second_id = self.get_nick_id(Identifier(second_nick))
+        first_id = self.get_nick_id(Identifier(first_nick), create=True)
+        second_id = self.get_nick_id(Identifier(second_nick), create=True)
         session = self.ssession()
         try:
             # Get second_id's values

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -247,14 +247,6 @@ def test_merge_nick_groups(db):
                        .filter(NickValues.key == key) \
                        .scalar()
         assert json.loads(str(found)) == value
-
-    with pytest.raises(ValueError):
-        db.merge_nick_groups(aliases[0], 'Mister_Bradshaw')
-    with pytest.raises(ValueError):
-        db.merge_nick_groups('Mister_Bradshaw', aliases[1])
-    with pytest.raises(ValueError):
-        db.merge_nick_groups('Mister_Bradshaw', 'Mister_Nesbitt')
-
     session.close()
 
 

--- a/test/test_db.py
+++ b/test/test_db.py
@@ -49,7 +49,7 @@ def test_get_nick_id(db):
     ]
 
     for test in tests:
-        test[0] = db.get_nick_id(test[2])
+        test[0] = db.get_nick_id(test[2], create=True)
         nick_id, slug, nick = test
         registered = session.query(Nicknames) \
                             .filter(Nicknames.canonical == nick) \
@@ -63,12 +63,14 @@ def test_get_nick_id(db):
     # Check that the retrieval actually is idempotent
     for test in tests:
         nick_id = test[0]
+        # no `create` this time, since the ID should already exist
         new_id = db.get_nick_id(test[2])
         assert nick_id == new_id
 
     # Even if the case is different
     for test in tests:
         nick_id = test[0]
+        # still no `create`, because the nick ID should already exist now
         new_id = db.get_nick_id(Identifier(test[2].upper()))
         assert nick_id == new_id
     session.close()
@@ -78,7 +80,7 @@ def test_alias_nick(db):
     nick = 'Embolalia'
     aliases = ['EmbölaliÅ', 'Embo`work', 'Embo']
 
-    nick_id = db.get_nick_id(nick)
+    nick_id = db.get_nick_id(nick, create=True)
     for alias in aliases:
         db.alias_nick(nick, alias)
 
@@ -97,7 +99,6 @@ def test_alias_nick(db):
 def test_set_nick_value(db):
     session = db.ssession()
     nick = 'Embolalia'
-    nick_id = db.get_nick_id(nick)
     data = {
         'key': 'value',
         'number_key': 1234,
@@ -108,25 +109,31 @@ def test_set_nick_value(db):
         for key, value in data.items():
             db.set_nick_value(nick, key, value)
 
+        # no `create` because that should be handled in `set_nick_value()`
+        nick_id = db.get_nick_id(nick)
+
         for key, value in data.items():
             found_value = session.query(NickValues.value) \
                                  .filter(NickValues.nick_id == nick_id) \
                                  .filter(NickValues.key == key) \
                                  .scalar()
             assert json.loads(str(found_value)) == value
-    check()
+
+        return nick_id
+
+    nid = check()
 
     # Test updates
     data['number_key'] = 'not a number anymore!'
     data['unicode'] = 'This is different toö!'
-    check()
+    assert nid == check()
     session.close()
 
 
 def test_get_nick_value(db):
     session = db.ssession()
     nick = 'Embolalia'
-    nick_id = db.get_nick_id(nick)
+    nick_id = db.get_nick_id(nick, create=True)
     data = {
         'key': 'value',
         'number_key': 1234,
@@ -180,6 +187,10 @@ def test_unalias_nick(db):
                        .filter(Nicknames.nick_id == nick_id) \
                        .all()
         assert len(found) == 1
+
+    with pytest.raises(ValueError):
+        db.unalias_nick('Mister_Bradshaw')
+
     session.close()
 
 
@@ -196,6 +207,9 @@ def test_forget_nick_group(db):
     db.set_nick_value(aliases[1], 'spam', 'eggs')
 
     db.forget_nick_group(aliases[0])
+
+    with pytest.raises(ValueError):
+        db.forget_nick_group('Mister_Bradshaw')
 
     # Nothing else has created values, so we know the tables are empty
     nicks = session.query(Nicknames).all()
@@ -233,6 +247,14 @@ def test_merge_nick_groups(db):
                        .filter(NickValues.key == key) \
                        .scalar()
         assert json.loads(str(found)) == value
+
+    with pytest.raises(ValueError):
+        db.merge_nick_groups(aliases[0], 'Mister_Bradshaw')
+    with pytest.raises(ValueError):
+        db.merge_nick_groups('Mister_Bradshaw', aliases[1])
+    with pytest.raises(ValueError):
+        db.merge_nick_groups('Mister_Bradshaw', 'Mister_Nesbitt')
+
     session.close()
 
 


### PR DESCRIPTION
Having `get_nick_id()` default to `create=True` may cause unexpected behavior if invalid nicknames are passed to it via plugins' use of the getter and setter methods.

We are taking this opportunity to fix the API design itself, with no period of deprecation and warnings, since this particular method is mostly used only by the database object itself, and isn't really intended for direct use by plugins.

I've also added some more assertions and error-case checking to some of the related tests for `sopel.db`. The tests required minimal changes to continue passing; only cases where some manual setup was using `get_nick_id()` as a shortcut to make sure the nick would exist in the database before running the test case needed to be changed.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
A code search on GitHub for `get_nick_id` returned very few results that weren't either a Sopel plugin or a clone of Sopel itself being used as the base for a custom bot. Of the results that were actually plugin code, only one out of a dozen or so might be problematic (and I will open an issue on that repo to let the author know about this planned change).

As I thought, not many people actually use this function directly. At least half the plugin results were from _my_ plugins or modified clones thereof (which already used `create=False` explicitly).