### PR TITLE
isup: catch up errors from get site and from requests differently

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ xmltodict==0.12
 pytz
 praw>=4.0.0,<6.0.0
 geoip2>=4.0,<5.0
-requests>=2.0.0,<3.0.0
+requests>=2.24.0,<3.0.0
 dnspython<3.0
 sqlalchemy>=1.4,<1.5

--- a/sopel/modules/isup.py
+++ b/sopel/modules/isup.py
@@ -59,10 +59,13 @@ def handle_isup(bot, trigger, secure=True):
     """
     try:
         site = get_site_url(trigger.group(2))
-        response = requests.head(site, verify=secure, timeout=(10.0, 5.0))
-        response.raise_for_status()
     except ValueError as error:
         bot.reply(str(error))
+        return
+
+    try:
+        response = requests.head(site, verify=secure, timeout=(10.0, 5.0))
+        response.raise_for_status()
     except requests.exceptions.SSLError:
         bot.say(
             '{} looks down to me (SSL error). Try using `{}isupinsecure`.'
@@ -83,6 +86,8 @@ def handle_isup(bot, trigger, secure=True):
         bot.say(
             '{} looks down to me (connection error).'
             .format(site))
+    except ValueError:
+        bot.reply('"{}" is not a valid URL.'.format(site))
     else:
         # If no exception happened, the request must have succeeded.
         bot.say(site + ' looks fine to me.')

--- a/test/modules/test_modules_isup.py
+++ b/test/modules/test_modules_isup.py
@@ -114,7 +114,7 @@ def test_isup_command_unparseable(irc, bot, user, requests_mock):
     """Test URL that can't be parsed."""
     requests_mock.head(
         'http://.foo',
-        exc=ValueError("Failed to parse: '.foo', label empty or too long"),
+        exc=ValueError("Invalid URL"),
     )
 
     irc.pm(user, '.isup .foo')
@@ -122,7 +122,7 @@ def test_isup_command_unparseable(irc, bot, user, requests_mock):
     assert len(bot.backend.message_sent) == 1, (
         '.isup command should output exactly one line')
     assert bot.backend.message_sent == rawlist(
-        'PRIVMSG User :User: Failed to parse: \'.foo\', label empty or too long'
+        'PRIVMSG User :User: "http://.foo" is not a valid URL.'
     )
 
 


### PR DESCRIPTION
### Description

Annoying little update from requests 2.27 that has a different behavior and doesn't work exactly the same way with requests_mock.

This fix works for both 7.1.x and 8.x.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
