### PR TITLE
irc: implement CHANTYPES parameter for ISUPPORT

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -348,6 +348,7 @@ def handle_isupport(bot, trigger):
     namesx_support = 'NAMESX' in bot.isupport
     uhnames_support = 'UHNAMES' in bot.isupport
     casemapping_support = 'CASEMAPPING' in bot.isupport
+    chantypes_support = 'CHANTYPES' in bot.isupport
 
     # parse ISUPPORT message from server
     parameters = {}
@@ -368,9 +369,15 @@ def handle_isupport(bot, trigger):
     if 'PREFIX' in bot.isupport:
         bot.modeparser.privileges = set(bot.isupport.PREFIX.keys())
 
-    # was CASEMAPPING support status updated?
-    if not casemapping_support and 'CASEMAPPING' in bot.isupport:
-        # Re-create the bot's nick with the proper identifier+casemapping
+    # rebuild nick when CASEMAPPING and/or CHANTYPES are set
+    if any((
+        # was CASEMAPPING support status updated?
+        not casemapping_support and 'CASEMAPPING' in bot.isupport,
+        # was CHANTYPES support status updated?
+        not chantypes_support and 'CHANTYPES' in bot.isupport,
+    )):
+        # these parameters change how the bot makes Identifiers
+        # since bot.nick is an Identifier, it must be rebuilt
         bot.rebuild_nick()
 
     # was BOT mode support status updated?

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -131,8 +131,14 @@ class AbstractBot(abc.ABC):
             'rfc1459': identifiers.rfc1459_lower,
             'rfc1459-strict': identifiers.rfc1459_strict_lower,
         }.get(self.isupport.get('CASEMAPPING'), identifiers.rfc1459_lower)
+        chantypes = (
+            self.isupport.get('CHANTYPES', identifiers.DEFAULT_CHANTYPES))
 
-        return identifiers.Identifier(name, casemapping=casemapping)
+        return identifiers.Identifier(
+            name,
+            casemapping=casemapping,
+            chantypes=chantypes,
+        )
 
     def safe_text_length(self, recipient: str) -> int:
         """Estimate a safe text length for an IRC message.

--- a/test/test_coretasks.py
+++ b/test/test_coretasks.py
@@ -335,6 +335,27 @@ def test_handle_isupport_casemapping(mockbot):
     assert mockbot.nick.lower() == 'test[a]'
 
 
+def test_handle_isupport_chantypes(mockbot):
+    # check default behavior (chantypes allows #, &, +, and !)
+    assert not mockbot.make_identifier('#channel').is_nick()
+    assert not mockbot.make_identifier('&channel').is_nick()
+    assert not mockbot.make_identifier('+channel').is_nick()
+    assert not mockbot.make_identifier('!channel').is_nick()
+
+    # now the bot "connects" to a server using `CHANTYPES=#`
+    mockbot.on_message(
+        ':irc.example.com 005 Sopel '
+        'CHANTYPES=# EXCEPTS INVEX CHANMODES=eIbq,k,flj,CFLMPQScgimnprstz '
+        'CHANLIMIT=#:120 PREFIX=(ov)@+ MAXLIST=bqeI:100 MODES=4 '
+        'NETWORK=example STATUSMSG=@+ CALLERID=g CASEMAPPING=ascii '
+        ':are supported by this server')
+
+    assert not mockbot.make_identifier('#channel').is_nick()
+    assert mockbot.make_identifier('&channel').is_nick()
+    assert mockbot.make_identifier('+channel').is_nick()
+    assert mockbot.make_identifier('!channel').is_nick()
+
+
 @pytest.mark.parametrize('modes', ['', 'Rw'])
 def test_handle_isupport_bot_mode(mockbot, modes):
     mockbot.config.core.modes = modes

--- a/test/tools/test_tools_identifiers.py
+++ b/test/tools/test_tools_identifiers.py
@@ -166,13 +166,28 @@ def test_identifier_compare_invalid(wrong_type):
         identifier < wrong_type
 
 
-def test_identifier_is_nick():
-    assert identifiers.Identifier('Exirel').is_nick()
+@pytest.mark.parametrize('name, chantypes', (
+    ('Exirel', identifiers.DEFAULT_CHANTYPES),
+    ('@Exirel', identifiers.DEFAULT_CHANTYPES),
+    ('+Exirel', ('#',)),
+    ('!Exirel', ('#',)),
+    ('&Exirel', ('#',)),
+))
+def test_identifier_is_nick(name, chantypes):
+    assert identifiers.Identifier(name, chantypes=chantypes).is_nick()
 
 
-def test_identifier_is_nick_channel():
-    assert not identifiers.Identifier('#exirel').is_nick()
+@pytest.mark.parametrize('name, chantypes', (
+    ('#Exirel', identifiers.DEFAULT_CHANTYPES),
+    ('+Exirel', identifiers.DEFAULT_CHANTYPES),
+    ('!Exirel', identifiers.DEFAULT_CHANTYPES),
+    ('&Exirel', identifiers.DEFAULT_CHANTYPES),
+    ('@Exirel', ('#', '@')),
+))
+def test_identifier_is_nick_channel(name, chantypes):
+    assert not identifiers.Identifier(name, chantypes=chantypes).is_nick()
 
 
 def test_identifier_is_nick_empty():
     assert not identifiers.Identifier('').is_nick()
+    assert not identifiers.Identifier('', chantypes=('',)).is_nick()


### PR DESCRIPTION
### Description

Tin.

This is based on #2231 which made it very easy to do: all commits are squashed into one that must be removed once that PR is merged.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
