### PR TITLE
rules: fix sphinx auto-doc warning and mypy error

### DIFF
--- a/docs/source/plugin/internals.rst
+++ b/docs/source/plugin/internals.rst
@@ -54,3 +54,17 @@ sopel.plugins.rules
    .. autoclass:: AbstractNamedRule
       :members:
       :undoc-members:
+
+   .. class:: TypedRule
+
+      A :class:`~typing.TypeVar` bound to :class:`AbstractRule`. When used in
+      the :meth:`AbstractRule.from_callable` class method, it means the return
+      value must be an instance of the class used to call that method and not a
+      different subclass of ``AbstractRule``.
+
+      .. versionadded:: 8.0
+
+         This ``TypeVar`` was added as part of a goal to start type-checking
+         Sopel and is not used at runtime.
+
+      .. TODO remove when sphinx-autodoc can manage TypeVar properly.

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -311,10 +311,13 @@ class PyModulePlugin(AbstractPluginHandler):
         :return: the plugin's version string
         :rtype: Optional[str]
         """
+        version: Optional[str] = None
         if hasattr(self._module, "__version__"):
-            return str(self._module.__version__)
-        if self.module_name.startswith("sopel."):
-            return release
+            version = str(self._module.__version__)
+        elif self.module_name.startswith("sopel."):
+            version = release
+
+        return version
 
     def load(self):
         """Load the plugin's module using :func:`importlib.import_module`.


### PR DESCRIPTION
### Description

Tin: I fixed two warning/error:

* Sphinx autodoc seems unable to properly manage `typing.TypeVar`, so I created a class declaration for the one used in `plugins.rules`,
* A new method wasn't returning explicitly, and `mypy` doesn't like that so I fixed that as well, given it's in `plugins.handlers`

Two quick fixes.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
