### PR TITLE
db, docs: update intersphinx & fix some references

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -23,7 +23,7 @@ from sopel import __version__
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+needs_sphinx = '4.0'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
@@ -35,7 +35,7 @@ extensions = [
 ]
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
-    'sqlalchemy': ('https://docs.sqlalchemy.org/en/13/', None),
+    'sqlalchemy': ('https://docs.sqlalchemy.org/en/14/', None),
 }
 
 # Make Sphinx warn for references (methods, functions, etc.) it can't find

--- a/sopel/db.py
+++ b/sopel/db.py
@@ -236,10 +236,10 @@ class SopelDB:
         """Execute an arbitrary SQL query against the database.
 
         :return: the query results
-        :rtype: :class:`sqlalchemy.engine.ResultProxy`
+        :rtype: :class:`sqlalchemy.engine.Result`
 
-        The ``ResultProxy`` object returned is a wrapper around a ``Cursor``
-        object as specified by PEP 249.
+        The ``Result`` object returned is a wrapper around a ``Cursor`` object
+        as specified by :pep:`249`.
         """
         return self.engine.execute(*args, **kwargs)
 


### PR DESCRIPTION
### Description
We've updated to SQLAlchemy 1.4.x on the development branch, and we should use the correct intersphinx base URL for that release series. SQLAlchemy has renamed its `ResultProxy` type to just `Result`, and along the way I also spotted a bare PEP number that could be a ref.

Surprisingly, that was the _only_ occurrence of `PEP` (case-sensitive) in the whole project.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches