### PR TITLE
adminchannel, coretasks: improve handling of bot's current nick

### DIFF
--- a/sopel/modules/adminchannel.py
+++ b/sopel/modules/adminchannel.py
@@ -112,8 +112,12 @@ def kick(bot, trigger):
         channel = opt
         reasonidx = 3
     reason = ' '.join(text[reasonidx:])
-    if nick != bot.make_identifier(bot.config.core.nick):
-        bot.kick(nick, channel, reason)
+
+    if nick == bot.nick:
+        bot.reply("Hey! Don't kick me. :(")
+        return
+
+    bot.kick(nick, channel, reason)
 
 
 def configureHostMask(mask):


### PR DESCRIPTION
### Description
Tin, kind of.

There's a bit more esoteric detail in the commit messages if anyone's interested, but the short version is that we really should be moving toward a world where `bot.nick` always represents the bot's _current_ nick in use—even if that doesn't match the config.

While we aren't there yet, this is a step (or two) forward on that path. I've made it so that `coretasks`' `NICK` event handler updates the bot's nick if it changes, and only warns for a change _away_ from the config value.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
On the way to writing this patch, I discovered that `bot.change_current_nick()` would send a `NICK` command to the server along with updating the `bot._nick` value. That's probably a bad idea, actually, and I didn't use it (also because it's redundant to send `NICK thenickwealreadyhave`). We should have another look at that method and rethink it…