### PR TITLE
translate: update `langcode()` helper to support Chinese

### DIFF
--- a/sopel/modules/translate.py
+++ b/sopel/modules/translate.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import json
 import logging
 import random
+import re
 
 import requests
 
@@ -158,7 +159,16 @@ def tr2(bot, trigger):
         return
 
     def langcode(p):
-        return p.startswith(':') and (2 < len(p) < 10) and p[1:].isalpha()
+        # TODO: We'd be much better off just using the langcodes PyPI package
+        # also TODO: it'd be nice not to require the : prefix, which using
+        # langcodes would make easier in lieu of adding an API key to fetch
+        # the list of supported languages
+        prefixed = p.startswith(':')
+        # the longest codes Google uses (ca. Jan 2022) are zh-CN and zh-TW
+        short_enough = (2 < len(p) < 8)
+        # pesky - in Chinese codes forced a switch from .isalpha(); see #2241
+        fits_pattern = re.match(r':[a-z\-]+', p.lower())
+        return all((prefixed, short_enough, fits_pattern))
 
     args = ['auto', 'en']
 


### PR DESCRIPTION
### Description
This is a semi-temporary fix for #2241. It's still not perfect (still allows using unsupported or nonexistent language codes), but there will be additional options available in Sopel 8.0 and beyond. Goal for this is to avoid adding any new dependencies in 7.1.x.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches