### PR TITLE
loader, plugin, plugins.rules: add `allow_bots` decorator

### DIFF
--- a/docs/source/plugin/anatomy.rst
+++ b/docs/source/plugin/anatomy.rst
@@ -124,6 +124,32 @@ Example::
 A rule with rate-limiting can return :const:`sopel.plugin.NOLIMIT` to let the
 user try again after a failed command, e.g. if a required argument is missing.
 
+Bypassing restrictions
+----------------------
+
+By default, a :term:`Rule` will not trigger on messages from Sopel itself,
+other users that are flagged as bots, or users who are
+:ref:`ignored <Ignore User>` or :ref:`rate-limited <Rate limiting>`. In
+certain cases, it might be desirable to bypass these defaults using one or
+more of these decorators:
+
+* :func:`sopel.plugin.allow_bots`: the rule will accept events from other
+  users who are flagged as bots (like Sopel itself)
+* :func:`sopel.plugin.echo`: the rule will accept Sopel's own output (e.g.
+  from calls to :func:`bot.say() <sopel.bot.Sopel.say>`)
+* :func:`sopel.plugin.unblockable`: the rule will ignore rate-limiting or
+  nick/host blocks and always process the event
+
+For example, Sopel itself uses the :func:`sopel.plugin.unblockable` decorator
+to track joins/parts from everyone, always, so plugins can *always* access
+data about any user in any channel.
+
+.. important::
+
+   The :func:`sopel.plugin.echo` decorator will send *anything* Sopel says
+   (that matches the rule) to the decorated callable, *including output from
+   the decorated callable*. Be careful not to create a feedback loop.
+
 Rule labels
 -----------
 

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -58,6 +58,7 @@ def clean_callable(func, config):
         # confusing to other code (and a waste of memory) for jobs.
         return
 
+    func.allow_bots = getattr(func, 'allow_bots', False)
     func.echo = getattr(func, 'echo', False)
     func.priority = getattr(func, 'priority', 'medium')
     func.output_prefix = getattr(func, 'output_prefix', '')

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -493,6 +493,13 @@ def echo(
 
     This decorator can be used to listen in on the messages that Sopel is
     sending and react accordingly.
+
+    .. important::
+
+        The decorated callable will receive *all* matching messages that Sopel
+        sends, including output from the same callable. Take care to avoid
+        creating feedback loops when using this feature.
+
     """
     def add_attribute(function):
         function.echo = True

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -24,6 +24,7 @@ __all__ = [
     # decorators
     'action_command',
     'action_commands',
+    'allow_bots',
     'command',
     'commands',
     'ctcp',
@@ -460,6 +461,28 @@ def thread(value: bool) -> typing.Callable:
         function.thread = threaded
         return function
 
+    return add_attribute
+
+
+def allow_bots(
+    function: typing.Optional[typing.Any] = None,
+) -> typing.Union[typing.Any, typing.Callable]:
+    """Decorate a function to specify that it should receive events from bots.
+
+    On networks implementing the `Bot Mode specification`__, messages and
+    other events from other clients that have identified themselves as bots
+    will be tagged as such, and Sopel will ignore them by default. This
+    decorator allows a function to opt into receiving these events.
+
+    .. __: https://ircv3.net/specs/extensions/bot-mode
+    """
+    def add_attribute(function):
+        function.allow_bots = True
+        return function
+
+    # hack to allow both @allow_bots and @allow_bots() to work
+    if callable(function):
+        return add_attribute(function)
     return add_attribute
 
 

--- a/test/plugins/test_plugins_rules.py
+++ b/test/plugins/test_plugins_rules.py
@@ -687,6 +687,45 @@ def test_rule_match_privmsg_echo(mockbot):
     assert match.group(0) == 'Hi!'
 
 
+@pytest.mark.parametrize(
+    'is_bot, allow_bots, is_echo, allow_echo, should_match',
+    [
+        (True, True, True, True, True),
+        (True, True, True, False, False),
+        (True, True, False, True, True),
+        (True, True, False, False, True),
+        (True, False, True, True, True),
+        (True, False, True, False, False),
+        (True, False, False, True, False),
+        (True, False, False, False, False),
+        (False, True, True, True, True),
+        (False, True, True, False, False),
+        (False, True, False, True, True),
+        (False, True, False, False, True),
+        (False, False, True, True, True),
+        (False, False, True, False, False),
+        (False, False, False, True, True),
+        (False, False, False, False, True),
+    ])
+def test_rule_match_privmsg_echo_and_bot_tag(
+    is_bot, allow_bots, is_echo, allow_echo, should_match, mockbot
+):
+    line = '{tags}:{nick}!user@example.com PRIVMSG #sopel :Hi!'.format(
+        tags='@bot ' if is_bot else '',
+        nick=mockbot.nick if is_echo else 'SomeUser',
+    )
+    pretrigger = trigger.PreTrigger(mockbot.nick, line)
+    regex = re.compile(r'.*')
+
+    rule = rules.Rule([regex], allow_bots=allow_bots, allow_echo=allow_echo)
+    matches = list(rule.match(mockbot, pretrigger))
+
+    if should_match:
+        assert len(matches) == 1, 'This combination should match the Rule'
+    else:
+        assert not matches, 'This combination should not match the Rule'
+
+
 def test_rule_match_join(mockbot):
     line = ':Foo!foo@example.com JOIN #sopel'
     pretrigger = trigger.PreTrigger(mockbot.nick, line)

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -13,6 +13,27 @@ enable = coretasks
 """
 
 
+def test_allow_bots():
+    # test decorator with parentheses
+    @plugin.allow_bots()
+    def mock(bot, trigger, match):
+        return True
+    assert mock.allow_bots is True
+
+    # test decorator without parentheses
+    @plugin.allow_bots
+    def mock(bot, trigger, match):
+        return True
+    assert mock.allow_bots is True
+
+    # test without decorator
+    def mock(bot, trigger, match):
+        return True
+    # on undecorated callables, the attr only exists after the loader loads them
+    # so this cannot `assert mock.allow_bots is False` here
+    assert not hasattr(mock, 'allow_bots')
+
+
 def test_find():
     @plugin.find('.*')
     def mock(bot, trigger, match):


### PR DESCRIPTION
### Description
You know, it's fun when you find an unmerged branch hanging around during a local cleanup.

It needs rebasing, which I'll handle in a moment, but it will fill a gap in the plugin decorator library. After #2089 we're missing a way for plugin authors to opt back into getting messages from other bots. Most will probably appreciate the filtering Sopel now does on their behalf, but I'm sure there are a few who [relied on the old behavior](https://xkcd.com/1172/)…

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - ~~I will make sure of this after rebasing.~~ It was true! And I even remembered to upgrade the dev-reqs before running tests.
- [x] I have tested the functionality of the things this change touches