### PR TITLE
reddit: handle image preview links

### DIFF
--- a/sopel/modules/reddit.py
+++ b/sopel/modules/reddit.py
@@ -34,7 +34,7 @@ post_or_comment_url = (
 )
 short_post_url = r'https?://(redd\.it|reddit\.com)/(?P<submission>[\w-]+)/?$'
 user_url = r'%s/u(?:ser)?/([\w-]+)' % domain
-image_url = r'https?://i\.redd\.it/\S+'
+image_url = r'https?://(?P<subdomain>i|preview)\.redd\.it/(?P<image>[^?\s]+)'
 video_url = r'https?://v\.redd\.it/([\w-]+)'
 gallery_url = r'https?://(?:www\.)?reddit\.com/gallery/([\w-]+)'
 
@@ -88,6 +88,9 @@ def get_is_cakeday(entrytime):
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def image_info(bot, trigger, match):
     url = match.group(0)
+    preview = match.group("subdomain") == "preview"
+    if preview:
+        url = "https://i.redd.it/{}".format(match.group("image"))
     results = list(
         bot.memory['reddit_praw']
         .subreddit('all')
@@ -98,7 +101,7 @@ def image_info(bot, trigger, match):
     except IndexError:
         # Fail silently if the image link can't be mapped to a submission
         return plugin.NOLIMIT
-    return say_post_info(bot, trigger, oldest.id, False, True)
+    return say_post_info(bot, trigger, oldest.id, preview, True)
 
 
 @plugin.url(video_url)


### PR DESCRIPTION
### Description
The reddit plugin currently does not handle preview links like this, which users sometimes mistakenly post ("Copy image link" instead of "Copy link").
https://preview.redd.it/rgcetuc1rmf81.jpg?width=576&auto=webp&s=61de9945ce109cefe95cda589c18d434b2d23553

It falls through to url.py, which fails to find a title.
This changes the reddit.py image link handling to also catch preview links, and show both the comment and full-res links in that case.

pytest is currently exploding on master and I don't know why so uh. CI is doing my QA for me

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
