### PR TITLE
backends: allow setting TLS version and ciphers

### DIFF
--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -231,6 +231,8 @@ class AbstractBot(abc.ABC):
             keyfile=self.settings.core.client_cert_file,
             verify_ssl=self.settings.core.verify_ssl,
             ca_certs=self.settings.core.ca_certs,
+            ssl_ciphers=self.settings.core.ssl_ciphers,
+            ssl_minimum_version=self.settings.core.ssl_minimum_version,
         )
 
     def run(self, host: str, port: int = 6667) -> None:


### PR DESCRIPTION
### Description
This resolves a TODO comment and two LGTM ignores regarding failing to specify a minimum SSL/TLS version for connections. It also introduces a new core config option, `tls_ciphers`, since python 3.10 tightens the defaults.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
