### PR TITLE
xkcd: account for Bing search returning mobile URLs

### DIFF
--- a/sopel/modules/xkcd.py
+++ b/sopel/modules/xkcd.py
@@ -48,7 +48,7 @@ def web_search(query):
     url = bing_search(query + sites_query)
     if not url:
         return None
-    match = re.match(r'(?:https?://)?xkcd.com/(\d+)/?', url)
+    match = re.match(r'(?:https?://)?(?:m\.)?xkcd\.com/(\d+)/?', url)
     if match:
         return match.group(1)
 


### PR DESCRIPTION
### Description
Yeah, `.xkcd` search hasn't been working very well because Bing decided to start returning `m.xkcd.com` URLs much of the time.

Interestingly, adding `-site:m.xkcd.com` made Bing return NO results, not the normal (non-mobile) link. That's why this patch modifies the regex to validate the result instead.

I'm not sure what's up with the optional protocol prefix, but didn't want to touch it in a patch intended for stable branch.

### Effect

```
# Before (v7.1.7)
11:20:16 <dgw> .xkcd team chat
11:20:16 <Sopel> dgw: Could not find any comics for that query.

# After (patch head, b706c0e841a35d095c549825ec4a08bc2bf13af5)
11:27:01 <~dgw> ,xkcd team chat
11:27:03 <SopelTest> [xkcd] Team Chat | Alt-text: 2078: He announces that he's finally making the jump from
                     screen+irssi to tmux+weechat. | https://xkcd.com/1782
```

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
Back in November I tried to fix this on the `search` plugin side with a few never-submitted tweaks that didn't actually help reliably. This solution is so stupid-simple… 😅

Along the way I considered trying to make the search more robust by pulling in results from _both_ `sopel.modules.search.bing_search()` and `sopel.modules.search.duck_search()`, but that's probably overkill.