### PR TITLE
url: bring additional sanity and calm to log output

### DIFF
--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -365,7 +365,7 @@ def process_urls(bot, trigger, urls):
         title = find_title(url)
         if not title:
             # No title found: don't handle this URL
-            LOGGER.warning('No title found; ignoring URL: %s', url)
+            LOGGER.debug('No title found; ignoring URL: %s', url)
             continue
 
         # If the URL is over bot.config.url.shorten_url_length, shorten the URL
@@ -423,7 +423,7 @@ def find_title(url, verify=True):
         # the data
         response.close()
     except requests.exceptions.ConnectionError:
-        LOGGER.exception('Unable to reach URL: %s', url)
+        LOGGER.debug('Unable to reach URL: %s', url, exc_info=True)
         return None
     except (
         requests.exceptions.InvalidURL,  # e.g. http:///


### PR DESCRIPTION
### Description
The sky is not falling if this plugin can't connect to a found URL, nor is it The End Of The World As We Know It if a title isn't found.

These are debug/info events, not errors/warnings.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
This is not marked as a resolution of #2207 because it doesn't technically address the core problem reported there. If sent to IRC as described, the "Traceback" can still become "part of [the] url". I will touch `IrcLoggingHandler` in a separate PR to address that.