### PR TITLE
logger: convert newlines to spaces in IRC logging handler

### DIFF
--- a/sopel/logger.py
+++ b/sopel/logger.py
@@ -33,7 +33,7 @@ class IrcLoggingHandler(logging.Handler):
             return
 
         try:
-            msg = self.format(record)
+            msg = self.format(record).replace('\n', ' ')
             self._bot.say(msg, self._channel)
         except (KeyboardInterrupt, SystemExit):
             raise


### PR DESCRIPTION
### Description
Tin. Stupid-simple "fix" for #2207.

/cc @RhinosF1

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
I discovered while trying to test this on top of #2249 that setting `logging_channel_level = DEBUG` causes some serious problems. That probably warrants its own issue, but since @Exirel will probably be the one to review this I wanted to see if he has any advice first before I go digging around in things to write up a real report.