### PR TITLE
loader, rules: use (pre)trigger.ctcp instead of tags

### DIFF
--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -85,14 +85,14 @@ def clean_callable(func, config):
             for command in cmds:
                 func._docs[command] = (doc, examples)
 
-    if hasattr(func, 'intents'):
+    if hasattr(func, 'ctcp'):
         # Can be implementation-dependent
         _regex_type = type(re.compile(''))
-        func.intents = [
-            (intent
-                if isinstance(intent, _regex_type)
-                else re.compile(intent, re.IGNORECASE))
-            for intent in func.intents
+        func.ctcp = [
+            (ctcp_pattern
+                if isinstance(ctcp_pattern, _regex_type)
+                else re.compile(ctcp_pattern, re.IGNORECASE))
+            for ctcp_pattern in func.ctcp
         ]
 
 
@@ -119,7 +119,7 @@ def is_limitable(obj):
         'search_rules',
         'search_rules_lazy_loaders',
         'event',
-        'intents',
+        'ctcp',
         'commands',
         'nickname_commands',
         'action_commands',
@@ -139,8 +139,8 @@ def is_triggerable(obj):
 
     A triggerable is a callable that will be used by the bot to handle a
     particular trigger (i.e. an IRC message): it can be a regex rule, an
-    event, an intent, a command, a nickname command, or an action command.
-    However, it must not be a job or a URL callback.
+    event, a CTCP command, a command, a nickname command, or an action
+    command. However, it must not be a job or a URL callback.
 
     .. seealso::
 
@@ -163,7 +163,7 @@ def is_triggerable(obj):
         'search_rules',
         'search_rules_lazy_loaders',
         'event',
-        'intents',
+        'ctcp',
         'commands',
         'nickname_commands',
         'action_commands',

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -784,6 +784,16 @@ def ctcp(
 
     :param str command_list: one or more CTCP command(s) on which to trigger
 
+    There are various CTCP commands to handle with this decorator, such as
+    ``ACTION``, ``VERSION``, and ``TIME``::
+
+        from sopel import plugin
+
+        @plugin.ctcp('TIME')
+        @plugin.rule('.*')
+        def ctcp_time(bot, trigger):
+            bot.say('Sorry, not a clock.')
+
     .. versionadded:: 7.1
 
         This is now ``ctcp`` instead of ``intent``, and it can be called

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -811,11 +811,11 @@ def ctcp(
 
     def add_attribute(function):
         function._sopel_callable = True
-        if not hasattr(function, "intents"):
-            function.intents = []
+        if not hasattr(function, "ctcp"):
+            function.ctcp = []
         for name in ctcp_commands:
-            if name not in function.intents:
-                function.intents.append(name)
+            if name not in function.ctcp:
+                function.ctcp.append(name)
         return function
     return add_attribute
 

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -979,7 +979,7 @@ class Rule(AbstractRule):
 
     def match_preconditions(self, bot, pretrigger):
         event = pretrigger.event
-        ctcp_command = pretrigger.tags.get('intent')
+        ctcp_command = pretrigger.ctcp
         nick = pretrigger.nick
         is_bot_message = (
             'bot' in pretrigger.tags and

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -456,7 +456,7 @@ class AbstractRule(abc.ABC):
     * label
     * doc, usages, and tests
     * output prefix
-    * matching patterns, events, and intents
+    * matching patterns, events, and CTCP commands
     * allow echo-message
     * threaded execution or not
     * rate limiting feature
@@ -774,7 +774,7 @@ class Rule(AbstractRule):
             'label': getattr(handler, 'rule_label', None),
             'priority': getattr(handler, 'priority', PRIORITY_MEDIUM),
             'events': getattr(handler, 'event', []),
-            'ctcp': getattr(handler, 'intents', []),
+            'ctcp': getattr(handler, 'ctcp', []),
             'allow_bots': getattr(handler, 'allow_bots', False),
             'allow_echo': getattr(handler, 'echo', False),
             'threaded': getattr(handler, 'thread', True),
@@ -979,7 +979,7 @@ class Rule(AbstractRule):
 
     def match_preconditions(self, bot, pretrigger):
         event = pretrigger.event
-        intent = pretrigger.tags.get('intent')
+        ctcp_command = pretrigger.tags.get('intent')
         nick = pretrigger.nick
         is_bot_message = (
             'bot' in pretrigger.tags and
@@ -992,7 +992,7 @@ class Rule(AbstractRule):
 
         return (
             self.match_event(event) and
-            self.match_ctcp(intent) and
+            self.match_ctcp(ctcp_command) and
             (
                 (not is_bot_message or self.allow_bots()) or
                 (is_echo_message and self.allow_echo())
@@ -1415,7 +1415,7 @@ class ActionCommand(AbstractNamedRule):
     """Action Command rule definition.
 
     An action command rule is a named rule that can be triggered only when the
-    trigger's intent is an ``ACTION``. Like the :class:`Command` rule, it
+    trigger's CTCP command is an ``ACTION``. Like the :class:`Command` rule, it
     allows command aliases.
 
     Here is an example with the ``dummy`` action command:
@@ -1429,7 +1429,7 @@ class ActionCommand(AbstractNamedRule):
 
     Apart from that, it behaves exactly like a :class:`generic rule <Rule>`.
     """
-    INTENT_REGEX = re.compile(r'ACTION', re.IGNORECASE)
+    CTCP_REGEX = re.compile(r'ACTION', re.IGNORECASE)
     PATTERN_TEMPLATE = r"""
         ({command})         # Command as group 1.
         (?:\s+              # Whitespace to end command.
@@ -1499,7 +1499,7 @@ class ActionCommand(AbstractNamedRule):
         :return: ``True`` when ``command`` matches ``ACTION``,
                  ``False`` otherwise
         """
-        return bool(command and self.INTENT_REGEX.match(command))
+        return bool(command and self.CTCP_REGEX.match(command))
 
 
 class FindRule(Rule):

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -212,7 +212,7 @@ class PreTrigger:
 
         self.sender = target
 
-        # Parse CTCP into a form consistent with IRCv3 intents
+        # Parse CTCP
         if self.event == 'PRIVMSG' or self.event == 'NOTICE':
             ctcp_match = PreTrigger.ctcp_regex.match(self.args[-1])
             if ctcp_match is not None:
@@ -256,8 +256,14 @@ class Trigger(str):
 
     Note that CTCP messages (``PRIVMSG``\\es and ``NOTICE``\\es which start
     and end with ``'\\x01'``) will have the ``'\\x01'`` bytes stripped, and
-    the command (e.g. ``ACTION``) placed mapped to the ``'intent'`` key in
-    :attr:`Trigger.tags`.
+    :attr:`trigger.ctcp <ctcp>` will contain the command (e.g. ``ACTION``).
+
+    .. note::
+
+        CTCP used to be stored as the ``intent`` tag. Since message intents
+        never made it past the IRCv3 draft stage, Sopel dropped support for
+        them in Sopel 8.
+
     """
     sender = property(lambda self: self._pretrigger.sender)
     """Where the message arrived from.

--- a/test/plugins/test_plugins_rules.py
+++ b/test/plugins/test_plugins_rules.py
@@ -643,14 +643,14 @@ def test_rule_match_privmsg_action(mockbot):
     match = matches[0]
     assert match.group(0) == 'Hello, world'
 
-    rule = rules.Rule([regex], intents=[re.compile(r'ACTION')])
+    rule = rules.Rule([regex], ctcp=[re.compile(r'ACTION')])
     matches = list(rule.match(mockbot, pretrigger))
     assert len(matches) == 1, 'Exactly one match must be found'
 
     match = matches[0]
     assert match.group(0) == 'Hello, world'
 
-    rule = rules.Rule([regex], intents=[re.compile(r'VERSION')])
+    rule = rules.Rule([regex], ctcp=[re.compile(r'VERSION')])
     assert not list(rule.match(mockbot, pretrigger))
 
 
@@ -748,19 +748,19 @@ def test_rule_match_event():
     assert rule.match_event('JOIN')
 
 
-def test_rule_match_intent():
+def test_rule_match_ctcp():
     regex = re.compile('.*')
 
     rule = rules.Rule([regex])
-    assert rule.match_intent(None)
+    assert rule.match_ctcp(None)
 
-    intents = [
+    ctcp = [
         re.compile('VERSION'),
     ]
-    rule = rules.Rule([regex], intents=intents)
-    assert not rule.match_intent(None)
-    assert rule.match_intent('VERSION')
-    assert not rule.match_intent('PING')
+    rule = rules.Rule([regex], ctcp=ctcp)
+    assert not rule.match_ctcp(None)
+    assert rule.match_ctcp('VERSION')
+    assert not rule.match_ctcp('PING')
 
 
 def test_rule_echo_message():
@@ -1078,7 +1078,7 @@ def test_kwargs_from_callable(mockbot):
     assert 'label' in kwargs
     assert 'priority' in kwargs
     assert 'events' in kwargs
-    assert 'intents' in kwargs
+    assert 'ctcp' in kwargs
     assert 'allow_echo' in kwargs
     assert 'threaded' in kwargs
     assert 'output_prefix' in kwargs
@@ -1091,7 +1091,7 @@ def test_kwargs_from_callable(mockbot):
     assert kwargs['label'] is None
     assert kwargs['priority'] == rules.PRIORITY_MEDIUM
     assert kwargs['events'] == ['PRIVMSG']
-    assert kwargs['intents'] == []
+    assert kwargs['ctcp'] == []
     assert kwargs['allow_echo'] is False
     assert kwargs['threaded'] is True
     assert kwargs['output_prefix'] == ''
@@ -1157,8 +1157,8 @@ def test_kwargs_from_callable_ctcp_intent(mockbot):
 
     # get kwargs
     kwargs = rules.Rule.kwargs_from_callable(handler)
-    assert 'intents' in kwargs
-    assert kwargs['intents'] == [re.compile(r'ACTION', re.IGNORECASE)]
+    assert 'ctcp' in kwargs
+    assert kwargs['ctcp'] == [re.compile(r'ACTION', re.IGNORECASE)]
 
 
 def test_kwargs_from_callable_allow_echo(mockbot):
@@ -2320,19 +2320,19 @@ def test_action_command_has_alias(mockbot):
     assert not rule.has_alias('unknown')
 
 
-def test_action_command_match_intent(mockbot):
+def test_action_command_match_ctcp(mockbot):
     rule = rules.ActionCommand('hello')
-    assert rule.match_intent('ACTION')
-    assert not rule.match_intent('VERSION')
-    assert not rule.match_intent('PING')
+    assert rule.match_ctcp('ACTION')
+    assert not rule.match_ctcp('VERSION')
+    assert not rule.match_ctcp('PING')
 
-    intents = (re.compile(r'VERSION'), re.compile(r'SOURCE'))
-    rule = rules.ActionCommand('hello', intents=intents)
-    assert rule.match_intent('ACTION'), 'ActionCommand always match ACTION'
-    assert not rule.match_intent('VERSION'), (
-        'ActionCommand never match other intents')
-    assert not rule.match_intent('PING'), (
-        'ActionCommand never match other intents')
+    ctcp = (re.compile(r'VERSION'), re.compile(r'SOURCE'))
+    rule = rules.ActionCommand('hello', ctcp=ctcp)
+    assert rule.match_ctcp('ACTION'), 'ActionCommand always match ACTION'
+    assert not rule.match_ctcp('VERSION'), (
+        'ActionCommand never match other CTCP commands')
+    assert not rule.match_ctcp('PING'), (
+        'ActionCommand never match other CTCP commands')
 
 
 def test_action_command_from_callable_invalid(mockbot):
@@ -2729,7 +2729,7 @@ def test_url_callback_match_filter_intent(mockbot):
     assert match.group(0) == 'https://example.com/test'
     assert match.group(1) == 'test'
 
-    rule = rules.URLCallback([regex], intents=[re.compile(r'ACTION')])
+    rule = rules.URLCallback([regex], ctcp=[re.compile(r'ACTION')])
     matches = list(rule.match(mockbot, pretrigger))
     assert len(matches) == 1, 'Exactly one match must be found'
 
@@ -2737,7 +2737,7 @@ def test_url_callback_match_filter_intent(mockbot):
     assert match.group(0) == 'https://example.com/test'
     assert match.group(1) == 'test'
 
-    rule = rules.URLCallback([regex], intents=[re.compile(r'VERSION')])
+    rule = rules.URLCallback([regex], ctcp=[re.compile(r'VERSION')])
     assert not list(rule.match(mockbot, pretrigger))
 
 

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -317,7 +317,7 @@ def test_clean_callable_default(tmpconfig, func):
     assert not hasattr(func, 'commands')
     assert not hasattr(func, 'nickname_commands')
     assert not hasattr(func, 'action_commands')
-    assert not hasattr(func, 'intents')
+    assert not hasattr(func, 'ctcp')
 
 
 def test_clean_callable_command(tmpconfig, func):
@@ -861,15 +861,15 @@ def test_clean_callable_example_nickname_custom_prefix(tmpconfig, func):
     assert docs[1] == ['TestBot: hello']
 
 
-def test_clean_callable_intents(tmpconfig, func):
-    setattr(func, 'intents', [r'abc'])
+def test_clean_callable_ctcp(tmpconfig, func):
+    setattr(func, 'ctcp', [r'abc'])
     loader.clean_callable(func, tmpconfig)
 
-    assert hasattr(func, 'intents')
-    assert len(func.intents) == 1
+    assert hasattr(func, 'ctcp')
+    assert len(func.ctcp) == 1
 
     # Test the regex is compiled properly
-    regex = func.intents[0]
+    regex = func.ctcp[0]
     assert regex.match('abc')
     assert regex.match('abcd')
     assert regex.match('ABC')
@@ -898,8 +898,8 @@ def test_clean_callable_intents(tmpconfig, func):
 
     # idempotency
     loader.clean_callable(func, tmpconfig)
-    assert len(func.intents) == 1
-    assert regex in func.intents
+    assert len(func.ctcp) == 1
+    assert regex in func.ctcp
 
     assert func.unblockable is False
     assert func.priority == 'medium'

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -248,7 +248,7 @@ def test_action_commands():
     def mock(bot, trigger, match):
         return True
     assert mock.action_commands == ['sopel']
-    assert not hasattr(mock, 'intents')
+    assert not hasattr(mock, 'ctcp')
     assert not hasattr(mock, 'rule')
 
 
@@ -257,7 +257,7 @@ def test_action_commands_args():
     def mock(bot, trigger, match):
         return True
     assert mock.action_commands == ['sopel', 'bot']
-    assert not hasattr(mock, 'intents')
+    assert not hasattr(mock, 'ctcp')
     assert not hasattr(mock, 'rule')
 
 
@@ -268,7 +268,7 @@ def test_action_commands_multiple():
     def mock(bot, trigger, match):
         return True
     assert mock.action_commands == ['robot', 'bot', 'sopel']
-    assert not hasattr(mock, 'intents')
+    assert not hasattr(mock, 'ctcp')
     assert not hasattr(mock, 'rule')
 
 
@@ -282,7 +282,7 @@ def test_all_commands():
     assert mock.commands == ['sopel']
     assert mock.action_commands == ['me_sopel']
     assert mock.nickname_commands == ['name_sopel']
-    assert not hasattr(mock, 'intents')
+    assert not hasattr(mock, 'ctcp')
     assert not hasattr(mock, 'rule')
 
 
@@ -320,14 +320,14 @@ def test_intent():
     @module.intent('ACTION')
     def mock(bot, trigger, match):
         return True
-    assert mock.intents == ['ACTION']
+    assert mock.ctcp == ['ACTION']
 
 
 def test_intent_args():
     @module.intent('ACTION', 'OTHER')
     def mock(bot, trigger, match):
         return True
-    assert mock.intents == ['ACTION', 'OTHER']
+    assert mock.ctcp == ['ACTION', 'OTHER']
 
 
 def test_intent_multiple():
@@ -336,7 +336,7 @@ def test_intent_multiple():
     @module.intent('PING',)
     def mock(bot, trigger, match):
         return True
-    assert mock.intents == ['PING', 'OTHER', 'ACTION']
+    assert mock.ctcp == ['PING', 'OTHER', 'ACTION']
 
 
 def test_rate():

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -269,21 +269,21 @@ def test_ctcp():
     @plugin.ctcp('ACTION')
     def mock(bot, trigger, match):
         return True
-    assert mock.intents == ['ACTION']
+    assert mock.ctcp == ['ACTION']
 
 
 def test_ctcp_empty():
     @plugin.ctcp()
     def mock(bot, trigger, match):
         return True
-    assert mock.intents == ['ACTION']
+    assert mock.ctcp == ['ACTION']
 
 
 def test_ctcp_direct():
     @plugin.ctcp
     def mock(bot, trigger, match):
         return True
-    assert mock.intents == ['ACTION']
+    assert mock.ctcp == ['ACTION']
 
 
 BAN_MESSAGE = ':Foo!foo@example.com PRIVMSG #chan :.ban ExiClone'

--- a/test/test_trigger.py
+++ b/test/test_trigger.py
@@ -118,6 +118,7 @@ def test_intents_pretrigger(nick):
     line = '@intent=ACTION :Foo!foo@example.com PRIVMSG #Sopel :Hello, world'
     pretrigger = PreTrigger(nick, line)
     assert pretrigger.tags == {'intent': 'ACTION'}
+    assert pretrigger.ctcp is None
     assert pretrigger.hostmask == 'Foo!foo@example.com'
     assert pretrigger.line == line
     assert pretrigger.args == ['#Sopel', 'Hello, world']
@@ -134,6 +135,7 @@ def test_unusual_pretrigger(nick):
     line = 'PING'
     pretrigger = PreTrigger(nick, line)
     assert pretrigger.tags == {}
+    assert pretrigger.ctcp is None
     assert pretrigger.hostmask is None
     assert pretrigger.line == line
     assert pretrigger.args == []
@@ -145,7 +147,8 @@ def test_unusual_pretrigger(nick):
 def test_ctcp_intent_pretrigger(nick):
     line = ':Foo!foo@example.com PRIVMSG Sopel :\x01VERSION\x01'
     pretrigger = PreTrigger(nick, line)
-    assert pretrigger.tags == {'intent': 'VERSION'}
+    assert pretrigger.tags == {}
+    assert pretrigger.ctcp == 'VERSION'
     assert pretrigger.hostmask == 'Foo!foo@example.com'
     assert pretrigger.line == line
     assert pretrigger.args == ['Sopel', '']
@@ -161,7 +164,8 @@ def test_ctcp_intent_pretrigger(nick):
 def test_ctcp_data_pretrigger(nick):
     line = ':Foo!foo@example.com PRIVMSG Sopel :\x01PING 1123321\x01'
     pretrigger = PreTrigger(nick, line)
-    assert pretrigger.tags == {'intent': 'PING'}
+    assert pretrigger.tags == {}
+    assert pretrigger.ctcp == 'PING'
     assert pretrigger.hostmask == 'Foo!foo@example.com'
     assert pretrigger.line == line
     assert pretrigger.args == ['Sopel', '1123321']
@@ -177,7 +181,8 @@ def test_ctcp_data_pretrigger(nick):
 def test_ctcp_action_pretrigger(nick):
     line = ':Foo!foo@example.com PRIVMSG #Sopel :\x01ACTION Hello, world\x01'
     pretrigger = PreTrigger(nick, line)
-    assert pretrigger.tags == {'intent': 'ACTION'}
+    assert pretrigger.tags == {}
+    assert pretrigger.ctcp == 'ACTION'
     assert pretrigger.hostmask == 'Foo!foo@example.com'
     assert pretrigger.line == line
     assert pretrigger.args == ['#Sopel', 'Hello, world']
@@ -212,7 +217,7 @@ def test_ctcp_action_trigger(nick, configfactory):
     assert trigger.groupdict == fakematch.groupdict
     assert trigger.args == ['#Sopel', 'Hello, world']
     assert trigger.plain == 'Hello, world'
-    assert trigger.tags == {'intent': 'ACTION'}
+    assert trigger.tags == {}
     assert trigger.ctcp == 'ACTION'
     assert trigger.account is None
     assert trigger.admin is True
@@ -287,7 +292,7 @@ def test_ircv3_intents_trigger(nick, configfactory):
     assert trigger.args == ['#Sopel', 'Hello, world']
     assert trigger.plain == 'Hello, world'
     assert trigger.tags == {'intent': 'ACTION'}
-    assert trigger.ctcp == 'ACTION'
+    assert trigger.ctcp is None
     assert trigger.account is None
     assert trigger.admin is True
     assert trigger.owner is True


### PR DESCRIPTION
### Description

Sopel 8's steps of #1683:

* replace `trigger.tags['intent']` by `trigger.ctcp` (same for `PreTrigger`)
* replace `plugin_callable.intents` by `plugin_callable.ctcp`
* replace `AbstractRule.match_intent` by `AbstractRule.match_ctcp`
* update tests and documentation accordingly
* add various type hint

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
