### PR TITLE
search: consistently warn about excessive "site:" operators if no results

### DIFF
--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -154,7 +154,15 @@ def search(bot, trigger):
     bu = bing_search(query) or '-'
     du = duck_search(query) or '-'
 
-    if bu == du:
+    if bu == '-' and du == '-':
+        msg = "No results found for '%s'." % query
+        if query.count('site:') >= 2:
+            # This check exists because of issue #1415. The git.io link will take the user there.
+            # (Better a sopel.chat link, but it's not set up to do that. This is shorter anyway.)
+            msg += " Try again with at most one 'site:' operator. See https://git.io/fpKtP for why."
+        bot.reply(msg)
+        return
+    elif bu == du:
         result = '%s (b, d)' % bu
     else:
         if len(bu) > 150:

--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -134,7 +134,12 @@ def bing(bot, trigger):
     if result:
         bot.say(result)
     else:
-        bot.reply("No results found for '%s'." % query)
+        msg = "No results found for '%s'." % query
+        if query.count('site:') >= 2:
+            # This check exists because of issue #1415. The git.io link will take the user there.
+            # (Better a sopel.chat link, but it's not set up to do that. This is shorter anyway.)
+            msg += " Try again with at most one 'site:' operator. See https://git.io/fpKtP for why."
+        bot.reply(msg)
 
 
 @plugin.command('search')


### PR DESCRIPTION
### Description
This applies the warning from #1418 (intended to help users avoid weird behavior as described in #1415) to _all_ search queries that contain multiple `site:` operators and return no result, regardless of which search engine is used.

For the combo `.search` command that uses both Bing and DDG, the warning triggers only if both engines return nothing.

I will finally declare #1415 closed after this patch, as we've done all we can do about it from the client end.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches