### PR TITLE
bot, irc: IRC backend using asyncio

### DIFF
--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -13,7 +13,7 @@ who should worry about :class:`sopel.bot.Sopel` only.
 .. important::
 
     When working on core IRC protocol related features, consult protocol
-    documentation at https://www.irchelp.org/protocol/rfc/
+    documentation at https://modern.ircdocs.horse/
 
 """
 # Copyright 2008, Sean B. Palmer, inamidst.com

--- a/sopel/irc/abstract_backends.py
+++ b/sopel/irc/abstract_backends.py
@@ -76,7 +76,7 @@ class AbstractIRCBackend(abc.ABC):
                 try:
                     data = str(line, encoding='iso8859-1')
                 except UnicodeDecodeError:
-                    raise RuntimeError('Unable to decode data from server.')
+                    raise ValueError('Unable to decode data from server.')
 
         return data
 

--- a/sopel/irc/abstract_backends.py
+++ b/sopel/irc/abstract_backends.py
@@ -4,8 +4,14 @@
 from __future__ import annotations
 
 import abc
+from typing import Optional, TYPE_CHECKING
 
 from .utils import safe
+
+
+if TYPE_CHECKING:
+    from sopel.irc import AbstractBot
+    from sopel.trigger import PreTrigger
 
 
 class AbstractIRCBackend(abc.ABC):
@@ -17,39 +23,68 @@ class AbstractIRCBackend(abc.ABC):
     Some methods of this class **MUST** be overridden by a subclass, or the
     backend implementation will not function correctly.
     """
-    def __init__(self, bot):
-        self.bot = bot
+    def __init__(self, bot: AbstractBot):
+        self.bot: AbstractBot = bot
 
     @abc.abstractmethod
-    def is_connected(self):
-        """Tell if the backend is connected or not.
-
-        :rtype: bool
-        """
+    def is_connected(self) -> bool:
+        """Tell if the backend is connected or not."""
 
     @abc.abstractmethod
-    def on_irc_error(self, pretrigger):
+    def on_irc_error(self, pretrigger: PreTrigger) -> None:
         """Action to perform when the server sends an error event.
 
         :param pretrigger: PreTrigger object with the error event
-        :type pretrigger: :class:`sopel.trigger.PreTrigger`
 
         On IRC error, if ``bot.hasquit`` is set, the backend should close the
         connection so the bot can quit or reconnect as required.
         """
 
     @abc.abstractmethod
-    def irc_send(self, data):
+    def irc_send(self, data: bytes) -> None:
         """Send an IRC line as raw ``data``.
 
         :param bytes data: raw line to send
+
+        This method must be thread-safe.
         """
 
-    def send_command(self, *args, **kwargs):
+    @abc.abstractmethod
+    def run_forever(self) -> None:
+        """Run the backend forever (blocking call).
+
+        This method is responsible for initiating the connection to the server,
+        and it must call ``bot.on_connect`` once connected, or ``bot.on_close``
+        if it fails to connect.
+
+        Upon successful connection, it must run forever, listening to the
+        server and allowing the bot to use :meth:`~.send_command` in a
+        thread-safe way.
+        """
+
+    def decode_line(self, line: bytes) -> str:
+        """Decode a raw IRC line from ``bytes`` to ``str``."""
+        # We can't trust clients to pass valid Unicode.
+        try:
+            data = str(line, encoding='utf-8')
+        except UnicodeDecodeError:
+            # not Unicode; let's try CP-1252
+            try:
+                data = str(line, encoding='cp1252')
+            except UnicodeDecodeError:
+                # Okay, let's try ISO 8859-1
+                try:
+                    data = str(line, encoding='iso8859-1')
+                except UnicodeDecodeError:
+                    raise RuntimeError('Unable to decode data from server.')
+
+        return data
+
+    def send_command(self, *args: str, text: Optional[str] = None) -> None:
         """Send a command through the IRC connection.
 
         :param args: IRC command to send with its argument(s)
-        :param str text: the text to send (optional keyword argument)
+        :param text: the text to send (optional keyword argument)
 
         Example::
 
@@ -65,17 +100,17 @@ class AbstractIRCBackend(abc.ABC):
             This will call the :meth:`sopel.bot.Sopel.on_message_sent`
             callback on the bot instance with the raw message sent.
         """
-        raw_command = self.prepare_command(*args, text=kwargs.get('text'))
+        raw_command = self.prepare_command(*args, text=text)
         self.irc_send(raw_command.encode('utf-8'))
         self.bot.on_message_sent(raw_command)
 
-    def prepare_command(self, *args, **kwargs):
+    def prepare_command(self, *args: str, text: Optional[str] = None) -> str:
         """Prepare an IRC command from ``args`` and optional ``text``.
 
-        :param list args: list of text, arguments of the IRC command to send
-        :param str text: optional text to send with the IRC command
+        :param args: arguments of the IRC command to send
+        :param text: text to send with the IRC command (optional keyword
+                     argument)
         :return: the raw message to send through the connection
-        :rtype: str
 
         From :rfc:`2812` Internet Relay Chat: Client Protocol, Section 2.3:
 
@@ -93,7 +128,6 @@ class AbstractIRCBackend(abc.ABC):
         The returned message contains the CR-LF pair required at the end,
         and can be sent as-is.
         """
-        text = kwargs.get('text')
         max_length = unicode_max_length = 510
         raw_command = ' '.join(args)
         if text is not None:
@@ -110,97 +144,102 @@ class AbstractIRCBackend(abc.ABC):
         # Ends the message with CR-LF
         return raw_command + '\r\n'
 
-    def send_ping(self, host):
+    def send_ping(self, host: str) -> None:
         """Send a ``PING`` command to the server.
 
-        :param str host: IRC server host
+        :param host: IRC server host
 
         A ``PING`` command should be sent at a regular interval to make sure
         the server knows the IRC connection is still active.
         """
         self.send_command('PING', safe(host))
 
-    def send_pong(self, host):
+    def send_pong(self, host: str) -> None:
         """Send a ``PONG`` command to the server.
 
-        :param str host: IRC server host
+        :param host: IRC server host
 
         A ``PONG`` command must be sent each time the server sends a ``PING``
         command to the client.
         """
         self.send_command('PONG', safe(host))
 
-    def send_nick(self, nick):
+    def send_nick(self, nick: str) -> None:
         """Send a ``NICK`` command with a ``nick``.
 
-        :param str nick: nickname to take
+        :param nick: nickname to take
         """
         self.send_command('NICK', safe(nick))
 
-    def send_user(self, user, mode, nick, name):
+    def send_user(self, user: str, mode: str, nick: str, name: str) -> None:
         """Send a ``USER`` command with a ``user``.
 
-        :param str user: IRC username
-        :param str mode: mode(s) to send for the user
-        :param str nick: nickname associated with this user
-        :param str name: "real name" for the user
+        :param user: IRC username
+        :param mode: mode(s) to send for the user
+        :param nick: nickname associated with this user
+        :param name: "real name" for the user
         """
         self.send_command('USER', safe(user), mode, safe(nick), text=name)
 
-    def send_pass(self, password):
+    def send_pass(self, password: str) -> None:
         """Send a ``PASS`` command with a ``password``.
 
-        :param str password: password for authentication
+        :param password: password for authentication
         """
         self.send_command('PASS', safe(password))
 
-    def send_join(self, channel, password=None):
+    def send_join(self, channel: str, password: Optional[str] = None) -> None:
         """Send a ``JOIN`` command to ``channel`` with optional ``password``.
 
-        :param str channel: channel to join
-        :param str password: optional password for protected channels
+        :param channel: channel to join
+        :param password: optional password for protected channels
         """
         if password is None:
             self.send_command('JOIN', safe(channel))
         else:
             self.send_command('JOIN', safe(channel), safe(password))
 
-    def send_part(self, channel, reason=None):
+    def send_part(self, channel: str, reason: Optional[str] = None) -> None:
         """Send a ``PART`` command to ``channel``.
 
-        :param str channel: the channel to part
-        :param str text: optional text for leaving the channel
+        :param channel: the channel to part
+        :param text: optional text for leaving the channel
         """
         self.send_command('PART', safe(channel), text=reason)
 
-    def send_quit(self, reason=None):
+    def send_quit(self, reason: Optional[str] = None) -> None:
         """Send a ``QUIT`` command.
 
-        :param str reason: optional text for leaving the server
+        :param reason: optional text for leaving the server
 
         This won't send anything if the backend isn't connected.
         """
         if self.is_connected():
             self.send_command('QUIT', text=reason)
 
-    def send_kick(self, channel, nick, reason=None):
+    def send_kick(
+        self,
+        channel: str,
+        nick: str,
+        reason: Optional[str] = None,
+    ) -> None:
         """Send a ``KICK`` command for ``nick`` in ``channel`` .
 
-        :param str channel: the channel from which to kick ``nick``
-        :param str nick: nickname to kick from the ``channel``
-        :param str reason: optional reason for the kick
+        :param channel: the channel from which to kick ``nick``
+        :param nick: nickname to kick from the ``channel``
+        :param reason: optional reason for the kick
         """
         self.send_command('KICK', safe(channel), safe(nick), text=reason)
 
-    def send_privmsg(self, dest, text):
+    def send_privmsg(self, dest: str, text: str) -> None:
         """Send a ``PRIVMSG`` command to ``dest`` with ``text``.
 
-        :param str dest: nickname or channel name
-        :param str text: the text to send
+        :param dest: nickname or channel name
+        :param text: the text to send
         """
         self.send_command('PRIVMSG', safe(dest), text=text)
 
-    def send_notice(self, dest, text):
+    def send_notice(self, dest: str, text: str) -> None:
         """Send a ``NOTICE`` command to ``dest`` with ``text``.
 
         :param str dest: nickname or channel name

--- a/sopel/irc/backends.py
+++ b/sopel/irc/backends.py
@@ -5,346 +5,322 @@
 # documentation at http://www.irchelp.org/irchelp/rfc/
 from __future__ import annotations
 
-import asynchat
-import asyncore
-import datetime
-import errno
-import inspect
+import asyncio
 import logging
-import os
-import socket
+import signal
 import ssl
 import threading
+from typing import Dict, Optional, Tuple, TYPE_CHECKING
 
-from sopel.tools import jobs
 from .abstract_backends import AbstractIRCBackend
-from .utils import get_cnames
+
+
+if TYPE_CHECKING:
+    from sopel.irc import AbstractBot
+    from sopel.trigger import PreTrigger
 
 
 LOGGER = logging.getLogger(__name__)
+QUIT_SIGNALS = [
+    getattr(signal, name)
+    for name in ['SIGUSR1', 'SIGTERM', 'SIGINT']
+    if hasattr(signal, name)
+]
+RESTART_SIGNALS = [
+    getattr(signal, name)
+    for name in ['SIGUSR2', 'SIGILL']
+    if hasattr(signal, name)
+]
 
 
-def _send_ping(backend):
-    if not backend.is_connected():
-        return
+class AsyncioBackend(AbstractIRCBackend):
+    """IRC Backend implementation using :mod:`asyncio`.
 
-    events = []
-    need_ping = True
-
-    # Ensure we have a time to check first
-    if backend.last_event_at:
-        events.append(backend.last_event_at)
-
-    if backend.last_ping_at:
-        events.append(backend.last_ping_at)
-
-    # At least a PING was sent, or a message was received
-    if events:
-        last_event = max(events)
-        dt = datetime.datetime.utcnow() - last_event
-        time_passed = dt.total_seconds()
-        need_ping = time_passed > backend.ping_interval
-
-    # Send PING only if needed
-    if need_ping:
-        try:
-            backend.send_ping(backend.host)
-            backend.last_ping_at = datetime.datetime.utcnow()
-        except socket.error:
-            LOGGER.exception('Socket error on PING')
-
-
-def _check_timeout(backend):
-    if not backend.is_connected():
-        return
-    dt = datetime.datetime.utcnow() - backend.last_event_at
-    time_passed = dt.total_seconds()
-    if time_passed > backend.server_timeout:
-        LOGGER.error(
-            'Server timeout detected after %ss; closing.', time_passed)
-        # discard buffers: no need to read/write anything more, just quit
-        LOGGER.debug('Discard current buffers.')
-        backend.discard_buffers()
-        # close now
-        backend.handle_close()
-
-
-class AsynchatBackend(AbstractIRCBackend, asynchat.async_chat):
-    """IRC backend implementation using :mod:`asynchat` (:mod:`asyncore`).
-
-    :param bot: a Sopel instance
-    :type bot: :class:`sopel.bot.Sopel`
-    :param int server_timeout: connection timeout in seconds
-    :param int ping_interval: ping interval in seconds
-
-    The ``server_timeout`` option defaults to ``120`` seconds if not provided.
-
-    The ``ping_interval`` defaults to ``server_timeout * 0.45`` if not specified.
+    :param bot: an instance of a bot that uses the backend
+    :param host: hostname/IP to connect to
+    :param port: port to connect to
+    :param source_address: optional source address as a tuple of
+                           ``(host, port)``
+    :param server_timeout: optional time (in seconds) before the backend reach
+                           a timeout (defaults to 120s)
+    :param ping_interval: optional ping interval (in seconds) between
+                          last message received and sending a PING to the
+                          server (defaults to ``server_timeout * 0.45``)
+    :param use_ssl: if the connection must use SSL/TLS or not
+    :param certfile: optional location of the certificates; used when
+                     ``use_ssl`` is ``True``
+    :param keyfile: optional location to the key file for certificates; used
+                    when ``use_ssl`` is ``True`` and ``certfile`` is not
+                    ``None``
+    :param verify_ssl: if the certificates must be verified; ignored if
+                       ``use_ssl`` is not ``True``
+    :param ca_certs: optional location to the CA certificates; ignored if
+                    ``verify_ssl`` is ``False``
     """
-    def __init__(self, bot, server_timeout=None, ping_interval=None, **kwargs):
-        AbstractIRCBackend.__init__(self, bot)
-        asynchat.async_chat.__init__(self)
-        self.writing_lock = threading.RLock()
-        self.set_terminator(b'\r\n')
-        self.buffer = ''
-        self.server_timeout = server_timeout or 120
-        self.ping_interval = ping_interval or (self.server_timeout * 0.45)
-        self.last_event_at = None
-        self.last_ping_at = None
-        self.host = None
-        self.port = None
-        self.source_address = None
-        self.timeout_scheduler = jobs.Scheduler(self)
+    def __init__(
+        self,
+        bot: AbstractBot,
+        host: str,
+        port: int,
+        source_address: Optional[Tuple[str, int]],
+        server_timeout: Optional[int] = None,
+        ping_interval: Optional[int] = None,
+        use_ssl: bool = False,
+        certfile: Optional[str] = None,
+        keyfile: Optional[str] = None,
+        verify_ssl: bool = True,
+        ca_certs: Optional[str] = None,
+        **kwargs,
+    ):
+        super().__init__(bot)
+        # connection parameters
+        self._host: str = host
+        self._port: int = port
+        self._source_address: Optional[Tuple[str, int]] = source_address
+        self._use_ssl: bool = use_ssl
+        self._certfile: Optional[str] = certfile
+        self._keyfile: Optional[str] = keyfile
+        self._verify_ssl: bool = verify_ssl
+        self._ca_certs: Optional[str] = ca_certs
 
-        # register timeout jobs
-        self.register_timeout_jobs([
-            (5, _send_ping),
-            (10, _check_timeout),
-        ])
+        # timeout configuration
+        self._server_timeout: float = float(server_timeout or 120)
+        self._ping_interval: float = float(
+            ping_interval or (self._server_timeout * 0.45)
+        )
 
-    def is_connected(self):
-        return self.connected
+        # connection flags
+        self._connected: bool = False
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
 
-    def on_irc_error(self, pretrigger):
-        if self.bot.hasquit:
-            # discard buffers: no need to read/write anything more, just quit
-            LOGGER.debug('Discard current buffers.')
-            self.discard_buffers()
-            # close now
-            self.handle_close()
+        # connection writer & reader
+        self._writer: Optional[asyncio.StreamWriter] = None
+        self._reader: Optional[asyncio.StreamReader] = None
 
-    def irc_send(self, data):
-        """Send an IRC line as raw ``data`` to the socket connection.
+        # connection tasks
+        self._read_task: Optional[asyncio.Task] = None
+        self._ping_task: Optional[asyncio.TimerHandle] = None
+        self._timeout_task: Optional[asyncio.TimerHandle] = None
 
-        :param bytes data: raw line to send
+    # signal handlers
 
-        This uses :meth:`asyncore.dispatcher.send` method to send ``data``
-        directly. This method is thread-safe.
+    def _signal_quit(self) -> None:
+        LOGGER.info('Receiving QUIT signal.')
+        self.bot.quit('Quit')
+
+    def _signal_restart(self) -> None:
+        LOGGER.info('Receiving RESTART signal.')
+        self.bot.restart('Restarting')
+
+    # timeout management
+
+    def _ping_callback(self) -> None:
+        # simply send a PING
+        LOGGER.debug(
+            'Sending PING after %0.1fs of inactivity.', self._ping_interval)
+        self.send_ping(self._host)
+
+    def _timeout_callback(self) -> None:
+        # cancel other tasks
+        for task in [self._ping_task, self._read_task]:
+            if task is not None:
+                task.cancel()
+        self._ping_task = None
+        self._read_task = None
+        # log a warning
+        LOGGER.warning(
+            'Reached timeout (%0.1fs); closing connection.',
+            self._server_timeout,
+        )
+
+    def _cancel_timeout_tasks(self) -> None:
+        # cancel every timeout tasks (PING & Server Timeout)
+        for task in [self._ping_task, self._timeout_task]:
+            if task is not None:
+                task.cancel()
+        self._ping_task = None
+        self._timeout_task = None
+
+    def _reset_timeout_tasks(self) -> None:
+        # cancel first
+        self._cancel_timeout_tasks()
+        # then schedule again
+        loop = asyncio.get_running_loop()
+        self._ping_task = loop.call_later(
+            self._ping_interval, self._ping_callback,
+        )
+        self._timeout_task = loop.call_later(
+            self._server_timeout, self._timeout_callback,
+        )
+
+    # backend interface
+
+    def is_connected(self) -> bool:
+        return self._connected
+
+    def on_irc_error(self, pretrigger: PreTrigger) -> None:
+        LOGGER.warning('Error received from server: %s', pretrigger.text)
+
+    def irc_send(self, data: bytes) -> None:
+        if self._loop is None:
+            raise RuntimeError('EventLoop not initialized.')
+
+        if threading.current_thread() is threading.main_thread():
+            self._loop.create_task(self.send(data))
+        else:
+            asyncio.run_coroutine_threadsafe(self.send(data), self._loop)
+
+    # read/write
+
+    async def send(self, data: bytes) -> None:
+        """Send ``data`` through the writer."""
+        if self._writer is None:
+            raise RuntimeError(
+                'Writer not initialized. '
+                'Are you sure the backend is running?')
+
+        try:
+            self._writer.write(data)
+            await self._writer.drain()
+        except asyncio.CancelledError:
+            LOGGER.debug('Writer was cancelled')
+
+    async def read_forever(self) -> None:
+        """Main reading loop of the backend.
+
+        This listens to the reader for an incoming IRC line, decodes the data,
+        and passes it to
+        :meth:`bot.on_message(data) <sopel.irc.AbstractBot.on_message>`, until
+        the reader reaches the EOF (i.e. connection closed).
+
+        It manages connection timeouts by scheduling two tasks:
+
+        * a PING task, that will send a PING to the server as defined by
+          the ping interval (from the configuration)
+        * a Timeout task, that will stop the bot if it reaches the timeout
+
+        Whenever a message is received, both tasks are cancelled and
+        rescheduled.
+
+        When the connection is closed, the reader will reach EOF, and return
+        an empty string, which in turn will end the coroutine.
+
+        .. seealso::
+
+            The :meth:`~.decode_line` method is used to decode the IRC line
+            from :class:`bytes` to :class:`str`.
+
         """
-        with self.writing_lock:
-            self.send(data)
+        if self._reader is None:
+            raise RuntimeError(
+                'Reader not initialized. '
+                'Are you sure the backend is running?')
 
-    def run_forever(self):
+        # cancel timeout tasks
+        self._cancel_timeout_tasks()
+
+        # loop forever until EOF
+        while not self._reader.at_eof():
+            try:
+                line: bytes = await self._reader.readuntil(separator=b'\r\n')
+            except asyncio.exceptions.IncompleteReadError as e:
+                LOGGER.warning('Receiving partial message from IRC.')
+                line = e.partial
+            except asyncio.exceptions.LimitOverrunError:
+                LOGGER.exception('Unable to read from IRC server.')
+                break
+
+            # connection is active: reset timeout tasks
+            self._reset_timeout_tasks()
+
+            # check content
+            if not line:
+                LOGGER.debug('No data received.')
+                continue
+
+            # use bot's callbacks
+            data = self.decode_line(line)
+            self.bot.log_raw(data, '<<')
+            self.bot.on_message(data)
+
+        # cancel timeout tasks when reading loop ends
+        self._cancel_timeout_tasks()
+
+    # run & connection
+
+    def get_connection_kwargs(self) -> Dict:
+        """Return the keyword arguments required to initiate connection."""
+        ssl_context: Optional[ssl.SSLContext] = None
+
+        if self._use_ssl:
+            ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
+            if self._certfile is not None:
+                # load_cert_chain requires a certfile (cannot be None)
+                ssl_context.load_cert_chain(
+                    certfile=self._certfile,
+                    keyfile=self._keyfile,
+                )
+
+            if self._verify_ssl and self._ca_certs is not None:
+                ssl_context.load_verify_locations(self._ca_certs)
+            elif not self._verify_ssl:
+                # deactivate SSL verification for hostname & certificate
+                ssl_context.check_hostname = False
+                ssl_context.verify_mode = ssl.CERT_NONE
+
+        return {
+            'host': self._host,
+            'port': self._port,
+            'ssl': ssl_context,
+            'local_addr': self._source_address,
+        }
+
+    async def _run_forever(self) -> None:
+        self._loop = asyncio.get_running_loop()
+
+        # register signal handlers
+        for quit_signal in QUIT_SIGNALS:
+            self._loop.add_signal_handler(quit_signal, self._signal_quit)
+        for restart_signal in RESTART_SIGNALS:
+            self._loop.add_signal_handler(restart_signal, self._signal_restart)
+
+        # open connection
+        try:
+            self._reader, self._writer = await asyncio.open_connection(
+                **self.get_connection_kwargs(),
+            )
+        except ssl.SSLError:
+            LOGGER.exception('Unable to connect due to SSL error.')
+            return
+
+        self._connected = True
+
+        LOGGER.debug('Connection registered.')
+        self.bot.on_connect()
+
+        LOGGER.debug('Waiting for messages...')
+        self._read_task = asyncio.create_task(self.read_forever())
+        try:
+            await self._read_task
+        except asyncio.CancelledError:
+            LOGGER.debug('Read task was cancelled.')
+        else:
+            LOGGER.debug('Reader received EOF.')
+
+        self._connected = False
+
+        # cancel timeout tasks
+        self._cancel_timeout_tasks()
+
+        # nothing to read anymore
+        LOGGER.debug('Shutting down writer.')
+        self._writer.close()
+        await self._writer.wait_closed()
+        LOGGER.debug('All clear, exiting now.')
+
+    def run_forever(self) -> None:
         """Run forever."""
         LOGGER.debug('Running forever.')
-        asyncore.loop()
-
-    def register_timeout_jobs(self, handlers):
-        """Register the timeout handlers for the timeout scheduler."""
-        for timer, handler in handlers:
-            job = jobs.Job(
-                intervals=[timer],
-                handler=handler,
-                threaded=False,
-                doc=inspect.getdoc(handler),
-            )
-            self.timeout_scheduler.register(job)
-            LOGGER.debug('Timeout Job registered: %s', str(job))
-
-    def initiate_connect(self, host, port, source_address):
-        """Initiate IRC connection.
-
-        :param str host: IRC server hostname
-        :param int port: IRC server port
-        :param str source_address: the source address from which to initiate
-                                   the connection attempt
-        """
-        self.host = host
-        self.port = port
-        self.source_address = source_address
-
-        LOGGER.info('Connecting to %s:%s...', host, port)
-        try:
-            LOGGER.debug('Set socket')
-            self.set_socket(socket.create_connection((host, port),
-                            source_address=source_address))
-            LOGGER.debug('Connection attempt')
-            self.connect((host, port))
-        except socket.error as e:
-            LOGGER.exception('Connection error: %s', e)
-            self.handle_close()
-
-    def handle_connect(self):
-        """Called when the active opener's socket actually makes a connection."""
-        LOGGER.info('Connection accepted by the server...')
-        self.timeout_scheduler.start()
-        self.bot.on_connect()
-
-    def handle_close(self):
-        """Called when the connection must be closed."""
-        LOGGER.debug('Stopping timeout watchdog')
-        self.timeout_scheduler.stop()
-        LOGGER.info('Closing connection')
-        self.close()
+        asyncio.run(self._run_forever())
+        LOGGER.info('Connection backend stopped.')
         self.bot.on_close()
-
-    def handle_error(self):
-        """Called when an exception is raised and not otherwise handled.
-
-        This method is an override of :meth:`asyncore.dispatcher.handle_error`,
-        the :class:`asynchat.async_chat` being a subclass of
-        :class:`asyncore.dispatcher`.
-        """
-        LOGGER.info('Connection error...')
-        self.bot.on_error()
-
-    def collect_incoming_data(self, data):
-        """Try to make sense of incoming data as Unicode.
-
-        :param bytes data: the incoming raw bytes
-
-        The incoming line is discarded (and thus ignored) if guessing the text
-        encoding and decoding it fails.
-        """
-        data += self.get_terminator()
-
-        # We can't trust clients to pass valid Unicode.
-        try:
-            data = str(data, encoding='utf-8')
-        except UnicodeDecodeError:
-            # not Unicode; let's try CP-1252
-            try:
-                data = str(data, encoding='cp1252')
-            except UnicodeDecodeError:
-                # Okay, let's try ISO 8859-1
-                try:
-                    data = str(data, encoding='iso8859-1')
-                except UnicodeDecodeError:
-                    self.bot.log_raw(data, '<<!')
-                    LOGGER.warning(
-                        "Couldn't guess character encoding of message, ignoring: %r",
-                        data,
-                    )
-                    return
-
-        if data:
-            self.bot.log_raw(data, '<<')
-        self.buffer += data
-        self.last_event_at = datetime.datetime.utcnow()
-
-    def found_terminator(self):
-        """Handle the end of an incoming message."""
-        line = self.buffer
-        self.buffer = ''
-        self.bot.on_message(line)
-
-    def on_scheduler_error(self, scheduler, exc):
-        """Called when the Job Scheduler fails."""
-        LOGGER.exception('Error with the timeout scheduler: %s', exc)
-        self.handle_close()
-
-    def on_job_error(self, scheduler, job, exc):
-        """Called when a job from the Job Scheduler fails."""
-        LOGGER.exception('Error with the timeout scheduler: %s', exc)
-        self.handle_close()
-
-
-class SSLAsynchatBackend(AsynchatBackend):
-    """SSL-aware extension of :class:`AsynchatBackend`.
-
-    :param bot: a Sopel instance
-    :type bot: :class:`sopel.bot.Sopel`
-    :param bool verify_ssl: whether to validate the IRC server's certificate
-                            (default ``True``, for good reason)
-    :param str ca_certs: filesystem path to a CA Certs file containing trusted
-                         root certificates
-    :param str certfile: filesystem path to a certificate for SSL/TLS client
-                         authentication (CertFP)
-    :param str keyfile: filesystem path to the private key for ``certfile``
-    """
-    def __init__(self, bot, verify_ssl=True, ca_certs=None, certfile=None, keyfile=None, **kwargs):
-        AsynchatBackend.__init__(self, bot, **kwargs)
-        self.verify_ssl = verify_ssl
-        self.ssl = None
-        self.ca_certs = ca_certs
-        self.certfile = certfile
-        self.keyfile = keyfile
-
-    def handle_connect(self):
-        """Handle potential TLS connection."""
-        # TODO: Refactor to use SSLContext and an appropriate PROTOCOL_* constant
-        # See https://lgtm.com/rules/1507225275976/
-        # These warnings are ignored for now, because we can't easily fix them
-        # while maintaining compatibility with py2.7 AND 3.3+, but in Sopel 8
-        # the supported range should narrow sufficiently to fix these for real.
-        # Each Python version still generally selects the most secure protocol
-        # version(s) it supports.
-        if not self.verify_ssl:
-            self.ssl = ssl.wrap_socket(self.socket,  # lgtm [py/insecure-default-protocol]
-                                       certfile=self.certfile,
-                                       keyfile=self.keyfile,
-                                       do_handshake_on_connect=True,
-                                       suppress_ragged_eofs=True)
-        else:
-            self.ssl = ssl.wrap_socket(self.socket,  # lgtm [py/insecure-default-protocol]
-                                       certfile=self.certfile,
-                                       keyfile=self.keyfile,
-                                       do_handshake_on_connect=True,
-                                       suppress_ragged_eofs=True,
-                                       cert_reqs=ssl.CERT_REQUIRED,
-                                       ca_certs=self.ca_certs)
-            # connect to host specified in config first
-            try:
-                ssl.match_hostname(self.ssl.getpeercert(), self.host)
-            except ssl.CertificateError:
-                # the host in config and certificate don't match
-                LOGGER.error("hostname mismatch between configuration and certificate")
-                # check (via exception) if a CNAME matches as a fallback
-                has_matched = False
-                for hostname in get_cnames(self.host):
-                    try:
-                        ssl.match_hostname(self.ssl.getpeercert(), hostname)
-                        LOGGER.warning(
-                            "using {0} instead of {1} for TLS connection"
-                            .format(hostname, self.host))
-                        has_matched = True
-                        break
-                    except ssl.CertificateError:
-                        pass
-
-                if not has_matched:
-                    # everything is broken
-                    LOGGER.error("Invalid certificate, no hostname matches.")
-                    # TODO: refactor access to bot's settings
-                    if hasattr(self.bot.settings.core, 'pid_file_path'):
-                        # TODO: refactor to quit properly (no "os._exit")
-                        os.unlink(self.bot.settings.core.pid_file_path)
-                        os._exit(1)
-        self.set_socket(self.ssl)
-        LOGGER.info('Connection accepted by the server...')
-        LOGGER.debug('Starting job scheduler for connection timeout...')
-        self.timeout_scheduler.start()
-        self.bot.on_connect()
-
-    def send(self, data):
-        """SSL-aware override for :meth:`~asyncore.dispatcher.send`."""
-        try:
-            result = self.socket.send(data)
-            return result
-        except ssl.SSLError as why:
-            if why[0] in (asyncore.EWOULDBLOCK, errno.ESRCH):
-                return 0
-            raise why
-
-    def recv(self, buffer_size):
-        """SSL-aware override for :meth:`~asyncore.dispatcher.recv`.
-
-        From a (now deleted) blog post by Evan "K7FOS" Fosmark:
-        https://k7fos.com/2010/09/ssl-support-in-asynchatasync_chat
-        """
-        try:
-            data = self.socket.read(buffer_size)
-            if not data:
-                self.handle_close()
-                return b''
-            return data
-        except ssl.SSLError as why:
-            if why[0] in (asyncore.ECONNRESET, asyncore.ENOTCONN,
-                          asyncore.ESHUTDOWN):
-                self.handle_close()
-                return ''
-            elif why[0] == errno.ENOENT:
-                # Required in order to keep it non-blocking
-                return b''
-            else:
-                raise

--- a/sopel/irc/backends.py
+++ b/sopel/irc/backends.py
@@ -1,8 +1,6 @@
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.
-# When working on core IRC protocol related features, consult protocol
-# documentation at http://www.irchelp.org/irchelp/rfc/
 from __future__ import annotations
 
 import asyncio

--- a/sopel/irc/utils.py
+++ b/sopel/irc/utils.py
@@ -5,26 +5,6 @@ from __future__ import annotations
 
 from typing import NamedTuple
 
-from dns import rdtypes, resolver
-
-
-def get_cnames(domain):
-    """Determine the CNAMEs for a given domain.
-
-    :param str domain: domain to check
-    :return: list (of str)
-    """
-    try:
-        answer = resolver.query(domain, "CNAME")
-    except resolver.NoAnswer:
-        return []
-
-    return [
-        data.to_text()[:-1]
-        for data in answer
-        if isinstance(data, rdtypes.ANY.CNAME.CNAME)
-    ]
-
 
 def safe(string):
     """Remove newlines from a string.

--- a/sopel/logger.py
+++ b/sopel/logger.py
@@ -107,6 +107,11 @@ def setup_logging(settings):
                 'propagate': False,
                 'handlers': ['exceptionfile'],
             },
+            # asyncio logging
+            'asyncio': {
+                'level': 'DEBUG',
+                'handlers': ['console'],
+            },
         },
         'handlers': {
             # output on stderr

--- a/sopel/tests/mocks.py
+++ b/sopel/tests/mocks.py
@@ -55,6 +55,14 @@ class MockIRCBackend(AbstractIRCBackend):
         Set to ``True`` to make the bot think it is connected.
         """
 
+    def initiate_connect(self, host, port, source_address):
+        self.host = host
+        self.port = port
+        self.source_address = source_address
+
+    def run_forever(self):
+        raise RuntimeError('MockIRCBackend cannot be used to run the client.')
+
     def is_connected(self):
         return self.connected
 

--- a/sopel/tests/mocks.py
+++ b/sopel/tests/mocks.py
@@ -55,11 +55,6 @@ class MockIRCBackend(AbstractIRCBackend):
         Set to ``True`` to make the bot think it is connected.
         """
 
-    def initiate_connect(self, host, port, source_address):
-        self.host = host
-        self.port = port
-        self.source_address = source_address
-
     def run_forever(self):
         raise RuntimeError('MockIRCBackend cannot be used to run the client.')
 


### PR DESCRIPTION
### Description

**TL;DR**: Tin. Close #1414.

Wouhou! This is it, that's the big PR for Sopel 8 that replaces the backend made with the now deprecated `asynchat` (and `asyncore`) module by a backend made with `asyncio`—and it wasn't easy. It might be complicated to review this, even more with all the added stuffs that feel unnecessary (like a heavy dose of type annotation).

I've tested it myself on two networks: Libera (with SSL on), and a private network (without SSL), and it all worked fine, ping timeout was handled properly, server timeout as well, ctrl+c is working fine as far as I can tell, even tho the sequence is a bit complicated if you try to interrupt the bot at the startup sequence (servers tend to wait quite some time before replying to a `QUIT` command and closing the connection).

So what's in the box?

* Asynchat based backends have been removed, and replaced by the `AsyncioBackend`
* A lot of parameters have been moved from `AbstractBackend.run` to the `__init__` of `AsyncioBackend`
* It is now easier to know what are the connection parameters, all put in one single method
* SSL is now managed with an SSL Context (this makes parts of #2246 obsolete, sadly, and I haven't put the TLS minimum version (yet))
* `asyncio`'s high level API is used when possible, instead of working with the low-level API; this means that I didn't dive into Protocol, Transport, Socket, etc. and I decided to use the `StreamReader` and `StreamWriter` object
* There is still a bit of `asyncio.Task` and `asyncio.TimerHandle` management involved (mostly for thread-safety and for timeout management)
* Signal handlers are now managed by the backend itself (it was impossible otherwise)
* Methods required on the `AbstractBot` ABC class and `AbstractIRCBackend` have been created or moved accordingly
* I had zero trouble with exiting the bot from the `start` command, so I went maybe a bit too ballistic on that one—but given it now runs an `EventLoop`... who knows?

What's missing?

* TLS management wasn't ported (yet) from #2246 
* I'm  not very happy with how `on_irc_error` and `on_error` callbacks are used (when/how)
* I know it works, but I would like to be a bit more sure about the timeout management
* I've no idea how to deal with CNAME check; I think @half-duplex asked about it on #2246 and I've to say... why did we check that? I'm not sure it's a good thing to keep...
* I know it's possible but I haven't tried yet to run every single rule handlers into an asyncio task, trough [asyncio.to_thread](https://docs.python.org/3/library/asyncio-task.html#asyncio.to_thread), and making `bot.on_message` a coroutine. That would involve a *lot* of change, while being 100% backward compatible with the current plugins & rules system. The end goal? To allow plugin to define `async` plugin callables :sunglasses: 
* A better documentation.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
