### PR TITLE
tell: catch missing message before it causes an exception

### DIFF
--- a/sopel/modules/tell.py
+++ b/sopel/modules/tell.py
@@ -180,6 +180,13 @@ def f_remind(bot, trigger):
         return
 
     tellee = trigger.group(3).rstrip('.,:;')
+
+    # all we care about is having at least one non-whitespace
+    # character after the name
+    if not trigger.group(4):
+        bot.reply("%s %s what?" % (verb, tellee))
+        return
+
     msg = _format_safe_lstrip(trigger.group(2).split(' ', 1)[1])
 
     if not msg:

--- a/sopel/modules/tell.py
+++ b/sopel/modules/tell.py
@@ -169,7 +169,9 @@ def _format_safe_lstrip(text):
 
 @plugin.command('tell', 'ask')
 @plugin.nickname_command('tell', 'ask')
-@plugin.example('$nickname, tell dgw he broke something again.')
+@plugin.example('$nickname, tell dgw he broke it again.', user_help=True)
+@plugin.example('.tell ', 'tell whom?')
+@plugin.example('.ask Exirel ', 'ask Exirel what?')
 def f_remind(bot, trigger):
     """Give someone a message the next time they're seen"""
     teller = trigger.nick


### PR DESCRIPTION
### Description
This fixes a regression introduced in v7.1.3 by #2162, backported to the 7.1.x branch as 0dec496727ff57c569de17a3f6ffe611abec118e. (Yep, this one's a _mea culpa_.)

Previously, the code was sort-of safe due to a strange use of `trigger.group(2).lstrip([…])`. The new code, using `trigger.group(2).split()` instead, did not ensure that it actually gets enough values out of the split. I chose instead to make sure enough "words" exist in the command before performing the split.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Acknowledgements
Thanks to monaco (@hedho) for reporting this via logs on our IRC channel.