### PR TITLE
seen: modify/fix stored value & delta calculation for Aware `trigger.time`

### DIFF
--- a/sopel/modules/seen.py
+++ b/sopel/modules/seen.py
@@ -9,7 +9,6 @@ https://sopel.chat
 """
 from __future__ import annotations
 
-import datetime
 import time
 
 from sopel import plugin
@@ -31,8 +30,8 @@ def seen(bot, trigger):
         bot.reply("I'm right here!")
         return
 
-    timestamp = bot.db.get_nick_value(nick, 'seen_timestamp')
-    if not timestamp:
+    saw = bot.db.get_nick_value(nick, 'seen_timestamp')
+    if not saw:
         bot.reply("Sorry, I haven't seen {nick} around.".format(nick=nick))
         return
 
@@ -40,8 +39,8 @@ def seen(bot, trigger):
     message = bot.db.get_nick_value(nick, 'seen_message')
     action = bot.db.get_nick_value(nick, 'seen_action')
 
-    saw = datetime.datetime.utcfromtimestamp(timestamp)
-    delta = seconds_to_human((trigger.time - saw).total_seconds())
+    # as of Sopel 8, trigger.time is an aware datetime
+    delta = seconds_to_human(trigger.time.timestamp() - saw)
 
     msg = "I last saw " + nick
     if bot.make_identifier(channel) == trigger.sender:

--- a/sopel/modules/seen.py
+++ b/sopel/modules/seen.py
@@ -9,8 +9,6 @@ https://sopel.chat
 """
 from __future__ import annotations
 
-import time
-
 from sopel import plugin
 from sopel.tools.time import seconds_to_human
 
@@ -65,7 +63,9 @@ def seen(bot, trigger):
 @plugin.require_chanmsg
 def note(bot, trigger):
     nick = trigger.nick
-    bot.db.set_nick_value(nick, 'seen_timestamp', time.time())
+    # as of Sopel 8, `trigger.time` is Aware, meaning we should store its value
+    # for timezone safety when comparing it later
+    bot.db.set_nick_value(nick, 'seen_timestamp', trigger.time.timestamp())
     bot.db.set_nick_value(nick, 'seen_channel', trigger.sender)
     bot.db.set_nick_value(nick, 'seen_message', trigger)
     bot.db.set_nick_value(nick, 'seen_action', trigger.ctcp is not None)


### PR DESCRIPTION
### Description
Fixes a bug on `master` reported on IRC by monaco (@hedho), related to `trigger.time` changes from #2099.

I chose to eliminate the bug by using Unix timestamps instead of `datetime` objects. `<datetime_obj>.timestamp()` [has been around since Python 3.3](https://docs.python.org/3.9/library/datetime.html#datetime.datetime.timestamp), so we're safe to use it with 8.x's minimum requirement of Python 3.7.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches