### PR TITLE
deps: forget about `python_version` specifier for `importlib_metadata`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ geoip2>=4.0,<5.0
 requests>=2.24.0,<3.0.0
 dnspython<3.0
 sqlalchemy>=1.4,<1.5
-importlib_metadata>=3.6; python_version < '3.10'
+importlib_metadata>=3.6
 packaging

--- a/sopel/__init__.py
+++ b/sopel/__init__.py
@@ -16,11 +16,9 @@ import locale
 import re
 import sys
 
-try:
-    import importlib.metadata as importlib_metadata
-except ImportError:
-    # TODO: remove fallback when dropping py3.7
-    import importlib_metadata
+# TODO: replace with stdlib importlib.metadata when dropping py3.7
+# version info used in this module works from py3.8+
+import importlib_metadata
 
 __all__ = [
     'bot',

--- a/sopel/plugins/__init__.py
+++ b/sopel/plugins/__init__.py
@@ -33,12 +33,11 @@ import imp
 import itertools
 import os
 
-try:
-    import importlib_metadata
-except ImportError:
-    # TODO: use stdlib only when possible, after dropping py3.9
-    # stdlib does not support `entry_points(group='filter')` until py3.10
-    import importlib.metadata as importlib_metadata
+# TODO: use stdlib importlib.metadata when possible, after dropping py3.9.
+# Stdlib does not support `entry_points(group='filter')` until py3.10, but
+# fallback logic is more trouble than it's worth when e.g. clean Ubuntu
+# py3.10 envs include old versions of this backport.
+import importlib_metadata
 
 from . import exceptions, handlers, rules  # noqa
 

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -559,8 +559,10 @@ class EntryPointPlugin(PyModulePlugin):
         Entry points are a `standard packaging mechanism`__ for Python, used by
         other applications (such as ``pytest``) for their plugins.
 
-        The ``importlib_metadata`` backport package is used on Python versions
-        older than 3.10, but its API is the same as :mod:`importlib.metadata`.
+        The ``importlib_metadata`` backport package is used for consistency
+        across all of Sopel's supported Python versions. Its API matches that
+        of :mod:`importlib.metadata` from Python 3.10 and up; Sopel will drop
+        this external requirement when practical.
 
         .. __: https://packaging.python.org/en/latest/specifications/entry-points/
 

--- a/test/plugins/test_plugins_handlers.py
+++ b/test/plugins/test_plugins_handlers.py
@@ -4,13 +4,9 @@ from __future__ import annotations
 import os
 import sys
 
+# TODO: use stdlib importlib.metadata when dropping py3.9
+import importlib_metadata
 import pytest
-
-try:
-    import importlib.metadata as importlib_metadata
-except ImportError:
-    # TODO: remove fallback when dropping py3.9
-    import importlib_metadata
 
 from sopel.plugins import handlers
 

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -3,13 +3,9 @@ from __future__ import annotations
 
 import sys
 
+# TODO: switch to stdlib importlib.metdata when dropping py3.9
+import importlib_metadata
 import pytest
-
-try:
-    import importlib.metadata as importlib_metadata
-except ImportError:
-    # TODO: remove fallback when dropping py3.9
-    import importlib_metadata
 
 from sopel import plugins
 


### PR DESCRIPTION
### Description
My clean install of Python 3.10 on Ubuntu 20.04 (via deadsnakes/ppa) came with an old version of `importlib_metadata` that tripped up the fallback logic I so carefully included.

Rather than contort the import logic, let's just use the backport until Sopel no longer supports Python versions where stdlib can't replace it entirely.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
The test suite passes on my py3.10 env with this patch, except for a few `DeprecationWarning`s (from third-party code) that I'd like to try to mitigate _without_ adding transitive deps into our requirements again. Did too much of that in 7.x.

`1311 passed, 8 xfailed, 4 warnings` is still a great sight to see. I'd just _rather_ see `1311 passed, 8 xfailed` instead. 😛