### PR TITLE
events: rename and extend invite-related numerics

### DIFF
--- a/sopel/tools/_events.py
+++ b/sopel/tools/_events.py
@@ -14,6 +14,8 @@ class events(str, Enum):
     # ircds.
     RPL_ISUPPORT = '005'
     RPL_WHOSPCRPL = '354'
+    RPL_INVITELIST = '336'
+    RPL_ENDOFINVITELIST = '337'
 
     # ################################################################### IRC v3
     # ## 3.1
@@ -183,8 +185,8 @@ class events(str, Enum):
     RPL_MYINFO = '004'
     RPL_BOUNCE = '005'
     RPL_UNIQOPIS = '325'
-    RPL_INVITELIST = '346'
-    RPL_ENDOFINVITELIST = '347'
+    RPL_INVEXLIST = '346'
+    RPL_ENDOFINVEXLIST = '347'
     RPL_EXCEPTLIST = '348'
     RPL_ENDOFEXCEPTLIST = '349'
     RPL_YOURESERVICE = '383'


### PR DESCRIPTION
Tin. This will have to be mentioned in the migration guide.

Goes along with ircdocs/modern-irc#177, which explains the change.

See also ircdocs/modern-irc#42 for more history/discussion.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
I'm just curious to see what Coveralls does now after it marked the most recent merge commit as failed because it somehow thought coverage had decreased to 0%. Hopefully whatever caused that has been fixed, otherwise my next patch will probably be ripping Coveralls out of our CI jobs…