### PR TITLE
search: replace git.io link with shortcut defined on sopel.chat

### DIFF
--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -118,7 +118,7 @@ def duck(bot, trigger):
             # This check exists because of issue #1415.
             # The shortcut link will take the user there.
             msg += " Try again with at most one 'site:' operator."
-            msg += " See https://sopel.chat/site-op for why."
+            msg += " See https://sopel.chat/i/1415 for why."
         bot.reply(msg)
 
 
@@ -140,7 +140,7 @@ def bing(bot, trigger):
             # This check exists because of issue #1415.
             # The shortcut link will take the user there.
             msg += " Try again with at most one 'site:' operator."
-            msg += " See https://sopel.chat/site-op for why."
+            msg += " See https://sopel.chat/i/1415 for why."
         bot.reply(msg)
 
 
@@ -162,7 +162,7 @@ def search(bot, trigger):
             # This check exists because of issue #1415.
             # The shortcut link will take the user there.
             msg += " Try again with at most one 'site:' operator."
-            msg += " See https://sopel.chat/site-op for why."
+            msg += " See https://sopel.chat/i/1415 for why."
         bot.reply(msg)
         return
     elif bu == du:

--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -115,9 +115,10 @@ def duck(bot, trigger):
     else:
         msg = "No results found for '%s'." % query
         if query.count('site:') >= 2:
-            # This check exists because of issue #1415. The git.io link will take the user there.
-            # (Better a sopel.chat link, but it's not set up to do that. This is shorter anyway.)
-            msg += " Try again with at most one 'site:' operator. See https://git.io/fpKtP for why."
+            # This check exists because of issue #1415.
+            # The shortcut link will take the user there.
+            msg += " Try again with at most one 'site:' operator."
+            msg += " See https://sopel.chat/site-op for why."
         bot.reply(msg)
 
 
@@ -136,9 +137,10 @@ def bing(bot, trigger):
     else:
         msg = "No results found for '%s'." % query
         if query.count('site:') >= 2:
-            # This check exists because of issue #1415. The git.io link will take the user there.
-            # (Better a sopel.chat link, but it's not set up to do that. This is shorter anyway.)
-            msg += " Try again with at most one 'site:' operator. See https://git.io/fpKtP for why."
+            # This check exists because of issue #1415.
+            # The shortcut link will take the user there.
+            msg += " Try again with at most one 'site:' operator."
+            msg += " See https://sopel.chat/site-op for why."
         bot.reply(msg)
 
 
@@ -157,9 +159,10 @@ def search(bot, trigger):
     if bu == '-' and du == '-':
         msg = "No results found for '%s'." % query
         if query.count('site:') >= 2:
-            # This check exists because of issue #1415. The git.io link will take the user there.
-            # (Better a sopel.chat link, but it's not set up to do that. This is shorter anyway.)
-            msg += " Try again with at most one 'site:' operator. See https://git.io/fpKtP for why."
+            # This check exists because of issue #1415.
+            # The shortcut link will take the user there.
+            msg += " Try again with at most one 'site:' operator."
+            msg += " See https://sopel.chat/site-op for why."
         bot.reply(msg)
         return
     elif bu == du:


### PR DESCRIPTION
### Description
Prerequisite: sopel-irc/sopel.chat#37

Tin. I don't mind one bit bundling this with the next bugfix release. We're just changing the link so it's guaranteed to keep working even if GitHub kills off git.io entirely without warning (kind of like they announced it would stop accepting new links without warning, so I don't think this is paranoid).

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches