### PR TITLE
rules: drop `draft/bot` tag

### DIFF
--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -982,10 +982,7 @@ class Rule(AbstractRule):
         intent = pretrigger.tags.get('intent')
         nick = pretrigger.nick
         is_bot_message = (
-            (
-                'draft/bot' in pretrigger.tags or  # can be removed...someday
-                'bot' in pretrigger.tags
-            ) and
+            'bot' in pretrigger.tags and
             event in ["PRIVMSG", "NOTICE"]
         )
         is_echo_message = (

--- a/test/plugins/test_plugins_rules.py
+++ b/test/plugins/test_plugins_rules.py
@@ -658,16 +658,10 @@ def test_rule_match_privmsg_bot_tag(mockbot):
     regex = re.compile(r'.*')
     rule = rules.Rule([regex])
 
-    line = '@draft/bot :TestBot!sopel@example.com PRIVMSG #sopel :Hi!'
-    pretrigger = trigger.PreTrigger(mockbot.nick, line)
-    assert not list(rule.match(mockbot, pretrigger)), (
-        'Line with `draft/bot` tag must be ignored'
-    )
-
     line = '@bot :TestBot!sopel@example.com PRIVMSG #sopel :Hi!'
     pretrigger = trigger.PreTrigger(mockbot.nick, line)
     assert not list(rule.match(mockbot, pretrigger)), (
-        'Line with final/ratified `bot` tag must be ignored'
+        'Line with `bot` tag must be ignored'
     )
 
 


### PR DESCRIPTION
### Description
Bot Mode spec has been ratified (ircv3/ircv3-specifications#495). Since we haven't published a release with support for this message tag yet, it's a very easy decision to take *right now* that we'll only support the finalized spec and not the WIP version.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches