### PR TITLE
Specify timezone when doing conversion in seen module

### DIFF
--- a/sopel/modules/seen.py
+++ b/sopel/modules/seen.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import datetime
 import time
+import pytz
 
 from sopel import plugin
 from sopel.tools.time import seconds_to_human
@@ -40,7 +41,7 @@ def seen(bot, trigger):
     message = bot.db.get_nick_value(nick, 'seen_message')
     action = bot.db.get_nick_value(nick, 'seen_action')
 
-    saw = datetime.datetime.utcfromtimestamp(timestamp)
+    saw = datetime.datetime.fromtimestamp(timestamp, pytz.utc)
     delta = seconds_to_human((trigger.time - saw).total_seconds())
 
     msg = "I last saw " + nick


### PR DESCRIPTION
### Description

I'm not sure why but the `seen` command started throwing this exception recently on my installation:

```
Traceback (most recent call last):
  File "/home/tim/sopel/lib/python3.10/site-packages/sopel/bot.py", line 674, in call_rule
    rule.execute(sopel, trigger)
  File "/home/tim/sopel/lib/python3.10/site-packages/sopel/plugins/rules.py", line 1079, in execute
    exit_code = self._handler(bot, trigger)
  File "/home/tim/sopel/lib/python3.10/site-packages/sopel/modules/seen.py", line 44, in seen
    delta = seconds_to_human((trigger.time - saw).total_seconds())
TypeError: can't subtract offset-naive and offset-aware datetimes
```

This PR fixes that by swapping from `utcfromtimestamp` to `fromtimestamp` and passing in the UTC timezone. The python docs actually recommend using `fromtimestamp` anyways if needing an offset-aware date time.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

I'm getting failures from `make test` but nothing within the code that I modified.