### PR TITLE
config: default to use_ssl=True, port=6697

### DIFF
--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -1006,21 +1006,21 @@ class CoreSection(StaticSection):
     ``systemd`` or similar.
     """
 
-    port = ValidatedAttribute('port', int, default=6667)
+    port = ValidatedAttribute('port', int, default=6697)
     """The port to connect on.
 
-    :default: ``6667`` normally; ``6697`` if :attr:`use_ssl` is ``True``
+    :default: ``6697``
 
     .. highlight:: ini
 
     **Required**::
 
-        port = 6667
-
-    And usually when SSL is enabled::
-
         port = 6697
-        use_ssl = yes
+
+    Or if SSL is disabled::
+
+        port = 6667
+        use_ssl = false
 
     """
 
@@ -1213,16 +1213,16 @@ class CoreSection(StaticSection):
 
     """
 
-    use_ssl = BooleanAttribute('use_ssl', default=False)
+    use_ssl = BooleanAttribute('use_ssl', default=True)
     """Whether to use a SSL/TLS encrypted connection.
 
-    :default: ``False``
+    :default: ``True``
 
-    Example with SSL on:
+    Example with SSL off:
 
     .. code-block:: ini
 
-        use_ssl = yes
+        use_ssl = false
 
     """
 
@@ -1248,7 +1248,7 @@ class CoreSection(StaticSection):
 
     .. code-block:: ini
 
-        use_ssl = yes
-        verify_ssl = yes
+        use_ssl = true
+        verify_ssl = true
 
     """


### PR DESCRIPTION
### Description
Replace the defaults `use_ssl=False; port=6667` with `use_ssl=True; port=6697` and update associated docs.

I replaced ini e.g. `use_ssl=on` with `use_ssl=true` to match what the sopel configurator produces.

It would be neat to check the connection/cert and handhold a bit through that setup, but that's... less trivial

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
Well... No unexpected errors. We still have py3.10 issues =|
- [x] I have tested the functionality of the things this change touches
