### PR TITLE
config: don't manually hunt for CA paths

### DIFF
--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import os.path
-
 from sopel.config.types import (
     BooleanAttribute,
     ChoiceAttribute,
@@ -21,29 +19,6 @@ COMMAND_DEFAULT_HELP_PREFIX = '.'
 """Default help prefix used in commands' usage messages."""
 URL_DEFAULT_SCHEMES = ['http', 'https', 'ftp']
 """Default URL schemes allowed for URLs."""
-
-
-def _find_certs():
-    """Find the TLS root CA store.
-
-    :returns: path to CA store file
-    :rtype: str
-    """
-    # check if the root CA store is at a known location
-    locations = [
-        '/etc/pki/tls/cert.pem',  # best first guess
-        '/etc/ssl/certs/ca-certificates.crt',  # Debian
-        '/etc/ssl/cert.pem',  # FreeBSD base OpenSSL
-        '/usr/local/openssl/cert.pem',  # FreeBSD userland OpenSSL
-        '/etc/pki/tls/certs/ca-bundle.crt',  # RHEL 6 / Fedora
-        '/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem',  # RHEL 7 / CentOS
-        '/etc/pki/tls/cacert.pem',  # OpenELEC
-        '/etc/ssl/ca-bundle.pem',  # OpenSUSE
-    ]
-    for certs in locations:
-        if os.path.isfile(certs):
-            return certs
-    return None
 
 
 def configure(config):
@@ -228,8 +203,8 @@ class CoreSection(StaticSection):
 
     """
 
-    ca_certs = FilenameAttribute('ca_certs', default=_find_certs())
-    """The path to the CA certs ``.pem`` file.
+    ca_certs = FilenameAttribute('ca_certs')
+    """The path to the CA certs ``PEM`` file.
 
     Example:
 
@@ -237,8 +212,7 @@ class CoreSection(StaticSection):
 
         ca_certs = /etc/ssl/certs/ca-certificates.crt
 
-    If not specified, Sopel will try to find the certificate trust store
-    itself from a set of known locations.
+    If not specified, the system default will be used.
 
     If the given value is not an absolute path, it will be interpreted relative
     to the directory containing the config file with which Sopel was started.


### PR DESCRIPTION
### Description
It was agreed in #2256 that we should probably not be hunting for CA paths ourselves. This removes that, and allows `ssl` to use its default (openssl's default). This _should_ be an invisible change.

To rebase this on top of or beneath #2256: discard this PR's backends.py changes (`wrap_socket()` had no sane default for ca_certs)

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
Contemporary caveats apply.
- [x] I have tested the functionality of the things this change touches
