### PR TITLE
safety: rework

### DIFF
--- a/sopel/modules/safety.py
+++ b/sopel/modules/safety.py
@@ -211,7 +211,7 @@ def shutdown(bot: Sopel):
 @plugin.priority('high')
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def url_handler(bot: SopelWrapper, trigger: Trigger):
-    """Checks for malicious URLs"""
+    """Checks for malicious URLs."""
     mode = bot.db.get_channel_value(
         trigger.sender,
         "safety",
@@ -279,7 +279,7 @@ def virustotal_lookup(
 
     :param url: The URL to look up
     :param local_only: If set, only check cache, do not make a new request
-    :param max_cache_age: If set, don't use cache older than this value.
+    :param max_cache_age: If set, don't use cache older than this value
     :returns: A dict containing information about findings, or None if not found
     """
     if url.startswith("hxxp"):
@@ -365,7 +365,7 @@ def virustotal_lookup(
 @plugin.example(".virustotal hxxps://malware.wicar.org/")
 @plugin.output_prefix("[safety][VirusTotal] ")
 def vt_command(bot: SopelWrapper, trigger: Trigger):
-    """Look up VT results on demand"""
+    """Look up VT results on demand."""
     if not bot.settings.safety.vt_api_key:
         bot.reply("Sorry, I don't have a VirusTotal API key configured.")
         return
@@ -421,7 +421,7 @@ def vt_command(bot: SopelWrapper, trigger: Trigger):
 @plugin.example(".safety on")
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def toggle_safety(bot: SopelWrapper, trigger: Trigger):
-    """Set safety setting for channel"""
+    """Set safety setting for channel."""
     if not trigger.admin and bot.channels[trigger.sender].privileges[trigger.nick] < plugin.OP:
         bot.reply('Only channel operators can change safety settings')
         return

--- a/sopel/modules/safety.py
+++ b/sopel/modules/safety.py
@@ -15,17 +15,21 @@ import os.path
 import re
 import threading
 from time import sleep
-from typing import Dict, Optional
+from typing import TYPE_CHECKING
 from urllib.parse import urlparse, urlunparse
 
 import requests
 
 from sopel import plugin, tools
-from sopel.bot import Sopel, SopelWrapper
-from sopel.config import Config, types
+from sopel.config import types
 from sopel.formatting import bold, color, colors
-from sopel.trigger import Trigger
 
+if TYPE_CHECKING:
+    from typing import Dict, Optional
+
+    from sopel.bot import Sopel, SopelWrapper
+    from sopel.config import Config
+    from sopel.trigger import Trigger
 
 LOGGER = logging.getLogger(__name__)
 PLUGIN_OUTPUT_PREFIX = '[safety] '

--- a/sopel/modules/safety.py
+++ b/sopel/modules/safety.py
@@ -21,7 +21,7 @@ from urllib.parse import urlparse, urlunparse
 import requests
 
 from sopel import plugin, tools
-from sopel.bot import Sopel
+from sopel.bot import Sopel, SopelWrapper
 from sopel.config import Config, types
 from sopel.formatting import bold, color, colors
 from sopel.trigger import Trigger
@@ -203,7 +203,7 @@ def shutdown(bot: Sopel):
 @plugin.rule(r'(?u).*(https?://\S+).*')
 @plugin.priority('high')
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
-def url_handler(bot: Sopel, trigger: Trigger):
+def url_handler(bot: SopelWrapper, trigger: Trigger):
     """Checks for malicious URLs"""
     mode = bot.db.get_channel_value(
         trigger.sender,
@@ -263,7 +263,7 @@ def url_handler(bot: Sopel, trigger: Trigger):
 
 
 def virustotal_lookup(
-    bot: Sopel,
+    bot: SopelWrapper,
     url: str,
     local_only: bool = False,
     max_cache_age: Optional[timedelta] = None,
@@ -357,7 +357,7 @@ def virustotal_lookup(
 @plugin.example(".virustotal https://malware.wicar.org/")
 @plugin.example(".virustotal hxxps://malware.wicar.org/")
 @plugin.output_prefix("[safety][VirusTotal] ")
-def vt_command(bot: Sopel, trigger: Trigger):
+def vt_command(bot: SopelWrapper, trigger: Trigger):
     """Look up VT results on demand"""
     if not bot.settings.safety.vt_api_key:
         bot.reply("Sorry, I don't have a VirusTotal API key configured.")
@@ -413,7 +413,7 @@ def vt_command(bot: Sopel, trigger: Trigger):
 @plugin.command('safety')
 @plugin.example(".safety on")
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
-def toggle_safety(bot: Sopel, trigger: Trigger):
+def toggle_safety(bot: SopelWrapper, trigger: Trigger):
     """Set safety setting for channel"""
     if not trigger.admin and bot.channels[trigger.sender].privileges[trigger.nick] < plugin.OP:
         bot.reply('Only channel operators can change safety settings')

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -319,7 +319,7 @@ def title_auto(bot: SopelWrapper, trigger: Trigger):
             # Guard against responding to other instances of this bot.
             if message != trigger:
                 bot.say(message)
-        bot.memory['last_seen_url'][trigger.sender] = url
+        bot.memory["last_seen_url"][trigger.sender] = url
 
 
 def process_urls(

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -306,8 +306,8 @@ def title_auto(bot: SopelWrapper, trigger: Trigger):
         if url in bot.memory.get("safety_cache", {}):
             if bot.memory["safety_cache"][url]["positives"] > 0:
                 continue
-        netloc = urlparse(url).netloc.lower()
-        if netloc in bot.memory.get("safety_cache_local", {}):
+        hostname = urlparse(url).hostname.lower()
+        if hostname in bot.memory.get("safety_cache_local", {}):
             continue
         urls.append(url)
 

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -301,13 +301,13 @@ def title_auto(bot: SopelWrapper, trigger: Trigger):
         trigger, exclusion_char=bot.config.url.exclusion_char, clean=True)
 
     urls = []
+    safety_cache = bot.memory.get("safety_cache", {})
+    safety_cache_local = bot.memory.get("safety_cache_local", {})
     for url in unchecked_urls:
         # Avoid fetching known malicious links
-        if url in bot.memory.get("safety_cache", {}):
-            if bot.memory["safety_cache"][url]["positives"] > 0:
-                continue
-        hostname = urlparse(url).hostname.lower()
-        if hostname in bot.memory.get("safety_cache_local", {}):
+        if url in safety_cache and safety_cache[url]["positives"] > 0:
+            continue
+        if urlparse(url).hostname.lower() in safety_cache_local:
             continue
         urls.append(url)
 


### PR DESCRIPTION
### Description
This fixes (or works towards fixing) a bunch of issues with safety.py:
- `.safety` doesn't say what the current state is
- Uses VirusTotal API v2 (though they have no current plans to deprecate it) instead of v3
- Doesn't find URLs in messages containing anything else ("`foo http://example.com`" fails)
- Doesn't make local cache accessible to other plugins
- Doesn't use already-cached VT results in local mode
- Doesn't allow configuration of local or strict defaults
- url.py was not checking the domain blacklist and was also failing to handle "`foo http://example.com`"
- Other tweaks and improvements

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
