### PR TITLE
url: remove traceback from debug log when fetching URL fails

### DIFF
--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -422,8 +422,8 @@ def find_title(url, verify=True):
         # Need to close the connection because we have not read all
         # the data
         response.close()
-    except requests.exceptions.ConnectionError:
-        LOGGER.debug('Unable to reach URL: %s', url, exc_info=True)
+    except requests.exceptions.ConnectionError as e:
+        LOGGER.debug("Unable to reach URL: %r: %s", url, e)
         return None
     except (
         requests.exceptions.InvalidURL,  # e.g. http:///


### PR DESCRIPTION
### Description
If url.py can't connect to a server because of things like certificate issues (https://expired.badssl.com/), DNS (http://fake.host.local/), etc, it currently dumps most of a page of exception tracebacks into logs. This is useful to nobody, and it shouldn't do that.

This patch replaces the page of tracebacks with the following:
`sopel.modules.url    DEBUG    - Unable to reach URL: 'http://fake.host/': HTTPConnectionPool(host='fake.host', port=80): Max retries exceeded with url: / (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f95ef238340>: Failed to establish a new connection: [Errno -2] Name or service not known'))`
I think that's quite sufficient for troubleshooting without being excessively spammy.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
