### PR TITLE
Add workaround for excessive whitespace in MediaWiki excerpts (fixes #2259)

### DIFF
--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -184,6 +184,9 @@ def say_snippet(bot, trigger, server, query, show_url=True):
 
     try:
         snippet = mw_snippet(server, query)
+        # Coalesce repeated whitespace to avoid problems with <math> on MediaWiki
+        # see https://github.com/sopel-irc/sopel/issues/2259
+        snippet = re.sub(r"\s+", " ", snippet)
     except KeyError:
         if show_url:
             bot.reply("Error fetching snippet for \"{}\".".format(page_name))


### PR DESCRIPTION
### Description

This PR coalesces repeated whitespace in MediaWiki excerpts (#2259)

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - **NOTE:** I do see 9 test failures, 72 errors, but this is the same result against the current `HEAD` (984e1b9)
- [x] I have tested the functionality of the things this change touches
