### PR TITLE
emoticons: table consistency & `.unflip` command alias

### DIFF
--- a/sopel/modules/emoticons.py
+++ b/sopel/modules/emoticons.py
@@ -40,9 +40,9 @@ def tableflip(bot, trigger):
 
 @plugin.command('unflip')
 @plugin.action_command('unflips table', 'unflips the table')
-@plugin.example('.unflip', '┬┬ ﻿ノ( ゜-゜ノ)')
+@plugin.example('.unflip', '┳━┳ ﻿ノ( ゜-゜ノ)')
 def unflip(bot, trigger):
-    bot.say('┬┬ ﻿ノ( ゜-゜ノ)')
+    bot.say('┳━┳ ﻿ノ( ゜-゜ノ)')
 
 
 @plugin.command('lenny')

--- a/sopel/modules/emoticons.py
+++ b/sopel/modules/emoticons.py
@@ -38,7 +38,7 @@ def tableflip(bot, trigger):
     bot.say('(╯°□°）╯︵ ┻━┻')
 
 
-@plugin.command('unflip')
+@plugin.command('unflip', 'tback')
 @plugin.action_command('unflips table', 'unflips the table')
 @plugin.example('.unflip', '┳━┳ ﻿ノ( ゜-゜ノ)')
 def unflip(bot, trigger):


### PR DESCRIPTION
### Description
Fixes the table becoming narrower after unflipping, and that the legs were thinner.

Also adds `.tback` as an alias for `.unflip`, because I'm used to it from somewhere and it's not a conflict with anything else.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches