### PR TITLE
bot, loader, plugin, rules: add NOTICE message to rate limits

### DIFF
--- a/docs/source/plugin/anatomy.rst
+++ b/docs/source/plugin/anatomy.rst
@@ -124,6 +124,18 @@ Example::
 A rule with rate-limiting can return :const:`sopel.plugin.NOLIMIT` to let the
 user try again after a failed command, e.g. if a required argument is missing.
 
+.. seealso::
+
+   There are three other decorators to use:
+
+   * :func:`sopel.plugin.rate_user`
+   * :func:`sopel.plugin.rate_channel`
+   * :func:`sopel.plugin.rate_global`
+
+   These decorators can be used independently and will always override the
+   value set by ``rate()``. They also accept a dedicated message. See their
+   respective documentation for more information.
+
 Bypassing restrictions
 ----------------------
 

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -48,9 +48,13 @@ def clean_callable(func, config):
     if is_limitable(func):
         # These attributes are a waste of memory on callables that don't pass
         # through Sopel's rate-limiting machinery
-        func.rate = getattr(func, 'rate', 0)
+        func.user_rate = getattr(func, 'user_rate', 0)
         func.channel_rate = getattr(func, 'channel_rate', 0)
         func.global_rate = getattr(func, 'global_rate', 0)
+        func.user_rate_message = getattr(func, 'user_rate_message', None)
+        func.channel_rate_message = getattr(func, 'channel_rate_message', None)
+        func.global_rate_message = getattr(func, 'global_rate_message', None)
+        func.default_rate_message = getattr(func, 'default_rate_message', None)
         func.unblockable = getattr(func, 'unblockable', False)
 
     if not is_triggerable(func) and not is_url_callback(func):

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -301,9 +301,13 @@ def test_clean_callable_default(tmpconfig, func):
     # Not added by default
     assert not hasattr(func, 'unblockable')
     assert not hasattr(func, 'priority')
-    assert not hasattr(func, 'rate')
+    assert not hasattr(func, 'user_rate')
     assert not hasattr(func, 'channel_rate')
     assert not hasattr(func, 'global_rate')
+    assert not hasattr(func, 'user_rate_message')
+    assert not hasattr(func, 'channel_rate_message')
+    assert not hasattr(func, 'global_rate_message')
+    assert not hasattr(func, 'default_rate_message')
     assert not hasattr(func, 'echo')
     assert not hasattr(func, 'allow_bots')
     assert not hasattr(func, 'output_prefix')
@@ -334,12 +338,20 @@ def test_clean_callable_command(tmpconfig, func):
     assert func.priority == 'medium'
     assert hasattr(func, 'thread')
     assert func.thread is True
-    assert hasattr(func, 'rate')
-    assert func.rate == 0
+    assert hasattr(func, 'user_rate')
+    assert func.user_rate == 0
     assert hasattr(func, 'channel_rate')
     assert func.channel_rate == 0
     assert hasattr(func, 'global_rate')
     assert func.global_rate == 0
+    assert hasattr(func, 'user_rate_message')
+    assert func.user_rate_message is None
+    assert hasattr(func, 'channel_rate_message')
+    assert func.channel_rate_message is None
+    assert hasattr(func, 'global_rate_message')
+    assert func.global_rate_message is None
+    assert hasattr(func, 'default_rate_message')
+    assert func.default_rate_message is None
     assert hasattr(func, 'echo')
     assert func.echo is False
     assert hasattr(func, 'allow_bots')
@@ -357,9 +369,13 @@ def test_clean_callable_command(tmpconfig, func):
     assert func.unblockable is False
     assert func.priority == 'medium'
     assert func.thread is True
-    assert func.rate == 0
+    assert func.user_rate == 0
     assert func.channel_rate == 0
     assert func.global_rate == 0
+    assert func.user_rate_message is None
+    assert func.channel_rate_message is None
+    assert func.global_rate_message is None
+    assert func.default_rate_message is None
     assert func.echo is False
     assert func.allow_bots is False
     assert func.output_prefix == ''
@@ -380,12 +396,20 @@ def test_clean_callable_event(tmpconfig, func):
     assert func.priority == 'medium'
     assert hasattr(func, 'thread')
     assert func.thread is True
-    assert hasattr(func, 'rate')
-    assert func.rate == 0
+    assert hasattr(func, 'user_rate')
+    assert func.user_rate == 0
     assert hasattr(func, 'channel_rate')
     assert func.channel_rate == 0
     assert hasattr(func, 'global_rate')
     assert func.global_rate == 0
+    assert hasattr(func, 'user_rate_message')
+    assert func.user_rate_message is None
+    assert hasattr(func, 'channel_rate_message')
+    assert func.channel_rate_message is None
+    assert hasattr(func, 'global_rate_message')
+    assert func.global_rate_message is None
+    assert hasattr(func, 'default_rate_message')
+    assert func.default_rate_message is None
     assert hasattr(func, 'echo')
     assert func.echo is False
     assert hasattr(func, 'allow_bots')
@@ -400,9 +424,13 @@ def test_clean_callable_event(tmpconfig, func):
     assert func.unblockable is False
     assert func.priority == 'medium'
     assert func.thread is True
-    assert func.rate == 0
+    assert func.user_rate == 0
     assert func.channel_rate == 0
     assert func.global_rate == 0
+    assert func.user_rate_message is None
+    assert func.channel_rate_message is None
+    assert func.global_rate_message is None
+    assert func.default_rate_message is None
     assert func.echo is False
     assert func.allow_bots is False
     assert func.output_prefix == ''
@@ -428,12 +456,20 @@ def test_clean_callable_rule(tmpconfig, func):
     assert func.priority == 'medium'
     assert hasattr(func, 'thread')
     assert func.thread is True
-    assert hasattr(func, 'rate')
-    assert func.rate == 0
+    assert hasattr(func, 'user_rate')
+    assert func.user_rate == 0
     assert hasattr(func, 'channel_rate')
     assert func.channel_rate == 0
     assert hasattr(func, 'global_rate')
     assert func.global_rate == 0
+    assert hasattr(func, 'user_rate_message')
+    assert func.user_rate_message is None
+    assert hasattr(func, 'channel_rate_message')
+    assert func.channel_rate_message is None
+    assert hasattr(func, 'global_rate_message')
+    assert func.global_rate_message is None
+    assert hasattr(func, 'default_rate_message')
+    assert func.default_rate_message is None
     assert hasattr(func, 'echo')
     assert func.echo is False
     assert hasattr(func, 'allow_bots')
@@ -450,9 +486,13 @@ def test_clean_callable_rule(tmpconfig, func):
     assert func.unblockable is False
     assert func.priority == 'medium'
     assert func.thread is True
-    assert func.rate == 0
+    assert func.user_rate == 0
     assert func.channel_rate == 0
     assert func.global_rate == 0
+    assert func.user_rate_message is None
+    assert func.channel_rate_message is None
+    assert func.global_rate_message is None
+    assert func.default_rate_message is None
     assert func.echo is False
     assert func.allow_bots is False
     assert func.output_prefix == ''
@@ -513,12 +553,20 @@ def test_clean_callable_find_rules(tmpconfig, func):
     assert func.priority == 'medium'
     assert hasattr(func, 'thread')
     assert func.thread is True
-    assert hasattr(func, 'rate')
-    assert func.rate == 0
+    assert hasattr(func, 'user_rate')
+    assert func.user_rate == 0
     assert hasattr(func, 'channel_rate')
     assert func.channel_rate == 0
     assert hasattr(func, 'global_rate')
     assert func.global_rate == 0
+    assert hasattr(func, 'user_rate_message')
+    assert func.user_rate_message is None
+    assert hasattr(func, 'channel_rate_message')
+    assert func.channel_rate_message is None
+    assert hasattr(func, 'global_rate_message')
+    assert func.global_rate_message is None
+    assert hasattr(func, 'default_rate_message')
+    assert func.default_rate_message is None
     assert hasattr(func, 'echo')
     assert func.echo is False
     assert hasattr(func, 'allow_bots')
@@ -537,9 +585,13 @@ def test_clean_callable_find_rules(tmpconfig, func):
     assert func.unblockable is False
     assert func.priority == 'medium'
     assert func.thread is True
-    assert func.rate == 0
+    assert func.user_rate == 0
     assert func.channel_rate == 0
     assert func.global_rate == 0
+    assert func.user_rate_message is None
+    assert func.channel_rate_message is None
+    assert func.global_rate_message is None
+    assert func.default_rate_message is None
     assert func.echo is False
     assert func.allow_bots is False
     assert func.output_prefix == ''
@@ -567,12 +619,20 @@ def test_clean_callable_search_rules(tmpconfig, func):
     assert func.priority == 'medium'
     assert hasattr(func, 'thread')
     assert func.thread is True
-    assert hasattr(func, 'rate')
-    assert func.rate == 0
+    assert hasattr(func, 'user_rate')
+    assert func.user_rate == 0
     assert hasattr(func, 'channel_rate')
     assert func.channel_rate == 0
     assert hasattr(func, 'global_rate')
     assert func.global_rate == 0
+    assert hasattr(func, 'user_rate_message')
+    assert func.user_rate_message is None
+    assert hasattr(func, 'channel_rate_message')
+    assert func.channel_rate_message is None
+    assert hasattr(func, 'global_rate_message')
+    assert func.global_rate_message is None
+    assert hasattr(func, 'default_rate_message')
+    assert func.default_rate_message is None
     assert hasattr(func, 'echo')
     assert func.echo is False
     assert hasattr(func, 'allow_bots')
@@ -591,9 +651,13 @@ def test_clean_callable_search_rules(tmpconfig, func):
     assert func.unblockable is False
     assert func.priority == 'medium'
     assert func.thread is True
-    assert func.rate == 0
+    assert func.user_rate == 0
     assert func.channel_rate == 0
     assert func.global_rate == 0
+    assert func.user_rate_message is None
+    assert func.channel_rate_message is None
+    assert func.global_rate_message is None
+    assert func.default_rate_message is None
     assert func.echo is False
     assert func.allow_bots is False
     assert func.output_prefix == ''
@@ -615,12 +679,20 @@ def test_clean_callable_nickname_command(tmpconfig, func):
     assert func.priority == 'medium'
     assert hasattr(func, 'thread')
     assert func.thread is True
-    assert hasattr(func, 'rate')
-    assert func.rate == 0
+    assert hasattr(func, 'user_rate')
+    assert func.user_rate == 0
     assert hasattr(func, 'channel_rate')
     assert func.channel_rate == 0
     assert hasattr(func, 'global_rate')
     assert func.global_rate == 0
+    assert hasattr(func, 'user_rate_message')
+    assert func.user_rate_message is None
+    assert hasattr(func, 'channel_rate_message')
+    assert func.channel_rate_message is None
+    assert hasattr(func, 'global_rate_message')
+    assert func.global_rate_message is None
+    assert hasattr(func, 'default_rate_message')
+    assert func.default_rate_message is None
     assert hasattr(func, 'echo')
     assert func.echo is False
     assert hasattr(func, 'allow_bots')
@@ -634,9 +706,13 @@ def test_clean_callable_nickname_command(tmpconfig, func):
     assert func.unblockable is False
     assert func.priority == 'medium'
     assert func.thread is True
-    assert func.rate == 0
+    assert func.user_rate == 0
     assert func.channel_rate == 0
     assert func.global_rate == 0
+    assert func.user_rate_message is None
+    assert func.channel_rate_message is None
+    assert func.global_rate_message is None
+    assert func.default_rate_message is None
     assert func.echo is False
     assert func.allow_bots is False
     assert func.output_prefix == ''
@@ -883,12 +959,20 @@ def test_clean_callable_ctcp(tmpconfig, func):
     assert func.priority == 'medium'
     assert hasattr(func, 'thread')
     assert func.thread is True
-    assert hasattr(func, 'rate')
-    assert func.rate == 0
+    assert hasattr(func, 'user_rate')
+    assert func.user_rate == 0
     assert hasattr(func, 'channel_rate')
     assert func.channel_rate == 0
     assert hasattr(func, 'global_rate')
     assert func.global_rate == 0
+    assert hasattr(func, 'user_rate_message')
+    assert func.user_rate_message is None
+    assert hasattr(func, 'channel_rate_message')
+    assert func.channel_rate_message is None
+    assert hasattr(func, 'global_rate_message')
+    assert func.global_rate_message is None
+    assert hasattr(func, 'default_rate_message')
+    assert func.default_rate_message is None
     assert hasattr(func, 'echo')
     assert func.echo is False
     assert hasattr(func, 'allow_bots')
@@ -904,9 +988,13 @@ def test_clean_callable_ctcp(tmpconfig, func):
     assert func.unblockable is False
     assert func.priority == 'medium'
     assert func.thread is True
-    assert func.rate == 0
+    assert func.user_rate == 0
     assert func.channel_rate == 0
     assert func.global_rate == 0
+    assert func.user_rate_message is None
+    assert func.channel_rate_message is None
+    assert func.global_rate_message is None
+    assert func.default_rate_message is None
     assert func.echo is False
     assert func.allow_bots is False
     assert func.output_prefix == ''
@@ -925,12 +1013,20 @@ def test_clean_callable_url(tmpconfig, func):
     assert func.unblockable is False
     assert hasattr(func, 'thread')
     assert func.thread is True
-    assert hasattr(func, 'rate')
-    assert func.rate == 0
+    assert hasattr(func, 'user_rate')
+    assert func.user_rate == 0
     assert hasattr(func, 'channel_rate')
     assert func.channel_rate == 0
     assert hasattr(func, 'global_rate')
     assert func.global_rate == 0
+    assert hasattr(func, 'user_rate_message')
+    assert func.user_rate_message is None
+    assert hasattr(func, 'channel_rate_message')
+    assert func.channel_rate_message is None
+    assert hasattr(func, 'global_rate_message')
+    assert func.global_rate_message is None
+    assert hasattr(func, 'default_rate_message')
+    assert func.default_rate_message is None
     assert hasattr(func, 'echo')
     assert func.echo is False
     assert hasattr(func, 'allow_bots')
@@ -943,9 +1039,13 @@ def test_clean_callable_url(tmpconfig, func):
     assert len(func.url_regex) == 1
     assert func.unblockable is False
     assert func.thread is True
-    assert func.rate == 0
+    assert func.user_rate == 0
     assert func.channel_rate == 0
     assert func.global_rate == 0
+    assert func.user_rate_message is None
+    assert func.channel_rate_message is None
+    assert func.global_rate_message is None
+    assert func.default_rate_message is None
     assert func.echo is False
     assert func.allow_bots is False
     assert func.output_prefix == ''

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -343,7 +343,19 @@ def test_rate():
     @module.rate(5)
     def mock(bot, trigger, match):
         return True
-    assert mock.rate == 5
+    assert mock.user_rate == 5
+    assert mock.channel_rate == 0, 'Default channel_rate should be 0'
+    assert mock.global_rate == 0, 'Default global_rate should be 0'
+
+
+def test_rate_only_once():
+    @module.rate(10)
+    @module.rate(5)
+    def mock(bot, trigger, match):
+        return True
+    assert mock.user_rate == 5, 'Only the first decorator has effect.'
+    assert mock.channel_rate == 0, 'Only the first decorator has effect.'
+    assert mock.global_rate == 0, 'Only the first decorator has effect.'
 
 
 def test_require_privmsg(bot, trigger, trigger_pm):

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -286,6 +286,83 @@ def test_ctcp_direct():
     assert mock.ctcp == ['ACTION']
 
 
+def test_rate_user():
+    @plugin.rate_user(10)
+    def mock(bot, trigger):
+        return True
+    assert mock.user_rate == 10
+    assert mock.user_rate_message is None
+    assert not hasattr(mock, 'channel_rate')
+    assert not hasattr(mock, 'global_rate')
+    assert not hasattr(mock, 'default_rate_message')
+
+    @plugin.rate_user(20, 'User rate message.')
+    def mock(bot, trigger):
+        return True
+    assert mock.user_rate == 20
+    assert mock.user_rate_message == 'User rate message.'
+    assert not hasattr(mock, 'channel_rate')
+    assert not hasattr(mock, 'global_rate')
+    assert not hasattr(mock, 'default_rate_message')
+
+
+def test_rate_channel():
+    @plugin.rate_channel(10)
+    def mock(bot, trigger):
+        return True
+    assert mock.channel_rate == 10
+    assert mock.channel_rate_message is None
+    assert not hasattr(mock, 'user_rate')
+    assert not hasattr(mock, 'global_rate')
+    assert not hasattr(mock, 'default_rate_message')
+
+    @plugin.rate_channel(20, 'Channel rate message.')
+    def mock(bot, trigger):
+        return True
+    assert mock.channel_rate == 20
+    assert mock.channel_rate_message == 'Channel rate message.'
+    assert not hasattr(mock, 'user_rate')
+    assert not hasattr(mock, 'global_rate')
+    assert not hasattr(mock, 'default_rate_message')
+
+
+def test_rate_global():
+    @plugin.rate_global(10)
+    def mock(bot, trigger):
+        return True
+    assert mock.global_rate == 10
+    assert mock.global_rate_message is None
+    assert not hasattr(mock, 'user_rate')
+    assert not hasattr(mock, 'channel_rate')
+    assert not hasattr(mock, 'default_rate_message')
+
+    @plugin.rate_global(20, 'Server rate message.')
+    def mock(bot, trigger):
+        return True
+    assert mock.global_rate == 20
+    assert mock.global_rate_message == 'Server rate message.'
+    assert not hasattr(mock, 'user_rate')
+    assert not hasattr(mock, 'channel_rate')
+    assert not hasattr(mock, 'default_rate_message')
+
+
+def test_rate_combine_rate_decorators():
+    @plugin.rate(400, 500, 600, message='Last default rate message')
+    @plugin.rate_global(2, 'Server rate message')
+    @plugin.rate_channel(5, 'Channel rate message')
+    @plugin.rate_user(10, 'User rate message')
+    @plugin.rate(40, 50, 60, message='Initial default rate message')
+    def mock(bot, trigger):
+        return True
+    assert mock.user_rate == 10
+    assert mock.user_rate_message == 'User rate message'
+    assert mock.channel_rate == 5
+    assert mock.channel_rate_message == 'Channel rate message'
+    assert mock.global_rate == 2
+    assert mock.global_rate_message == 'Server rate message'
+    assert mock.default_rate_message == 'Last default rate message'
+
+
 BAN_MESSAGE = ':Foo!foo@example.com PRIVMSG #chan :.ban ExiClone'
 BAN_PRIVATE_MESSAGE = ':Foo!foo@example.com PRIVMSG Sopel :.ban #chan ExiClone'
 


### PR DESCRIPTION
### Description

Fix #830 by adding an optional message and three new decorators for specific rate limit messages (user, channel, and server).

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
