### PR TITLE
rules: properly track rate limits of rules

### DIFF
--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -654,7 +654,9 @@ def test_call_rule_rate_limited_user(mockbot):
         plugin='testplugin',
         label='testrule',
         handler=testrule,
-        rate_limit=100)
+        rate_limit=100,
+        threaded=False,
+    )
 
     # trigger
     line = ':Test!test@example.com PRIVMSG #channel :hello'


### PR DESCRIPTION
### Description

Fix #2295 by switching from a scalar object (tuple of datetime and return value) to the `RuleMetrics` object, which can tell if the rule is limited or not based on the internal state.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

I had to deactivate the "admin" thing locally to test it live, and it works!