### PR TITLE
Remove Python EOL warnings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,16 +37,6 @@ if sys.version_info < (3, 7):
     # Maybe not the best way to do this, but this question is tiring.
     raise ImportError('Sopel requires Python 3.7+.')
 
-# Py3.7 EOL: https://www.python.org/dev/peps/pep-0537/#and-beyond-schedule
-if sys.version_info < (3, 8):
-    # TODO check this warning before releasing Sopel 8.0
-    print(
-        'Warning: Python 3.7 will reach end of life by June 2022 '
-        'and will receive no further updates. '
-        'Sopel 9.0 will drop support for it.',
-        file=sys.stderr,
-    )
-
 
 def read_reqs(path):
     with open(path, 'r') as fil:

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -26,16 +26,6 @@ if sys.version_info < (3, 7):
     tools.stderr('Error: Sopel requires Python 3.7+.')
     sys.exit(1)
 
-# Py3.7 EOL: https://www.python.org/dev/peps/pep-0537/#and-beyond-schedule
-if sys.version_info < (3, 8):
-    # TODO check this warning before releasing Sopel 8.0
-    print(
-        'Warning: Python 3.7 will reach end of life by June 2022 '
-        'and will receive no further updates. '
-        'Sopel 9.0 will drop support for it.',
-        file=sys.stderr,
-    )
-
 LOGGER = logging.getLogger(__name__)
 
 ERR_CODE = 1


### PR DESCRIPTION
### Description

This PR corrects the warning message emitted by Sopel when running on Python prior to 3.8 to give the correct EOL for CPython 3.7

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
