### PR TITLE
cli: look harder for $PWD/cfg, don't automatically start wizard

### DIFF
--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -219,18 +219,17 @@ def get_configuration(options):
     .. seealso::
 
        The configuration file is loaded by
-       :func:`~sopel.cli.run.utils.load_settings` or created using the
-       configuration wizard.
+       :func:`~sopel.cli.run.utils.load_settings`
 
     """
     try:
         settings = utils.load_settings(options)
     except config.ConfigurationNotFound as error:
-        print(
-            "Welcome to Sopel!\n"
-            "I can't seem to find the configuration file, "
-            "so let's generate it!\n")
-        settings = utils.wizard(error.filename)
+        raise config.ConfigurationError(
+            "%s\n"
+            "If you're just setting up Sopel, welcome! "
+            "You can use `sopel configure` to get started easily." % error
+        )
 
     settings._is_daemonized = options.daemonize
     return settings

--- a/test/cli/test_cli_run.py
+++ b/test/cli/test_cli_run.py
@@ -215,7 +215,9 @@ def test_get_configuration(tmpdir):
     ]))
 
     parser = build_parser()
-    options = parser.parse_args(['start', '-c', 'default.cfg'])
+    options = parser.parse_args(
+        ['start', '-c', str(working_dir.join('default.cfg'))]
+    )
 
     with cd(working_dir.strpath):
         result = get_configuration(options)

--- a/test/cli/test_cli_utils.py
+++ b/test/cli/test_cli_utils.py
@@ -118,7 +118,10 @@ def test_find_config_local(tmpdir, config_dir):
         assert found_config == working_dir.join('local.cfg').strpath
 
         found_config = find_config(config_dir.strpath, 'local')
-        assert found_config == config_dir.join('local').strpath
+        assert found_config == working_dir.join('local.cfg').strpath
+
+        found_config = find_config(config_dir.strpath, 'config')
+        assert found_config == config_dir.join('config.cfg').strpath
 
 
 def test_find_config_default(tmpdir, config_dir):


### PR DESCRIPTION
Github won't let me reopen #2093.
+`Bugfix` because it now prints the .cfg path instead of ".sopel/foo"

### Description
This fixes two annoyances:
- Sopel automatically adds `.cfg` when searching the config dir, but it doesn't when searching the current working directory
- If the config file is not found, it currently automatically starts the configuration wizard.

Combining these two, a user (me) will (does, regularly) `cd` to their non-default Sopel config dir, run `sopel -c mybot` expecting it to load mybot.cfg and run, but instead have Sopel create ~/.sopel/ and ~/.sopel/mybot.cfg and start the config wizard.

Searching `$PWD/{config}.{ext}` is straightforward, but not automatically running the wizard is probably subject to opinions. I changed it to the below output, but I would also be content with "Do you want to run the configuration wizard? y/n", or at least not creating the folder/file until the end of the wizard so the user has an opportunity to ^C without having to then `rm -rf ~/.sopel`

Amended "couldn't find config":
```
$ sopel
ConfigurationError: Unable to find the configuration file /home/user/.sopel/default.cfg
If you're just setting up Sopel, welcome! You can use `sopel configure` to get started easily.
```

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
