### PR TITLE
pytest: configure in setup.cfg

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,0 @@
-[pytest]
-# sopel/modules/ files contain tests
-python_files=*.py
-addopts = --tb=short
-norecursedirs = contrib

--- a/setup.cfg
+++ b/setup.cfg
@@ -63,3 +63,8 @@ no-accept-encodings = True
 [mypy]
 plugins = sqlalchemy.ext.mypy.plugin
 show_error_codes = True
+
+[tool:pytest]
+python_files = *.py
+addopts = --tb=short
+norecursedirs = contrib


### PR DESCRIPTION
### Description
pytest can be configured in setup.cfg instead of its own pytest.ini to further reduce the number of files hanging around in the project root.

I'd have done this in the checkstyle.sh PR, but I didn't notice it =\

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [ ] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [ ] I have tested the functionality of the things this change touches