### PR TITLE
cli: remove ssl cert warning

### DIFF
--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -53,10 +53,6 @@ def run(settings, pid_file, daemon=False):
     # Also show the location of the config file used to load settings
     print("\nLoaded config file: {}".format(settings.filename))
 
-    if not settings.core.ca_certs:
-        tools.stderr(
-            'Could not open CA certificates file. SSL will not work properly!')
-
     # Define empty variable `p` for bot
     p = None
     while True:


### PR DESCRIPTION
### Description
I missed this in #2278 :neutral_face:
Since `ca_certs=None` is now valid, the warning is nonsense. If the setting is truly invalid, Sopel will quit with an exception:
```
ValueError: Invalid value for core.ca_certs: Value must be an existing or creatable file.
```
or
```
ssl.SSLError: [X509: NO_CERTIFICATE_OR_CRL_FOUND] no certificate or crl found (_ssl.c:4123)
```
(Though after the latter, it'll still attempt to reconnect after shutting down??)

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
