### PR TITLE
url: replace deprecated `dnspython` method

### DIFF
--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -363,7 +363,7 @@ def process_urls(
             try:
                 ips = [ip_address(parsed_url.hostname)]
             except ValueError:
-                ips = [ip_address(ip) for ip in dns.resolver.query(parsed_url.hostname)]
+                ips = [ip_address(ip) for ip in dns.resolver.resolve(parsed_url.hostname)]
 
             private = False
             for ip in ips:


### PR DESCRIPTION
### Description
The `query()` method has been deprecated, and was generating warnings in our CI logs. Fingers crossed that the `dnspython` maintainers will keep the old method around until their next major version, which Sopel (even on the stable branch) excludes in its requirements. (This is my excuse for not bothering to backport the change to 7.1.x.)

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches