### PR TITLE
irc, memories: fix handling QUITs, and prevent infinite failed-connection retries

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -23,7 +23,9 @@ exclude_lines =
     if 0:
     if False:
     if __name__ == .__main__.:
-    
+    if typing.TYPE_CHECKING:
+    if TYPE_CHECKING:
+
 show_missing = True
 
 [html]

--- a/sopel/irc/backends.py
+++ b/sopel/irc/backends.py
@@ -71,7 +71,7 @@ class AsyncioBackend(AbstractIRCBackend):
         verify_ssl: bool = True,
         ca_certs: Optional[str] = None,
         ssl_ciphers: Optional[List[str]] = None,
-        ssl_minimum_version: Optional[ssl.TLSVersion] = None,
+        ssl_minimum_version: ssl.TLSVersion = ssl.TLSVersion.TLSv1_2,
         **kwargs,
     ):
         super().__init__(bot)
@@ -84,7 +84,7 @@ class AsyncioBackend(AbstractIRCBackend):
         self._keyfile: Optional[str] = keyfile
         self._verify_ssl: bool = verify_ssl
         self._ca_certs: Optional[str] = ca_certs
-        self._ssl_ciphers: str = ":".join(ssl_ciphers)
+        self._ssl_ciphers: str = ":".join(ssl_ciphers or [])
         self._ssl_minimum_version: ssl.TLSVersion = ssl_minimum_version
 
         # timeout configuration

--- a/sopel/irc/backends.py
+++ b/sopel/irc/backends.py
@@ -308,6 +308,17 @@ class AsyncioBackend(AbstractIRCBackend):
             )
         except ssl.SSLError:
             LOGGER.exception('Unable to connect due to SSL error.')
+            # tell the bot to quit without restart
+            self.bot.hasquit = True
+            self.bot.wantsrestart = False
+            return
+        except Exception:
+            LOGGER.exception('Unable to connect.')
+            # until there is a way to prevent an infinite loop of connection
+            # error and reconnect, we have to tell the bot to quit here
+            # TODO: prevent infinite connection failure loop
+            self.bot.hasquit = True
+            self.bot.wantsrestart = False
             return
 
         self._connected = True

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -475,7 +475,7 @@ class RuleMetrics:
         time_limit: datetime.datetime,
     ) -> bool:
         """Determine if the rule hits the time limit."""
-        if not self.started_at and not self.ended_at:
+        if not self.started_at:
             # not even started, so not limited
             return False
 

--- a/sopel/tools/memories.py
+++ b/sopel/tools/memories.py
@@ -8,12 +8,14 @@ from __future__ import annotations
 
 from collections import defaultdict
 import threading
-from typing import Callable
+import typing
 
 from .identifiers import Identifier
 
+if typing.TYPE_CHECKING:
+    from typing import Callable, Optional
 
-IdentifierFactory = Callable[[str], Identifier]
+    IdentifierFactory = Callable[[str], Identifier]
 
 
 class SopelMemory(dict):
@@ -157,11 +159,16 @@ class SopelIdentifierMemory(SopelMemory):
         self.make_identifier = identifier_factory
         """A factory to transform keys into identifiers."""
 
-    def __getitem__(self, key):
-        return super().__getitem__(self.make_identifier(key))
+    def _make_key(self, key: Optional[str]) -> Optional[Identifier]:
+        if key is not None:
+            return self.make_identifier(key)
+        return None
+
+    def __getitem__(self, key: Optional[str]):
+        return super().__getitem__(self._make_key(key))
 
     def __contains__(self, key):
-        return super().__contains__(self.make_identifier(key))
+        return super().__contains__(self._make_key(key))
 
-    def __setitem__(self, key, value):
-        super().__setitem__(self.make_identifier(key), value)
+    def __setitem__(self, key: Optional[str], value):
+        super().__setitem__(self._make_key(key), value)

--- a/test/tools/test_tools_memories.py
+++ b/test/tools/test_tools_memories.py
@@ -4,6 +4,11 @@ from __future__ import annotations
 from sopel.tools import identifiers, memories
 
 
+def test_sopel_identifier_memory_none():
+    memory = memories.SopelIdentifierMemory()
+    assert None not in memory
+
+
 def test_sopel_identifier_memory_str():
     user = identifiers.Identifier('Exirel')
     memory = memories.SopelIdentifierMemory()


### PR DESCRIPTION
### Description

This started with our instance of Sopel running from source with the bot becoming unresponsive after a user quit the server: there was a bug in how `SopelIdentifierMemory` deals with `None in memory`. This caused an unexpected exception at the wrong place, which put the bot in a weird unstable state from which it doesn't recover.

I also fixed the case where an SSL connection error would block the bot in an infinite restart loop.

I'm still not sure the message handling is safe, but at least *this particular cause* is fixed.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
