### PR TITLE
coretasks: always log nicks as strings

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -712,7 +712,7 @@ def track_nicks(bot, trigger):
     if old in bot.users:
         bot.users[new] = bot.users.pop(old)
 
-    LOGGER.info("User named %r is now known as %r.", old, str(new))
+    LOGGER.info("User named %r is now known as %r.", str(old), str(new))
 
 
 @plugin.rule('(.*)')
@@ -1348,7 +1348,7 @@ def recv_chghost(bot, trigger):
     bot.users[trigger.nick].host = new_host
     LOGGER.info(
         "Update user@host for nick %r: %s@%s",
-        trigger.nick, new_user, new_host)
+        str(trigger.nick), new_user, new_host)
 
 
 @plugin.event('ACCOUNT')
@@ -1364,7 +1364,7 @@ def account_notify(bot, trigger):
     if account == '*':
         account = None
     bot.users[trigger.nick].account = account
-    LOGGER.info("Update account for nick %r: %s", trigger.nick, account)
+    LOGGER.info("Update account for nick %r: %s", str(trigger.nick), account)
 
 
 @plugin.event(events.RPL_WHOSPCRPL)


### PR DESCRIPTION
### Description
Log output containing `Identifier(nickname)` isn't super useful. It just wastes bytes in the log file.

Oh yeah, it also looks weird.

The instance I noticed appears to have come from 5e5bce244467c673aa90e999a0904444873d35de, released in Sopel 7.1.0, which I guess tells ya how much I usually look at INFO messages. Only even noticed today because I was skimming through stdout to check for any more glitches after merging #2306.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches