### PR TITLE
tools: fix `get_sendable_message()` with both multibyte chars & whitespace

### DIFF
--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -111,7 +111,7 @@ def get_sendable_message(text, max_length=400):
             unicode_max_length = unicode_max_length - 1
         else:
             # Split at the last best space found
-            excess = text[last_space:]
+            excess = text[last_space:] + excess
             text = text[:last_space]
 
     return text, excess.lstrip()

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -88,12 +88,12 @@ def get_sendable_message(text, max_length=400):
     :return: a tuple of two values, the sendable text and its excess text
     :rtype: (str, str)
 
-    We're arbitrarily saying that the max is 400 bytes of text when
-    messages will be split. Otherwise, we'd have to account for the bot's
-    hostmask, which is hard.
+    We're arbitrarily saying that the (default) max is 400 bytes of text
+    when messages will be split, but callers can specify a different value
+    (e.g. to account precisely for the bot's hostmask).
 
     The ``max_length`` is the max length of text in **bytes**, but we take
-    care of Unicode 2-byte characters by working on the Unicode string,
+    care of multibyte UTF-8 characters by working on the Unicode string,
     then making sure the bytes version is smaller than the max length.
 
     .. versionadded:: 6.6.2

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -101,6 +101,62 @@ def test_get_sendable_message_two_bytes():
     assert excess == 'α α'
 
 
+def test_get_sendable_message_three_bytes():
+    text, excess = tools.get_sendable_message('अअअअ', 6)
+    assert text == 'अअ'
+    assert excess == 'अअ'
+
+    text, excess = tools.get_sendable_message('अअअअ', 7)
+    assert text == 'अअ'
+    assert excess == 'अअ'
+
+    text, excess = tools.get_sendable_message('अअअअ', 8)
+    assert text == 'अअ'
+    assert excess == 'अअ'
+
+    text, excess = tools.get_sendable_message('अ अअअ', 6)
+    assert text == 'अ'
+    assert excess == 'अअअ'
+
+    text, excess = tools.get_sendable_message('अअ अअ', 6)
+    assert text == 'अअ'
+    assert excess == 'अअ'
+
+    text, excess = tools.get_sendable_message('अअअ अ', 6)
+    assert text == 'अअ'
+    assert excess == 'अ अ'
+
+
+def test_get_sendable_message_four_bytes():
+    text, excess = tools.get_sendable_message('𡃤𡃤𡃤𡃤', 8)
+    assert text == '𡃤𡃤'
+    assert excess == '𡃤𡃤'
+
+    text, excess = tools.get_sendable_message('𡃤𡃤𡃤𡃤', 9)
+    assert text == '𡃤𡃤'
+    assert excess == '𡃤𡃤'
+
+    text, excess = tools.get_sendable_message('𡃤𡃤𡃤𡃤', 10)
+    assert text == '𡃤𡃤'
+    assert excess == '𡃤𡃤'
+
+    text, excess = tools.get_sendable_message('𡃤𡃤𡃤𡃤', 11)
+    assert text == '𡃤𡃤'
+    assert excess == '𡃤𡃤'
+
+    text, excess = tools.get_sendable_message('𡃤 𡃤𡃤𡃤', 8)
+    assert text == '𡃤'
+    assert excess == '𡃤𡃤𡃤'
+
+    text, excess = tools.get_sendable_message('𡃤𡃤 𡃤𡃤', 8)
+    assert text == '𡃤𡃤'
+    assert excess == '𡃤𡃤'
+
+    text, excess = tools.get_sendable_message('𡃤𡃤𡃤 𡃤', 8)
+    assert text == '𡃤𡃤'
+    assert excess == '𡃤 𡃤'
+
+
 def test_chain_loaders(configfactory):
     re_numeric = re.compile(r'\d+')
     re_text = re.compile(r'\w+')

--- a/test/test_tools.py
+++ b/test/test_tools.py
@@ -157,6 +157,36 @@ def test_get_sendable_message_four_bytes():
     assert excess == '𡃤 𡃤'
 
 
+def test_get_sendable_message_bigger_multibyte_whitespace():
+    """Tests that the logic doesn't break for multi-word strings with emoji.
+
+    Testing multibyte characters without whitespace is fine, but there's an
+    alternate code path to exercise.
+    """
+    text = (
+        'Egg 🍳 and bacon; 🐷 egg, 🍳 sausage 🌭 and bacon; 🥓 egg 🐣 and spam; '
+        'egg, 🍳 bacon 🥓 and spam, egg, 🍳 bacon, 🥓 sausage 🌭 and spam; spam, '
+        'bacon, 🐖 sausage 🌭 and spam; spam, egg, 🍳 spam, spam, bacon 🐖 and '
+        'spam; spam, spam, spam, egg 🥚🍳 and spam; spam, spam, spam, spam, spam, '
+        'spam, baked beans, 🍛 spam, spam, spam and spam; lobster 🦞 thermidor aux '
+        'crevettes with a mornay sauce garnished with truffle paté, 👨😏 brandy'
+        'and a fried 🍤 egg 🥚🍳 on 🔛 top 🎩 and spam')
+
+    first, second = tools.get_sendable_message(text)
+    expected_first = (
+        'Egg 🍳 and bacon; 🐷 egg, 🍳 sausage 🌭 and bacon; 🥓 egg 🐣 and spam; '
+        'egg, 🍳 bacon 🥓 and spam, egg, 🍳 bacon, 🥓 sausage 🌭 and spam; spam, '
+        'bacon, 🐖 sausage 🌭 and spam; spam, egg, 🍳 spam, spam, bacon 🐖 and '
+        'spam; spam, spam, spam, egg 🥚🍳 and spam; spam, spam, spam, spam, spam, '
+        'spam, baked beans, 🍛 spam, spam, spam and spam; lobster 🦞 thermidor aux')
+    expected_second = (
+        'crevettes with a mornay sauce garnished with truffle paté, 👨😏 brandy'
+        'and a fried 🍤 egg 🥚🍳 on 🔛 top 🎩 and spam')
+
+    assert first == expected_first
+    assert second == expected_second
+
+
 def test_chain_loaders(configfactory):
     re_numeric = re.compile(r'\d+')
     re_text = re.compile(r'\w+')


### PR DESCRIPTION
### Description
Fixes a bug reported on IRC by deadyeti, where text containing both emoji and spaces (tweets, in their case) was not split correctly in `tools.get_sendable_message()`, resulting in the second message containing only one word.

I also added test cases (some as regression insurance) and tweaked the function documentation as long as I was touching it.

h/t to @half-duplex for jumping straight into the code and finding the root cause while I was still working on a test case to reproduce the bug. 😅

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### RFC
Is this important enough to prompt a maintenance release? We haven't been planning to cut any more package versions off the 7.1.x series, in favor of focusing everyone's time and attention on finishing 8.0.

@sopel-irc/rockstars please weigh in if you have Thoughts.