### PR TITLE
coretasks: gracefully handle missing hostmask with userhost-in-names

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -520,11 +520,17 @@ def handle_names(bot, trigger):
 
     names = trigger.split()
     for name in names:
+        username = hostname = None
+
         if uhnames or userhost_in_names:
-            name, mask = name.rsplit('!', 1)
-            username, hostname = mask.split('@', 1)
-        else:
-            username = hostname = None
+            try:
+                name, mask = name.rsplit('!', 1)
+                username, hostname = mask.split('@', 1)
+            except ValueError:
+                # server advertised either UHNAMES or userhost-in-names, but
+                # isn't sending the hostmask with all listed nicks
+                # It's probably ZNC. https://github.com/znc/znc/issues/1224
+                pass
 
         priv = 0
         for prefix, value in mapping.items():

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -530,7 +530,10 @@ def handle_names(bot, trigger):
                 # server advertised either UHNAMES or userhost-in-names, but
                 # isn't sending the hostmask with all listed nicks
                 # It's probably ZNC. https://github.com/znc/znc/issues/1224
-                pass
+                LOGGER.debug(
+                    '%s is enabled, but still got RPL_NAMREPLY item without a hostmask. '
+                    'IRC server/bouncer is not spec compliant.',
+                    'UHNAMES' if uhnames else 'userhost-in-names')
 
         priv = 0
         for prefix, value in mapping.items():

--- a/test/test_coretasks.py
+++ b/test/test_coretasks.py
@@ -558,3 +558,17 @@ def test_join_time(mockbot):
     assert mockbot.channels["#test"].join_time == datetime(
         2021, 1, 1, 12, 0, 0, 15000, tzinfo=timezone.utc
     )
+
+
+def test_handle_rpl_namreply_with_malformed_uhnames(mockbot, caplog):
+    """Make sure Sopel can cope with expected but missing hostmask in 353"""
+    mockbot.on_message(
+        ':somenet.behind.znc 005 Sopel '
+        'UHNAMES '
+        ':are supported by this server')
+    mockbot.on_message(
+        ':somenet.behind.znc 353 Sopel = #sopel '
+        ':correct!~right@alwa.ys incorrect')
+
+    assert len(caplog.messages) == 0, (
+        'Bot emitted a log entry because it failed to parse the NAMREPLY.')

--- a/test/test_coretasks.py
+++ b/test/test_coretasks.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+import logging
 
 import pytest
 
@@ -562,6 +563,7 @@ def test_join_time(mockbot):
 
 def test_handle_rpl_namreply_with_malformed_uhnames(mockbot, caplog):
     """Make sure Sopel can cope with expected but missing hostmask in 353"""
+    caplog.set_level(logging.DEBUG)
     mockbot.on_message(
         ':somenet.behind.znc 005 Sopel '
         'UHNAMES '
@@ -570,5 +572,5 @@ def test_handle_rpl_namreply_with_malformed_uhnames(mockbot, caplog):
         ':somenet.behind.znc 353 Sopel = #sopel '
         ':correct!~right@alwa.ys incorrect')
 
-    assert len(caplog.messages) == 0, (
-        'Bot emitted a log entry because it failed to parse the NAMREPLY.')
+    assert len(caplog.messages) == 1
+    assert 'RPL_NAMREPLY item without a hostmask' in caplog.messages[0]


### PR DESCRIPTION
This doesn't fix the noncompliant server, but it will keep Sopel from dying early and skipping the rest of the items in a given malformed `RPL_NAMREPLY` line.

Workaround (but not a "fix" per se) for #2289 and #2311.

Includes a very basic test that could be made more comprehensive, but I'm feeling very done with this problem.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches