### PR TITLE
plugins.handlers: override get_version() for EntryPointPlugin

### DIFF
--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -591,9 +591,9 @@ class EntryPointPlugin(PyModulePlugin):
         :return: the plugin's version string
         :rtype: Optional[str]
         """
-        version: Optional[str] = None
+        version: Optional[str] = super().get_version()
 
-        if hasattr(self._module, "__package__"):
+        if version is None and hasattr(self._module, "__package__"):
             try:
                 version = importlib_metadata.version(self._module.__package__)
             except ValueError:

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -51,6 +51,9 @@ import itertools
 import os
 from typing import Optional
 
+# TODO: refactor along with usage in sopel.__init__ in py3.8+ world
+import importlib_metadata
+
 from sopel import __version__ as release, loader
 from . import exceptions
 
@@ -581,6 +584,19 @@ class EntryPointPlugin(PyModulePlugin):
 
     def load(self):
         self._module = self.entry_point.load()
+
+    def get_version(self) -> Optional[str]:
+        """Retrieve the plugin's version.
+
+        :return: the plugin's version string
+        :rtype: Optional[str]
+        """
+        version: Optional[str] = None
+
+        if hasattr(self._module, "__package__"):
+            version = importlib_metadata.version(self._module.__package__)
+
+        return version
 
     def get_meta_description(self):
         """Retrieve a meta description for the plugin.

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -594,7 +594,11 @@ class EntryPointPlugin(PyModulePlugin):
         version: Optional[str] = None
 
         if hasattr(self._module, "__package__"):
-            version = importlib_metadata.version(self._module.__package__)
+            try:
+                version = importlib_metadata.version(self._module.__package__)
+            except ValueError:
+                # package name is probably empty-string; just give up
+                pass
 
         return version
 


### PR DESCRIPTION
### Description
The `_module` of an entry point plugin is unlikely to have its own `__version__`. What's important is the version of the package from which that entry point was loaded.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
I haven't written a test for this (yet?). Am not even sure if it should call the superclass version (`PyModulePlugin.get_version()`) somewhere as a fallback. Doing that doesn't seem very useful, but I'm open to others' thoughts.