### PR TITLE
wikipedia: use say() instead of reply() when reporting a URL error

### DIFF
--- a/sopel/modules/wikipedia.py
+++ b/sopel/modules/wikipedia.py
@@ -173,7 +173,7 @@ def mw_search(server, query, num):
     return None
 
 
-def say_snippet(bot, trigger, server, query, show_url=True):
+def say_snippet(bot, trigger, server, query, show_url=True, commanded=False):
     page_name = query.replace('_', ' ')
     query = quote(query.replace(' ', '_'))
     url = 'https://{}/wiki/{}'.format(server, query)
@@ -188,8 +188,11 @@ def say_snippet(bot, trigger, server, query, show_url=True):
         # see https://github.com/sopel-irc/sopel/issues/2259
         snippet = re.sub(r"\s+", " ", snippet)
     except KeyError:
-        if show_url:
-            bot.reply("Error fetching snippet for \"{}\".".format(page_name))
+        msg = 'Error fetching snippet for "{}".'.format(page_name)
+        if commanded:
+            bot.reply(msg)
+        else:
+            bot.say(msg)
         return
 
     msg = '{} | "{}'.format(page_name, snippet)
@@ -223,7 +226,7 @@ def say_section(bot, trigger, server, query, section):
 
     snippet = mw_section(server, query, section)
     if not snippet:
-        bot.reply("Error fetching section \"{}\" for page \"{}\".".format(section, page_name))
+        bot.say('Error fetching section "{}" for page "{}".'.format(section, page_name))
         return
 
     msg = '{} - {} | "{}"'.format(page_name, section.replace('_', ' '), snippet)
@@ -309,7 +312,7 @@ def wikipedia(bot, trigger):
         return plugin.NOLIMIT
     else:
         query = query[0]
-    say_snippet(bot, trigger, server, query)
+    say_snippet(bot, trigger, server, query, commanded=True)
 
 
 @plugin.command('wplang')


### PR DESCRIPTION
### Description

This PR removes user highlights `bot.reply()` from the `wikipedia` plugin, in favor of the non-highlighting `bot.say()`

Note: this PR is motivated by a personal opinion about netiquette; a user sharing a Wikipedia URL may not even know the Sopel instance exists, and the bot highlighting them is the kind of thing I consider a bit of an aggravation. Feel free to close this PR on that basis :sweat_smile: 

### Existing behavior
```
16:33 <SnoopJ> https://en.wikipedia.org/wiki/Diffraction_spike#/media/File:Comparison_strut_diffraction_spikes.svg
16:33 <terribot> SnoopJ: Error fetching section "/media/File:Comparison_strut_diffraction_spikes.svg" for page "Diffraction spike".
```

### Behavior with this patch
```
16:34 <SnoopJ> https://en.wikipedia.org/wiki/Diffraction_spike#/media/File:Comparison_strut_diffraction_spikes.svg
16:34 <terribot> [wikipedia] Error fetching section "/media/File:Comparison_strut_diffraction_spikes.svg" for page "Diffraction spike".
```

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
