### PR TITLE
pip: allow praw from v4 to v7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 xmltodict==0.12
 pytz
-praw>=4.0.0,<6.0.0
+praw>=4.0.0,<8.0.0
 geoip2>=4.0,<5.0
 requests>=2.24.0,<3.0.0
 dnspython<3.0


### PR DESCRIPTION
### Description

Tin, fix #1903.

I've check a set of URLs (user, subreddit, comments, image, and video) with praw versions 6.5 and 7.6 and everything worked so far. I've read their changelog and didn't see anything that would generate an error on our side.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
