### PR TITLE
docs: improve coverage of `flood_max_wait` setting

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -327,6 +327,9 @@ sending any new message (0.5s + 0.428s).
 You can **deactivate** this extra wait penalty by setting
 :attr:`~CoreSection.flood_penalty_ratio` to 0.
 
+To **deactivate all flood prevention (at your own risk)**, you need only to
+set :attr:`~CoreSection.flood_max_wait` to 0.
+
 The default configuration works fine with most tested networks, but individual
 bots' owners are invited to tweak as necessary to respect their network's flood
 policy.
@@ -340,9 +343,6 @@ policy.
 
     Even more additional configuration options: ``flood_max_wait``,
     ``flood_text_length``, and ``flood_penalty_ratio``.
-
-    It is now possible to deactivate the extra penalty for longer messages by
-    setting ``flood_penalty_ratio`` to 0.
 
 .. note::
 

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -554,9 +554,13 @@ class CoreSection(StaticSection):
     """
 
     flood_max_wait = ValidatedAttribute('flood_max_wait', float, default=2)
-    """How much time to wait at most when flood protection kicks in.
+    """How many seconds to wait at most when flood protection kicks in.
 
     :default: ``2``
+
+    .. note::
+
+        If the maximum wait is 0, flood protection is effectively disabled.
 
     This is equivalent to the default value:
 


### PR DESCRIPTION
### Description
Tin. Fixes a couple of omissions that led me astray while trying to reproduce an issue someone asked for help with on IRC.

Removed redundant text in the 7.1 `versionadded`, since the same information already appears just a few lines earlier.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - Docs only.
- [x] I have tested the functionality of the things this change touches
  - Docs-only.