### PR TITLE
loader, plugin: remove deprecated features

### DIFF
--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -74,8 +74,13 @@ def clean_callable(func, config):
 
     if any(hasattr(func, attr) for attr in ['commands', 'nickname_commands', 'action_commands']):
         if hasattr(func, 'example'):
-            # If no examples are flagged as user-facing, just show the first one like Sopel<7.0 did
-            examples = [rec["example"] for rec in func.example if rec["help"]] or [func.example[0]["example"]]
+            # If no examples are flagged as user-facing,
+            # just show the first one like Sopel<7.0 did
+            examples = [
+                rec["example"]
+                for rec in func.example
+                if rec["is_help"]
+            ] or [func.example[0]["example"]]
             for i, example in enumerate(examples):
                 example = example.replace('$nickname', nick)
                 if example[0] != help_prefix and not example.startswith(nick):

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -582,17 +582,16 @@ def command(*command_list: str) -> Callable:
 
     .. note::
 
-        You can use a regular expression for the command name(s), but this is
-        **not recommended** since version 7.1. For backward compatibility,
-        this behavior will be kept until version 8.0.
+        The command name will be escaped for use in a regular expression.
+        As such it is not possible to use something like ``.command\\d+`` to
+        catch something like ``.command1`` or ``.command2``.
 
-        Regex patterns are confusing for your users; please don't use them in
-        command names!
+        You have several options at your disposal to replace a regex in the
+        command name:
 
-        If you still want to use a regex pattern, please use the :func:`rule`
-        decorator instead. For extra arguments and subcommands based on a regex
-        pattern, you should handle these inside your decorated function, by
-        using the ``trigger`` object.
+        * use a command alias
+        * parse the arguments with your own regex within your plugin callable
+        * use a :func:`rule` instead
 
     """
     def add_attribute(function):
@@ -629,15 +628,18 @@ def nickname_command(*command_list: str) -> Callable:
 
     .. note::
 
-        You can use a regular expression for the command name(s), but this is
-        **not recommended** since version 7.1. For backward compatibility,
-        this behavior will be kept until version 8.0.
+        The command name will be escaped to be used in a regex command. As such
+        it is not possible to use something like ``command\\d+`` to catch
+        something like ``Bot: command1`` or ``Bot: command2``.
 
-        Regex patterns are confusing for your users; please don't use them in
-        command names!
+        You have several options at your disposal to replace a regex in the
+        command name:
 
-        If you need to use a regex pattern, please use the :func:`rule`
-        decorator instead, with the ``$nick`` variable::
+        * use a command alias
+        * parse the arguments with your own regex within your plugin callable
+        * use a :func:`rule`
+
+        The :func:`rule` can be used with a ``$nick`` variable::
 
             @rule(r'$nick .*')
                 # Would trigger on anything starting with "$nickname[:,]? ",
@@ -679,15 +681,18 @@ def action_command(*command_list: str) -> Callable:
 
     .. note::
 
-        You can use a regular expression for the command name(s), but this is
-        **not recommended** since version 7.1. For backward compatibility,
-        this behavior will be kept until version 8.0.
+        The command name will be escaped for use in a regular expression.
+        As such it is not possible to use something like ``/me command\\d+``
+        to catch something like ``/me command1`` or ``/me command2``.
 
-        Regex patterns are confusing for your users; please don't use them in
-        command names!
+        You have several options at your disposal to replace a regex in the
+        command name:
 
-        If you need to use a regex pattern, please use the :func:`rule`
-        decorator instead, with the :func:`ctcp` decorator::
+        * use a command alias
+        * parse the arguments with your own regex within your plugin callable
+        * use a :func:`rule`
+
+        The :func:`rule` must be used with the :func:`ctcp` decorator::
 
             @rule(r'hello!?')
             @ctcp('ACTION')

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -1586,11 +1586,6 @@ class example:
             "is_pattern": self.use_re,
             "is_admin": self.admin,
             "is_owner": self.owner,
-            # old-style flags
-            # TODO: to be removed in Sopel 8.0
-            "privmsg": self.privmsg,
-            "admin": self.admin,
-            "help": self.user_help,
         }
         func.example.append(record)
         return func

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -1249,41 +1249,6 @@ class AbstractNamedRule(Rule):
         """
         return name in self._aliases
 
-    def escape_name(self, name):
-        """Escape the provided name if needed.
-
-        .. note::
-
-            Until now, Sopel has allowed command name to be regex pattern.
-            It was mentioned in the documentation without much details, and
-            there were no tests for it.
-
-            In order to ensure backward compatibility with previous versions of
-            Sopel, we make sure to escape command name only when it's needed.
-
-            **It is not recommended to use a regex pattern for your command
-            name. This feature will be removed in Sopel 8.0.**
-
-        """
-        if set('.^$*+?{}[]\\|()') & set(name):
-            # the name contains a regex pattern special character
-            # we assume the user knows what they are doing
-            try:
-                # make sure it compiles properly
-                # (nobody knows what they are doing)
-                re.compile(name)
-            except re.error as error:
-                original_name = name
-                name = re.escape(name)
-                LOGGER.warning(
-                    'Command name "%s" is an invalid regular expression '
-                    'and will be replaced by "%s": %s',
-                    original_name, name, error)
-        else:
-            name = re.escape(name)
-
-        return name
-
     @abc.abstractmethod
     def get_rule_regex(self):
         """Make the rule regex for this named rule.
@@ -1403,8 +1368,8 @@ class Command(AbstractNamedRule):
 
         to create a compiled regex to return.
         """
-        name = [self.escape_name(self._name)]
-        aliases = [self.escape_name(alias) for alias in self._aliases]
+        name = [re.escape(self._name)]
+        aliases = [re.escape(alias) for alias in self._aliases]
         pattern = r'|'.join(name + aliases)
 
         # Escape all whitespace with a single backslash.
@@ -1525,8 +1490,8 @@ class NickCommand(AbstractNamedRule):
 
         to create a compiled regex to return.
         """
-        name = [self.escape_name(self._name)]
-        aliases = [self.escape_name(alias) for alias in self._aliases]
+        name = [re.escape(self._name)]
+        aliases = [re.escape(alias) for alias in self._aliases]
         pattern = r'|'.join(name + aliases)
 
         return _compile_pattern(
@@ -1610,8 +1575,8 @@ class ActionCommand(AbstractNamedRule):
 
         to create a compiled regex to return.
         """
-        name = [self.escape_name(self._name)]
-        aliases = [self.escape_name(alias) for alias in self._aliases]
+        name = [re.escape(self._name)]
+        aliases = [re.escape(alias) for alias in self._aliases]
         pattern = r'|'.join(name + aliases)
         pattern = self.PATTERN_TEMPLATE.format(command=pattern)
         return re.compile(pattern, re.IGNORECASE | re.VERBOSE)


### PR DESCRIPTION
### Description

Tin. Part of #2120:

* some internal flags about example
* remove support for regex in command name

I didn't touch the currency plugin, will do in another PR.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
