### PR TITLE
reqs: allow xmltodict 0.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "xmltodict<0.14",
+    "xmltodict>=0.12,<0.14",
     "pytz",
     "praw>=4.0.0,<8.0.0",
     "geoip2>=4.0,<5.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 ]
 requires-python = ">=3.7"
 dependencies = [
-    "xmltodict==0.12",
+    "xmltodict<0.14",
     "pytz",
     "praw>=4.0.0,<8.0.0",
     "geoip2>=4.0,<5.0",


### PR DESCRIPTION
### Description
Tin. I tried and tried, but couldn't find any reason not to allow the newer version of xmltodict now that we no longer support Python 2.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
On IRC, @Strykar said this _does_ break something, but I have no idea what (no details). I invite them to post said details here.