### PR TITLE
seen: catch database write errors

### DIFF
--- a/sopel/modules/seen.py
+++ b/sopel/modules/seen.py
@@ -9,8 +9,15 @@ https://sopel.chat
 """
 from __future__ import annotations
 
+import logging
+
+from sqlalchemy.exc import SQLAlchemyError
+
 from sopel import plugin
 from sopel.tools.time import seconds_to_human
+
+
+logger = logging.getLogger(__name__)
 
 
 @plugin.command('seen')
@@ -63,9 +70,12 @@ def seen(bot, trigger):
 @plugin.require_chanmsg
 def note(bot, trigger):
     nick = trigger.nick
-    # as of Sopel 8, `trigger.time` is Aware, meaning we should store its value
-    # for timezone safety when comparing it later
-    bot.db.set_nick_value(nick, 'seen_timestamp', trigger.time.timestamp())
-    bot.db.set_nick_value(nick, 'seen_channel', trigger.sender)
-    bot.db.set_nick_value(nick, 'seen_message', trigger)
-    bot.db.set_nick_value(nick, 'seen_action', trigger.ctcp is not None)
+    try:
+        # as of Sopel 8, `trigger.time` is Aware, meaning we should store its value
+        # for timezone safety when comparing it later
+        bot.db.set_nick_value(nick, 'seen_timestamp', trigger.time.timestamp())
+        bot.db.set_nick_value(nick, 'seen_channel', trigger.sender)
+        bot.db.set_nick_value(nick, 'seen_message', trigger)
+        bot.db.set_nick_value(nick, 'seen_action', trigger.ctcp is not None)
+    except SQLAlchemyError as error:
+        logger.error("Unable to save seen, database error: %s" % error)


### PR DESCRIPTION
### Description
Currently, if the DB writes that the `seen` plugin tries to do fail for any reason, the error will propagate up into `bot.error()` and cause very antisocial error report messages from the bot every time the channel receives messages, if the `reply_errors` (sic) feature is turned on. In particular, I've seen this with a disk that becomes full with the `sqlite3` backend, but this patch should cover a broad class of such failures.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - Just the same test failures I see when I run `make qa` against `master` (0479737d):
   `12 failed, 1268 passed, 8 xfailed, 1 warning, 73 errors in 44.38s`  
- [x] I have tested the functionality of the things this change touches