### PR TITLE
ci, plugins: Python 3.10 and other improvements

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,10 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.7
-          - 3.8
-          - 3.9
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,7 +5,7 @@ flake8-future-import
 flake8-import-order
 flake8-type-checking; python_version >= '3.8'
 furo==2022.4.7  # Sphinx theme
-pytest~=6.2.5
+pytest~=7.1.0
 pytest-vcr~=1.0.2
 requests-mock~=1.9.3
 sphinx>=4,<5

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ dependencies = [
 "Source" = "https://github.com/sopel-irc/sopel"
 "Coverage" = "https://coveralls.io/github/sopel-irc/sopel"
 
-
 [project.scripts]
 sopel = "sopel.cli.run:main"
 sopel-config = "sopel.cli.config:main"
@@ -62,3 +61,11 @@ sopel-plugins = "sopel.cli.plugins:main"
 
 [project.entry-points.pytest11]
 pytest-sopel = "sopel.tests.pytest_plugin"
+
+[tool.pytest.ini_options]
+python_files = "*.py"
+addopts = "--tb=short -p no:nose"
+norecursedirs = "build contrib"
+filterwarnings = [
+    "ignore::pytest.PytestAssertRewriteWarning",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,6 +28,7 @@ classifiers = [
     "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
     "Topic :: Communications :: Chat :: Internet Relay Chat",
 ]
 requires-python = ">=3.7"

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,3 +35,5 @@ show_error_codes = True
 python_files = *.py
 addopts = --tb=short -p no:nose
 norecursedirs = contrib
+filterwarnings =
+    ignore::pytest.PytestAssertRewriteWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,10 +30,3 @@ no-accept-encodings = True
 [mypy]
 plugins = sqlalchemy.ext.mypy.plugin
 show_error_codes = True
-
-[tool:pytest]
-python_files = *.py
-addopts = --tb=short -p no:nose
-norecursedirs = build contrib
-filterwarnings =
-    ignore::pytest.PytestAssertRewriteWarning

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,5 +33,5 @@ show_error_codes = True
 
 [tool:pytest]
 python_files = *.py
-addopts = --tb=short
+addopts = --tb=short -p no:nose
 norecursedirs = contrib

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,6 @@ show_error_codes = True
 [tool:pytest]
 python_files = *.py
 addopts = --tb=short -p no:nose
-norecursedirs = contrib
+norecursedirs = build contrib
 filterwarnings =
     ignore::pytest.PytestAssertRewriteWarning

--- a/sopel/plugins/__init__.py
+++ b/sopel/plugins/__init__.py
@@ -29,7 +29,7 @@ exist for each type of plugin.
 from __future__ import annotations
 
 import collections
-import imp
+import importlib
 import itertools
 import os
 
@@ -67,12 +67,8 @@ def find_internal_plugins():
     Internal plugins can be found under ``sopel.modules``. This list does not
     include the ``coretasks`` plugin.
     """
-    plugin_dir = imp.find_module(
-        'modules',
-        [imp.find_module('sopel')[1]]
-    )[1]
-
-    for name, _ in _list_plugin_filenames(plugin_dir):
+    modules = importlib.import_module('sopel.modules')
+    for name, _ in _list_plugin_filenames(modules.__path__[0]):
         yield handlers.PyModulePlugin(name, 'sopel.modules')
 
 

--- a/sopel/plugins/__init__.py
+++ b/sopel/plugins/__init__.py
@@ -68,8 +68,12 @@ def find_internal_plugins():
     include the ``coretasks`` plugin.
     """
     modules = importlib.util.find_spec('sopel.modules')
-    submodule_dir = modules.submodule_search_locations[0]  # only one expected
-    for name, _ in _list_plugin_filenames(submodule_dir):
+    plugin_list = itertools.chain.from_iterable(
+        _list_plugin_filenames(path)
+        for path in modules.submodule_search_locations
+    )
+
+    for name, _ in set(plugin_list):
         yield handlers.PyModulePlugin(name, 'sopel.modules')
 
 

--- a/sopel/plugins/__init__.py
+++ b/sopel/plugins/__init__.py
@@ -67,8 +67,9 @@ def find_internal_plugins():
     Internal plugins can be found under ``sopel.modules``. This list does not
     include the ``coretasks`` plugin.
     """
-    modules = importlib.import_module('sopel.modules')
-    for name, _ in _list_plugin_filenames(modules.__path__[0]):
+    modules = importlib.util.find_spec('sopel.modules')
+    submodule_dir = modules.submodule_search_locations[0]  # only one expected
+    for name, _ in _list_plugin_filenames(submodule_dir):
         yield handlers.PyModulePlugin(name, 'sopel.modules')
 
 


### PR DESCRIPTION
### Description

Tin. Fix #2274.

I haven't check yet if all tests pass on older version of Python with the newest pytest, so the PR is going to do that for me here (hence, the draft).

* Added "python 3.10" to the CI config
* Updated pytest to 7.1+
* Fixed an issue with Python 3.10 and the `imp` module (leftover from previous cleanup)
* Suppress a Pytest warning about plugin file rewrite (pytest does too much black magic)

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
