### PR TITLE
coretasks: `.blocks hostmask` -> `.blocks host`

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -1272,26 +1272,26 @@ def blocks(bot, trigger):
         "success_del": "Successfully deleted block: %s",
         "success_add": "Successfully added block: %s",
         "no_nick": "No matching nick block found for: %s",
-        "no_host": "No matching hostmask block found for: %s",
-        "invalid": "Invalid format for %s a block. Try: .blocks add (nick|hostmask) sopel",
+        "no_host": "No matching host block found for: %s",
+        "invalid": "Invalid format for %s a block. Try: .blocks add (nick|host) sopel",
         "invalid_display": "Invalid input for displaying blocks.",
         "nonelisted": "No %s listed in the blocklist.",
         'huh': "I could not figure out what you wanted to do.",
     }
 
-    masks = set(s for s in bot.config.core.host_blocks if s != '')
+    hosts = set(s for s in bot.config.core.host_blocks if s != '')
     nicks = set(bot.make_identifier(nick)
                 for nick in bot.config.core.nick_blocks
                 if nick != '')
     text = trigger.group().split()
 
     if len(text) == 3 and text[1] == "list":
-        if text[2] == "hostmask":
-            if len(masks) > 0:
-                blocked = ', '.join(str(mask) for mask in masks)
-                bot.say("Blocked hostmasks: {}".format(blocked))
+        if text[2] == "host":
+            if len(hosts) > 0:
+                blocked = ', '.join(str(host) for host in hosts)
+                bot.say("Blocked hosts: {}".format(blocked))
             else:
-                bot.reply(STRINGS['nonelisted'] % ('hostmasks'))
+                bot.reply(STRINGS['nonelisted'] % ('hosts'))
         elif text[2] == "nick":
             if len(nicks) > 0:
                 blocked = ', '.join(str(nick) for nick in nicks)
@@ -1306,9 +1306,9 @@ def blocks(bot, trigger):
             nicks.add(text[3])
             bot.config.core.nick_blocks = nicks
             bot.config.save()
-        elif text[2] == "hostmask":
-            masks.add(text[3].lower())
-            bot.config.core.host_blocks = list(masks)
+        elif text[2] == "host":
+            hosts.add(text[3].lower())
+            bot.config.core.host_blocks = list(hosts)
         else:
             bot.reply(STRINGS['invalid'] % ("adding"))
             return
@@ -1325,13 +1325,13 @@ def blocks(bot, trigger):
             bot.config.core.nick_blocks = [str(n) for n in nicks]
             bot.config.save()
             bot.reply(STRINGS['success_del'] % (text[3]))
-        elif text[2] == "hostmask":
-            mask = text[3].lower()
-            if mask not in masks:
+        elif text[2] == "host":
+            host = text[3].lower()
+            if host not in hosts:
                 bot.reply(STRINGS['no_host'] % (text[3]))
                 return
-            masks.remove(mask)
-            bot.config.core.host_blocks = [str(m) for m in masks]
+            hosts.remove(host)
+            bot.config.core.host_blocks = [str(m) for m in hosts]
             bot.config.save()
             bot.reply(STRINGS['success_del'] % (text[3]))
         else:


### PR DESCRIPTION
### Description
Tin. Simple subcommand rename w/variables changed to match.

These are not, and AFAICT never have been, actual host*masks*. Having the subcommand name and code variables refer to them as (host)masks has been a point of confusion for, literally, years.

This is just the first step toward making the ignore/block system work more intuitively, but you know what they say about journeys of a thousand miles…

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - Successfully verified listing "host" blocks, adding one (and made sure it actually ignored my test user), and then removing it.

### Notes
For full context, thought processes, tentative future plans, and so on: See #1355.

That covers a lot of ground, and most of it is rightly left for the next release (again) so we can try to ship 8.0 this year. But this is a simple patch that makes room for some of those improvements, and didn't take much work to write. Hopefully it won't take much work to review, either. 😁

### IMPORTANT
Assuming this is merged, https://sopel.chat/usage/ignoring-people/ needs an update for when 8.0 goes live.