### PR TITLE
coretasks: fix/improve `.blocks` help output

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -1259,14 +1259,16 @@ def _get_sasl_pass_and_mech(bot):
 
 
 @plugin.commands('blocks')
+@plugin.example(r'.blocks add host some\.malicious\.network', user_help=True)
+@plugin.example(r'.blocks add nick sp(a|4)mb(o|0)t\d*', user_help=True)
 @plugin.thread(False)
 @plugin.unblockable
 @plugin.priority('low')
 @plugin.require_admin
 def blocks(bot, trigger):
     """
-    Manage Sopel's blocking features.\
-    See [ignore system documentation]({% link _usage/ignoring-people.md %}).
+    Manage Sopel's blocking features.
+    See https://sopel.chat/usage/ignoring-people/ for usage notes.
     """
     STRINGS = {
         "success_del": "Successfully deleted block: %s",


### PR DESCRIPTION
### Description
Replaced the Liquid link tag with an actual URL, since the primary purpose of these docstrings is for help output on IRC.

Added a couple examples, to show the syntax and also make it crystal clear that the inputs are interpreted as regex.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Example
New output of `.help blocks` on my test bot, using the new sopel-help package:

![image](https://user-images.githubusercontent.com/164140/186299825-b20b43a8-d2a3-453c-b197-f9c8dd6042ea.png)

### Notes
Yes, I'm jumping the gun a bit on #2344 by using "host" instead of "hostmask" here, but this stuff is so simple that it's just not worth messing with stacked PRs, rebasing, etc. 😁