### PR TITLE
irc: `LINELEN` ISUPPORT token support/use

### DIFF
--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -184,6 +184,11 @@ class AbstractBot(abc.ABC):
             and can be used with :func:`sopel.tools.get_sendable_message`.
 
         """
+        # Clients "SHOULD" assume messages will be truncated at 512 bytes if
+        # the LINELEN ISUPPORT token is not present.
+        # See https://modern.ircdocs.horse/#linelen-parameter
+        max_line_length = self.isupport.get('LINELEN', 512)
+
         if self.hostmask is not None:
             hostmask_length = len(self.hostmask)
         else:
@@ -200,7 +205,7 @@ class AbstractBot(abc.ABC):
             )
 
         return (
-            512  # maximum IRC line length in bytes, per RFC
+            max_line_length
             - 1  # leading colon
             - hostmask_length  # calculated/maximum length of own hostmask prefix
             - 1  # space between prefix & command

--- a/sopel/irc/isupport.py
+++ b/sopel/irc/isupport.py
@@ -115,6 +115,7 @@ ISUPPORT_PARSERS = {
     'HOSTLEN': int,
     'INVEX': _optional(_single_character, default='I'),
     'KICKLEN': int,
+    'LINELEN': int,
     'MAXLIST': _map_items(int),
     'MAXTARGETS': _optional(int),
     'MODES': _optional(int),

--- a/test/test_irc.py
+++ b/test/test_irc.py
@@ -34,6 +34,19 @@ def prefix_length(bot):
     return 1 + len(bot.nick) + 1 + 1 + len(bot.user) + 1 + 63 + 1
 
 
+def test_safe_text_length_with_linelen_no_hostmask(tmpconfig, botfactory):
+    # this test doesn't work using only the plain `bot` fixture
+    bot = botfactory.preloaded(tmpconfig)
+
+    assert bot.hostmask is None
+    bot.on_message(
+        ':irc.example.com 005 Sopel NETWORK=LLTest LINELEN=1024 '
+        ':are supported by this server')
+    # normal lines are capped at 512 bytes, and 1024 is exactly twice that
+    # expect the extra 512 in full + the result of hostmask_unknown below
+    assert bot.safe_text_length('#channel') == 414 + 512
+
+
 def test_safe_text_length_hostmask_unknown(bot):
     assert bot.hostmask is None
     assert bot.safe_text_length('#channel') == 414


### PR DESCRIPTION
Take advantage of the `LINELEN` token in 005 to send longer messages than the RFC limit of 512 bytes, when possible.

Can't say I've ever seen a network actually advertise this token, but it's relatively easy to add and test so why not support it.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
This was previously flagged as obsolete, but InspIRCd still uses it (refs: ircdocs/irc-defs#82, https://github.com/inspircd/inspircd/blob/e147b461173c58eb443eee0ac56f7d3c3c4b2c3a/src/server.cpp#L218).

Docs link in the code points to a nonexistent section at time of writing. See ircdocs/modern-irc#189 for the patch that will add it.