### PR TITLE
unicode_info: Use unicodedata2, if available

### DIFF
--- a/sopel/modules/unicode_info.py
+++ b/sopel/modules/unicode_info.py
@@ -8,9 +8,13 @@ https://sopel.chat
 """
 from __future__ import annotations
 
-import unicodedata
-
 from sopel import plugin
+
+# unicodedata2 can provide a more-modern UCD than the one that comes with Python, use it if present
+try:
+    import unicodedata2 as unicodedata
+except ImportError:
+    import unicodedata
 
 
 def get_codepoint_name(char):


### PR DESCRIPTION
### Description

This PR adds support for the [`unicodedata2`](https://pypi.org/project/unicodedata2/) library to the `unicode_info` plugin, allowing the plugin to report information about codepoints from more modern versions of Unicode than the one shipped with the stdlib of the Python executing the bot.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
