### PR TITLE
remind: skip `remind_monitoring()` if IRC connection not ready

### DIFF
--- a/sopel/modules/remind.py
+++ b/sopel/modules/remind.py
@@ -160,6 +160,10 @@ def shutdown(bot):
 @plugin.interval(2.5)
 def remind_monitoring(bot):
     """Check for reminder"""
+    if not bot.backend.is_connected():
+        # IRC connection not ready; wait until next check.
+        return
+
     now = int(time.time())
     unixtimes = [int(key) for key in bot.rdb]
     oldtimes = [t for t in unixtimes if t <= now]


### PR DESCRIPTION
### Description
Past-due reminders could be consumed during startup (and emit an error to the log about the event loop not being started yet).

The documentation for `@plugin.interval()` has had a warning in it about not assuming that the IRC connection will be available for I don't even know how long, at this point. It's about time core followed its advice.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches