### PR TITLE
privileges, url: configurable minimum channel access requirement for `.urlban` and friends

### DIFF
--- a/sopel/privileges.py
+++ b/sopel/privileges.py
@@ -56,6 +56,16 @@ In that case, ``priv`` contains both VOICE and OP privileges, but not HALFOP.
 from __future__ import annotations
 
 
+__all__ = [
+    'VOICE',
+    'HALFOP',
+    'OP',
+    'ADMIN',
+    'OWNER',
+    'OPER',
+]
+
+
 VOICE = 1
 """Privilege level for the +v channel permission
 


### PR DESCRIPTION
### Description
Tin, more or less.

Added `__all__` to `sopel.privileges` for ease of fetching the names of valid privilege constants programmatically.

`.urlban`/`.urlallow` and friends are now only available to bot owner/admins and channel OPs by default, with the option to change the channel access level required via config setting.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
Naming Things Is Hard as always. Suggestions welcome if anyone's got a better idea for the new option name in `UrlSection`.

Decided not to add the new option to `configure()`, at least for now. Doing so seemed like overkill.