### PR TITLE
bot: report exception type for relevant errors

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -930,7 +930,8 @@ class Sopel(irc.AbstractBot):
         """
         message = 'Unexpected error'
         if exception:
-            message = '{} ({})'.format(message, exception)
+            detail = ' ({})'.format(exception) if str(exception) else ''
+            message = 'Unexpected {}{}'.format(type(exception).__name__, detail)
 
         if trigger:
             message = '{} from {} at {}. Message was: {}'.format(


### PR DESCRIPTION
### Description

This PR modifies the error report issued as an IRC message to include the ~`repr()`~ `type()` of exceptions when relevant to prevent a somewhat obscure category of errors. Closes #2353 

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
