### PR TITLE
send_notice: sanitize `dest` argument before sending it on wire

### DIFF
--- a/sopel/irc/abstract_backends.py
+++ b/sopel/irc/abstract_backends.py
@@ -245,4 +245,4 @@ class AbstractIRCBackend(abc.ABC):
         :param str dest: nickname or channel name
         :param str text: the text to send
         """
-        self.send_command('NOTICE', dest, text=text)
+        self.send_command('NOTICE', safe(dest), text=text)


### PR DESCRIPTION
all arguments should be inspected for newlines to avoid IRC injection.
the `text` argument is already checked (in `prepare_command()`).

### Description
The PR adds a sanitization (remove possible newlines) on `dest` argument. It is a security measure to avoid injection of arbirtrary IRC command via `dest` parameter.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [ ] I have tested the functionality of the things this change touches