### PR TITLE
trigger: Make `sender` property more consistent

### DIFF
--- a/docs/source/package/trigger.rst
+++ b/docs/source/package/trigger.rst
@@ -4,3 +4,8 @@ Triggers
 
 .. automodule:: sopel.trigger
     :members:
+
+Command context
+---------------
+
+.. autodata:: sopel.trigger.COMMANDS_WITH_CONTEXT

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -38,7 +38,7 @@ __all__ = [
 IdentifierFactory = Callable[[str], identifiers.Identifier]
 
 
-COMMANDS_WITH_CONTEXT = [
+COMMANDS_WITH_CONTEXT = frozenset({
     'INVITE',
     'JOIN',
     'KICK',
@@ -47,8 +47,8 @@ COMMANDS_WITH_CONTEXT = [
     'PART',
     'PRIVMSG',
     'TOPIC',
-]
-"""List of commands with a :attr:`trigger.sender<Trigger.sender>`.
+})
+"""Set of commands with a :attr:`trigger.sender<Trigger.sender>`.
 
 Most IRC messages a plugin will want to handle (channel messages and PMs) are
 associated with a context, exposed in the Trigger's ``sender`` property.

--- a/test/test_trigger.py
+++ b/test/test_trigger.py
@@ -80,6 +80,56 @@ def test_quit_pretrigger(nick):
     assert pretrigger.sender is None
 
 
+def test_quit_pretrigger_empty(nick):
+    """Make sure empty quit message is also fine"""
+    line = ':Foo!foo@example.com QUIT'
+    pretrigger = PreTrigger(nick, line)
+    assert pretrigger.tags == {}
+    assert pretrigger.hostmask == 'Foo!foo@example.com'
+    assert pretrigger.line == line
+    assert pretrigger.args == []
+    assert pretrigger.text == 'QUIT'  # TODO BUG: the command is not part of `pretrigger.args`
+    assert pretrigger.plain == ''
+    assert pretrigger.event == 'QUIT'
+    assert pretrigger.nick == Identifier('Foo')
+    assert pretrigger.user == 'foo'
+    assert pretrigger.host == 'example.com'
+    assert pretrigger.sender is None
+
+
+def test_away_pretrigger(nick):
+    line = ':Foo!foo@example.com AWAY :away message text'
+    pretrigger = PreTrigger(nick, line)
+    assert pretrigger.tags == {}
+    assert pretrigger.hostmask == 'Foo!foo@example.com'
+    assert pretrigger.line == line
+    assert pretrigger.args == ['away message text']
+    assert pretrigger.text == 'away message text'
+    assert pretrigger.plain == 'away message text'
+    assert pretrigger.event == 'AWAY'
+    assert pretrigger.nick == Identifier('Foo')
+    assert pretrigger.user == 'foo'
+    assert pretrigger.host == 'example.com'
+    assert pretrigger.sender is None
+
+
+def test_away_pretrigger_back(nick):
+    """Make sure empty away message (meaning "I'm back") is also fine"""
+    line = ':Foo!foo@example.com AWAY'
+    pretrigger = PreTrigger(nick, line)
+    assert pretrigger.tags == {}
+    assert pretrigger.hostmask == 'Foo!foo@example.com'
+    assert pretrigger.line == line
+    assert pretrigger.args == []
+    assert pretrigger.text == 'AWAY'  # TODO BUG: the command is not part of `pretrigger.args`
+    assert pretrigger.plain == ''
+    assert pretrigger.event == 'AWAY'
+    assert pretrigger.nick == Identifier('Foo')
+    assert pretrigger.user == 'foo'
+    assert pretrigger.host == 'example.com'
+    assert pretrigger.sender is None
+
+
 def test_join_pretrigger(nick):
     line = ':Foo!foo@example.com JOIN #Sopel'
     pretrigger = PreTrigger(nick, line)
@@ -142,6 +192,7 @@ def test_unusual_pretrigger(nick):
     assert pretrigger.text == 'PING'
     assert pretrigger.plain == ''
     assert pretrigger.event == 'PING'
+    assert pretrigger.sender is None
 
 
 def test_ctcp_intent_pretrigger(nick):


### PR DESCRIPTION
### Description
Short sleep does not make me a great comprehensive reader of specs, but commands that are 1) sent from the server to a client and 2) include a <target> (channel/nick), are actually quite rare. The IRC protocol is mostly numeric replies, and very few event types actually refer to a user (nick) or channel.

The idea here, though, is that unless I forgot about an event type that actually is tied to a channel or query (PM) buffer, it is ONLY the new list of `COMMANDS_WITH_CONTEXT` that should have the `sender` set to any value other than `None`.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
Undecided yet if this is enough to call #2331 closed. I remember a discussion about transitioning to a new property called `trigger.context` or similar, for clarity, but can't find it on the relevant issue. Maybe it was an IRC conversation.

'Breaking Change' label because this could be a [spacebar heating](https://xkcd.com/1172/) incident if anyone relies on the old (buggy) behavior for some weird plugin thing and it needs to be mentioned in the changelog for 8.0.

While updating/adding tests I also found an actual bug in how `text` gets set (it contradicts Sopel's documentation). TODO comments related. I will work on that next.