### PR TITLE
trigger: make `text` empty if `args` is empty, per docs

### DIFF
--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -228,7 +228,8 @@ class PreTrigger:
             self.args.append(self.text)
         else:
             self.args = line.split(' ')
-            self.text = self.args[-1]
+            # see `text` attr documentation above, and #2360
+            self.text = self.args[-1] if len(self.args) > 1 else ''
 
         self.event = self.args[0]
         self.args = self.args[1:]

--- a/test/test_trigger.py
+++ b/test/test_trigger.py
@@ -88,7 +88,7 @@ def test_quit_pretrigger_empty(nick):
     assert pretrigger.hostmask == 'Foo!foo@example.com'
     assert pretrigger.line == line
     assert pretrigger.args == []
-    assert pretrigger.text == 'QUIT'  # TODO BUG: the command is not part of `pretrigger.args`
+    assert pretrigger.text == ''
     assert pretrigger.plain == ''
     assert pretrigger.event == 'QUIT'
     assert pretrigger.nick == Identifier('Foo')
@@ -121,7 +121,7 @@ def test_away_pretrigger_back(nick):
     assert pretrigger.hostmask == 'Foo!foo@example.com'
     assert pretrigger.line == line
     assert pretrigger.args == []
-    assert pretrigger.text == 'AWAY'  # TODO BUG: the command is not part of `pretrigger.args`
+    assert pretrigger.text == ''
     assert pretrigger.plain == ''
     assert pretrigger.event == 'AWAY'
     assert pretrigger.nick == Identifier('Foo')
@@ -189,7 +189,7 @@ def test_unusual_pretrigger(nick):
     assert pretrigger.hostmask is None
     assert pretrigger.line == line
     assert pretrigger.args == []
-    assert pretrigger.text == 'PING'
+    assert pretrigger.text == ''
     assert pretrigger.plain == ''
     assert pretrigger.event == 'PING'
     assert pretrigger.sender is None


### PR DESCRIPTION
### Description
An IRC command/event such as 'AWAY' with no message, or 'PING', will have an empty `args` list.

Documentation for the (Pre)Trigger `text` attribute says that it will contain the last item in `args` if the line does not contain ':', but it previously—erroneously—contained the command name in such cases.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
Starting this as a draft because it's built on top of #2359. Whether I separate the histories or not, I'll have to faff with _something_ after merging one before the other can be merged. Would rather have the simplest rebase imaginable (which this strategy will get me) than a rebase that requires the interactive mode.

Same as the parent PR, 'Breaking Change' label because fixing this after so long could cause a [spacebar heating](https://xkcd.com/1172/) incident.