### PR TITLE
unicode_info: ignore type check on unicodedata2

### DIFF
--- a/sopel/modules/unicode_info.py
+++ b/sopel/modules/unicode_info.py
@@ -10,11 +10,14 @@ from __future__ import annotations
 
 from sopel import plugin
 
-# unicodedata2 can provide a more-modern UCD than the one that comes with Python, use it if present
+# Python built-in unicodedata uses UCD version 13 (as of Python 3.10)
+# unicodedata2 can provide a more recent version, so we use that if present
+# See also: https://docs.python.org/3/library/unicodedata.html
 try:
-    import unicodedata2 as unicodedata
+    # ignore type check for these imports (no stubs for unicodedata2)
+    import unicodedata2 as unicodedata  # type: ignore[import]
 except ImportError:
-    import unicodedata
+    import unicodedata  # type: ignore[no-redef]
 
 
 def get_codepoint_name(char):


### PR DESCRIPTION
### Description

* ignore import error because `unicodedata2` doesn't have a stub
* ignore no-redef error because `unicodedata2` is optional and it has the same interface as `unicodedata`

Also modified some comments because nitpicking is my pride.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
