### PR TITLE
backends: try only utf8 when UTF8ONLY

### DIFF
--- a/sopel/irc/abstract_backends.py
+++ b/sopel/irc/abstract_backends.py
@@ -67,16 +67,15 @@ class AbstractIRCBackend(abc.ABC):
         # We can't trust clients to pass valid Unicode.
         try:
             data = str(line, encoding='utf-8')
-        except UnicodeDecodeError:
+        except UnicodeDecodeError as e:
+            # ...unless the server announces UTF8ONLY
+            if "UTF8ONLY" in self.isupport:
+                raise e
             # not Unicode; let's try CP-1252
             try:
                 data = str(line, encoding='cp1252')
             except UnicodeDecodeError:
-                # Okay, let's try ISO 8859-1
-                try:
-                    data = str(line, encoding='iso8859-1')
-                except UnicodeDecodeError:
-                    raise ValueError('Unable to decode data from server.')
+                raise ValueError('Unable to decode data from server.')
 
         return data
 

--- a/test/irc/test_irc_abstract_backends.py
+++ b/test/irc/test_irc_abstract_backends.py
@@ -1,7 +1,9 @@
 """Tests for core ``sopel.irc.backends``"""
 from __future__ import annotations
 
+import pytest
 
+from sopel.irc.isupport import ISupport
 from sopel.tests.mocks import MockIRCBackend
 
 
@@ -298,3 +300,40 @@ def test_send_notice_safe():
     expected = 'NOTICE #sopel :Helloworld!\r\n'
     assert backend.message_sent == [expected.encode('utf-8')]
     assert bot.message_sent == [expected]
+
+
+def test_decode_line_utf8():
+    bot = BotCollector()
+    backend = MockIRCBackend(bot)
+    backend.isupport = ISupport()
+
+    test = "PRIVMSG #sopel :Hello, Martín!"
+    assert backend.decode_line(test.encode("utf-8")) == test
+
+
+def test_decode_line_utf8only():
+    bot = BotCollector()
+    backend = MockIRCBackend(bot)
+    backend.isupport = ISupport(UTF8ONLY=None)
+
+    test = "PRIVMSG #sopel :Hello, Martín!"
+    with pytest.raises(UnicodeDecodeError):
+        backend.decode_line(test.encode("cp1252"))
+
+
+def test_decode_line_nonsense():
+    bot = BotCollector()
+    backend = MockIRCBackend(bot)
+    backend.isupport = ISupport()
+
+    with pytest.raises(ValueError):
+        backend.decode_line(bytes(range(256)))
+
+
+def test_decode_line_cp1252():
+    bot = BotCollector()
+    backend = MockIRCBackend(bot)
+    backend.isupport = ISupport()
+
+    test = "PRIVMSG #sopel :Hello, Martín!"
+    assert backend.decode_line(test.encode("cp1252")) == test


### PR DESCRIPTION
### Description
When UTF8ONLY is active, raise a decoding error if the message fails to decode instead of attempting other encodings.

As far as I can tell, Sopel never sends non-utf8 data unless someone's poking at the backend directly, so no other changes should be necessary to consider UTF8ONLY supported. (Actually, even this doesn't seem mandatory, just sensible)

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
