### PR TITLE
formatting: fix `color('some text', 0)`

### DIFF
--- a/sopel/formatting.py
+++ b/sopel/formatting.py
@@ -190,7 +190,7 @@ def color(text, fg=None, bg=None):
     :param mixed fg: the foreground color
     :param mixed bg: the background color
     :raises TypeError: if ``text`` is not a string
-    :raises ValueError: if ``fg`` or ``bg`` is an unrecognized color value)
+    :raises ValueError: if ``fg`` or ``bg`` is an unrecognized color value
     :rtype: str
 
     The color can be a string of the color name, or an integer in the range
@@ -236,7 +236,7 @@ def hex_color(text, fg=None, bg=None):
     :param str fg: the foreground color
     :param str bg: the background color
     :raises TypeError: if ``text`` is not a string
-    :raises ValueError: if ``fg`` or ``bg`` is an unrecognized color value)
+    :raises ValueError: if ``fg`` or ``bg`` is an unrecognized color value
     :rtype: str
 
     The color can be provided with a string of either 3 or 6 hexadecimal digits.

--- a/sopel/formatting.py
+++ b/sopel/formatting.py
@@ -197,7 +197,7 @@ def color(text, fg=None, bg=None):
     0-99. The known color names can be found in the :class:`colors` class of
     this module.
     """
-    if not fg and not bg:
+    if fg is None and bg is None:
         return text
 
     fg = _get_color(fg)

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -29,6 +29,12 @@ def test_color():
     assert color(text, 0) == '\x0300' + text + '\x03'  # ensure that color 0 isn't treated as boolean false
     pytest.raises(ValueError, color, text, 100)
     pytest.raises(ValueError, color, text, 'INVALID')
+    pytest.raises(ValueError, color, text, '')
+    # test background color as well
+    pytest.raises(ValueError, color, text, '', '')
+    pytest.raises(ValueError, color, text, None, '')
+    pytest.raises(ValueError, color, text, colors.PINK, '')
+    pytest.raises(ValueError, color, text, '', colors.PINK)
 
 
 def test_hex_color():

--- a/test/test_formatting.py
+++ b/test/test_formatting.py
@@ -24,6 +24,9 @@ def test_color():
     assert color(text) == text
     assert color(text, colors.PINK) == '\x0313' + text + '\x03'
     assert color(text, colors.PINK, colors.TEAL) == '\x0313,10' + text + '\x03'
+    assert color(text, '3') == '\x0303' + text + '\x03'  # ensure single-digit str is zero-padded
+    assert color(text, 3) == '\x0303' + text + '\x03'  # ensure ints are zero-padded
+    assert color(text, 0) == '\x0300' + text + '\x03'  # ensure that color 0 isn't treated as boolean false
     pytest.raises(ValueError, color, text, 100)
     pytest.raises(ValueError, color, text, 'INVALID')
 


### PR DESCRIPTION
### Description
A literal `0` (nominally the color white, in mIRC convention) evaluates as `False`, which was being skipped by the `not` and making the function return its input text unchanged.

Regression check added to existing `test_color()` case.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
No further 7.x releases are planned, but this fix probably _should_ be included if another patch version happens.

This took about 10x as long as it should have because I ran into `setuptools>=64.0` breaking how Sopel does editable installs and had to figure out that problem before I could actually test the patch. That problem needs its own issue/PR, but I still need to do a little more research before I can open a useful one of either.

Kudos to @xnaas for hacking some extra color schemes into a forked sopel-rainbow plugin, which revealed this bug.