### PR TITLE
build: pin setuptools while we figure out PEP-0660 editable install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=63.0", "wheel"]
+requires = ["setuptools~=63.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
### Description
In setuptools 64.0, editable installs were changed. As of 65.x, I was unable to install sopel as an editable distribution without getting ImportErrors even when trying to do something as simple as run `pytest --version` (which shouldn't load any Sopel code).

I *believe* this is enough to work around the issue for now, given that pyproject.toml packages are supposed to use build isolation and the used setuptools version is separate from whatever's installed in the user's environment. At least my brief testing bore this out, with ~=63.0 requested by the TOML file and 65.something installed in pip.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
No milestone; this is entirely for us developers, not tied to any release. (It's a build-time dependency, not required at runtime.)