### PR TITLE
abstract_backends: safe() all prepare_command args

### DIFF
--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -47,7 +47,7 @@ from sopel import tools, trigger
 from sopel.tools import identifiers
 from .backends import AsyncioBackend
 from .isupport import ISupport
-from .utils import CapReq, safe
+from .utils import CapReq
 
 if TYPE_CHECKING:
     from sopel.config import Config
@@ -563,7 +563,6 @@ class AbstractBot(abc.ABC):
         if self.backend is None:
             raise RuntimeError(ERR_BACKEND_NOT_INITIALIZED)
 
-        args = [safe(arg) for arg in args]
         self.backend.send_command(*args, text=text)
 
     # IRC Commands
@@ -867,7 +866,7 @@ class AbstractBot(abc.ABC):
             # update recipient metadata
             flood_left = recipient_stack['flood_left'] - 1
             recipient_stack['flood_left'] = max(0, flood_left)
-            recipient_stack['messages'].append((time.time(), safe(text)))
+            recipient_stack['messages'].append((time.time(), text))
 
         # Now that we've sent the first part, we need to send the rest if
         # requested. Doing so recursively seems simpler than iteratively.

--- a/sopel/irc/abstract_backends.py
+++ b/sopel/irc/abstract_backends.py
@@ -128,7 +128,7 @@ class AbstractIRCBackend(abc.ABC):
         and can be sent as-is.
         """
         max_length = unicode_max_length = 510
-        raw_command = ' '.join(args)
+        raw_command = ' '.join(safe(arg) for arg in args)
         if text is not None:
             raw_command = '{args} :{text}'.format(args=raw_command,
                                                   text=safe(text))
@@ -151,7 +151,7 @@ class AbstractIRCBackend(abc.ABC):
         A ``PING`` command should be sent at a regular interval to make sure
         the server knows the IRC connection is still active.
         """
-        self.send_command('PING', safe(host))
+        self.send_command('PING', host)
 
     def send_pong(self, host: str) -> None:
         """Send a ``PONG`` command to the server.
@@ -161,14 +161,14 @@ class AbstractIRCBackend(abc.ABC):
         A ``PONG`` command must be sent each time the server sends a ``PING``
         command to the client.
         """
-        self.send_command('PONG', safe(host))
+        self.send_command('PONG', host)
 
     def send_nick(self, nick: str) -> None:
         """Send a ``NICK`` command with a ``nick``.
 
         :param nick: nickname to take
         """
-        self.send_command('NICK', safe(nick))
+        self.send_command('NICK', nick)
 
     def send_user(self, user: str, mode: str, nick: str, name: str) -> None:
         """Send a ``USER`` command with a ``user``.
@@ -178,14 +178,14 @@ class AbstractIRCBackend(abc.ABC):
         :param nick: nickname associated with this user
         :param name: "real name" for the user
         """
-        self.send_command('USER', safe(user), mode, safe(nick), text=name)
+        self.send_command('USER', user, mode, nick, text=name)
 
     def send_pass(self, password: str) -> None:
         """Send a ``PASS`` command with a ``password``.
 
         :param password: password for authentication
         """
-        self.send_command('PASS', safe(password))
+        self.send_command('PASS', password)
 
     def send_join(self, channel: str, password: Optional[str] = None) -> None:
         """Send a ``JOIN`` command to ``channel`` with optional ``password``.
@@ -194,9 +194,9 @@ class AbstractIRCBackend(abc.ABC):
         :param password: optional password for protected channels
         """
         if password is None:
-            self.send_command('JOIN', safe(channel))
+            self.send_command('JOIN', channel)
         else:
-            self.send_command('JOIN', safe(channel), safe(password))
+            self.send_command('JOIN', channel, password)
 
     def send_part(self, channel: str, reason: Optional[str] = None) -> None:
         """Send a ``PART`` command to ``channel``.
@@ -204,7 +204,7 @@ class AbstractIRCBackend(abc.ABC):
         :param channel: the channel to part
         :param text: optional text for leaving the channel
         """
-        self.send_command('PART', safe(channel), text=reason)
+        self.send_command('PART', channel, text=reason)
 
     def send_quit(self, reason: Optional[str] = None) -> None:
         """Send a ``QUIT`` command.
@@ -228,7 +228,7 @@ class AbstractIRCBackend(abc.ABC):
         :param nick: nickname to kick from the ``channel``
         :param reason: optional reason for the kick
         """
-        self.send_command('KICK', safe(channel), safe(nick), text=reason)
+        self.send_command('KICK', channel, nick, text=reason)
 
     def send_privmsg(self, dest: str, text: str) -> None:
         """Send a ``PRIVMSG`` command to ``dest`` with ``text``.
@@ -236,7 +236,7 @@ class AbstractIRCBackend(abc.ABC):
         :param dest: nickname or channel name
         :param text: the text to send
         """
-        self.send_command('PRIVMSG', safe(dest), text=text)
+        self.send_command('PRIVMSG', dest, text=text)
 
     def send_notice(self, dest: str, text: str) -> None:
         """Send a ``NOTICE`` command to ``dest`` with ``text``.

--- a/test/irc/test_irc_abstract_backends.py
+++ b/test/irc/test_irc_abstract_backends.py
@@ -48,6 +48,33 @@ def test_prepare_command_text_too_long():
     assert result == expected
 
 
+def test_prepare_command_command_safe():
+    backend = MockIRCBackend(BotCollector())
+
+    result = backend.prepare_command(
+        "PRIVMSG\r\nMODE #sopel +o Mallory\r\nPRIVMSG", "#sopel", text="Hello"
+    )
+    assert result == "PRIVMSGMODE #sopel +o MalloryPRIVMSG #sopel :Hello\r\n"
+
+
+def test_prepare_command_target_safe():
+    backend = MockIRCBackend(BotCollector())
+
+    result = backend.prepare_command(
+        "PRIVMSG", "#sopel\r\nMODE #sopel +o Mallory\r\nPRIVMSG #sopel", text="Hello"
+    )
+    assert result == "PRIVMSG #sopelMODE #sopel +o MalloryPRIVMSG #sopel :Hello\r\n"
+
+
+def test_prepare_command_text_safe():
+    backend = MockIRCBackend(BotCollector())
+
+    result = backend.prepare_command(
+        "PRIVMSG", "#sopel", text="Hello\r\nMODE #sopel +o Mallory"
+    )
+    assert result == "PRIVMSG #sopel :HelloMODE #sopel +o Mallory\r\n"
+
+
 def test_send_command():
     bot = BotCollector()
     backend = MockIRCBackend(bot)


### PR DESCRIPTION
### Description
We previously had a silly pattern of calling safe() for most (but not all!) arguments passed to send_command. This is _usually_ not an issue since the contents are either not user-generated or must be sent through IRC (so cannot contain `\r\n`), but sometimes that's not the case, especially for privmsg/notice. Some plugins may also call send_command directly. Let's just pre-empt the whole class of potential problems by safe()ing _all_ args in `prepare_command()`.

Supersedes #2356. Thanks to @semarie for finding this issue.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
