### PR TITLE
trigger, irc: use STATUSMSG to handle status specific messages in channels

### DIFF
--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -322,6 +322,7 @@ class AbstractBot(abc.ABC):
             message,
             url_schemes=self.settings.core.auto_url_schemes,
             identifier_factory=self.make_identifier,
+            statusmsg_prefixes=self.isupport.get('STATUSMSG'),
         )
         if all(
             cap not in self.enabled_capabilities
@@ -371,6 +372,7 @@ class AbstractBot(abc.ABC):
                 ":{0}!{1}@{2} {3}".format(self.nick, self.user, host, raw),
                 url_schemes=self.settings.core.auto_url_schemes,
                 identifier_factory=self.make_identifier,
+                statusmsg_prefixes=self.isupport.get('STATUSMSG'),
             )
             self.dispatch(pretrigger)
 

--- a/sopel/tests/factories.py
+++ b/sopel/tests/factories.py
@@ -118,6 +118,7 @@ class TriggerFactory:
             raw,
             url_schemes=url_schemes,
             identifier_factory=mockbot.make_identifier,
+            statusmsg_prefixes=mockbot.isupport.get('STATUSMSG'),
         )
         return trigger.Trigger(mockbot.settings, pretrigger, match)
 

--- a/sopel/tests/pytest_plugin.py
+++ b/sopel/tests/pytest_plugin.py
@@ -90,7 +90,12 @@ def get_example_test(tested_func, msg, results, privmsg, admin,
         # TODO enable message tags
         full_message = ':{} PRIVMSG {} :{}'.format(hostmask, sender, msg)
         pretrigger = trigger.PreTrigger(
-            mockbot.nick, full_message, url_schemes=url_schemes)
+            mockbot.nick,
+            full_message,
+            url_schemes=url_schemes,
+            identifier_factory=mockbot.make_identifier,
+            statusmsg_prefixes=mockbot.isupport.get('STATUSMSG'),
+        )
         test_trigger = trigger.Trigger(mockbot.settings, pretrigger, match)
         pattern = re.compile(r'^%s: ' % re.escape(mockbot.nick))
 
@@ -116,6 +121,8 @@ def get_example_test(tested_func, msg, results, privmsg, admin,
                     mockbot.nick,
                     message.decode('utf-8'),
                     url_schemes=url_schemes,
+                    identifier_factory=mockbot.make_identifier,
+                    statusmsg_prefixes=mockbot.isupport.get('STATUSMSG'),
                 )
                 for message in wrapper.backend.message_sent
             )

--- a/test/test_trigger.py
+++ b/test/test_trigger.py
@@ -46,6 +46,7 @@ def test_basic_pretrigger(nick):
     assert pretrigger.user == 'foo'
     assert pretrigger.host == 'example.com'
     assert pretrigger.sender == '#Sopel'
+    assert pretrigger.status_prefix is None
 
 
 def test_pm_pretrigger(nick):
@@ -62,6 +63,37 @@ def test_pm_pretrigger(nick):
     assert pretrigger.user == 'foo'
     assert pretrigger.host == 'example.com'
     assert pretrigger.sender == Identifier('Foo')
+    assert pretrigger.status_prefix is None
+
+
+def test_statusmsg_pretrigger(nick):
+    line = ':Foo!foo@example.com PRIVMSG @#Sopel :Hello, world'
+    pretrigger = PreTrigger(nick, line, statusmsg_prefixes=tuple('@'))
+    assert pretrigger.tags == {}
+    assert pretrigger.hostmask == 'Foo!foo@example.com'
+    assert pretrigger.line == line
+    assert pretrigger.args == ['@#Sopel', 'Hello, world']
+    assert pretrigger.text == 'Hello, world'
+    assert pretrigger.plain == 'Hello, world'
+    assert pretrigger.event == 'PRIVMSG'
+    assert pretrigger.nick == Identifier('Foo')
+    assert pretrigger.user == 'foo'
+    assert pretrigger.host == 'example.com'
+    assert pretrigger.sender == '#Sopel'
+    assert pretrigger.status_prefix == '@'
+
+
+def test_statusmsg_custom_prefix_pretrigger(nick):
+    line = ':Foo!foo@example.com PRIVMSG £#Sopel :Hello, world'
+    pretrigger = PreTrigger(nick, line, statusmsg_prefixes=('@', '£'))
+    assert pretrigger.sender == '#Sopel'
+    assert pretrigger.status_prefix == '£'
+
+    # no statusmsg_prefixes set (use default)
+    line = ':Foo!foo@example.com PRIVMSG £#Sopel :Hello, world'
+    pretrigger = PreTrigger(nick, line)
+    assert pretrigger.sender == '£#Sopel'
+    assert pretrigger.status_prefix is None
 
 
 def test_quit_pretrigger(nick):
@@ -78,6 +110,7 @@ def test_quit_pretrigger(nick):
     assert pretrigger.user == 'foo'
     assert pretrigger.host == 'example.com'
     assert pretrigger.sender is None
+    assert pretrigger.status_prefix is None
 
 
 def test_quit_pretrigger_empty(nick):
@@ -95,6 +128,7 @@ def test_quit_pretrigger_empty(nick):
     assert pretrigger.user == 'foo'
     assert pretrigger.host == 'example.com'
     assert pretrigger.sender is None
+    assert pretrigger.status_prefix is None
 
 
 def test_away_pretrigger(nick):
@@ -111,6 +145,7 @@ def test_away_pretrigger(nick):
     assert pretrigger.user == 'foo'
     assert pretrigger.host == 'example.com'
     assert pretrigger.sender is None
+    assert pretrigger.status_prefix is None
 
 
 def test_away_pretrigger_back(nick):
@@ -128,6 +163,7 @@ def test_away_pretrigger_back(nick):
     assert pretrigger.user == 'foo'
     assert pretrigger.host == 'example.com'
     assert pretrigger.sender is None
+    assert pretrigger.status_prefix is None
 
 
 def test_join_pretrigger(nick):
@@ -144,6 +180,7 @@ def test_join_pretrigger(nick):
     assert pretrigger.user == 'foo'
     assert pretrigger.host == 'example.com'
     assert pretrigger.sender == Identifier('#Sopel')
+    assert pretrigger.status_prefix is None
 
 
 def test_tags_pretrigger(nick):
@@ -162,6 +199,7 @@ def test_tags_pretrigger(nick):
     assert pretrigger.user == 'foo'
     assert pretrigger.host == 'example.com'
     assert pretrigger.sender == '#Sopel'
+    assert pretrigger.status_prefix is None
 
 
 def test_intents_pretrigger(nick):
@@ -179,6 +217,7 @@ def test_intents_pretrigger(nick):
     assert pretrigger.user == 'foo'
     assert pretrigger.host == 'example.com'
     assert pretrigger.sender == '#Sopel'
+    assert pretrigger.status_prefix is None
 
 
 def test_unusual_pretrigger(nick):
@@ -193,6 +232,7 @@ def test_unusual_pretrigger(nick):
     assert pretrigger.plain == ''
     assert pretrigger.event == 'PING'
     assert pretrigger.sender is None
+    assert pretrigger.status_prefix is None
 
 
 def test_ctcp_intent_pretrigger(nick):
@@ -210,6 +250,7 @@ def test_ctcp_intent_pretrigger(nick):
     assert pretrigger.user == 'foo'
     assert pretrigger.host == 'example.com'
     assert pretrigger.sender == Identifier('Foo')
+    assert pretrigger.status_prefix is None
 
 
 def test_ctcp_data_pretrigger(nick):
@@ -227,6 +268,7 @@ def test_ctcp_data_pretrigger(nick):
     assert pretrigger.user == 'foo'
     assert pretrigger.host == 'example.com'
     assert pretrigger.sender == Identifier('Foo')
+    assert pretrigger.status_prefix is None
 
 
 def test_ctcp_action_pretrigger(nick):
@@ -244,6 +286,7 @@ def test_ctcp_action_pretrigger(nick):
     assert pretrigger.user == 'foo'
     assert pretrigger.host == 'example.com'
     assert pretrigger.sender == '#Sopel'
+    assert pretrigger.status_prefix is None
 
 
 def test_ctcp_action_trigger(nick, configfactory):
@@ -289,6 +332,7 @@ def test_ircv3_extended_join_pretrigger(nick):
     assert pretrigger.user == 'foo'
     assert pretrigger.host == 'example.com'
     assert pretrigger.sender == Identifier('#Sopel')
+    assert pretrigger.status_prefix is None
 
 
 def test_ircv3_extended_join_trigger(nick, configfactory):
@@ -376,3 +420,16 @@ def test_ircv3_server_time_trigger(nick, configfactory):
     line = '@time=2016-01-09T04:20 :Foo!foo@example.com PRIVMSG #Sopel :Hello, world'
     pretrigger = PreTrigger(nick, line)
     assert pretrigger.time is not None
+
+
+def test_statusmsg_trigger(nick, configfactory):
+    line = ':Foo!foo@example.com PRIVMSG @#channel :text message'
+    pretrigger = PreTrigger(nick, line, statusmsg_prefixes=tuple('@'))
+    config = configfactory('default.cfg', TMP_CONFIG)
+    fakematch = re.match('.*', line)
+
+    trigger = Trigger(config, pretrigger, fakematch)
+
+    assert trigger.sender == '#channel'
+    assert trigger.sender == Identifier('#channel')
+    assert trigger.status_prefix == '@'


### PR DESCRIPTION
### Description

Fix #1886.

In this PR, I modified `PreTrigger` to parse the `sender` to check if the prefix was a `STATUSMSG` prefix, i.e. a message intended to a specific privilege level in the channel (such as ops, voice, etc.). Once this is done, the `PreTrigger` remove that prefix from the `sender` to create an instance of `Identifier`. On the bot's side, every time a `PreTrigger` is instantiated, `bot.isupport.get('STATUSMSG')` is provided.

I added some tests to show how that works and ensure it works as intended without breaking anything, so we should be all good.

Two notes to consider for the future:

* we may want to change the list of channel prefix to something more restrictive, or not
* we may want to set a default value for the `STATUSMSG` value, or have something a bit smarter about that

Both to be considered later, not in this PR.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
