### PR TITLE
backends: simplify UTF8ONLY handling

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -331,10 +331,6 @@ def handle_isupport(bot, trigger):
 
     bot._isupport = bot._isupport.apply(**parameters)
 
-    # update backend's utf8only setting
-    if 'UTF8ONLY' in bot.isupport:
-        bot.backend.utf8only = True
-
     # update bot's mode parser
     if 'CHANMODES' in bot.isupport:
         bot.modeparser.chanmodes = bot.isupport.CHANMODES

--- a/sopel/irc/abstract_backends.py
+++ b/sopel/irc/abstract_backends.py
@@ -24,9 +24,6 @@ class AbstractIRCBackend(abc.ABC):
     backend implementation will not function correctly.
     """
     def __init__(self, bot: AbstractBot):
-        self.utf8only: bool = False
-        """Whether we are operating in utf8-only mode."""
-
         self.bot: AbstractBot = bot
 
     @abc.abstractmethod
@@ -72,7 +69,7 @@ class AbstractIRCBackend(abc.ABC):
             data = str(line, encoding='utf-8')
         except UnicodeDecodeError as e:
             # ...unless the server announces UTF8ONLY
-            if self.utf8only:
+            if 'UTF8ONLY' in self.bot.isupport:
                 raise e
             # not Unicode; let's try CP-1252
             try:

--- a/test/irc/test_irc_abstract_backends.py
+++ b/test/irc/test_irc_abstract_backends.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import pytest
 
+from sopel.irc.isupport import ISupport
 from sopel.tests.mocks import MockIRCBackend
 
 
@@ -303,6 +304,7 @@ def test_send_notice_safe():
 
 def test_decode_line_utf8():
     bot = BotCollector()
+    bot.isupport = ISupport()
     backend = MockIRCBackend(bot)
 
     test = "PRIVMSG #sopel :Hello, Martín!"
@@ -311,8 +313,8 @@ def test_decode_line_utf8():
 
 def test_decode_line_utf8only():
     bot = BotCollector()
+    bot.isupport = ISupport(UTF8ONLY=None)
     backend = MockIRCBackend(bot)
-    backend.utf8only = True
 
     test = "PRIVMSG #sopel :Hello, Martín!"
     with pytest.raises(UnicodeDecodeError):
@@ -321,6 +323,7 @@ def test_decode_line_utf8only():
 
 def test_decode_line_nonsense():
     bot = BotCollector()
+    bot.isupport = ISupport()
     backend = MockIRCBackend(bot)
 
     with pytest.raises(ValueError):
@@ -329,6 +332,7 @@ def test_decode_line_nonsense():
 
 def test_decode_line_cp1252():
     bot = BotCollector()
+    bot.isupport = ISupport()
     backend = MockIRCBackend(bot)
 
     test = "PRIVMSG #sopel :Hello, Martín!"

--- a/test/test_coretasks.py
+++ b/test/test_coretasks.py
@@ -471,17 +471,6 @@ def test_handle_isupport_namesx_with_multi_prefix(mockbot):
     )
 
 
-def test_handle_isupport_utf8only(mockbot):
-    assert not mockbot.backend.utf8only
-
-    mockbot.on_message(
-        ":irc.example.com 005 Sopel UTF8ONLY :are supported by this server"
-    )
-
-    assert "UTF8ONLY" in mockbot.isupport
-    assert mockbot.backend.utf8only
-
-
 def test_handle_rpl_myinfo(mockbot):
     """Test handling RPL_MYINFO events."""
     assert not hasattr(mockbot, 'myinfo'), (


### PR DESCRIPTION
### Description
The IRC backend doesn't need an attribute for UTF8ONLY that must be updated separately by coretasks when receiving 005. Because the backend has a `self.bot` passed in at construction time, it can check the active ISUPPORT flags directly.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches