### PR TITLE
remind: use `bot.connection_registered` instead of internal method

### DIFF
--- a/sopel/modules/remind.py
+++ b/sopel/modules/remind.py
@@ -160,7 +160,7 @@ def shutdown(bot):
 @plugin.interval(2.5)
 def remind_monitoring(bot):
     """Check for reminder"""
-    if not bot.backend.is_connected():
+    if not bot.connection_registered:
         # IRC connection not ready; wait until next check.
         return
 


### PR DESCRIPTION
### Description
Methods on `bot.backend` are really supposed to be used internally only, not by plugin code.

Improving the reliability of `bot.connection_registered` (the reason it wasn't already used here) is being taken care of in a separate patch, #2375.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [ ] I have tested the functionality of the things this change touches
  - Can't be tested For Real™ until the fixes land for `bot.connection_registered`.