### PR TITLE
bot, irc, coretasks: more robust `bot.connection_registered` value

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -976,6 +976,8 @@ class Sopel(irc.AbstractBot):
     def _shutdown(self) -> None:
         """Internal bot shutdown method."""
         LOGGER.info("Shutting down")
+        # Proactively tell plugins (at least the ones that bother to check)
+        self._connection_registered = False
         # Stop Job Scheduler
         LOGGER.info("Stopping the Job Scheduler.")
         self._scheduler.stop()

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -275,7 +275,7 @@ def startup(bot, trigger):
             bot.say(privmsg, bot.config.core.owner)
 
     # set flag
-    bot.connection_registered = True
+    bot._connection_registered = True
 
     # handle auth method
     auth_after_register(bot)

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -74,7 +74,7 @@ class AbstractBot(abc.ABC):
 
         self.backend: Optional[AbstractIRCBackend] = None
         """IRC Connection Backend."""
-        self.connection_registered = False
+        self._connection_registered = False
         """Flag stating whether the IRC Connection is registered yet."""
         self.settings = settings
         """Bot settings."""
@@ -91,6 +91,13 @@ class AbstractBot(abc.ABC):
         self.hasquit = False
         self.wantsrestart = False
         self.last_raw_line = ''  # last raw line received
+
+    @property
+    def connection_registered(self) -> bool:
+        return (
+            self.backend is not None
+            and self.backend.is_connected()
+            and self._connection_registered)
 
     @property
     def nick(self) -> identifiers.Identifier:
@@ -413,6 +420,7 @@ class AbstractBot(abc.ABC):
 
     def on_close(self) -> None:
         """Call shutdown methods."""
+        self._connection_registered = False
         self._shutdown()
 
     def _shutdown(self) -> None:
@@ -646,6 +654,7 @@ class AbstractBot(abc.ABC):
         if self.backend is None:
             raise RuntimeError(ERR_BACKEND_NOT_INITIALIZED)
 
+        self._connection_registered = False
         self.backend.send_quit(reason=message)
         self.hasquit = True
         # Wait for acknowledgment from the server. Per RFC 2812 it should be

--- a/test/test_coretasks.py
+++ b/test/test_coretasks.py
@@ -222,7 +222,9 @@ def test_execute_perform_send_commands(mockbot):
     ]
 
     mockbot.config.core.commands_on_connect = commands
-    mockbot.connection_registered = True
+    # For testing, pretend connection already happened
+    mockbot.backend.connected = True
+    mockbot._connection_registered = True
 
     coretasks._execute_perform(mockbot)
     assert mockbot.backend.message_sent == rawlist(*commands)
@@ -234,7 +236,9 @@ def test_execute_perform_replaces_nickname(mockbot):
     sent_command = 'MODE {} +Xxw'.format(mockbot.config.core.nick)
 
     mockbot.config.core.commands_on_connect = [command, ]
-    mockbot.connection_registered = True  # For testing, simulate connected
+    # For testing, pretend connection already happened
+    mockbot.backend.connected = True
+    mockbot._connection_registered = True
 
     coretasks._execute_perform(mockbot)
     assert mockbot.backend.message_sent == rawlist(sent_command)


### PR DESCRIPTION
### Description
The `connection_registered` attribute itself is now a property, which first checks to see if the bot's `backend` exists (is not `None`) and then whether the `backend.is_connected()`, before finally seeing if the internal `_connection_registered` flag has been set.

Also added a few places where the internal flag should be reset back to its initial value of `False`, such as if the bot is about to quit or the backend's `on_close()` handler was called.

All of this is to try and make `bot.connection_registered` reliable for plugins like `remind`, which have scheduled tasks that might need to send data to IRC and need a reliable way to check whether the connection is ready to accept such data before operating.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - Note that this required adding a bit more setup to two `test_coretasks` units.