### PR TITLE
xkcd: switch to DDG for keyword lookup

### DIFF
--- a/sopel/modules/xkcd.py
+++ b/sopel/modules/xkcd.py
@@ -15,7 +15,7 @@ import re
 import requests
 
 from sopel import plugin
-from sopel.modules.search import bing_search
+from sopel.modules.search import duck_search
 
 PLUGIN_OUTPUT_PREFIX = '[xkcd] '
 
@@ -45,7 +45,7 @@ def get_info(number=None):
 
 
 def web_search(query):
-    url = bing_search(query + sites_query)
+    url = duck_search(query + sites_query)
     if not url:
         return None
     match = re.match(r'(?:https?://)?(?:m\.)?xkcd\.com/(\d+)/?', url)


### PR DESCRIPTION
### Description
Bing has become supremely unreliable. In a shocking turn of events, it seems that DuckDuckGo no longer vomits on the long string of `-site:` operators used in this plugin.

**Current `master`:**

```
16:03:35 <~dgw> ,xkcd group chat
16:03:36 <SopelTest> dgw: Could not find any comics for that query.

# [Ed. note: Same for any other non-integer query]
```

**With this patch:**

```
16:31:03 <~dgw> ,xkcd group chat
16:31:04 <SopelTest> [xkcd] Group Chat Rules | Alt-text: There's no group chat member more enigmatic than the cool
                     person who you all assume has the chat on mute, but who then instantly chimes in with no delay
                     the moment something relevant to them is mentioned. | https://xkcd.com/2235
```

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches (see before/after above)

### Notes
Someone else can investigate backporting this to 7.1.x if they like, but it's easy enough for someone to just use the newer `xkcd.py` in an old bot if they want. The `sopel.modules.search` stuff hasn't really changed. I don't particularly want to spend time on things that don't progress 8.0 at this point.

This is the simplest, fastest way to get `.xkcd some keywords` working again, because `.ddg` output works as expected. I might still try to fix Bing search separately… Had some small amount of success by fussing with the user agent Sopel sends, but it still wouldn't reliably obey `site:` operators. (It's probably picking up ads on the page; I would bet the HTML has changed.)