### PR TITLE
xkcd: try searchxkcd.com backend, with web-search as fallback

### DIFF
--- a/sopel/modules/xkcd.py
+++ b/sopel/modules/xkcd.py
@@ -79,7 +79,7 @@ def searchxkcd_search(query):
         if not hits:
             return None
         first = hits[0]['objectID']
-    except (JSONDecodeError, KeyError, IndexError):
+    except (JSONDecodeError, LookupError):
         LOGGER.debug("Data format from searchxkcd API could not be understood.")
         return None
 

--- a/sopel/modules/xkcd.py
+++ b/sopel/modules/xkcd.py
@@ -9,6 +9,8 @@ https://sopel.chat
 """
 from __future__ import annotations
 
+from json import JSONDecodeError
+import logging
 import random
 import re
 
@@ -17,7 +19,12 @@ import requests
 from sopel import plugin
 from sopel.modules.search import bing_search
 
+LOGGER = logging.getLogger(__name__)
 PLUGIN_OUTPUT_PREFIX = '[xkcd] '
+
+# used with permission of site owner
+# https://twitter.com/Dmdboi/status/1589202274999767041
+SEARCHXKCD_API = 'https://gq67pznq1k.execute-api.eu-west-1.amazonaws.com/search'
 
 ignored_sites = [
     # For searching the web
@@ -51,6 +58,32 @@ def web_search(query):
     match = re.match(r'(?:https?://)?(?:m\.)?xkcd\.com/(\d+)/?', url)
     if match:
         return match.group(1)
+
+
+def searchxkcd_search(query):
+    parameters = {
+        'q': query,
+        'page': 0,
+    }
+    try:
+        response = requests.post(SEARCHXKCD_API, params=parameters)
+    except requests.exceptions.ConnectionError as e:
+        LOGGER.debug("Unable to reach searchxkcd API: %s", e)
+        return None
+    except Exception as e:
+        LOGGER.debug("Unexpected error calling searchxkcd API: %s", e)
+        return None
+
+    try:
+        hits = response.json()['results']['hits']
+        if not hits:
+            return None
+        first = hits[0]['objectID']
+    except (JSONDecodeError, KeyError, IndexError):
+        LOGGER.debug("Data format from searchxkcd API could not be understood.")
+        return None
+
+    return first
 
 
 @plugin.command('xkcd')
@@ -90,7 +123,10 @@ def xkcd(bot, trigger):
             if (query.lower() == "latest" or query.lower() == "newest"):
                 requested = latest
             else:
-                number = web_search(query)
+                number = searchxkcd_search(query)
+                if number is None:
+                    # generic web-search engine as fallback
+                    number = web_search(query)
                 if not number:
                     bot.reply('Could not find any comics for that query.')
                     return


### PR DESCRIPTION
### Description
Asked the creator of searchxkcd.com on Twitter about an API. Was told there is no true public API (yet), but I could pull the backend URL out of network tools. So have I done.

Makes the most sense to keep the original `web_search()` method around as a backup option. For example, two days after the latest comic's release on Friday (today is Sunday), searching searchxkcd.com for its title returns no results. For this special case we have the 'latest' operator, but there are no guarantees for how frequently searchxkcd's index is updated with fresh comics.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
Complements #2376, but shouldn't replace it. The two patches work together to fix _and_ improve search results in `xkcd`.

Aside: Sure would be nice if xkcd itself provided a JSON file listing all of the comics' basic data in one place. The data already exists for each individual comic; that's how this plugin fetches comics by number.