### PR TITLE
CodeQL minor nitpick pass

### DIFF
--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -101,8 +101,10 @@ class StaticSection:
         attribute = getattr(self.__class__, name)
         if default is NO_DEFAULT and not attribute.is_secret:
             try:
+                # get current value of this setting to use as prompt default
                 default = getattr(self, name)
             except AttributeError:
+                # there is no current value; that's OK
                 pass
             except ValueError:
                 print('The configured value for this option was invalid.')

--- a/sopel/formatting.py
+++ b/sopel/formatting.py
@@ -23,6 +23,9 @@ __all__ = [
     'CONTROL_STRIKETHROUGH',
     'CONTROL_MONOSPACE',
     'CONTROL_REVERSE',
+    # convenience lists
+    'CONTROL_FORMATTING',
+    'CONTROL_NON_PRINTING',
     # utility functions
     'color',
     'hex_color',

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -32,10 +32,6 @@ from .memories import (  # NOQA
 from . import time, web  # NOQA
 
 
-# Can be implementation-dependent
-_regex_type = type(re.compile(''))
-
-
 # Long kept for Python compatibility, but it's time we let these go.
 raw_input = deprecated(  # pragma: no cover
     'Use the `input` function directly.',

--- a/sopel/tools/memories.py
+++ b/sopel/tools/memories.py
@@ -8,11 +8,11 @@ from __future__ import annotations
 
 from collections import defaultdict
 import threading
-import typing
+from typing import TYPE_CHECKING
 
 from .identifiers import Identifier
 
-if typing.TYPE_CHECKING:
+if TYPE_CHECKING:
     from typing import Callable, Optional
 
     IdentifierFactory = Callable[[str], Identifier]


### PR DESCRIPTION
### Description
For #2381 I made sure we wouldn't introduce any Error-level alerts, because those would have given the `master` branch a ❌ check status. Anything below that level (that wasn't a false-positive or a test case) was mostly left alone.

This PR's branch name, `useless-code`, is inspired by the alert label that caught my eye first. At time of opening that label also applies to most of the alerts that will be fixed by this patch.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [ ] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - I managed to break my flake8 somehow, but these tweaks are so minor I did not waste time trying to fix it just for this PR
- [x] I have tested the functionality of the things this change touches