### PR TITLE
tools: deprecations & reorganization (feat. `sopel.cli`)

### DIFF
--- a/sopel/cli/config.py
+++ b/sopel/cli/config.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 import argparse
 import os
 
-from sopel import tools
 from . import utils
 
 
@@ -108,8 +107,8 @@ def handle_list(options):
             print(name)
 
     if not found:
-        tools.stderr('No config file found at this location: %s' % configdir)
-        tools.stderr('Use `sopel-config init` to create a new config file.')
+        utils.stderr('No config file found at this location: %s' % configdir)
+        utils.stderr('Use `sopel-config init` to create a new config file.')
 
     return 0  # successful operation
 
@@ -132,20 +131,20 @@ def handle_init(options):
     config_name, ext = os.path.splitext(config_filename)
 
     if ext and ext != '.cfg':
-        tools.stderr('Configuration wizard accepts .cfg files only')
+        utils.stderr('Configuration wizard accepts .cfg files only')
         return 1
     elif not ext:
         config_filename = config_name + '.cfg'
 
     if os.path.isfile(config_filename):
-        tools.stderr('Configuration file %s already exists' % config_filename)
+        utils.stderr('Configuration file %s already exists' % config_filename)
         return 1
 
     print('Starting Sopel config wizard for: %s' % config_filename)
     try:
         utils.wizard(config_name)
     except KeyboardInterrupt:
-        tools.stderr('\nOperation cancelled; no file has been created.')
+        utils.stderr('\nOperation cancelled; no file has been created.')
         return 1  # cancelled operation
 
     return 0  # successful operation
@@ -163,7 +162,7 @@ def handle_get(options):
     try:
         settings = utils.load_settings(options)
     except Exception as error:
-        tools.stderr(error)
+        utils.stderr(error)
         return 2
 
     section = options.section
@@ -171,10 +170,10 @@ def handle_get(options):
 
     # Making sure the section.option exists
     if not settings.parser.has_section(section):
-        tools.stderr('Section "%s" does not exist' % section)
+        utils.stderr('Section "%s" does not exist' % section)
         return 1
     if not settings.parser.has_option(section, option):
-        tools.stderr(
+        utils.stderr(
             'Section "%s" does not have a "%s" option' % (section, option))
         return 1
 

--- a/sopel/cli/plugins.py
+++ b/sopel/cli/plugins.py
@@ -5,7 +5,7 @@ import argparse
 import inspect
 import operator
 
-from sopel import config, plugins, tools
+from sopel import config, plugins
 from . import utils
 
 
@@ -254,7 +254,7 @@ def handle_show(options):
 
     # plugin does not exist
     if plugin_name not in usable_plugins:
-        tools.stderr('No plugin named %s' % plugin_name)
+        utils.stderr('No plugin named %s' % plugin_name)
         return ERR_CODE
 
     plugin, is_enabled = usable_plugins[plugin_name]
@@ -313,32 +313,32 @@ def handle_configure(options):
 
     # plugin does not exist
     if plugin_name not in usable_plugins:
-        tools.stderr('No plugin named %s' % plugin_name)
+        utils.stderr('No plugin named %s' % plugin_name)
         return ERR_CODE
 
     plugin, is_enabled = usable_plugins[plugin_name]
     try:
         plugin.load()
     except Exception as error:
-        tools.stderr('Cannot load plugin %s: %s' % (plugin_name, error))
+        utils.stderr('Cannot load plugin %s: %s' % (plugin_name, error))
         return ERR_CODE
 
     if not plugin.has_configure():
-        tools.stderr('Nothing to configure for plugin %s' % plugin_name)
+        utils.stderr('Nothing to configure for plugin %s' % plugin_name)
         return 0  # nothing to configure is not exactly an error case
 
     print('Configure %s' % plugin.get_label())
     try:
         plugin.configure(settings)
     except KeyboardInterrupt:
-        tools.stderr(
+        utils.stderr(
             '\nOperation cancelled; the config file has not been modified.')
         return ERR_CODE  # cancelled operation
 
     settings.save()
 
     if not is_enabled:
-        tools.stderr(
+        utils.stderr(
             "Plugin {0} has been configured but is not enabled. "
             "Use 'sopel-plugins enable {0}' to enable it".format(plugin_name)
         )
@@ -350,7 +350,7 @@ def _handle_disable_plugin(settings, plugin_name, force):
     excluded = settings.core.exclude
     # nothing left to do if already excluded
     if plugin_name in excluded:
-        tools.stderr('Plugin %s already disabled.' % plugin_name)
+        utils.stderr('Plugin %s already disabled.' % plugin_name)
         return False
 
     # recalculate state: at the moment, the plugin is not in the excluded list
@@ -364,7 +364,7 @@ def _handle_disable_plugin(settings, plugin_name, force):
 
     # if not enabled at this point, exclude if options.force is used
     if not is_enabled and not force:
-        tools.stderr(
+        utils.stderr(
             'Plugin %s is disabled but not excluded; '
             'use -f/--force to force its exclusion.'
             % plugin_name)
@@ -380,7 +380,7 @@ def display_unknown_plugins(unknown_plugins):
     :param list unknown_plugins: list of unknown plugins
     """
     # at least one of the plugins does not exist
-    tools.stderr(utils.get_many_text(
+    utils.stderr(utils.get_many_text(
         unknown_plugins,
         one='No plugin named {item}.',
         two='No plugin named {first} or {second}.',
@@ -406,7 +406,7 @@ def handle_disable(options):
 
     # coretasks is sacred
     if 'coretasks' in plugin_names:
-        tools.stderr('Plugin coretasks cannot be disabled.')
+        utils.stderr('Plugin coretasks cannot be disabled.')
         return ERR_CODE  # do nothing and return an error code
 
     unknown_plugins = [
@@ -457,7 +457,7 @@ def _handle_enable_plugin(settings, usable_plugins, plugin_name, allow_only):
 
     # coretasks is sacred
     if plugin_name == 'coretasks':
-        tools.stderr('Plugin coretasks is always enabled.')
+        utils.stderr('Plugin coretasks is always enabled.')
         return False
 
     # is it already enabled, but should we enforce anything?
@@ -465,10 +465,10 @@ def _handle_enable_plugin(settings, usable_plugins, plugin_name, allow_only):
     if is_enabled and not allow_only:
         # already enabled, and no allow-only option: all good
         if plugin_name in enabled:
-            tools.stderr('Plugin %s is already enabled.' % plugin_name)
+            utils.stderr('Plugin %s is already enabled.' % plugin_name)
         else:
             # suggest to use --allow-only option
-            tools.stderr(
+            utils.stderr(
                 'Plugin %s is enabled; '
                 'use option -a/--allow-only to enforce allow only policy.'
                 % plugin_name)
@@ -485,7 +485,7 @@ def _handle_enable_plugin(settings, usable_plugins, plugin_name, allow_only):
         ]
     elif plugin_name in enabled:
         # not excluded, and already in enabled list: all good
-        tools.stderr('Plugin %s is already enabled' % plugin_name)
+        utils.stderr('Plugin %s is already enabled' % plugin_name)
         return False
 
     if plugin_name not in enabled and (enabled or allow_only):
@@ -563,9 +563,9 @@ def main():
         elif action == 'enable':
             return handle_enable(options)
     except KeyboardInterrupt:
-        tools.stderr('Bye!')
+        utils.stderr('Bye!')
         return ERR_CODE
     except config.ConfigurationNotFound as err:
-        tools.stderr(err)
-        tools.stderr('Use `sopel-config init` to create a new config file.')
+        utils.stderr(err)
+        utils.stderr('Use `sopel-config init` to create a new config file.')
         return ERR_CODE

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -16,14 +16,14 @@ import signal
 import sys
 import time
 
-from sopel import __version__, bot, config, logger, tools
+from sopel import __version__, bot, config, logger
 from . import utils
 
 # This is in case someone somehow manages to install Sopel on an old version
 # of pip (<9.0.0), which doesn't know about `python_requires`, or tries to run
 # from source on an unsupported version of Python.
 if sys.version_info < (3, 7):
-    tools.stderr('Error: Sopel requires Python 3.7+.')
+    utils.stderr('Error: Sopel requires Python 3.7+.')
     sys.exit(1)
 
 LOGGER = logging.getLogger(__name__)
@@ -62,7 +62,7 @@ def run(settings, pid_file, daemon=False):
             p = bot.Sopel(settings, daemon=daemon)
             p.setup()
         except KeyboardInterrupt:
-            tools.stderr('Bot setup interrupted')
+            utils.stderr('Bot setup interrupted')
             break
         except Exception:
             # In that case, there is nothing we can do.
@@ -71,7 +71,7 @@ def run(settings, pid_file, daemon=False):
             # direct access to the exception traceback right in the console.
             # Besides, we can't know if logging has been set up or not, so
             # we can't rely on that here.
-            tools.stderr('Unexpected error in bot setup')
+            utils.stderr('Unexpected error in bot setup')
             raise
 
         try:
@@ -204,7 +204,7 @@ def check_not_root():
         if os.environ.get("USERNAME") == "Administrator":
             raise RuntimeError('Error: Do not run Sopel as Administrator.')
     else:
-        tools.stderr(
+        utils.stderr(
             "Warning: %s is an uncommon operating system platform. "
             "Sopel should still work, but please contact Sopel's developers "
             "if you experience issues."
@@ -305,11 +305,11 @@ def command_start(opts):
     try:
         settings = get_configuration(opts)
     except config.ConfigurationError as e:
-        tools.stderr(e)
+        utils.stderr(e)
         return ERR_CODE_NO_RESTART
 
     if settings.core.not_configured:
-        tools.stderr('Bot is not configured, can\'t start')
+        utils.stderr('Bot is not configured, can\'t start')
         return ERR_CODE_NO_RESTART
 
     # Step Two: Handle process-lifecycle options and manage the PID file
@@ -317,10 +317,10 @@ def command_start(opts):
     pid_file_path = get_pid_filename(settings, pid_dir)
     pid = get_running_pid(pid_file_path)
 
-    if pid is not None and tools.check_pid(pid):
-        tools.stderr('There\'s already a Sopel instance running '
+    if pid is not None and utils.check_pid(pid):
+        utils.stderr('There\'s already a Sopel instance running '
                      'with this config file.')
-        tools.stderr('Try using either the `sopel stop` '
+        utils.stderr('Try using either the `sopel stop` '
                      'or the `sopel restart` command.')
         return ERR_CODE
 
@@ -370,11 +370,11 @@ def command_stop(opts):
     try:
         settings = utils.load_settings(opts)
     except config.ConfigurationNotFound as error:
-        tools.stderr('Configuration "%s" not found' % error.filename)
+        utils.stderr('Configuration "%s" not found' % error.filename)
         return ERR_CODE
 
     if settings.core.not_configured:
-        tools.stderr('Sopel is not configured, can\'t stop')
+        utils.stderr('Sopel is not configured, can\'t stop')
         return ERR_CODE
 
     # Configure logging
@@ -384,17 +384,17 @@ def command_stop(opts):
     filename = get_pid_filename(settings, settings.core.pid_dir)
     pid = get_running_pid(filename)
 
-    if pid is None or not tools.check_pid(pid):
-        tools.stderr('Sopel is not running!')
+    if pid is None or not utils.check_pid(pid):
+        utils.stderr('Sopel is not running!')
         return ERR_CODE
 
     # Stop Sopel
     if opts.kill:
-        tools.stderr('Killing the Sopel')
+        utils.stderr('Killing the Sopel')
         os.kill(pid, signal.SIGKILL)
         return
 
-    tools.stderr('Signaling Sopel to stop gracefully')
+    utils.stderr('Signaling Sopel to stop gracefully')
     if hasattr(signal, 'SIGUSR1'):
         os.kill(pid, signal.SIGUSR1)
     else:
@@ -413,11 +413,11 @@ def command_restart(opts):
     try:
         settings = utils.load_settings(opts)
     except config.ConfigurationNotFound as error:
-        tools.stderr('Configuration "%s" not found' % error.filename)
+        utils.stderr('Configuration "%s" not found' % error.filename)
         return ERR_CODE
 
     if settings.core.not_configured:
-        tools.stderr('Sopel is not configured, can\'t stop')
+        utils.stderr('Sopel is not configured, can\'t stop')
         return ERR_CODE
 
     # Configure logging
@@ -427,11 +427,11 @@ def command_restart(opts):
     filename = get_pid_filename(settings, settings.core.pid_dir)
     pid = get_running_pid(filename)
 
-    if pid is None or not tools.check_pid(pid):
-        tools.stderr('Sopel is not running!')
+    if pid is None or not utils.check_pid(pid):
+        utils.stderr('Sopel is not running!')
         return ERR_CODE
 
-    tools.stderr('Asking Sopel to restart')
+    utils.stderr('Asking Sopel to restart')
     if hasattr(signal, 'SIGUSR2'):
         os.kill(pid, signal.SIGUSR2)
     else:
@@ -488,7 +488,7 @@ def main(argv=None):
         print("\n\nInterrupted")
         return ERR_CODE
     except RuntimeError as err:
-        tools.stderr(str(err))
+        utils.stderr(str(err))
         return ERR_CODE
 
 

--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import inspect
 import logging
 import os
+import sys
 
-from sopel import config, plugins, tools
+from sopel import config, plugins
 
 # Allow clean import *
 __all__ = [
@@ -88,7 +89,7 @@ def wizard(filename):
             os.makedirs(configdir)
             print('Config directory created')
     except Exception:
-        tools.stderr('There was a problem creating {}'.format(configdir))
+        stderr('There was a problem creating {}'.format(configdir))
         raise
 
     name, ext = os.path.splitext(basename)
@@ -115,8 +116,8 @@ def wizard(filename):
     try:
         settings.save()
     except Exception:  # TODO: Be specific
-        tools.stderr("Encountered an error while writing the config file. "
-                     "This shouldn't happen. Check permissions.")
+        stderr("Encountered an error while writing the config file. "
+               "This shouldn't happen. Check permissions.")
         raise
 
     print("Config file written successfully!")
@@ -141,8 +142,8 @@ def plugins_wizard(filename):
     try:
         settings.save()
     except Exception:  # TODO: Be specific
-        tools.stderr("Encountered an error while writing the config file. "
-                     "This shouldn't happen. Check permissions.")
+        stderr("Encountered an error while writing the config file. "
+               "This shouldn't happen. Check permissions.")
         raise
 
     return settings
@@ -357,3 +358,46 @@ def get_many_text(items, one, two, many):
         message = many.format(left=left, last=last)
 
     return message
+
+
+def check_pid(pid):
+    """Check if a process is running with the given ``PID``.
+
+    :param int pid: PID to check
+    :return bool: ``True`` if the given PID is running, ``False`` otherwise
+
+    *Availability: POSIX systems only.*
+
+    .. versionchanged:: 8.0
+
+        Moved from :mod:`sopel.tools` to :mod:`sopel.cli.utils`.
+
+    .. note::
+
+        Matching the :py:func:`os.kill` behavior this function needs on Windows
+        was rejected in
+        `Python issue #14480 <https://bugs.python.org/issue14480>`_, so
+        :func:`check_pid` cannot be used on Windows systems.
+
+    """
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    else:
+        return True
+
+
+def stderr(string):
+    """Print the given ``string`` to stderr.
+
+    :param str string: the string to output
+
+    Just a convenience function.
+
+    .. versionchanged:: 8.0
+
+        Moved from :mod:`sopel.tools` to :mod:`sopel.cli.utils`.
+
+    """
+    print(string, file=sys.stderr)

--- a/sopel/config/__init__.py
+++ b/sopel/config/__init__.py
@@ -52,7 +52,6 @@ from __future__ import annotations
 import configparser
 import os
 
-from sopel import tools
 from . import core_section, types
 
 
@@ -344,7 +343,7 @@ class Config:
         d = 'n'
         if default:
             d = 'y'
-        ans = tools.get_input(question + ' (y/n)? [' + d + '] ')
+        ans = input(question + ' (y/n)? [' + d + '] ')
         if not ans:
             ans = d
         return ans.lower() == 'y'

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -12,7 +12,7 @@ from sopel.config.types import (
     StaticSection,
     ValidatedAttribute,
 )
-from sopel.tools import Identifier
+from sopel.tools.identifiers import Identifier
 
 
 COMMAND_DEFAULT_PREFIX = r'\.'

--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -32,7 +32,6 @@ import os.path
 import re
 
 from sopel.lifecycle import deprecated
-from sopel.tools import get_input
 
 
 LOGGER = logging.getLogger(__name__)
@@ -191,7 +190,7 @@ class BaseValidated(abc.ABC):
         if self.is_secret:
             value = getpass.getpass(prompt + ' (hidden input) ')
         else:
-            value = get_input(prompt + ' ')
+            value = input(prompt + ' ')
 
         if not value and default is NO_DEFAULT:
             raise ValueError("You must provide a value for this option.")
@@ -362,7 +361,7 @@ class BooleanAttribute(BaseValidated):
         the ``default`` value is returned instead.
         """
         prompt = '{} ({})'.format(prompt, 'Y/n' if default else 'y/N')
-        value = get_input(prompt + ' ') or default
+        value = input(prompt + ' ') or default
         section = getattr(parent, section_name)
         return self._parse(value, parent, section)
 
@@ -607,7 +606,7 @@ class ListAttribute(BaseValidated):
             default = []
         print(prompt)
         values = []
-        value = get_input(each_prompt + ' ') or default
+        value = input(each_prompt + ' ') or default
         if (value == default) and not default:
             value = ''
         while value:
@@ -615,7 +614,7 @@ class ListAttribute(BaseValidated):
                 values.extend(value)
             else:
                 values.append(value)
-            value = get_input(each_prompt + ' ')
+            value = input(each_prompt + ' ')
 
         section = getattr(parent, section_name)
         values = self._serialize(values, parent, section)

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -119,6 +119,12 @@ class OutputRedirect:
     A simplified object used to write to both the terminal and a log file.
     """
 
+    @deprecated(
+        "Remnant of Sopel's pre-7.0 logging system. "
+        "You shouldn't have been using this anyway.",
+        version='8.0',
+        removed_in='8.1',
+    )
     def __init__(self, logpath, stderr=False, quiet=False):
         """Create an object which will log to both a file and the terminal.
 

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import codecs
 import logging
-import os
 import re
 import sys
 
@@ -171,36 +170,28 @@ class OutputRedirect:
             sys.__stdout__.flush()
 
 
+@deprecated(
+    "Plugins should use a logger object.",
+    version='8.0',
+    removed_in='8.1',
+)
 def stderr(string):
-    """Print the given ``string`` to stderr.
+    # don't like importing inside functions, but circular imports ensue otherwise
+    from sopel.cli.utils import stderr as _stderr
 
-    :param str string: the string to output
-
-    This is equivalent to ``print >> sys.stderr, string``
-    """
-    print(string, file=sys.stderr)
+    return _stderr(string)
 
 
+@deprecated(
+    "Function for internal use, moved to `sopel.cli.utils`.",
+    version='8.0',
+    removed_in='8.1',
+)
 def check_pid(pid):
-    """Check if a process is running with the given ``PID``.
+    # don't like importing inside functions, but circular imports ensue otherwise
+    from sopel.cli.utils import check_pid as _check_pid
 
-    :param int pid: PID to check
-    :return bool: ``True`` if the given PID is running, ``False`` otherwise
-
-    *Availability: POSIX systems only.*
-
-    .. note::
-        Matching the :py:func:`os.kill` behavior this function needs on Windows
-        was rejected in
-        `Python issue #14480 <https://bugs.python.org/issue14480>`_, so
-        :py:func:`check_pid` cannot be used on Windows systems.
-    """
-    try:
-        os.kill(pid, 0)
-    except OSError:
-        return False
-    else:
-        return True
+    return _check_pid(pid)
 
 
 def get_hostmask_regex(mask):


### PR DESCRIPTION
### Description
Started looking at `sopel.tools` as a follow-up to #2379 and noticed some more cleanup that could be done. Specifically:

* `OutputRedirect` class is used by nothing, appears to be a relic of the 3.x-era logging system, and should be deprecated.
* `check_pid()` belongs under the `cli` namespace, because that's the only code that needs it. And plugins shouldn't be touching PIDs anyway.
* `stderr()` also ideally should never be used by plugins. If they really really want to print directly to a terminal instead of using a logger, they have access to `import sys; print('some bs', file=sys.stderr)` on their own.
* `get_input()` is already deprecated, but I had to replace uses of it to eliminate circular imports (because I'm perhaps foolishly keeping the moved functions available in `tools` until 8.1).

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
I was going to do this stuff a bit more atomically, moving things from `tools` to `cli` in a series of several commits, but that approach ran into circular-import errors if I tried to only move one function at a time. So I'm sorry, but I couldn't find a reasonable way to break it down into smaller commits. You'll just have to review the whole thing at once. 🙏