### PR TITLE
irc: annotate submodules with internal-use warnings

### DIFF
--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -6,9 +6,15 @@ the Sopel bot.
 
 In particular, it defines the interface for the IRC backend
 (:class:`~sopel.irc.abstract_backends.AbstractIRCBackend`), and the
-interface for the bot itself (:class:`~sopel.irc.AbstractBot`). This is all
-internal code that isn't supposed to be used directly by a plugin developer,
-who should worry about :class:`sopel.bot.Sopel` only.
+interface for the bot itself (:class:`~sopel.irc.AbstractBot`).
+
+.. warning::
+
+    This is all internal code, not intended for direct use by plugins. It is
+    subject to change between versions, even patch releases, without any
+    advance warning.
+
+    Please use the public APIs on :class:`bot <sopel.bot.Sopel>`.
 
 .. important::
 

--- a/sopel/irc/abstract_backends.py
+++ b/sopel/irc/abstract_backends.py
@@ -1,3 +1,14 @@
+""":mod:`sopel.irc.abstract_backends` defines the IRC backend interface.
+
+.. warning::
+
+    This is all internal code, not intended for direct use by plugins. It is
+    subject to change between versions, even patch releases, without any
+    advance warning.
+
+    Please use the public APIs on :class:`bot <sopel.bot.Sopel>`.
+
+"""
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.

--- a/sopel/irc/backends.py
+++ b/sopel/irc/backends.py
@@ -1,3 +1,14 @@
+""":mod:`sopel.irc.backends` defines Sopel's IRC connection handlers.
+
+.. warning::
+
+    This is all internal code, not intended for direct use by plugins. It is
+    subject to change between versions, even patch releases, without any
+    advance warning.
+
+    Please use the public APIs on :class:`bot <sopel.bot.Sopel>`.
+
+"""
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.

--- a/sopel/irc/isupport.py
+++ b/sopel/irc/isupport.py
@@ -172,6 +172,12 @@ class ISupport:
     The list of possible parameters can be found at
     `modern.ircdocs.horse's RPL_ISUPPORT Parameters`__.
 
+    .. important::
+
+        While this object's attributes and dict-like behavior are part of
+        Sopel's public API, its *methods* are considered internal code and
+        plugins should not call them.
+
     .. __: https://modern.ircdocs.horse/#rplisupport-parameters
     """
     def __init__(self, **kwargs):

--- a/sopel/irc/modes.py
+++ b/sopel/irc/modes.py
@@ -13,9 +13,14 @@ actions represented by the raw message:
 Errors (ignored modes and unused parameters) are also included, mostly for
 detecting when an IRC server is not conforming to specifications.
 
-This is mostly for internal use only as plugin developers should be more
-interested in :attr:`privileges<sopel.tools.target.Channel.privileges>` rather
-than how Sopel knows about them.
+.. important::
+
+    This is mostly for internal use only as plugin developers should be more
+    interested in :attr:`privileges<sopel.tools.target.Channel.privileges>`
+    rather than how Sopel knows about them.
+
+    The interface of this module is subject to change between Sopel releases
+    without advance notice, even in patch versions.
 
 .. seealso::
 

--- a/sopel/irc/utils.py
+++ b/sopel/irc/utils.py
@@ -1,3 +1,12 @@
+""":mod:`sopel.irc.utils` contains low-level tools for IRC protocol handling.
+
+.. warning::
+
+    This is all internal code, not intended for direct use by plugins. It is
+    subject to change between versions, even patch releases, without any
+    advance notice.
+
+"""
 # Copyright 2019, Florian Strzelecki <florian.strzelecki@gmail.com>
 #
 # Licensed under the Eiffel Forum License 2.


### PR DESCRIPTION
### Description
The top-level docs page for `sopel.irc` did, in fact, have an inline note about the `irc` module being for internal use. That wouldn't catch the eye of someone landing on a submodule via search (internal or web), though. Seemed prudent to beef up the presentation to `.. warning::` and also add a notice to each submodule.

Annotating `sopel.irc.isupport` was extra fun, because part of it *is* included in the bot's public API.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - Haven't run tests because this doesn't touch code, but `make quality` passes.
- [x] I have tested the functionality of the things this change touches
  - No code changes to test, but Sphinx didn't throw any (new) warnings and the HTML output seems to work as I intended.