### PR TITLE
pyproject.toml: list maintainers, historical authors

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,8 +13,18 @@ namespaces = false
 name = "sopel"
 version = "8.0.0.dev0"
 description = "Simple and extensible IRC bot"
+maintainers = [
+  { name="dgw", email="dgw@technobabbl.es" },
+  { name="Florian Strzelecki", email="florian.strzelecki@gmail.com" },
+]
 authors = [
   { name="dgw", email="dgw@technobabbl.es" },
+  { name="Florian Strzelecki", email="florian.strzelecki@gmail.com" },
+  { name="Sean B. Palmer" },
+  { name="Else Powell" },
+  { name="Elad Alfassa" },
+  { name="Dimitri Molenaars" },
+  { name="Michael Yanovich" },
 ]
 readme = "README.rst"
 license = { text="EFL-2.0" }


### PR DESCRIPTION
### Description
This PR adds the `maintainers` field to the project metadata, and adds historical contributors with more than 100 commits (as tracked by Sopel's repository) to the `authors` field. The latter is completely arbitrary, so people who know the long tail of the project's history may have suggestions for changes to that. A simple alternative would be to move anybody who's in the `CREDITS` file into this field.

Closes #2339 

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
