### PR TITLE
irc, backends: dummy non-connected backend for convenience

### DIFF
--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -45,7 +45,7 @@ from typing import (
 
 from sopel import tools, trigger
 from sopel.tools import identifiers
-from .backends import AsyncioBackend
+from .backends import AsyncioBackend, NotConnectedBackend
 from .isupport import ISupport
 from .utils import CapReq, safe
 
@@ -72,7 +72,7 @@ class AbstractBot(abc.ABC):
         self._nick: identifiers.Identifier = self.make_identifier(
             settings.core.nick)
 
-        self.backend: Optional[AbstractIRCBackend] = None
+        self.backend: AbstractIRCBackend = NotConnectedBackend(self)
         """IRC Connection Backend."""
         self._connection_registered = False
         """Flag stating whether the IRC Connection is registered yet."""

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -94,6 +94,17 @@ class AbstractBot(abc.ABC):
 
     @property
     def connection_registered(self) -> bool:
+        """Whether the IRC connection is registered.
+
+        This is a property so it can accurately reflect not only the socket
+        state (connection to IRC server), but also whether the connection is
+        ready to accept "normal" IRC commands.
+
+        Before registration is completed, only a very limited set of commands
+        are allowed to be used. Sopel itself takes care of these, so plugins
+        will be more concerned with whether they are allowed to use methods
+        like :meth:`say` yet.
+        """
         return (
             self.backend is not None
             and self.backend.is_connected()

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -45,7 +45,7 @@ from typing import (
 
 from sopel import tools, trigger
 from sopel.tools import identifiers
-from .backends import AsyncioBackend, NotConnectedBackend
+from .backends import AsyncioBackend, UninitializedBackend
 from .isupport import ISupport
 from .utils import CapReq, safe
 
@@ -72,7 +72,7 @@ class AbstractBot(abc.ABC):
         self._nick: identifiers.Identifier = self.make_identifier(
             settings.core.nick)
 
-        self.backend: AbstractIRCBackend = NotConnectedBackend(self)
+        self.backend: AbstractIRCBackend = UninitializedBackend(self)
         """IRC Connection Backend."""
         self._connection_registered = False
         """Flag stating whether the IRC Connection is registered yet."""

--- a/sopel/irc/backends.py
+++ b/sopel/irc/backends.py
@@ -31,6 +31,37 @@ RESTART_SIGNALS = [
 ]
 
 
+class NotConnectedBackend(AbstractIRCBackend):
+    """IRC Backend shim to use before the bot has started connecting.
+
+    :param bot: an instance of a bot that uses the backend
+
+    This exists to intercept attempts to do "illegal" things before
+    connection, like sending messages to IRC before we even have a socket.
+    """
+    def __init__(
+        self,
+        bot: AbstractBot,
+    ):
+        super().__init__(bot)
+
+    def is_connected(self) -> bool:
+        """This backend type is never connected.
+
+        :return: False
+        """
+        return False
+
+    def on_irc_error(self, pretrigger: PreTrigger) -> None:
+        raise RuntimeError("Received error from unconnected backend.")
+
+    def irc_send(self, data: bytes) -> None:
+        raise RuntimeError("Attempt to send data to unconnected backend.")
+
+    def run_forever(self) -> None:
+        raise RuntimeError("Attempt to run dummy backend that cannot connect.")
+
+
 class AsyncioBackend(AbstractIRCBackend):
     """IRC Backend implementation using :mod:`asyncio`.
 

--- a/sopel/irc/backends.py
+++ b/sopel/irc/backends.py
@@ -31,7 +31,7 @@ RESTART_SIGNALS = [
 ]
 
 
-class NotConnectedBackend(AbstractIRCBackend):
+class UninitializedBackend(AbstractIRCBackend):
     """IRC Backend shim to use before the bot has started connecting.
 
     :param bot: an instance of a bot that uses the backend

--- a/sopel/irc/backends.py
+++ b/sopel/irc/backends.py
@@ -45,20 +45,63 @@ class UninitializedBackend(AbstractIRCBackend):
     ):
         super().__init__(bot)
 
-    def is_connected(self) -> bool:
-        """This backend type is never connected.
+    def is_connected(self) -> False:
+        """Check if the backend is connected to an IRC server.
 
-        :return: False
+        **Always returns False:** This backend type is never connected.
+
+        Jobs (:func:`~.plugin.interval`) or other time-based triggers can be
+        invoked before the bot is finished initizalizing, even before it has
+        begun the IRC connection process. We need to provide a reliable way for
+        those triggers to abort early if they need a connection.
+
+        .. note::
+
+            Your plugin code doesn't need to call this directly; unless your
+            plugin does something during connection setup, it should check the
+            :attr:`bot.connection_registered <.AbstractBot.connection_registered>`
+            flag, which also takes into account whether the IRC connection is
+            ready to accept normal commands like PRIVMSG.
+
         """
         return False
 
     def on_irc_error(self, pretrigger: PreTrigger) -> None:
+        """Dummy IRC error handler.
+
+        Since it should be impossible to receive an error from IRC when there
+        is no server connection, this implementation raises an error if it is
+        ever called.
+        """
         raise RuntimeError("Received error from unconnected backend.")
 
     def irc_send(self, data: bytes) -> None:
+        """Dummy method to send IRC data.
+
+        Since it is impossible to send data to IRC without an IRC connection,
+        this implementation raises an error if it is ever called.
+
+        .. note::
+
+            Plugins will likely never need to call this method directly, but
+            many public API methods of ``bot`` call it.
+
+            Plugin code that can be triggered by anything that isn't an IRC
+            event/message should check the
+            :attr:`bot.connection_registered <.AbstractBot.connection_registered>`
+            flag before calling any bot method that modifies IRC state.
+
+        """
         raise RuntimeError("Attempt to send data to unconnected backend.")
 
     def run_forever(self) -> None:
+        """Dummy connection setup method.
+
+        Since this implementation is a placeholder and does not actually
+        connect to IRC, it raises an error if it is ever called. The bot
+        should switch to an appropriate backend type before trying to
+        connect; not doing so is a bug.
+        """
         raise RuntimeError("Attempt to run dummy backend that cannot connect.")
 
 


### PR DESCRIPTION
### Description
Part of a strategy for addressing #2373, we want to have a backend that works like a normal backend but isn't connected yet, for use instead of a `NoneType` object (which obviously won't have any of the methods a backend would).

The idea is to make it so calls to things like `backend.is_connected()` still work even pre-connection, so it's easier for core & plugin code to be responsible and check the connection status before trying to send things over the IRC connection.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [ ] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - Will revisit this when the PR is actually final (starting as draft)
- [ ] I have tested the functionality of the things this change touches
  - Ditto above