### PR TITLE
plugin: `require_privilege()` implies `require_chanmsg()`

### DIFF
--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -1200,17 +1200,20 @@ def require_privilege(
     <.bot.Sopel.say>`, but when ``reply`` is true, then it uses
     :meth:`bot.reply() <.bot.Sopel.reply>` instead.
 
-    Privilege requirements are ignored in private messages.
+    Use of ``require_privilege()`` implies :func:`require_chanmsg`.
 
     .. versionchanged:: 7.0
         Added the ``reply`` parameter.
+
+    .. versionchanged:: 8.0
+        Decorated callables no longer run in response to private messages.
     """
     def actual_decorator(function):
         @functools.wraps(function)
         def guarded(bot, trigger, *args, **kwargs):
-            # If this is a privmsg, ignore privilege requirements
+            # If this is a privmsg, do not trigger
             if trigger.is_privmsg:
-                return function(bot, trigger, *args, **kwargs)
+                return
             channel_privs = bot.channels[trigger.sender].privileges
             allowed = channel_privs.get(trigger.nick, 0) >= level
             if not trigger.is_privmsg and not allowed:

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -400,11 +400,12 @@ def test_require_account(bot, trigger, trigger_account):
     assert mock_(bot, trigger_account) is True
 
 
-def test_require_privilege(bot, trigger):
+def test_require_privilege(bot, trigger, trigger_pm):
     @module.require_privilege(module.VOICE)
     def mock_v(bot, trigger, match=None):
         return True
     assert mock_v(bot, trigger) is True
+    assert mock_v(bot, trigger_pm) is not True
 
     @module.require_privilege(module.OP, 'You must be at least opped!')
     def mock_o(bot, trigger, match=None):


### PR DESCRIPTION
### Description
This is the simple way. It doesn't preserve any backward compatibility for uses imported via `sopel.module`, and I don't think that's needed. It'd be a spaghetti mess for not much gain.

Closes #2399.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - With an actual test, in fact.