### PR TITLE
irc: use `threading.Event` for internal `_connection_registered` flag

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -977,7 +977,7 @@ class Sopel(irc.AbstractBot):
         """Internal bot shutdown method."""
         LOGGER.info("Shutting down")
         # Proactively tell plugins (at least the ones that bother to check)
-        self._connection_registered = False
+        self._connection_registered.clear()
         # Stop Job Scheduler
         LOGGER.info("Stopping the Job Scheduler.")
         self._scheduler.stop()

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -277,7 +277,7 @@ def startup(bot, trigger):
             bot.say(privmsg, bot.config.core.owner)
 
     # set flag
-    bot._connection_registered = True
+    bot._connection_registered.set()
 
     # handle auth method
     auth_after_register(bot)

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -80,7 +80,7 @@ class AbstractBot(abc.ABC):
 
         self.backend: Optional[AbstractIRCBackend] = None
         """IRC Connection Backend."""
-        self._connection_registered = False
+        self._connection_registered = threading.Event()
         """Flag stating whether the IRC Connection is registered yet."""
         self.settings = settings
         """Bot settings."""
@@ -103,7 +103,7 @@ class AbstractBot(abc.ABC):
         return (
             self.backend is not None
             and self.backend.is_connected()
-            and self._connection_registered)
+            and self._connection_registered.is_set())
 
     @property
     def nick(self) -> identifiers.Identifier:
@@ -428,7 +428,7 @@ class AbstractBot(abc.ABC):
 
     def on_close(self) -> None:
         """Call shutdown methods."""
-        self._connection_registered = False
+        self._connection_registered.clear()
         self._shutdown()
 
     def _shutdown(self) -> None:
@@ -662,7 +662,7 @@ class AbstractBot(abc.ABC):
         if self.backend is None:
             raise RuntimeError(ERR_BACKEND_NOT_INITIALIZED)
 
-        self._connection_registered = False
+        self._connection_registered.clear()
         self.backend.send_quit(reason=message)
         self.hasquit = True
         # Wait for acknowledgment from the server. Per RFC 2812 it should be

--- a/test/test_coretasks.py
+++ b/test/test_coretasks.py
@@ -224,7 +224,7 @@ def test_execute_perform_send_commands(mockbot):
     mockbot.config.core.commands_on_connect = commands
     # For testing, pretend connection already happened
     mockbot.backend.connected = True
-    mockbot._connection_registered = True
+    mockbot._connection_registered.set()
 
     coretasks._execute_perform(mockbot)
     assert mockbot.backend.message_sent == rawlist(*commands)
@@ -238,7 +238,7 @@ def test_execute_perform_replaces_nickname(mockbot):
     mockbot.config.core.commands_on_connect = [command, ]
     # For testing, pretend connection already happened
     mockbot.backend.connected = True
-    mockbot._connection_registered = True
+    mockbot._connection_registered.set()
 
     coretasks._execute_perform(mockbot)
     assert mockbot.backend.message_sent == rawlist(sent_command)


### PR DESCRIPTION
### Description
This will let us add API features that take advantage of the `.wait()` method available for Event objects.

Shouldn't affect plugin code (internal or third-party) much, if at all, since this is an internal value. `connection_registered` (no underscore) is still the name in all released versions of Sopel, anyway. In 8.0 it has become a property that checks multiple pieces of state so the answer returned can be more consistent.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Dev impact
Follow-up to #2375, where @Exirel proposed this idea but did not block the merge. I thought about it, opened #2391, and left it for 9.0. Then I thought some more this weekend and realized, it doesn't _matter_ what type `bot._connection_registered` is any more because it's private now. We can do whatever we want to it.

So I decided to make it a `threading.Event` object in 8.0, making the "big" change (data type) now to open the road for new API features in 8.1. I picture something like `bot.wait_for_registration(timeout=None)`, but workshopping that and other ideas is best left for another day (_after_ 8.0 is released).