### PR TITLE
logger: use newer, more robust IRC connection check

### DIFF
--- a/sopel/logger.py
+++ b/sopel/logger.py
@@ -29,8 +29,8 @@ class IrcLoggingHandler(logging.Handler):
         :param record: the log record to output
         :type record: :class:`logging.LogRecord`
         """
-        if self._bot.backend is None or not self._bot.backend.is_connected():
-            # Don't emit logs when the bot is not connected.
+        if not self._bot.connection_registered:
+            # Don't emit logs to IRC when the bot is not connected & registered.
             return
 
         try:


### PR DESCRIPTION
### Description
The revamped `connection_registered` bot property checks for a backend, a socket connection, AND connection registration. This is what we need to prevent doing a `say()` before the IRC connection is ready.

This might be a fix for #2255, but I haven't tested for that specific case yet. Regardless, this old-style check is due for replacement.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
