### PR TITLE
reqs: do not require sopel-py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,6 @@ dependencies = [
     "importlib_metadata>=3.6",
     "packaging",
     "sopel-help>=0.4.0",
-    "sopel-py>=1.0.1",  # TODO: drop for 8.1
 ]
 
 [project.urls]


### PR DESCRIPTION
### Description
Tin. Makes more sense to cleanly drop this in 8.0, rather than wait for 8.1.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
I was already thinking along these lines, but IRC discussion this morning pushed me the rest of the way.