### PR TITLE
reload: better document limitations of `.reload` command

### DIFF
--- a/sopel/modules/reload.py
+++ b/sopel/modules/reload.py
@@ -35,7 +35,11 @@ def _load(bot, plugin):
 @plugin.require_admin
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def f_reload(bot, trigger):
-    """Reloads a plugin (for use by admins only)."""
+    """Reload a plugin (for use by admins only)
+
+    NOTE: Designed to work with single-file plugins only, during development.
+    Restart the bot instead when making significant changes.
+    """
     name = trigger.group(2)
 
     if not name or name == '*' or name.upper() == 'ALL THE THINGS':
@@ -75,7 +79,7 @@ def f_update(bot, trigger):
 @plugin.require_admin
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def f_load(bot, trigger):
-    """Loads a plugin (for use by admins only)."""
+    """Load a plugin (for use by admins only)"""
     name = trigger.group(2)
     if not name:
         bot.reply('Load what?')


### PR DESCRIPTION
### Description
Tin. Lighter weight (no-code) alternative to #2043.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - Easy, because no code is touched. I verified the appearance of `.help reload` output.