### PR TITLE
reddit: add `slash_info` toggle

### DIFF
--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -232,6 +232,7 @@ def find_config(config_dir: str, name: str, extension: str = '.cfg') -> str:
         '/home/username/.sopel/extra.ini'
 
     .. versionchanged:: 8.0
+
         Files in the ``config_dir`` are now preferred, and files without the
         requested extension are no longer returned.
 


### PR DESCRIPTION
### Description
Bot owners can now turn off `u/someone` and `r/subredditname` expansion without having to use the dumpster fire called per-channel settings. Closes #2194.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
Bundles a whitespace change I thought had been added to #2299 during merge, but I messed it up. I'd rather stick it in an unrelated PR than push directly to `master`. 😅