### PR TITLE
logging: disallow `DEBUG` channel logs & stop inheriting console log level

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -825,6 +825,12 @@ Example of configuration to log errors only in the ``##bot_logs`` channel::
     logging_channel_level = ERROR
     logging_channel_format = %(message)s
 
+.. note::
+
+   ``DEBUG`` is not supported for ``logging_channel_level``. The bot would
+   either flood itself off the network or spend most of its time waiting for
+   flood protection delays (thus becoming unusable).
+
 .. versionadded:: 7.0
 
    Configuration options ``logging_channel_level``, ``logging_channel_format``

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -807,9 +807,10 @@ Log to a Channel
 ----------------
 
 It is possible to send logs to an IRC channel, by configuring
-:attr:`~CoreSection.logging_channel`. By default, it uses the same log level,
-format, and date-format parameters as console logs. This can be overridden
-with these settings:
+:attr:`~CoreSection.logging_channel`. By default, it logs ``WARNING`` or higher
+messages, using the same date and log-line format parameters as the console
+logging output. The following settings can be used to customize output to the
+logging channel:
 
 * ``format`` with :attr:`~CoreSection.logging_channel_format`
 * ``datefmt`` with :attr:`~CoreSection.logging_channel_datefmt`
@@ -834,8 +835,12 @@ Example of configuration to log errors only in the ``##bot_logs`` channel::
 .. versionadded:: 7.0
 
    Configuration options ``logging_channel_level``, ``logging_channel_format``
-   and ``logging_channel_datefmt`` has been added to extend logging
+   and ``logging_channel_datefmt`` have been added to extend logging
    configuration.
+
+.. versionchanged:: 8.0
+
+   Channel logging no longer inherits the console ``logging_level`` setting.
 
 Raw Logs
 --------

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -245,13 +245,12 @@ class Sopel(irc.AbstractBot):
     def setup_logging(self) -> None:
         """Set up logging based on config options."""
         logger.setup_logging(self.settings)
-        base_level = self.settings.core.logging_level or 'INFO'
         base_format = self.settings.core.logging_format
         base_datefmt = self.settings.core.logging_datefmt
 
         # configure channel logging if required by configuration
         if self.settings.core.logging_channel:
-            channel_level = self.settings.core.logging_channel_level or base_level
+            channel_level = self.settings.core.logging_channel_level
             channel_format = self.settings.core.logging_channel_format or base_format
             channel_datefmt = self.settings.core.logging_channel_datefmt or base_datefmt
             channel_params = {}

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -872,8 +872,6 @@ class CoreSection(StaticSection):
                                             'WARNING')
     """The lowest severity of logs to display in IRC channel logs.
 
-    If not specified, this falls back to using :attr:`logging_level`.
-
     .. seealso::
 
         The :ref:`Log to a Channel` chapter.
@@ -881,8 +879,9 @@ class CoreSection(StaticSection):
     .. versionadded:: 7.0
     .. versionchanged:: 8.0
 
-        Removed ``DEBUG`` from available choices; setting it causes the bot to
-        get caught in an ever-increasing flood prevention loop.
+        No longer uses the value of :attr:`logging_level` if not set. Removed
+        ``DEBUG`` from the available choices; setting it caused the bot to get
+        caught in an ever-increasing flood prevention loop.
 
     """
 

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -868,7 +868,7 @@ class CoreSection(StaticSection):
 
     logging_channel_level = ChoiceAttribute('logging_channel_level',
                                             ['CRITICAL', 'ERROR', 'WARNING',
-                                             'INFO', 'DEBUG'],
+                                             'INFO'],
                                             'WARNING')
     """The lowest severity of logs to display in IRC channel logs.
 
@@ -879,6 +879,11 @@ class CoreSection(StaticSection):
         The :ref:`Log to a Channel` chapter.
 
     .. versionadded:: 7.0
+    .. versionchanged:: 8.0
+
+        Removed ``DEBUG`` from available choices; setting it causes the bot to
+        get caught in an ever-increasing flood prevention loop.
+
     """
 
     logging_datefmt = ValidatedAttribute('logging_datefmt')


### PR DESCRIPTION
### Description
Setting `logging_channel_level = DEBUG` sends so much to IRC that the bot got stuck waiting for flood protection to release.

The only sensible solution is to disallow setting channel logs to the `DEBUG` level, and along the way I've also made it so that channel logging always defaults to `WARNING` if not configured, instead of inheriting the console's `logging_level` setting.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
Indirectly related to #2255, both because I discovered that bug while working on this one last year _and_ because I devised this solution while testing to see if that issue could be closed after #2410.