### PR TITLE
safety: logging level tweaks

### DIFF
--- a/sopel/modules/safety.py
+++ b/sopel/modules/safety.py
@@ -120,6 +120,7 @@ def setup(bot: Sopel):
             # Python on Windows throws an exception if the file is in use
             LOGGER.warning('Could not delete %s: %s', old_file, str(err))
 
+    LOGGER.info('Ensuring unsafe domain list is up-to-date (safety plugin setup)')
     update_local_cache(bot, init=True)
 
 

--- a/sopel/modules/safety.py
+++ b/sopel/modules/safety.py
@@ -118,7 +118,7 @@ def setup(bot: Sopel):
         except Exception as err:
             # for lack of a more specific error type...
             # Python on Windows throws an exception if the file is in use
-            LOGGER.info('Could not delete %s: %s', old_file, str(err))
+            LOGGER.warning('Could not delete %s: %s', old_file, str(err))
 
     update_local_cache(bot, init=True)
 
@@ -141,12 +141,12 @@ def download_domain_list(bot: Sopel, path: str) -> bool:
     url = bot.settings.safety.domain_blocklist_url
     if url is None or not url.startswith("http"):
         url = "https://raw.githubusercontent.com/StevenBlack/hosts/master/hosts"
-    LOGGER.info("Downloading unsafe domain list from %s", url)
+    LOGGER.debug("Downloading unsafe domain list from %s", url)
     old_etag = bot.db.get_plugin_value("safety", "unsafe_domain_list_etag")
     if old_etag:
         r = requests.head(url)
         if r.headers["ETag"] == old_etag and os.path.isfile(path):
-            LOGGER.info("Unsafe domain list unchanged, skipping")
+            LOGGER.debug("Unsafe domain list unchanged, skipping")
             return False
 
     r = requests.get(url, stream=True)
@@ -486,6 +486,6 @@ def _clean_cache(bot: Sopel):
 
         LOGGER.debug('Safety cache cleanup finished.')
     else:
-        LOGGER.info(
+        LOGGER.debug(
             'Skipping safety cache cleanup: Cache is locked, '
             'cleanup already running.')


### PR DESCRIPTION
### Description
* failure to delete old malwaredomains file is upgraded to a warning: fixing the problem requires manual intervention
* domain list update is now all debug, all the time, except if there is an error (which generates a warning so the bot owner can see if it's repeatedly failed)
* cache cleanup being skipped is also debug now; it didn't make sense for "cleanup already running" to be louder than "starting cleanup"

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
I'm looking specifically at `info()` logging calls in light of #2419 and very well might run through all the places where the most common messages I see in logs of the bots I run/admin just to double-check that we're using the INFO level sensibly.