### PR TITLE
README: update source-install clone URI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ for installing from the latest source below.
 Latest source
 =============
 First, either clone the repository with ``git clone
-git://github.com/sopel-irc/sopel.git`` or download a tarball `from GitHub
+https://github.com/sopel-irc/sopel.git`` or download a tarball `from GitHub
 <https://github.com/sopel-irc/sopel/releases/latest>`_.
 
 Note: Sopel requires Python 3.7+ to run.


### PR DESCRIPTION
### Description
GitHub disabled plaintext `git://` support about a year ago, after announcing the change in September 2021:
https://github.blog/2021-09-01-improving-git-protocol-security-github/

Most users likely either install our package from PyPI or clone using whatever URI is copied when navigating the Clone option on github.com, so nobody flagged this as a problem until now (long-time IRC friend told me to "fix your README", so I am).

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
Doesn't technically apply to any milestone, but I flagged it for 8.0 because the PyPI package description is based on the README and I'd rather not ship any more package versions that include outdated source-clone instructions.