### PR TITLE
url: Wrap DNS resolution in try/except

### DIFF
--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -406,7 +406,18 @@ def process_urls(
             try:
                 ips = [ip_address(parsed_url.hostname)]
             except ValueError:
-                ips = [ip_address(ip) for ip in dns.resolver.resolve(parsed_url.hostname)]
+                # Extra try/except here in case the DNS resolution fails, see #2348
+                try:
+                    ips = [ip_address(ip) for ip in dns.resolver.resolve(parsed_url.hostname)]
+                except Exception as exc:
+                    LOGGER.debug(
+                        "Cannot resolve hostname %s, ignoring URL %s"
+                        " (exception was: %r)",
+                        parsed_url.hostname,
+                        url,
+                        exc,
+                    )
+                    continue
 
             private = False
             for ip in ips:


### PR DESCRIPTION
### Description

This changeset adds a bit of caution to the DNS resolution that might happen in the `[url]` plugin, to fix #2348

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - `1370 passed, 8 xfailed, 1 warning in 52.60s`
