### PR TITLE
irc: unescape hexadecimal sequences in ISUPPORT parameter values

### DIFF
--- a/sopel/irc/isupport.py
+++ b/sopel/irc/isupport.py
@@ -131,10 +131,37 @@ ISUPPORT_PARSERS = {
 }
 
 
+def _unescape_param(param):
+    """Handle escape sequences in ISUPPORT parameter values.
+
+    Sopel follows the recommendation of `modern.ircdocs.horse`__ which only
+    recognizes the escape sequences ``\\x20, \\x5C, \\x3D``. All other such
+    escape sequences will be passed through unaltered.
+
+    .. __: https://modern.ircdocs.horse/#rplisupport-005
+    """
+    HEX_PATTERN = r"\\x([0-9a-fA-F]{2})"
+
+    def _unescape(match):
+        num = match.group(1).upper()
+        if num == "20":
+            result = " "
+        elif num == "5C":
+            result = "\\"
+        elif num == "3D":
+            result = "="
+        else:
+            result = match.group(0)
+
+        return result
+
+    return re.sub(HEX_PATTERN, _unescape, param)
+
+
 def parse_parameter(arg):
     items = arg.split('=', 1)
     if len(items) == 2:
-        key, value = items
+        key, value = items[0], _unescape_param(items[1])
     else:
         key, value = items[0], None
 

--- a/test/irc/test_irc_isupport.py
+++ b/test/irc/test_irc_isupport.py
@@ -271,6 +271,10 @@ VALID_PARSE_VALUE = (
     ('STATUSMSG=ABCD', ('STATUSMSG', ('A', 'B', 'C', 'D'))),
     ('TOPICLEN=5', ('TOPICLEN', 5)),
     ('USERLEN=5', ('USERLEN', 5)),
+    ('NETWORK=Libera\\x20Chat', ('NETWORK', 'Libera Chat')),
+    ('NETWORK=Libera\\x5CChat', ('NETWORK', 'Libera\\Chat')),
+    ('NETWORK=Libera\\x3DChat', ('NETWORK', 'Libera=Chat')),
+    ('NETWORK=Libera\\x0aChat', ('NETWORK', 'Libera\\x0aChat')),
 )
 
 


### PR DESCRIPTION
### Description

This changeset handles hexadecimal escape sequences in `ISUPPORT` parameter values, implementing #2195

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
