### PR TITLE
url: fix premature loop termination, docstring cleanup & slight refactoring

### DIFF
--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -389,10 +389,10 @@ def process_urls(
 
         parsed_url = urlparse(url)
 
-        # Check the URL does not match an existing URL callback
         if check_callbacks(bot, url, use_excludes=not requested):
+            # URL matches a callback OR is excluded, ignore
             yield (url, None, None, None, True)
-            return
+            continue
 
         # Prevent private addresses from being queried if enable_private_resolution is False
         # FIXME: This does nothing when an attacker knows how to host a 302


### PR DESCRIPTION
### Description

This changeset resolves #2230 by dropping the incorrect information from the relevant docstrings, and also does some light refactoring of `title_auto(), process_urls()` for the sake of future maintenance. Also included is a fix for a bug discovered while writing this PR, where a URL matching a registered callback causes following URLs in the message to be ignored.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - `1426 passed, 8 xfailed, 1 warning in 52.07s`
- [x] I have tested the functionality of the things this change touches
