### PR TITLE
Add more placeholders to rate-limit messages, move template interpolation from `Rule` to `Sopel`

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -630,6 +630,8 @@ class Sopel(irc.AbstractBot):
         next_time = metrics.last_time + rate_limit
         time_left = next_time - at_time
 
+        message: Optional[str] = None
+
         if template:
             message = template.format(
                 nick=trigger.nick,
@@ -643,8 +645,6 @@ class Sopel(irc.AbstractBot):
                 rate_limit_sec=rate_limit.total_seconds(),
                 rate_limit_type=rate_limit_type,
             )
-        else:
-            message = None
 
         return True, message
 

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -599,16 +599,17 @@ class Sopel(irc.AbstractBot):
         is_channel = trigger.sender and not trigger.sender.is_nick()
         channel = trigger.sender if is_channel else None
 
-        # TODO: these functions call now() and probably shouldn't
-        if rule.is_user_rate_limited(trigger.nick):
+        at_time = trigger.time
+
+        if rule.is_user_rate_limited(nick=trigger.nick, at_time=at_time):
             template = rule.user_rate_template
             rate_limit_type = "user"
             rate_limit_sec = rule._user_rate_limit
-        elif is_channel and rule.is_channel_rate_limited(channel=channel):
+        elif is_channel and rule.is_channel_rate_limited(channel=channel, at_time=at_time):
             template = rule.channel_rate_template
             rate_limit_type = "channel"
             rate_limit_sec = rule._channel_rate_limit
-        elif rule.is_global_rate_limited():
+        elif rule.is_global_rate_limited(at_time=at_time):
             template = rule.global_rate_template
             rate_limit_type = "global"
             rate_limit_sec = rule._global_rate_limit

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -604,15 +604,15 @@ class Sopel(irc.AbstractBot):
         if rule.is_user_rate_limited(nick=trigger.nick, at_time=at_time):
             template = rule.user_rate_template
             rate_limit_type = "user"
-            rate_limit_sec = rule._user_rate_limit
+            rate_limit = rule.user_rate_limit
         elif is_channel and rule.is_channel_rate_limited(channel=channel, at_time=at_time):
             template = rule.channel_rate_template
             rate_limit_type = "channel"
-            rate_limit_sec = rule._channel_rate_limit
+            rate_limit = rule.channel_rate_limit
         elif rule.is_global_rate_limited(at_time=at_time):
             template = rule.global_rate_template
             rate_limit_type = "global"
-            rate_limit_sec = rule._global_rate_limit
+            rate_limit = rule.global_rate_limit
         else:
             return False, None
 
@@ -623,6 +623,7 @@ class Sopel(irc.AbstractBot):
                 sender=trigger.sender,
                 plugin=rule.get_plugin_name(),
                 label=rule.get_rule_label(),
+                rate_limit=rate_limit,
                 rate_limit_sec=rate_limit_sec,
                 rate_limit_type=rate_limit_type,
             )

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -1112,10 +1112,27 @@ def rate(
         @rate(10, 10, 10, message='Hit the rate limit for this function.')
             # will send a NOTICE
 
-    The message can contain a placeholder for ``nick``: the message will be
-    formatted with the nick that hit rate limit::
+    The message can contain placeholders which will be filled in:
 
-        @rate(10, 10, 2, message='Sorry {nick}, you hit the rate limit!')
+    * ``nick``: the nick that hit the rate limit
+    * ``channel``: the channel in which the rate limit was hit (will be
+      ``'private-message'`` for private messages)
+    * ``sender``: the sender (nick or channel) of the message which hit
+      the rate limit
+    * ``plugin``: the name of the plugin that hit the rate limit
+    * ``label``: the label of the plugin handler that hit the rate limit
+    * ``time_left``: the time remaining before the rate limit expires, as
+      a string
+    * ``time_left_sec``: the time remaining before the rate limit expires,
+      expressed in number of seconds
+    * ``rate_limit``: the rate limit, as a string
+    * ``rate_limit_sec``: the rate limit, expressed in number of seconds
+    * ``rate_limit_type``: the type of rate limit that was hit (one of
+      ``user, group, global``)
+
+    For example::
+
+        @rate(10, 10, 2, message='Sorry {nick}, you hit the {rate_limit_type} rate limit!')
 
     Rate-limited functions that use scheduled future commands should import
     :class:`threading.Timer` instead of :mod:`sched`, or rate limiting will
@@ -1168,10 +1185,9 @@ def rate_user(
             # will send a NOTICE only when a user hits their own limit
             # as other rate limits don't have any message set
 
-    The message can contain a placeholder for ``nick``: the message will be
-    formatted with the nick that hit rate limit::
+    The message can contain the same placeholders supported by :func:`rate`::
 
-        @rate_user(5, 'Sorry {nick}, you hit your 5s limit!')
+        @rate_user(5, 'Sorry {nick}, you hit your {rate_limit_sec}s limit!')
 
     If you don't provide a message, the default message set by :func:`rate`
     (if any) will be used instead.
@@ -1213,13 +1229,11 @@ def rate_channel(
     If you don't provide a message, the default message set by :func:`rate`
     (if any) will be used instead.
 
-    The message can contain placeholders for ``nick`` and ``channel``: the
-    message will be formatted with the nick that hit rate limit for said
-    ``channel``::
+    The message can contain the same placeholders supported by :func:`rate`::
 
         @rate_channel(
             5,
-            'Sorry {nick}, you hit the 5s limit for the {channel} channel!',
+            'Sorry {nick}, you hit the {rate_limit_sec}s limit for the {channel} channel!',
         )
 
     .. versionadded:: 8.0
@@ -1248,7 +1262,9 @@ def rate_global(
     :param message: optional; message sent as NOTICE when a user hits the limit
 
     This decorator can be used alone or with the :func:`rate` decorator, as it
-    will always take precedence::
+    will always take precedence.
+
+    For example::
 
         @rate(10, 10, 10)
         @rate_global(5, 'You hit the global rate limit for this function.')
@@ -1259,8 +1275,7 @@ def rate_global(
     If you don't provide a message, the default message set by :func:`rate`
     (if any) will be used instead.
 
-    The message can contain a placeholder for ``nick``: the message will be
-    formatted with the nick that hit rate limit::
+    The message can contain the same placeholders supported by :func:`rate`::
 
         @rate_global(5, 'Sorry {nick}, you hit the 5s limit!')
 

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -735,55 +735,50 @@ class AbstractRule(abc.ABC):
     def is_user_rate_limited(self, nick: Identifier) -> bool:
         """Tell when the rule reached the ``nick``'s rate limit.
 
-        :return: ``True`` when the rule reached the limit, ``False`` otherwise
+        :return: ``True`` when the rule reached the limit, ``False`` otherwise.
         """
 
     @abc.abstractmethod
     def is_channel_rate_limited(self, channel: Identifier) -> bool:
         """Tell when the rule reached the ``channel``'s rate limit.
 
-        :return: ``True`` when the rule reached the limit, ``False`` otherwise
+        :return: ``True`` when the rule reached the limit, ``False`` otherwise.
         """
 
     @abc.abstractmethod
     def is_global_rate_limited(self) -> bool:
         """Tell when the rule reached the global rate limit.
 
-        :return: ``True`` when the rule reached the limit, ``False`` otherwise
+        :return: ``True`` when the rule reached the limit, ``False`` otherwise.
         """
 
+    @property
     @abc.abstractmethod
-    def get_user_rate_message(self, nick: Identifier) -> Optional[str]:
-        """Give the message to send with a NOTICE to ``nick``.
+    def user_rate_template(self) -> Optional[str]:
+        """Give the message template to send with a NOTICE to ``nick``.
 
-        :param nick: the nick that is rate limited
         :return: A formatted string, or ``None`` if no message is set.
 
-        This method is called by the bot when a trigger hits the user rate
+        This property is accessed by the bot when a trigger hits the user rate
         limit (i.e. for the specificed ``nick``).
         """
 
+    @property
     @abc.abstractmethod
-    def get_channel_rate_message(
-        self,
-        nick: Identifier,
-        channel: Identifier,
-    ) -> Optional[str]:
-        """Give the message to send with a NOTICE to ``nick``.
+    def channel_rate_template(self) -> Optional[str]:
+        """Give the message template to send with a NOTICE to ``nick``.
 
-        :param nick: the nick that reached the channel's rate limit
-        :param channel: the channel that is rate limited
         :return: A formatted string, or ``None`` if no message is set.
 
         This method is called by the bot when a trigger hits the channel rate
         limit (i.e. for the specificed ``channel``).
         """
 
+    @property
     @abc.abstractmethod
-    def get_global_rate_message(self, nick: Identifier) -> Optional[str]:
+    def global_rate_template(self) -> Optional[str]:
         """Give the message to send with a NOTICE to ``nick``.
 
-        :param nick: the nick that reached the global rate limit
         :return: A formatted string, or ``None`` if no message is set.
 
         This method is called by the bot when a trigger hits the global rate
@@ -1158,36 +1153,20 @@ class Rule(AbstractRule):
         rate_limit = datetime.timedelta(seconds=self._global_rate_limit)
         return self._metrics_global.is_limited(now - rate_limit)
 
-    def get_user_rate_message(self, nick):
+    @property
+    def user_rate_template(self):
         template = self._user_rate_message or self._default_rate_message
+        return template
 
-        if not template:
-            return None
-
-        return template.format(
-            nick=nick,
-        )
-
-    def get_channel_rate_message(self, nick, channel):
+    @property
+    def channel_rate_template(self):
         template = self._channel_rate_message or self._default_rate_message
+        return template
 
-        if not template:
-            return None
-
-        return template.format(
-            nick=nick,
-            channel=channel,
-        )
-
-    def get_global_rate_message(self, nick):
+    @property
+    def global_rate_template(self):
         template = self._global_rate_message or self._default_rate_message
-
-        if not template:
-            return None
-
-        return template.format(
-            nick=nick,
-        )
+        return template
 
     def execute(self, bot, trigger):
         if not self._handler:

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -36,6 +36,8 @@ from typing import (
 )
 from urllib.parse import urlparse
 
+import pytz
+
 from sopel import tools
 from sopel.config.core_section import (
     COMMAND_DEFAULT_HELP_PREFIX, COMMAND_DEFAULT_PREFIX, URL_DEFAULT_SCHEMES)
@@ -465,11 +467,11 @@ class RuleMetrics:
 
     def start(self) -> None:
         """Record a starting time (before execution)."""
-        self.started_at = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
+        self.started_at = pytz.utc.localize(datetime.datetime.utcnow())
 
     def end(self) -> None:
         """Record a ending time (after execution)."""
-        self.ended_at = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
+        self.ended_at = pytz.utc.localize(datetime.datetime.utcnow())
 
     def set_return_value(self, value: Any) -> None:
         """Set the last return value of a rule."""
@@ -1189,7 +1191,7 @@ class Rule(AbstractRule):
         at_time: Optional[datetime.datetime] = None,
     ) -> bool:
         if at_time is None:
-            at_time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
+            at_time = pytz.utc.localize(datetime.datetime.utcnow())
         metrics = self.get_user_metrics(nick)
         return metrics.is_limited(at_time - self.user_rate_limit)
 
@@ -1199,7 +1201,7 @@ class Rule(AbstractRule):
         at_time: Optional[datetime.datetime] = None,
     ) -> bool:
         if at_time is None:
-            at_time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
+            at_time = pytz.utc.localize(datetime.datetime.utcnow())
         metrics = self.get_channel_metrics(channel)
         return metrics.is_limited(at_time - self.channel_rate_limit)
 
@@ -1208,7 +1210,7 @@ class Rule(AbstractRule):
         at_time: Optional[datetime.datetime] = None,
     ) -> bool:
         if at_time is None:
-            at_time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
+            at_time = pytz.utc.localize(datetime.datetime.utcnow())
         metrics = self.get_global_metrics()
         return metrics.is_limited(at_time - self.global_rate_limit)
 

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -465,11 +465,11 @@ class RuleMetrics:
 
     def start(self) -> None:
         """Record a starting time (before execution)."""
-        self.started_at = datetime.datetime.utcnow()
+        self.started_at = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
 
     def end(self) -> None:
         """Record a ending time (after execution)."""
-        self.ended_at = datetime.datetime.utcnow()
+        self.ended_at = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
 
     def set_return_value(self, value: Any) -> None:
         """Set the last return value of a rule."""
@@ -1146,21 +1146,21 @@ class Rule(AbstractRule):
 
     def is_user_rate_limited(self, nick, at_time=None) -> bool:
         if at_time is None:
-            at_time = datetime.datetime.utcnow()
+            at_time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
         metrics: RuleMetrics = self._metrics_nick.get(nick, RuleMetrics())
         rate_limit = datetime.timedelta(seconds=self._user_rate_limit)
         return metrics.is_limited(at_time - rate_limit)
 
     def is_channel_rate_limited(self, channel, at_time=None) -> bool:
         if at_time is None:
-            at_time = datetime.datetime.utcnow()
+            at_time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
         metrics: RuleMetrics = self._metrics_sender.get(channel, RuleMetrics())
         rate_limit = datetime.timedelta(seconds=self._channel_rate_limit)
         return metrics.is_limited(at_time - rate_limit)
 
     def is_global_rate_limited(self, at_time=None) -> bool:
         if at_time is None:
-            at_time = datetime.datetime.utcnow()
+            at_time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
         rate_limit = datetime.timedelta(seconds=self._global_rate_limit)
         return self._metrics_global.is_limited(at_time - rate_limit)
 

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -475,6 +475,16 @@ class RuleMetrics:
         """Set the last return value of a rule."""
         self.last_return_value = value
 
+    @property
+    def last_time(self) -> Optional[datetime.datetime]:
+        """Last recorded start/end time for the associated rule"""
+        # detect if we just started something or if it ended
+        last_time = self.started_at
+        if self.ended_at and self.started_at < self.ended_at:
+            last_time = self.ended_at
+
+        return last_time
+
     def is_limited(
         self,
         time_limit: datetime.datetime,
@@ -484,15 +494,12 @@ class RuleMetrics:
             # not even started, so not limited
             return False
 
-        # detect if we just started something or if it ended
-        last_time = self.started_at
         if self.ended_at and self.started_at < self.ended_at:
-            last_time = self.ended_at
             # since it ended, check the return value
             if self.last_return_value == IGNORE_RATE_LIMIT:
                 return False
 
-        return last_time > time_limit
+        return self.last_time > time_limit
 
     def __enter__(self) -> RuleMetrics:
         self.start()

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -1144,25 +1144,34 @@ class Rule(AbstractRule):
     def is_unblockable(self):
         return self._unblockable
 
+    @property
+    def user_rate_limit(self) -> datetime.timedelta:
+        return datetime.timedelta(seconds=self._user_rate_limit)
+
+    @property
+    def channel_rate_limit(self) -> datetime.timedelta:
+        return datetime.timedelta(seconds=self._channel_rate_limit)
+
+    @property
+    def global_rate_limit(self) -> datetime.timedelta:
+        return datetime.timedelta(seconds=self._global_rate_limit)
+
     def is_user_rate_limited(self, nick, at_time=None) -> bool:
         if at_time is None:
             at_time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
         metrics: RuleMetrics = self._metrics_nick.get(nick, RuleMetrics())
-        rate_limit = datetime.timedelta(seconds=self._user_rate_limit)
-        return metrics.is_limited(at_time - rate_limit)
+        return metrics.is_limited(at_time - self.user_rate_limit)
 
     def is_channel_rate_limited(self, channel, at_time=None) -> bool:
         if at_time is None:
             at_time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
         metrics: RuleMetrics = self._metrics_sender.get(channel, RuleMetrics())
-        rate_limit = datetime.timedelta(seconds=self._channel_rate_limit)
-        return metrics.is_limited(at_time - rate_limit)
+        return metrics.is_limited(at_time - self.channel_rate_limit)
 
     def is_global_rate_limited(self, at_time=None) -> bool:
         if at_time is None:
             at_time = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
-        rate_limit = datetime.timedelta(seconds=self._global_rate_limit)
-        return self._metrics_global.is_limited(at_time - rate_limit)
+        return self._metrics_global.is_limited(at_time - self.global_rate_limit)
 
     @property
     def user_rate_template(self):

--- a/test/plugins/test_plugins_rules.py
+++ b/test/plugins/test_plugins_rules.py
@@ -1633,10 +1633,6 @@ def test_rule_rate_limit_messages(mockbot, triggerfactory):
     def handler(bot, trigger):
         return 'hello'
 
-    wrapper = triggerfactory.wrapper(
-        mockbot, ':Foo!foo@example.com PRIVMSG #channel :test message')
-    mocktrigger = wrapper._trigger
-
     regex = re.compile(r'.*')
     rule = rules.Rule(
         [regex],
@@ -1649,22 +1645,14 @@ def test_rule_rate_limit_messages(mockbot, triggerfactory):
         global_rate_message='Server message: {nick}',
         default_rate_message='Default message: {nick}',
     )
-    assert rule.get_user_rate_message(mocktrigger.nick) == 'User message: Foo'
-    assert rule.get_channel_rate_message(
-        mocktrigger.nick, mocktrigger.sender
-    ) == 'Channel message: Foo/#channel'
-    assert rule.get_global_rate_message(
-        mocktrigger.nick
-    ) == 'Server message: Foo'
+    assert rule.user_rate_template == 'User message: {nick}'
+    assert rule.channel_rate_template == 'Channel message: {nick}/{channel}'
+    assert rule.global_rate_template == 'Server message: {nick}'
 
 
 def test_rule_rate_limit_messages_default(mockbot, triggerfactory):
     def handler(bot, trigger):
         return 'hello'
-
-    wrapper = triggerfactory.wrapper(
-        mockbot, ':Foo!foo@example.com PRIVMSG #channel :test message')
-    mocktrigger = wrapper._trigger
 
     regex = re.compile(r'.*')
     rule = rules.Rule(
@@ -1675,19 +1663,14 @@ def test_rule_rate_limit_messages_default(mockbot, triggerfactory):
         channel_rate_limit=20,
         default_rate_message='Default message',
     )
-    assert rule.get_user_rate_message(mocktrigger.nick) == 'Default message'
-    assert rule.get_channel_rate_message(
-        mocktrigger.nick, mocktrigger.sender) == 'Default message'
-    assert rule.get_global_rate_message(mocktrigger.nick) == 'Default message'
+    assert rule.user_rate_template == 'Default message'
+    assert rule.channel_rate_template == 'Default message'
+    assert rule.global_rate_template == 'Default message'
 
 
 def test_rule_rate_limit_messages_default_mixed(mockbot, triggerfactory):
     def handler(bot, trigger):
         return 'hello'
-
-    wrapper = triggerfactory.wrapper(
-        mockbot, ':Foo!foo@example.com PRIVMSG #channel :test message')
-    mocktrigger = wrapper._trigger
 
     regex = re.compile(r'.*')
     rule = rules.Rule(
@@ -1699,10 +1682,9 @@ def test_rule_rate_limit_messages_default_mixed(mockbot, triggerfactory):
         user_rate_message='User message.',
         default_rate_message='The default.',
     )
-    assert rule.get_user_rate_message(mocktrigger.nick) == 'User message.'
-    assert rule.get_channel_rate_message(
-        mocktrigger.nick, mocktrigger.sender) == 'The default.'
-    assert rule.get_global_rate_message(mocktrigger.nick) == 'The default.'
+    assert rule.user_rate_template == 'User message.'
+    assert rule.channel_rate_template == 'The default.'
+    assert rule.global_rate_template == 'The default.'
 
     rule = rules.Rule(
         [regex],
@@ -1713,10 +1695,9 @@ def test_rule_rate_limit_messages_default_mixed(mockbot, triggerfactory):
         channel_rate_message='Channel message.',
         default_rate_message='The default.',
     )
-    assert rule.get_user_rate_message(mocktrigger.nick) == 'The default.'
-    assert rule.get_channel_rate_message(
-        mocktrigger.nick, mocktrigger.sender) == 'Channel message.'
-    assert rule.get_global_rate_message(mocktrigger.nick) == 'The default.'
+    assert rule.user_rate_template == 'The default.'
+    assert rule.channel_rate_template == 'Channel message.'
+    assert rule.global_rate_template == 'The default.'
 
     rule = rules.Rule(
         [regex],
@@ -1727,10 +1708,9 @@ def test_rule_rate_limit_messages_default_mixed(mockbot, triggerfactory):
         global_rate_message='Server message.',
         default_rate_message='The default.',
     )
-    assert rule.get_user_rate_message(mocktrigger.nick) == 'The default.'
-    assert rule.get_channel_rate_message(
-        mocktrigger.nick, mocktrigger.sender) == 'The default.'
-    assert rule.get_global_rate_message(mocktrigger.nick) == 'Server message.'
+    assert rule.user_rate_template == 'The default.'
+    assert rule.channel_rate_template == 'The default.'
+    assert rule.global_rate_template == 'Server message.'
 
 
 # -----------------------------------------------------------------------------

--- a/test/plugins/test_plugins_rules.py
+++ b/test/plugins/test_plugins_rules.py
@@ -5,6 +5,7 @@ import datetime
 import re
 
 import pytest
+import pytz
 
 from sopel import bot, loader, plugin, trigger
 from sopel.plugins import rules
@@ -468,7 +469,7 @@ def test_manager_has_action_command_aliases():
 # tests for :class:`Manager`
 
 def test_rulemetrics():
-    now = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
+    now = pytz.utc.localize(datetime.datetime.utcnow())
     time_window = datetime.timedelta(seconds=3600)
     metrics = rules.RuleMetrics()
 

--- a/test/plugins/test_plugins_rules.py
+++ b/test/plugins/test_plugins_rules.py
@@ -468,7 +468,7 @@ def test_manager_has_action_command_aliases():
 # tests for :class:`Manager`
 
 def test_rulemetrics():
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc)
     time_window = datetime.timedelta(seconds=3600)
     metrics = rules.RuleMetrics()
 


### PR DESCRIPTION
### Description

Fix #2325.

This changeset includes:

  - [x] plumbing changes in data flow about rate-limiting between `Sopel` and `Rule`
  - [x] new template fields for rate limit messages
    - unless somebody has suggestions for more fields, I'm considering this complete

---

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
