### PR TITLE
pronouns: make base URL of links configurable

### DIFF
--- a/sopel/modules/pronouns.py
+++ b/sopel/modules/pronouns.py
@@ -37,7 +37,7 @@ def configure(settings):
 
 
 def setup(bot):
-    bot.config.define_section('pronouns', PronounsSection)
+    bot.settings.define_section('pronouns', PronounsSection)
 
     # Copied from svelte-pronounisland, leaving a *lot* out.
     # If ambiguous, the earlier one will be used.
@@ -56,7 +56,7 @@ def setup(bot):
         'ey/em': 'ey/em/eir/eirs/eirself',
     }
 
-    if not bot.config.pronouns.fetch_complete_list:
+    if not bot.settings.pronouns.fetch_complete_list:
         return
 
     # and now try to get the current list our fork of the backend uses
@@ -142,7 +142,7 @@ def pronouns(bot, trigger):
             say_pronouns(bot, trigger.nick, pronouns)
         else:
             bot.reply("I don't know your pronouns! You can set them with "
-                      "{}setpronouns".format(bot.config.core.help_prefix))
+                      "{}setpronouns".format(bot.settings.core.help_prefix))
     else:
         pronouns = bot.db.get_nick_value(trigger.group(3), 'pronouns')
         if pronouns:
@@ -157,7 +157,7 @@ def pronouns(bot, trigger):
         else:
             bot.reply("I don't know {}'s pronouns. They can set them with "
                       "{}setpronouns".format(trigger.group(3),
-                                             bot.config.core.help_prefix))
+                                             bot.settings.core.help_prefix))
 
 
 def say_pronouns(bot, nick, pronouns):

--- a/sopel/modules/pronouns.py
+++ b/sopel/modules/pronouns.py
@@ -15,7 +15,6 @@ from sopel import plugin
 from sopel.config import types
 
 
-BACKEND = 'https://pronouns.sopel.chat'
 LOGGER = logging.getLogger(__name__)
 
 
@@ -23,17 +22,30 @@ class PronounsSection(types.StaticSection):
     fetch_complete_list = types.BooleanAttribute('fetch_complete_list', default=True)
     """Whether to attempt fetching the complete list the web backend uses, at bot startup."""
 
+    link_base_url = types.ValidatedAttribute(
+        'link_base_url', default='https://pronouns.sopel.chat')
+    """Base URL for links to pronoun info.
+
+    Defaults to an instance of https://github.com/sopel-irc/pronoun-service
+    hosted by the Sopel project, but it's easy to make your own instance
+    available at a custom domain using one of many free static site hosts.
+    """
+
 
 def configure(settings):
     """
     | name | example | purpose |
     | ---- | ------- | ------- |
     | fetch_complete_list | True | Whether to attempt fetching the complete pronoun list from the web backend at startup. |
+    | link_base_url | https://pronouns.sopel.chat | Base URL for pronoun info links. |
     """
     settings.define_section('pronouns', PronounsSection)
     settings.pronouns.configure_setting(
         'fetch_complete_list',
         'Fetch the most current list of pronoun sets at startup?')
+    settings.pronouns.configure_setting(
+        'link_base_url',
+        'Base URL for pronoun info links:')
 
 
 def setup(bot):
@@ -152,7 +164,7 @@ def pronouns(bot, trigger):
             # gender, but like… it's a bot.
             bot.say(
                 "I am a bot. Beep boop. My pronouns are it/it/its/its/itself. "
-                "See {}/it for examples.".format(BACKEND)
+                "See {}/it for examples.".format(bot.settings.pronouns.link_base_url)
             )
         else:
             bot.reply("I don't know {}'s pronouns. They can set them with "
@@ -167,11 +179,11 @@ def say_pronouns(bot, nick, pronouns):
         short = pronouns
 
     bot.say(
-        "{nick}'s pronouns are {pronouns}. See {BACKEND}/{short} for examples."
+        "{nick}'s pronouns are {pronouns}. See {base_url}/{short} for examples."
         .format(
             nick=nick,
             pronouns=pronouns,
-            BACKEND=BACKEND,
+            base_url=bot.settings.pronouns.link_base_url,
             short=short,
         )
     )


### PR DESCRIPTION
### Description
Adds the option to use "your own domain" for the pronoun-info links output by the `pronouns` plugin.

Since it's so easy for _us_ to host our own `pronoun.is` clone, that means it's also easy for our users to do so. I think bot owners having the ability to choose how this plugin's links look is very much in keeping with the plugin's spirit, and it's simple to do.

This is a follow-up to #2437—and by rights should have been done _in_ #2437, but I didn't think of it yet.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - `1430 passed, 8 xfailed, 1 warning in 38.28s`
- [x] I have tested the functionality of the things this change touches