### PR TITLE
bot, trigger: use status prefix in SopelWrapper

### DIFF
--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -329,6 +329,18 @@ class Trigger(str):
         else:
             # message sent from a channel
 
+    .. important::
+
+        If the message was sent to a `specific status prefix`__, the ``sender``
+        does not include the status prefix. Be sure to use the
+        :attr:`status_prefix` when replying.
+
+        Note that the ``bot`` argument passed to plugin callables is a
+        :class:`~sopel.bot.SopelWrapper` that handles this for the default
+        ``destination`` of the methods it overrides (most importantly,
+        :meth:`~sopel.bot.SopelWrapper.say` &
+        :meth:`~sopel.bot.SopelWrapper.reply`).
+
     .. warning::
 
         The ``sender`` Will be ``None`` for commands that have no implicit
@@ -337,6 +349,7 @@ class Trigger(str):
         The :attr:`COMMANDS_WITH_CONTEXT` attribute lists IRC commands for
         which ``sender`` can be relied upon.
 
+    .. __: https://modern.ircdocs.horse/#statusmsg-parameter
     """
     status_prefix = property(lambda self: self._pretrigger.status_prefix)
     """The prefix used for the :attr:`sender` for status-specific messages.

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -102,6 +102,32 @@ def mockplugin(tmpdir):
 # -----------------------------------------------------------------------------
 # sopel.bot.SopelWrapper
 
+def test_wrapper_default_destination(mockbot, triggerfactory):
+    wrapper = triggerfactory.wrapper(
+        mockbot, ':Test!test@example.com PRIVMSG #channel :test message')
+
+    assert wrapper.default_destination == '#channel'
+
+
+def test_wrapper_default_destination_none(mockbot, triggerfactory):
+    wrapper = triggerfactory.wrapper(
+        mockbot, ':irc.example.com 301 Sopel :I am away.')
+
+    assert wrapper.default_destination is None
+
+
+def test_wrapper_default_destination_statusmsg(mockbot, triggerfactory):
+    mockbot._isupport = mockbot.isupport.apply(
+        STATUSMSG=tuple('+'),
+    )
+
+    wrapper = triggerfactory.wrapper(
+        mockbot, ':Test!test@example.com PRIVMSG +#channel :test message')
+
+    assert wrapper._trigger.sender == '#channel'
+    assert wrapper.default_destination == '+#channel'
+
+
 def test_wrapper_say(mockbot, triggerfactory):
     wrapper = triggerfactory.wrapper(
         mockbot, ':Test!test@example.com PRIVMSG #channel :test message')
@@ -109,6 +135,20 @@ def test_wrapper_say(mockbot, triggerfactory):
 
     assert mockbot.backend.message_sent == rawlist(
         'PRIVMSG #channel :Hi!'
+    )
+
+
+def test_wrapper_say_statusmsg(mockbot, triggerfactory):
+    mockbot._isupport = mockbot.isupport.apply(
+        STATUSMSG=tuple('+'),
+    )
+
+    wrapper: bot.SopelWrapper = triggerfactory.wrapper(
+        mockbot, ':Test!test@example.com PRIVMSG +#channel :test message')
+    wrapper.say('Hi!')
+
+    assert mockbot.backend.message_sent == rawlist(
+        'PRIVMSG +#channel :Hi!'
     )
 
 
@@ -132,6 +172,20 @@ def test_wrapper_notice(mockbot, triggerfactory):
     )
 
 
+def test_wrapper_notice_statusmsg(mockbot, triggerfactory):
+    mockbot._isupport = mockbot.isupport.apply(
+        STATUSMSG=tuple('+'),
+    )
+
+    wrapper: bot.SopelWrapper = triggerfactory.wrapper(
+        mockbot, ':Test!test@example.com PRIVMSG +#channel :test message')
+    wrapper.notice('Hi!')
+
+    assert mockbot.backend.message_sent == rawlist(
+        'NOTICE +#channel :Hi!'
+    )
+
+
 def test_wrapper_notice_override_destination(mockbot, triggerfactory):
     wrapper = triggerfactory.wrapper(
         mockbot, ':Test!test@example.com PRIVMSG #channel :test message')
@@ -152,6 +206,20 @@ def test_wrapper_action(mockbot, triggerfactory):
     )
 
 
+def test_wrapper_action_statusmsg(mockbot, triggerfactory):
+    mockbot._isupport = mockbot.isupport.apply(
+        STATUSMSG=tuple('+'),
+    )
+
+    wrapper: bot.SopelWrapper = triggerfactory.wrapper(
+        mockbot, ':Test!test@example.com PRIVMSG +#channel :test message')
+    wrapper.action('Hi!')
+
+    assert mockbot.backend.message_sent == rawlist(
+        'PRIVMSG +#channel :\x01ACTION Hi!\x01'
+    )
+
+
 def test_wrapper_action_override_destination(mockbot, triggerfactory):
     wrapper = triggerfactory.wrapper(
         mockbot, ':Test!test@example.com PRIVMSG #channel :test message')
@@ -169,6 +237,20 @@ def test_wrapper_reply(mockbot, triggerfactory):
 
     assert mockbot.backend.message_sent == rawlist(
         'PRIVMSG #channel :Test: Hi!'
+    )
+
+
+def test_wrapper_reply_statusmsg(mockbot, triggerfactory):
+    mockbot._isupport = mockbot.isupport.apply(
+        STATUSMSG=tuple('+'),
+    )
+
+    wrapper: bot.SopelWrapper = triggerfactory.wrapper(
+        mockbot, ':Test!test@example.com PRIVMSG +#channel :test message')
+    wrapper.reply('Hi!')
+
+    assert mockbot.backend.message_sent == rawlist(
+        'PRIVMSG +#channel :Test: Hi!'
     )
 
 


### PR DESCRIPTION
### Description

Fix #2440 by adding a default destination on the `SopelWrapper` (idea from @SnoopJ) that properly handles status-specific prefix. Most of my work was to add tests and docstrings.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
