### PR TITLE
bot: eliminate problematic xrefs from `SopelWrapper` docs

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -1230,9 +1230,9 @@ class SopelWrapper:
                               (e.g. plugin tag)
 
     This wrapper will be used to call Sopel's triggered commands and rules as
-    their ``bot`` argument. It acts as a proxy to :meth:`send messages<say>`
-    to the sender (either a channel or in a private message) and even to
-    :meth:`reply to someone<reply>` in a channel.
+    their ``bot`` argument. It acts as a proxy, providing the ``trigger``'s
+    ``sender`` (source channel or private message) as the default
+    ``destination`` argument for overridden methods.
     """
     def __init__(self, sopel, trigger, output_prefix=''):
         if not output_prefix:


### PR DESCRIPTION
### Description
The formatting, in particular, is what was problematic here. Sphinx doesn't provide a way to negate the monospace formatting of a `:meth:` reference when using a custom title, so the only way to avoid having random monospace words in the middle of this paragraph is... rewriting to eliminate the xrefs.

Which is to say, if there's a better answer to [this question](https://stackoverflow.com/q/45741326/5991) in the future, we can put this back the way it was.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - No code changes; didn't run `make test` locally but `make quality` was indeed fine.
- [x] I have tested the functionality of the things this change touches
