### PR TITLE
tools.time: tweaks & tests

### DIFF
--- a/sopel/modules/remind.py
+++ b/sopel/modules/remind.py
@@ -427,10 +427,7 @@ def parse_regex_match(match, default_timezone=None):
     :rtype: :class:`TimeReminder`
     """
     try:
-        # Removing the `or` clause will BREAK the fallback to default_timezone!
-        # We need some invalid value other than None to trigger the ValueError.
-        # validate_timezone(None) excepting would be easier, but it doesn't.
-        timezone = validate_timezone(match.group('tz') or '')
+        timezone = validate_timezone(match.group('tz'))
     except ValueError:
         timezone = default_timezone or 'UTC'
 

--- a/sopel/tools/time.py
+++ b/sopel/tools/time.py
@@ -9,7 +9,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import cast, Optional, Tuple, TYPE_CHECKING, Union
+from typing import cast, NamedTuple, Optional, Tuple, TYPE_CHECKING, Union
 
 import pytz
 
@@ -25,6 +25,35 @@ HOURS = 60 * MINUTES
 DAYS = 24 * HOURS
 MONTHS = int(30.5 * DAYS)
 YEARS = 365 * DAYS
+
+
+class Duration(NamedTuple):
+    """Named tuple representation of a duration.
+
+    This can be used as a tuple as well as an object::
+
+        >>> d = Duration(minutes=12, seconds=34)
+        >>> d.minutes
+        12
+        >>> d.seconds
+        34
+        >>> years, months, days, hours, minutes, seconds = d
+        >>> (years, months, days, hours, minutes, seconds)
+        (0, 0, 0, 0, 12, 34)
+
+    """
+    years: int = 0
+    """Years spent."""
+    months: int = 0
+    """Months spent."""
+    days: int = 0
+    """Days spent."""
+    hours: int = 0
+    """Hours spent."""
+    minutes: int = 0
+    """Minutes spent."""
+    seconds: int = 0
+    """Seconds spent."""
 
 
 def validate_timezone(zone: Optional[str]) -> str:
@@ -255,21 +284,26 @@ def format_time(
     return time.astimezone(target_tz).strftime(tformat)
 
 
-def seconds_to_split(seconds: int) -> Tuple[int, int, int, int, int, int]:
+def seconds_to_split(seconds: int) -> Duration:
     """Split an amount of ``seconds`` into years, months, days, etc.
 
     :param seconds: amount of time in seconds
-    :return: the time split into a tuple of years, months, days, hours,
+    :return: the time split into a named tuple of years, months, days, hours,
              minutes, and seconds
 
     Examples::
 
         >>> seconds_to_split(7800)
-        (0, 0, 0, 2, 10, 0)
+        Duration(years=0, months=0, days=0, hours=2, minutes=10, seconds=0)
         >>> seconds_to_split(143659)
-        (0, 0, 1, 15, 54, 19)
+        Duration(years=0, months=0, days=1, hours=15, minutes=54, seconds=19)
 
     .. versionadded:: 7.1
+
+    .. versionchanged:: 8.0
+
+        This function returns a :class:`Duration` named tuple.
+
     """
     years, seconds_left = divmod(int(seconds), YEARS)
     months, seconds_left = divmod(seconds_left, MONTHS)
@@ -277,7 +311,7 @@ def seconds_to_split(seconds: int) -> Tuple[int, int, int, int, int, int]:
     hours, seconds_left = divmod(seconds_left, HOURS)
     minutes, seconds_left = divmod(seconds_left, MINUTES)
 
-    return years, months, days, hours, minutes, seconds_left
+    return Duration(years, months, days, hours, minutes, seconds_left)
 
 
 def get_time_unit(

--- a/sopel/tools/time.py
+++ b/sopel/tools/time.py
@@ -9,7 +9,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import Optional, overload, Tuple, TYPE_CHECKING, Union
+from typing import cast, Optional, Tuple, TYPE_CHECKING, Union
 
 import pytz
 
@@ -27,22 +27,13 @@ MONTHS = int(30.5 * DAYS)
 YEARS = 365 * DAYS
 
 
-@overload
-def validate_timezone(zone: None) -> None:
-    ...
-
-
-@overload
-def validate_timezone(zone: str) -> str:
-    ...
-
-
-def validate_timezone(zone):
+def validate_timezone(zone: Optional[str]) -> str:
     """Return an IETF timezone from the given IETF zone or common abbreviation.
 
     :param zone: in a strict or a human-friendly format
     :return: the valid IETF timezone properly formatted
     :raise ValueError: when ``zone`` is not a valid timezone
+                       (including empty string and ``None`` value)
 
     Prior to checking timezones, two transformations are made to make the zone
     names more human-friendly:
@@ -58,16 +49,23 @@ def validate_timezone(zone):
     If the zone is not valid, :exc:`ValueError` will be raised.
 
     .. versionadded:: 6.0
+
+    .. versionchanged:: 8.0
+
+        If ``zone`` is ``None``, raises a :exc:`ValueError` as if it was an
+        empty string or an invalid timezone instead of returning ``None``.
+
     """
     if zone is None:
-        return None
+        raise ValueError('Invalid time zone.')
 
     zone = '/'.join(reversed(zone.split(', '))).replace(' ', '_')
     try:
         tz = pytz.timezone(zone)
     except pytz.exceptions.UnknownTimeZoneError:
         raise ValueError('Invalid time zone.')
-    return tz.zone
+
+    return cast(str, tz.zone)
 
 
 def validate_format(tformat: str) -> str:

--- a/test/tools/test_tools_time.py
+++ b/test/tools/test_tools_time.py
@@ -2,11 +2,36 @@
 from __future__ import annotations
 
 import datetime
+from typing import TYPE_CHECKING
 
 import pytest
 import pytz
 
+from sopel.db import SopelDB
 from sopel.tools import time
+
+
+if TYPE_CHECKING:
+    from sopel.config import Config
+
+
+TMP_CONFIG = """
+[core]
+owner = Pepperpots
+db_filename = {db_filename}
+"""
+
+
+@pytest.fixture
+def tmpconfig(configfactory, tmpdir):
+    content = TMP_CONFIG.format(db_filename=tmpdir.join('test.sqlite'))
+    return configfactory('default.cfg', content)
+
+
+@pytest.fixture
+def db(tmpconfig):
+    db = SopelDB(tmpconfig)
+    return db
 
 
 def test_validate_timezone():
@@ -47,6 +72,96 @@ def test_validate_format_none():
         time.validate_format(None)
 
 
+def test_get_nick_timezone(db: SopelDB):
+    nick = 'IronMan'
+    assert time.get_nick_timezone(db, nick) is None
+
+    db.set_nick_value(nick, 'timezone', 'Europe/Paris')
+    assert time.get_nick_timezone(db, nick) == 'Europe/Paris'
+
+    db.set_nick_value(nick, 'timezone', 'Invalid_TZ')
+    assert time.get_nick_timezone(db, nick) is None
+
+
+def test_get_channel_timezone(db: SopelDB):
+    channel = '#test'
+    assert time.get_channel_timezone(db, channel) is None
+
+    db.set_channel_value(channel, 'timezone', 'Europe/Paris')
+    assert time.get_channel_timezone(db, channel) == 'Europe/Paris'
+
+    db.set_channel_value(channel, 'timezone', 'Invalid_TZ')
+    assert time.get_channel_timezone(db, channel) is None
+
+
+def test_get_timezone(db: SopelDB, tmpconfig: Config):
+    zone = 'Europe/Paris'
+    zone_nick = 'America/New_York'
+    zone_channel = 'Asia/Tokyo'
+    nick = 'IronMan'
+    channel = '#test'
+
+    assert time.get_timezone(db) is None
+    assert time.get_timezone(db, tmpconfig) == 'UTC', (
+        'Must use default timezone from config'
+    )
+    assert time.get_timezone(db, tmpconfig, zone) == zone
+    assert time.get_timezone(db, tmpconfig, zone, nick, channel) == zone
+
+    # channel tz when no tz and no nick tz (or tz is invalid)
+    db.set_channel_value(channel, 'timezone', zone_channel)
+    assert time.get_timezone(
+        db, tmpconfig, None, nick, channel
+    ) == zone_channel, 'Channel '
+    assert time.get_timezone(
+        db, tmpconfig, 'Invalid/Tz', nick, channel
+    ) == zone_channel
+
+    # nick tz has priority
+    db.set_nick_value(nick, 'timezone', zone_nick)
+    assert time.get_timezone(db, tmpconfig, None, nick, channel) == zone_nick
+
+
+def test_get_timezone_zone_nick_or_channel(db: SopelDB, tmpconfig):
+    zone_nick = 'America/New_York'
+    zone_channel = 'Asia/Tokyo'
+    nick = 'IronMan'
+    channel = '#test'
+
+    db.set_nick_value(nick, 'timezone', zone_nick)
+    db.set_channel_value(channel, 'timezone', zone_channel)
+
+    # when zone is actually a nick
+    assert time.get_timezone(db, tmpconfig, zone=nick) == zone_nick
+    assert time.get_timezone(
+        db, tmpconfig, zone=nick, channel=channel
+    ) == zone_nick, 'zone argument must have priority over channel arguments'
+    assert time.get_timezone(
+        db, tmpconfig, zone=nick, nick=nick, channel=channel
+    ) == zone_nick, 'zone argument must have priority over other arguments'
+
+    # when zone is actually a channel
+    assert time.get_timezone(db, tmpconfig, zone=channel) == zone_channel
+    assert time.get_timezone(
+        db, tmpconfig, zone=channel, nick=nick
+    ) == zone_channel, 'zone argument must have priority over nick argument'
+    assert time.get_timezone(
+        db, tmpconfig, zone=channel, nick=nick, channel=channel
+    ) == zone_channel, 'zone argument must have priority over other arguments'
+
+
+def test_get_timezone_zone_has_priority(db: SopelDB, tmpconfig: Config):
+    zone = 'Europe/Paris'
+    nick = 'IronMan'
+    channel = '#test'
+
+    db.set_nick_value(nick, 'timezone', 'America/New_York')
+    db.set_channel_value(channel, 'timezone', 'Asia/Tokyo')
+    assert time.get_timezone(db, tmpconfig, zone, nick, channel) == zone, (
+        'zone argument must have priority over other arguments'
+    )
+
+
 UTC = pytz.timezone('UTC')
 PARIS = pytz.timezone('Europe/Paris')
 
@@ -79,8 +194,67 @@ TIME_FORMAT_PAIRS = [
 
 
 @pytest.mark.parametrize('time_arg, result', TIME_FORMAT_PAIRS)
-def test_format_time(time_arg, result):
+def test_format_time(time_arg: datetime.datetime, result: str):
     assert time.format_time(time=time_arg) == result
+
+
+def test_format_time_config_default_format(tmpconfig: Config):
+    time_arg = datetime.datetime(2023, 4, 22, 19, 38, 26)
+    tmpconfig.core.default_time_format = '%Y-%m-%d at %H:%M'
+    assert time.format_time(
+        config=tmpconfig, time=time_arg
+    ) == '2023-04-22 at 19:38'
+
+    # with timezone
+    assert time.format_time(
+        config=tmpconfig, time=time_arg, zone='Europe/Paris',
+    ) == '2023-04-22 at 21:38'
+
+
+def test_format_time_nick_format(tmpconfig: Config, db: SopelDB):
+    nick = 'IronMan'
+    time_arg = datetime.datetime(2023, 4, 22, 19, 38, 26)
+    tmpconfig.core.default_time_format = '%Y-%m-%d at %H:%M'
+    db.set_nick_value(nick, 'time_format', '%H:%M on %h %d of %Y')
+    assert time.format_time(
+        db, config=tmpconfig, nick=nick, time=time_arg
+    ) == '19:38 on Apr 22 of 2023'
+
+    # with timezone
+    assert time.format_time(
+        db, config=tmpconfig, nick=nick, time=time_arg, zone='Europe/Paris',
+    ) == '21:38 on Apr 22 of 2023'
+
+
+def test_format_time_channel_format(tmpconfig: Config, db: SopelDB):
+    nick = 'IronMan'
+    channel = '#test'
+    time_arg = datetime.datetime(2023, 4, 22, 19, 38, 26)
+    tmpconfig.core.default_time_format = '%Y-%m-%d at %H:%M'
+    db.set_channel_value(channel, 'time_format', '%H:%M on %h %d of %Y')
+    assert time.format_time(
+        db, config=tmpconfig, channel=channel, time=time_arg
+    ) == '19:38 on Apr 22 of 2023'
+
+    # with timezone
+    assert time.format_time(
+        db, config=tmpconfig,
+        channel=channel,
+        time=time_arg,
+        zone='Europe/Paris',
+    ) == '21:38 on Apr 22 of 2023'
+
+    # nick has priority
+    db.set_nick_value(nick, 'time_format', '%h %d of %Y at %H:%M')
+    assert time.format_time(
+        db, config=tmpconfig, nick=nick, channel=channel, time=time_arg
+    ) == 'Apr 22 of 2023 at 19:38'
+
+
+def test_format_time_utcnow():
+    result = time.format_time()
+    parsed = datetime.datetime.strptime(result, '%Y-%m-%d - %H:%M:%S +0000')
+    assert result == time.format_time(time=parsed)
 
 
 def test_seconds_to_human():

--- a/test/tools/test_tools_time.py
+++ b/test/tools/test_tools_time.py
@@ -308,6 +308,17 @@ def test_seconds_to_split():
     assert time.seconds_to_split(143659) == (0, 0, 1, 15, 54, 19)
     assert time.seconds_to_split(128000) == (0, 0, 1, 11, 33, 20)
     assert time.seconds_to_split(3000000) == (0, 1, 4, 5, 20, 0)
+    assert time.seconds_to_split(0) == (0, 0, 0, 0, 0, 0)
+
+
+def test_seconds_to_split_duration():
+    duration = time.seconds_to_split(364465915)
+    assert duration.years == 11
+    assert duration.months == 6
+    assert duration.days == 20
+    assert duration.hours == 8
+    assert duration.minutes == 31
+    assert duration.seconds == 55
 
 
 def test_get_time_unit():

--- a/test/tools/test_tools_time.py
+++ b/test/tools/test_tools_time.py
@@ -42,11 +42,10 @@ def test_validate_timezone():
     assert time.validate_timezone('Israel') == 'Israel'
 
 
-def test_validate_timezone_none():
-    assert time.validate_timezone(None) is None
-
-
 def test_validate_timezone_invalid():
+    with pytest.raises(ValueError):
+        time.validate_timezone(None)
+
     with pytest.raises(ValueError):
         time.validate_timezone('Invalid/Timezone')
 


### PR DESCRIPTION
### Evolved description

- **Breaking:** `validate_timezone()` raises `ValueError` even if passed `None` now, instead of returning `None`
- "Duration" named tuple returned from `seconds_to_split()` function
- Added tests to cover original & fixed behaviors

### Original description

Tin. Oh, and also I added type annotations and fixed the resulting type errors.

I ensure that the tests all pass on the current version of `sopel.tools.time`, **then** I added type annotations, so there is a guarantee that it works pretty much as it did before... except for a bug I fixed where you could call a function without a `db` and it would raise an `AttributeError` because `NoneType` doesn't have the right method.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
