### PR TITLE
find: fix flags in pipe-separated substitutions

### DIFF
--- a/sopel/modules/find.py
+++ b/sopel/modules/find.py
@@ -147,7 +147,7 @@ def kick_cleanup(bot, trigger):
              (?P<new>         # Group 4 is what to replace with
                (?:\\\||[^|])* # One or more non-pipe or escaped pipe
              )
-             (?:|             # Optional separator followed by group 5 (flags)
+             (?:\|            # Optional separator followed by group 5 (flags)
                 (?P<flags>\S+)
              )?
             """)

--- a/sopel/modules/find.py
+++ b/sopel/modules/find.py
@@ -122,32 +122,32 @@ def kick_cleanup(bot, trigger):
 # If you want to search for an actual slash AND a pipe in the same message,
 # you can escape your separator, in old and/or new.
 @plugin.rule(r"""(?:
-             (?P<nick>\S+)    # Catch a nick in group 1
-             [:,]\s+)?        # Followed by optional colon/comma and whitespace
-             s(?P<sep>/)      # The literal s and a separator / as group 2
-             (?P<old>         # Group 3 is the thing to find
-               (?:\\/|[^/])+  # One or more non-slashes or escaped slashes
+             (?P<nick>\S+)     # Catch a nick in group 1
+             [:,]\s+)?         # Followed by optional colon/comma and whitespace
+             s(?P<sep>/)       # The literal s and a separator / as group 2
+             (?P<old>          # Group 3 is the thing to find
+               (?:\\/|[^/])+   # One or more non-slashes or escaped slashes
              )
-             /                # The separator again
-             (?P<new>         # Group 4 is what to replace with
-               (?:\\/|[^/])*  # One or more non-slashes or escaped slashes
+             /                 # The separator again
+             (?P<new>          # Group 4 is what to replace with
+               (?:\\/|[^/])*   # One or more non-slashes or escaped slashes
              )
-             (?:/             # Optional separator followed by group 5 (flags)
+             (?:/              # Optional separator followed by group 5 (flags)
                 (?P<flags>\S+)
              )?
             """)
 @plugin.rule(r"""(?:
-             (?P<nick>\S+)    # Catch a nick in group 1
-             [:,]\s+)?        # Followed by optional colon/comma and whitespace
-             s(?P<sep>\|)     # The literal s and a separator | as group 2
-             (?P<old>         # Group 3 is the thing to find
+             (?P<nick>\S+)     # Catch a nick in group 1
+             [:,]\s+)?         # Followed by optional colon/comma and whitespace
+             s(?P<sep>\|)      # The literal s and a separator | as group 2
+             (?P<old>          # Group 3 is the thing to find
                (?:\\\||[^|])+  # One or more non-pipe or escaped pipe
              )
-             \|               # The separator again
-             (?P<new>         # Group 4 is what to replace with
-               (?:\\\||[^|])* # One or more non-pipe or escaped pipe
+             \|                # The separator again
+             (?P<new>          # Group 4 is what to replace with
+               (?:\\\||[^|])*  # One or more non-pipe or escaped pipe
              )
-             (?:\|            # Optional separator followed by group 5 (flags)
+             (?:\|             # Optional separator followed by group 5 (flags)
                 (?P<flags>\S+)
              )?
             """)


### PR DESCRIPTION
### Description
Unescaped `|` was messing up capturing the flags at the end of the line.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
Introduced in #1993, first released in v7.1.0. Should be backported _if_ we make a 7.1.10 release (but I'm still not planning one).