### PR TITLE
core: better bot-mode handling

### DIFF
--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -103,15 +103,15 @@ To have Sopel set additional user modes upon connection, use the
 :attr:`~CoreSection.modes` setting::
 
     [core]
-    modes = BpR
+    modes = pR
 
 In this example, upon connection to the IRC server, Sopel will send this::
 
-    MODE Sopel +BpR
+    MODE Sopel +pR
 
-Which means: this is a Bot (B), don't show channels it is in (p), and only
-registered users (R) can send it messages. The list of supported modes depends
-on the IRC server the bot connects to.
+Which means: don't show channels this user is in (p), and only registered
+users (R) can send it messages. The list of supported modes depends on the IRC
+server the bot connects to.
 
 .. important::
 
@@ -123,6 +123,17 @@ on the IRC server the bot connects to.
 
    .. __: https://libera.chat/guides/usermodes
    .. __: https://www.unrealircd.org/docs/User_modes
+
+.. note::
+
+   As of version 8.0, Sopel automatically informs networks that it is a bot if
+   `the BOT feature flag`__ is advertised.
+
+   On nonstandard networks that *have* a "bot" mode character but *do not*
+   advertise it in ISUPPORT, the ``modes`` setting can be used to disclose
+   that your Sopel instance is a bot.
+
+   .. __: https://ircv3.net/specs/extensions/bot-mode#the-bot-isupport-token
 
 Owner & Admins
 --------------

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -949,13 +949,19 @@ class CoreSection(StaticSection):
 
     """
 
-    modes = ValidatedAttribute('modes', default='B')
+    modes = ValidatedAttribute('modes')
     """User modes to be set on connection.
-
-    :default: ``B``
 
     Include only the mode letters; this value is automatically prefixed with
     ``+`` before Sopel sends the MODE command to IRC.
+
+    .. versionchanged:: 8.0.0
+
+        Now empty by default. Previous default was ``B``, which has been
+        dropped in favor of the formal `bot mode specification`__.
+
+        .. __: https://ircv3.net/specs/extensions/bot-mode
+
     """
 
     name = ValidatedAttribute('name', default='Sopel: https://sopel.chat/')

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -1489,12 +1489,17 @@ def recv_whox(bot, trigger):
             "While populating `bot.accounts` a WHO response was malformed.")
         return
     _, _, channel, user, host, nick, status, account, realname = trigger.args
+    botmode = bot.isupport.get('BOT')
     away = 'G' in status
+    is_bot = (botmode in status) if botmode else None
     modes = ''.join([c for c in status if c in '~&@%+!'])
-    _record_who(bot, channel, user, host, nick, realname, account, away, modes)
+    _record_who(bot, channel, user, host, nick, realname, account, away, is_bot, modes)
 
 
-def _record_who(bot, channel, user, host, nick, realname=None, account=None, away=None, modes=None):
+def _record_who(
+    bot, channel, user, host, nick, realname=None,
+    account=None, away=None, is_bot=None, modes=None,
+):
     nick = bot.make_identifier(nick)
     channel = bot.make_identifier(channel)
     if nick not in bot.users:
@@ -1515,6 +1520,8 @@ def _record_who(bot, channel, user, host, nick, realname=None, account=None, awa
         usr.account = account
     if away is not None:
         usr.away = away
+    if is_bot is not None:
+        usr.is_bot = is_bot
     priv = 0
     if modes:
         mapping = {
@@ -1543,10 +1550,15 @@ def _record_who(bot, channel, user, host, nick, realname=None, account=None, awa
 def recv_who(bot, trigger):
     """Track ``WHO`` responses when ``WHOX`` is not enabled."""
     channel, user, host, _, nick, status = trigger.args[1:7]
+    botmode = bot.isupport.get('BOT')
     realname = trigger.args[-1].partition(' ')[-1]
     away = 'G' in status
+    is_bot = (botmode in status) if botmode else None
     modes = ''.join([c for c in status if c in '~&@%+!'])
-    _record_who(bot, channel, user, host, nick, realname, away=away, modes=modes)
+    _record_who(
+        bot, channel, user, host, nick, realname,
+        away=away, is_bot=is_bot, modes=modes,
+    )
 
 
 @plugin.event('AWAY')

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -38,6 +38,7 @@ from sopel.tools import events, jobs, SopelMemory, target
 
 if TYPE_CHECKING:
     from sopel.bot import Sopel, SopelWrapper
+    from sopel.tools import Identifier
     from sopel.trigger import Trigger
 
 
@@ -1497,8 +1498,16 @@ def recv_whox(bot, trigger):
 
 
 def _record_who(
-    bot, channel, user, host, nick, realname=None,
-    account=None, away=None, is_bot=None, modes=None,
+    bot: Sopel,
+    channel: Identifier,
+    user: str,
+    host: str,
+    nick: str,
+    realname: Optional[str] = None,
+    account: Optional[str] = None,
+    away: Optional[bool] = None,
+    is_bot: Optional[bool] = None,
+    modes: Optional[str] = None,
 ):
     nick = bot.make_identifier(nick)
     channel = bot.make_identifier(channel)

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -33,13 +33,13 @@ class User:
         host: Optional[str],
     ) -> None:
         assert isinstance(nick, identifiers.Identifier)
-        self.nick = nick
+        self.nick: identifiers.Identifier = nick
         """The user's nickname."""
-        self.user = user
+        self.user: Optional[str] = user
         """The user's local username."""
-        self.host = host
+        self.host: Optional[str] = host
         """The user's hostname."""
-        self.realname = None
+        self.realname: Optional[str] = None
         """The user's realname.
 
         Will be ``None`` if not received from the server yet.
@@ -50,12 +50,12 @@ class User:
         This maps channel name :class:`~sopel.tools.identifiers.Identifier`\\s
         to :class:`Channel` objects.
         """
-        self.account = None
+        self.account: Optional[str] = None
         """The IRC services account of the user.
 
         This relies on IRCv3 account tracking being enabled.
         """
-        self.away = None
+        self.away: Optional[bool] = None
         """Whether the user is marked as away."""
         self.is_bot: Optional[bool] = None
         """Whether the user is flagged as a bot.
@@ -64,9 +64,15 @@ class User:
         server does not support a 'bot' user mode.
         """
 
-    hostmask = property(lambda self: '{}!{}@{}'.format(self.nick, self.user,
-                                                       self.host))
-    """The user's full hostmask."""
+    @property
+    def hostmask(self) -> str:
+        """The user's full hostmask (``nick!user@host``)."""
+        # TODO: this won't work as expected if `user`/`host` is still `None`
+        return '{}!{}@{}'.format(
+            self.nick,
+            self.user,
+            self.host,
+        )
 
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, User):
@@ -105,7 +111,7 @@ class Channel:
         identifier_factory: IdentifierFactory = identifiers.Identifier,
     ) -> None:
         assert isinstance(name, identifiers.Identifier)
-        self.name = name
+        self.name: identifiers.Identifier = name
         """The name of the channel."""
 
         self.make_identifier: IdentifierFactory = identifier_factory
@@ -139,7 +145,7 @@ class Channel:
         bitwise integer values. This can be compared to appropriate constants
         from :mod:`sopel.privileges`.
         """
-        self.topic = ''
+        self.topic: str = ''
         """The topic of the channel."""
 
         self.modes: Dict[str, Union[Set, str, bool]] = {}

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -23,7 +23,7 @@ class User:
     :param str host: the user's hostname ("host.name" in `user@host.name`)
     """
     __slots__ = (
-        'nick', 'user', 'host', 'realname', 'channels', 'account', 'away',
+        'nick', 'user', 'host', 'realname', 'channels', 'account', 'away', 'is_bot',
     )
 
     def __init__(
@@ -57,6 +57,12 @@ class User:
         """
         self.away = None
         """Whether the user is marked as away."""
+        self.is_bot: Optional[bool] = None
+        """Whether the user is flagged as a bot.
+
+        Will be ``None`` if the user hasn't yet been WHOed, or if the IRC
+        server does not support a 'bot' user mode.
+        """
 
     hostmask = property(lambda self: '{}!{}@{}'.format(self.nick, self.user,
                                                        self.host))

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -36,13 +36,22 @@ class User:
         self.nick: identifiers.Identifier = nick
         """The user's nickname."""
         self.user: Optional[str] = user
-        """The user's local username."""
+        """The user's local username.
+
+        Will be ``None`` if Sopel has not yet received complete user
+        information from the IRC server.
+        """
         self.host: Optional[str] = host
-        """The user's hostname."""
+        """The user's hostname.
+
+        Will be ``None`` if Sopel has not yet received complete user
+        information from the IRC server.
+        """
         self.realname: Optional[str] = None
         """The user's realname.
 
-        Will be ``None`` if not received from the server yet.
+        Will be ``None`` if Sopel has not yet received complete user
+        information from the IRC server.
         """
         self.channels: Dict[identifiers.Identifier, 'Channel'] = {}
         """The channels the user is in.
@@ -54,9 +63,16 @@ class User:
         """The IRC services account of the user.
 
         This relies on IRCv3 account tracking being enabled.
+
+        Will be ``None`` if the user is not logged into an account (including
+        when account tracking is not supported by the IRC server.)
         """
         self.away: Optional[bool] = None
-        """Whether the user is marked as away."""
+        """Whether the user is marked as away.
+
+        Will be ``None`` if the user's current away state hasn't been
+        established yet (via WHO or other means such as ``away-notify``).
+        """
         self.is_bot: Optional[bool] = None
         """Whether the user is flagged as a bot.
 

--- a/test/tools/test_tools_target.py
+++ b/test/tools/test_tools_target.py
@@ -5,6 +5,22 @@ from sopel import plugin
 from sopel.tools import Identifier, target
 
 
+def test_user():
+    nick = Identifier('River')
+    username = 'tamr'
+    host = 'good.ship.serenity'
+    user = target.User(nick, username, host)
+
+    assert user.nick == nick
+    assert user.user == username
+    assert user.host == host
+    assert user.realname is None
+    assert user.channels == {}
+    assert user.account is None
+    assert user.away is None
+    assert user.is_bot is None
+
+
 def test_channel():
     name = Identifier('#chan')
     channel = target.Channel(name)


### PR DESCRIPTION
### Description
Sending mode `+B` by default is pretty silly. As of #2088 we should have stopped doing so. Now we will.

More importantly, WHO replies contain a bot flag on servers that support the bot-mode spec; it's indicated by the same character as the modechar advertised in ISupport's `BOT` token. We should track that—and you guessed it: this patch adds an `is_bot` attribute to `User` objects.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
I'm hoping to write some more tests when I have time, because this part of coretasks seems pretty under-tested. Therefore, I'm starting the patch as a draft, to collect feedback until I get to that step.