### PR TITLE
translate: Make help more helpful about language :hints

### DIFF
--- a/sopel/modules/translate.py
+++ b/sopel/modules/translate.py
@@ -142,16 +142,16 @@ def tr(bot, trigger):
 @plugin.command('translate', 'tr')
 @plugin.example('.tr :en :fr my dog',
                 '"mon chien" (en to fr, translate.google.com)',
-                online=True, vcr=True)
+                online=True, vcr=True, user_help=True)
 @plugin.example('.tr מחשב',
                 '"computer" (iw to en, translate.google.com)',
                 online=True, vcr=True)
 @plugin.example('.tr mon chien',
                 '"my dog" (fr to en, translate.google.com)',
-                online=True, vcr=True)
+                online=True, vcr=True, user_help=True)
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def tr2(bot, trigger):
-    """Translates a phrase, with an optional language hint."""
+    """Translates a phrase, with an optional language :hint."""
     command = trigger.group(2)
 
     if not command:


### PR DESCRIPTION
### Description
Don't make me PM the bot to not even be reminded how .tr wants language hints.

You may now discuss whether we should reorder the examples, have one or two hints, why we don't have a `@plugin.help("Something less docstring-ish here")`, etc. in comments.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
