### PR TITLE
build: pin urllib3 to <2.0 for now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ dependencies = [
     "praw>=4.0.0,<8.0.0",
     "geoip2>=4.0,<5.0",
     "requests>=2.24.0,<3.0.0",
+    "urllib3<2.0",  # TODO: unpin when vcrpy etc. will tolerate it
     "dnspython<3.0",
     "sqlalchemy>=1.4,<1.5",
     "importlib_metadata>=3.6",


### PR DESCRIPTION
CI is broken with urllib3 2.x, but the specific package that fails our tests (vcrpy) is not moving very swiftly to release a fix.

While they debate which versions of urllib3 to support, we just want to have working CI so we can start merging our slowly growing PR backlog.

Because urllib3 is a transitive dependency of requests, it belongs in the regular requirement list even though this pin is to fix tests.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
This has been blocking us for about two weeks, and that's more than long enough to warrant a temporary dependency pin (even though I prefer to avoid them, in general). I'm subscribed to the upstream issue already [pointed out by @SnoopJ](https://github.com/sopel-irc/sopel/pull/2434#issuecomment-1541338658), for notifications relevant to undoing this.