### PR TITLE
test: cover obvious SASL PLAIN edge cases

### DIFF
--- a/test/coretasks/test_coretasks_cap.py
+++ b/test/coretasks/test_coretasks_cap.py
@@ -1,4 +1,4 @@
-"""Test behavior of SASL by ``sopel.coretasks``"""
+"""Test behavior of CAP management by ``sopel.coretasks``"""
 from __future__ import annotations
 
 from typing import Tuple, TYPE_CHECKING

--- a/test/coretasks/test_coretasks_sasl.py
+++ b/test/coretasks/test_coretasks_sasl.py
@@ -319,6 +319,16 @@ def test_sasl_plain_nonempty_server_message(
     ), ('Bot must abort SASL PLAIN auth if server reply to starting '
         'AUTHENTICATE PLAIN is not as expected per SASL spec')
 
+    # per spec, server should send ERR_SASLABORTED
+    n = len(mockbot.backend.message_sent)
+    mockbot.on_message(
+        ':irc.example.com 906 TestBot :SASL authentication aborted')
+    assert mockbot.backend.message_sent[n:] == rawlist(
+        'CAP END',
+        'QUIT :SASL Auth Failed',
+    ), ('Sopel must finish capability negotiation after SASL even if aborted, '
+        'and then QUIT because auth failed')
+
 
 def test_sasl_nak(botfactory: BotFactory, tmpconfig) -> None:
     mockbot = botfactory.preloaded(tmpconfig, preloads=['coretasks'])


### PR DESCRIPTION
The major edge cases handled in Sopel's SASL PLAIN code are:

- Unexpected continuation message from the server (`AUTHENTICATE PLAIN` ack'd by something other than `AUTHENTICATE +`)
- Very long password that b64encodes to exactly 400 bytes
- Very long password that b64encodes to over 400 bytes

IRCv3 recently merging [a patch to add an example](https://github.com/ircv3/ircv3-specifications/pull/521) of split token negotiation inspired me to cover that in our behavior tests.

Along the way I fixed a couple typos, and realized it would also be pretty easy to validate Sopel aborting SASL PLAIN on a non-empty message from the server.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - This change is literally tests, so it tested itself 😁

### Notes
Big thanks to @Exirel for writing tests of the main SASL PLAIN codepath, which I copied and adapted to cover these edge cases.