### PR TITLE
tools.calculation: replace deprecated `ast.Num` with `ast.Constant`

### DIFF
--- a/sopel/tools/calculation.py
+++ b/sopel/tools/calculation.py
@@ -57,8 +57,11 @@ class ExpressionEvaluator:
         A subclass could overwrite this to handle more nodes, calling it only
         for nodes it does not implement itself.
         """
-        if isinstance(node, ast.Num):
-            return node.n
+        if (
+            isinstance(node, ast.Constant) and
+            isinstance(node.value, (int, float))
+        ):
+            return node.value
 
         elif (isinstance(node, ast.BinOp) and
                 type(node.op) in self.binary_ops):
@@ -78,7 +81,7 @@ class ExpressionEvaluator:
             return self.unary_ops[type(node.op)](operand)
 
         raise ExpressionEvaluator.Error(
-            "Ast.Node '%s' not implemented." % (type(node).__name__,))
+            "ast.Node '%s' not implemented." % (type(node).__name__,))
 
 
 def guarded_mul(left, right):


### PR DESCRIPTION
`ast.Num` and friends have been deprecated since Python 3.8, but only started to generate warnings in Python 3.12 prereleases.

Feels like stdlib made a bad trade here, simplifying Python internals in exchange for making users write uglier, more complicated type checks such as this. But it's been so long, it's not as if they'll un-deprecate the older, more-convenient-for-the-user classes.

### Compatibility
I was under the impression that `ast.Constant` would work as far back as Python 3.6, but apparently not. This change has to wait until we're ready to drop Python 3.7.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches