### PR TITLE
Replace uses of deprecated `datetime.utcnow()`

### DIFF
--- a/docs/source/plugin/time.rst
+++ b/docs/source/plugin/time.rst
@@ -14,8 +14,6 @@ Here is a full example of that, adapted from the built-in ``.t`` command::
 
     import datetime
 
-    import pytz
-
     from sopel import plugin
     from sopel.tools.time import format_time, get_timezone
 
@@ -24,7 +22,7 @@ Here is a full example of that, adapted from the built-in ``.t`` command::
     @plugin.require_chanmsg
     def my_command(bot, trigger):
         """Give time in a channel."""
-        time = pytz.UTC.localize(datetime.datetime.utcnow())
+        time = datetime.datetime.now(datetime.timezone.utc)
         timezone = get_timezone(
             bot.db,
             bot.settings,

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -8,7 +8,7 @@
 from __future__ import annotations
 
 from ast import literal_eval
-import datetime
+from datetime import datetime, timezone
 import inspect
 import itertools
 import logging
@@ -1045,7 +1045,7 @@ class Sopel(irc.AbstractBot):
 
         if trigger:
             message = '{} from {} at {}. Message was: {}'.format(
-                message, trigger.nick, str(datetime.datetime.utcnow()), trigger.group(0)
+                message, trigger.nick, str(datetime.now(timezone.utc)), trigger.group(0)
             )
 
         LOGGER.exception(message)

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -25,7 +25,7 @@ from __future__ import annotations
 import base64
 import collections
 import copy
-import datetime
+from datetime import datetime, timedelta, timezone
 import functools
 import logging
 import re
@@ -906,7 +906,7 @@ def _send_who(bot, mask):
 
     target_id = bot.make_identifier(mask)
     if not target_id.is_nick():
-        bot.channels[target_id].last_who = datetime.datetime.utcnow()
+        bot.channels[target_id].last_who = datetime.now(timezone.utc)
 
 
 @plugin.interval(30)
@@ -916,10 +916,10 @@ def _periodic_send_who(bot):
         # WHO not needed to update 'away' status
         return
 
-    # Loops through the channels to find the one that has the longest time since the last WHO
-    # request, and issues a WHO request only if the last request for the channel was more than
+    # Loop through the channels to find the one that has the longest time since the last WHO
+    # request, and issue a WHO request only if the last request for the channel was more than
     # 120 seconds ago.
-    who_trigger_time = datetime.datetime.utcnow() - datetime.timedelta(seconds=120)
+    who_trigger_time = datetime.now(timezone.utc) - timedelta(seconds=120)
     selected_channel = None
     for channel_name, channel in bot.channels.items():
         if channel.last_who is None:

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -32,7 +32,7 @@ from __future__ import annotations
 
 import abc
 from collections import deque
-from datetime import datetime
+from datetime import datetime, timezone
 import logging
 import os
 import threading
@@ -471,7 +471,7 @@ class AbstractBot(abc.ABC):
             # quit if too many errors
             dt_seconds: float = 0.0
             if self.last_error_timestamp is not None:
-                dt = datetime.utcnow() - self.last_error_timestamp
+                dt = datetime.now(timezone.utc) - self.last_error_timestamp
                 dt_seconds = dt.total_seconds()
 
             if dt_seconds < 5:
@@ -480,7 +480,7 @@ class AbstractBot(abc.ABC):
             # remove 1 error per full 5s that passed since last error
             self.error_count = int(max(0, self.error_count - dt_seconds // 5))
 
-        self.last_error_timestamp = datetime.utcnow()
+        self.last_error_timestamp = datetime.now(timezone.utc)
         self.error_count = self.error_count + 1
 
     def rebuild_nick(self) -> None:

--- a/sopel/modules/remind.py
+++ b/sopel/modules/remind.py
@@ -9,7 +9,7 @@ https://sopel.chat
 from __future__ import annotations
 
 import collections
-from datetime import datetime
+from datetime import datetime, timezone
 import io  # don't use `codecs` for loading the DB; it will split lines on some IRC formatting
 import logging
 import os
@@ -263,7 +263,7 @@ def remind_in(bot, trigger):
             timezone,
             trigger.nick,
             trigger.sender,
-            datetime.utcfromtimestamp(timestamp))
+            datetime.fromtimestamp(timestamp, timezone.utc))
         bot.reply('Okay, will remind at %s' % human_time)
     else:
         bot.reply('Okay, will remind in %s secs' % duration)
@@ -495,7 +495,7 @@ def remind_at(bot, trigger):
             reminder.timezone.zone,
             trigger.nick,
             trigger.sender,
-            datetime.utcfromtimestamp(timestamp))
+            datetime.fromtimestamp(timestamp, timezone.utc))
         bot.reply('Okay, will remind at %s' % human_time)
     else:
         bot.reply('Okay, will remind in %s secs' % duration)

--- a/sopel/modules/uptime.py
+++ b/sopel/modules/uptime.py
@@ -7,14 +7,14 @@ https://sopel.chat
 """
 from __future__ import annotations
 
-import datetime
+from datetime import datetime, timedelta, timezone
 
 from sopel import plugin
 
 
 def setup(bot):
     if "start_time" not in bot.memory:
-        bot.memory["start_time"] = datetime.datetime.utcnow()
+        bot.memory["start_time"] = datetime.now(timezone.utc)
 
 
 @plugin.command('uptime')
@@ -22,7 +22,7 @@ def setup(bot):
 @plugin.output_prefix('[uptime] ')
 def uptime(bot, trigger):
     """Return the uptime of Sopel."""
-    delta = datetime.timedelta(seconds=round((datetime.datetime.utcnow() -
-                                              bot.memory["start_time"])
-                                             .total_seconds()))
+    delta = timedelta(seconds=round((datetime.now(timezone.utc) -
+                                    bot.memory["start_time"])
+                                    .total_seconds()))
     bot.say("I've been sitting here for {} and I keep going!".format(delta))

--- a/sopel/tools/time.py
+++ b/sopel/tools/time.py
@@ -57,10 +57,10 @@ class Duration(NamedTuple):
 
 
 def validate_timezone(zone: Optional[str]) -> str:
-    """Return an IETF timezone from the given IETF zone or common abbreviation.
+    """Normalize and validate an IANA timezone name.
 
     :param zone: in a strict or a human-friendly format
-    :return: the valid IETF timezone properly formatted
+    :return: the valid IANA timezone properly formatted
     :raise ValueError: when ``zone`` is not a valid timezone
                        (including empty string and ``None`` value)
 
@@ -107,7 +107,7 @@ def validate_format(tformat: str) -> str:
     .. versionadded:: 6.0
     """
     try:
-        time = datetime.datetime.utcnow()
+        time = datetime.datetime.now(datetime.timezone.utc)
         time.strftime(tformat)
     except (ValueError, TypeError):
         raise ValueError('Invalid time format.')
@@ -232,7 +232,7 @@ def format_time(
     :param channel: channel whose time format to use, if set (optional)
     :param time: the time value to format (optional)
 
-    ``time``, if given, should be a ``datetime.datetime`` object, and will be
+    ``time``, if given, should be a ``~datetime.datetime`` object, and will be
     treated as being in the UTC timezone if it is :ref:`naïve
     <datetime-naive-aware>`. If ``time`` is not given, the current time will
     be used.
@@ -257,7 +257,7 @@ def format_time(
 
     # get an aware datetime
     if not time:
-        time = pytz.utc.localize(datetime.datetime.utcnow())
+        time = datetime.datetime.now(datetime.timezone.utc)
     elif not time.tzinfo:
         time = pytz.utc.localize(time)
 

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -9,7 +9,7 @@ aid of Sopel's core development.
 """
 from __future__ import annotations
 
-import datetime
+from datetime import datetime, timezone
 import re
 from typing import (
     Callable,
@@ -190,17 +190,15 @@ class PreTrigger:
                     self.tags[tag[0]] = None
 
         # Client time or server time
-        self.time = datetime.datetime.utcnow().replace(
-            tzinfo=datetime.timezone.utc
-        )
+        self.time = datetime.now(timezone.utc)
         if 'time' in self.tags:
             # ensure "time" is a string (typecheck)
             tag_time = self.tags['time'] or ''
             try:
-                self.time = datetime.datetime.strptime(
+                self.time = datetime.strptime(
                     tag_time,
                     "%Y-%m-%dT%H:%M:%S.%fZ",
-                ).replace(tzinfo=datetime.timezone.utc)
+                ).replace(tzinfo=timezone.utc)
             except ValueError:
                 pass  # Server isn't conforming to spec, ignore the server-time
 

--- a/test/plugins/test_plugins_rules.py
+++ b/test/plugins/test_plugins_rules.py
@@ -5,7 +5,6 @@ import datetime
 import re
 
 import pytest
-import pytz
 
 from sopel import bot, loader, plugin, trigger
 from sopel.plugins import rules
@@ -469,7 +468,7 @@ def test_manager_has_action_command_aliases():
 # tests for :class:`Manager`
 
 def test_rulemetrics():
-    now = pytz.utc.localize(datetime.datetime.utcnow())
+    now = datetime.datetime.now(datetime.timezone.utc)
     time_window = datetime.timedelta(seconds=3600)
     metrics = rules.RuleMetrics()
 

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -1556,7 +1556,7 @@ def test_user_quit(
 
     assert 'MrPraline' in mockbot.channels['#test'].users
 
-    servertime = datetime.utcnow() + timedelta(seconds=10)
+    servertime = datetime.now(timezone.utc) + timedelta(seconds=10)
     mockbot.on_message(
         "@time={servertime} :{user} QUIT :Ping timeout: 246 seconds".format(
             servertime=servertime.strftime('%Y-%m-%dT%H:%M:%SZ'),


### PR DESCRIPTION
### Description
As @SnoopJ mentioned on IRC right after opening #2457, `datetime.utcnow()` is deprecated in Python 3.12 (and also `datetime.utcfromtimestamp()`). The recommended replacements for those items have been usable for most of Python 3's history—though we don't get to use`datetime.UTC` instead of `datetime.timezone.utc` until Python 3.11 is our minimum version.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
As often happens when I poke at stuff, there are some minor documentation corrections lumped in here that I didn't think warranted (a) separate PR(s).

I wanted to go further with this and get rid of `pytz`, but [`zoneinfo`](https://docs.python.org/3.9/library/zoneinfo.html) isn't available until Python 3.9. (There is a [`backports.zoneinfo`](https://pypi.org/project/backports.zoneinfo/) package, but it hasn't been updated in a while and its issue tracker is starting to fill with reports of errors & warnings.)