### PR TITLE
remind: fix import streamlining gone haywire

### DIFF
--- a/sopel/modules/remind.py
+++ b/sopel/modules/remind.py
@@ -9,7 +9,7 @@ https://sopel.chat
 from __future__ import annotations
 
 import collections
-from datetime import datetime, timezone
+import datetime
 import io  # don't use `codecs` for loading the DB; it will split lines on some IRC formatting
 import logging
 import os
@@ -263,7 +263,7 @@ def remind_in(bot, trigger):
             timezone,
             trigger.nick,
             trigger.sender,
-            datetime.fromtimestamp(timestamp, timezone.utc))
+            datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc))
         bot.reply('Okay, will remind at %s' % human_time)
     else:
         bot.reply('Okay, will remind in %s secs' % duration)
@@ -396,7 +396,7 @@ class TimeReminder:
 
         """
         if not today:
-            today = datetime.now(self.timezone)
+            today = datetime.datetime.now(self.timezone)
         else:
             today = today.astimezone(self.timezone)
 
@@ -404,7 +404,7 @@ class TimeReminder:
         month = self.month if self.month is not None else today.month
         day = self.day if self.day is not None else today.day
 
-        at_time = datetime(
+        at_time = datetime.datetime(
             year, month, day,
             self.hour, self.minute, self.second,
             tzinfo=today.tzinfo)
@@ -495,7 +495,7 @@ def remind_at(bot, trigger):
             reminder.timezone.zone,
             trigger.nick,
             trigger.sender,
-            datetime.fromtimestamp(timestamp, timezone.utc))
+            datetime.datetime.fromtimestamp(timestamp, datetime.timezone.utc))
         bot.reply('Okay, will remind at %s' % human_time)
     else:
         bot.reply('Okay, will remind in %s secs' % duration)

--- a/test/modules/test_modules_remind.py
+++ b/test/modules/test_modules_remind.py
@@ -81,7 +81,7 @@ VALID_MATCH_LINES = (
             13, 37, 0, 'Europe/Paris', None, None, None, 'message'
         ),
     ),
-    # These should not pass but we are very tolerant a the moment
+    # These should not pass but we are very tolerant at the moment
     ('1:7 message',
      remind.TimeReminder(1, 7, 0, 'UTC', None, None, None, 'message')),
     ('13:7 message',


### PR DESCRIPTION
"Unexpected AttributeError: 'str' object has no attribute 'utc'" begone.

Fixes a bug I introduced in #2468 by not being careful enough with my imports. Code review or not, I should've caught it. (And I was reminded to finish/open this PR by `mypy --check-untyped-defs` flagging these errors, so that's all the more reason to work toward #2461 in the longer term.)

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes
`mypy --check-untyped-defs` still reports errors in `sopel/modules/remind.py` after this patch, but they'll be fixed separately. @SnoopJ and I have been chipping away at that list over the weekend.