### PR TITLE
safety, url: skip handling invalid links with empty hostnames

### DIFF
--- a/sopel/modules/safety.py
+++ b/sopel/modules/safety.py
@@ -231,7 +231,7 @@ def url_handler(bot: SopelWrapper, trigger: Trigger):
 
         try:
             hostname = urlparse(url).hostname.lower()
-        except ValueError:
+        except (ValueError, AttributeError):
             pass  # Invalid address
         else:
             if any(regex.search(hostname) for regex in known_good):

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -343,7 +343,8 @@ def title_auto(bot: SopelWrapper, trigger: Trigger):
         # Avoid fetching known malicious links
         if url in safety_cache and safety_cache[url]["positives"] > 0:
             continue
-        if urlparse(url).hostname.lower() in safety_cache_local:
+        parsed = urlparse(url)
+        if not parsed.hostname or parsed.hostname.lower() in safety_cache_local:
             continue
         urls.append(url)
 


### PR DESCRIPTION
### Description

This PR fixes an edge-case in `url` and `safety` when the result of `urlparse` has a `hostname` of `None`

```
19:20 <+dgw> https://?bonk
19:20 <+Sopel> Unexpected AttributeError ('NoneType' object has no attribute 'lower') from dgw at 2023-06-13 23:20:54.685361+00:00. Message was: https://?bonk
19:20 <+Sopel> Unexpected AttributeError ('NoneType' object has no attribute 'lower') from dgw at 2023-06-13 23:20:54.705164+00:00. Message was: https://?bonk
```

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - This also doesn't seem to introduce any new failure to `mypy` over Sopel's codebase
- [x] I have tested the functionality of the things this change touches
