### PR TITLE
bot: don't add duplicate timestamp into error log line

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -8,7 +8,6 @@
 from __future__ import annotations
 
 from ast import literal_eval
-from datetime import datetime, timezone
 import inspect
 import itertools
 import logging
@@ -1052,8 +1051,8 @@ class Sopel(irc.AbstractBot):
             message = 'Unexpected {}{}'.format(type(exception).__name__, detail)
 
         if trigger:
-            message = '{} from {} at {}. Message was: {}'.format(
-                message, trigger.nick, str(datetime.now(timezone.utc)), trigger.group(0)
+            message = '{} from {}. Message was: {}'.format(
+                message, trigger.nick, trigger.group(0)
             )
 
         LOGGER.exception(message)


### PR DESCRIPTION
If a Trigger causes an error in a plugin, we already know when the error happened because the logger call is timestamped. The error as reported to IRC also is timestamped, and `datetime.now()` is not useful data.

(It is, however, confusing data. Considered replacing it with `trigger.time` but decided against that, since `server-time` means those could be in the past/future, making the timestamp embedded in the log message even *more* confusing instead of less.)

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches