### PR TITLE
Cherry-pick: Drop `imp` usage on 7.1.x branch

### DIFF
--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -44,21 +44,17 @@ away from the rest of the application.
 # Licensed under the Eiffel Forum License 2.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import imp
+import abc
 import importlib
+import importlib.util
 import inspect
 import itertools
 import os
+import sys
+from typing import Optional
 
 from sopel import loader
 from . import exceptions
-
-try:
-    reload = importlib.reload
-except AttributeError:
-    # py2: no reload function
-    # TODO: imp is deprecated, to be removed when py2 support is dropped
-    reload = imp.reload
 
 
 class AbstractPluginHandler(object):
@@ -301,7 +297,7 @@ class PyModulePlugin(AbstractPluginHandler):
 
         This method assumes the plugin is already loaded.
         """
-        self._module = reload(self._module)
+        self._module = importlib.reload(self._module)
 
     def is_loaded(self):
         return self._module is not None
@@ -402,45 +398,31 @@ class PyFilePlugin(PyModulePlugin):
 
         if good_file:
             name = os.path.basename(filename)[:-3]
-            module_type = imp.PY_SOURCE
+            spec = importlib.util.spec_from_file_location(
+                name,
+                filename,
+            )
         elif good_dir:
             name = os.path.basename(filename)
-            module_type = imp.PKG_DIRECTORY
+            spec = importlib.util.spec_from_file_location(
+                name,
+                os.path.join(filename, '__init__.py'),
+                submodule_search_locations=filename,
+            )
         else:
             raise exceptions.PluginError('Invalid Sopel plugin: %s' % filename)
 
         self.filename = filename
         self.path = filename
-        self.module_type = module_type
+        self.module_spec = spec
 
         super(PyFilePlugin, self).__init__(name)
 
     def _load(self):
-        # The current implementation uses `imp.load_module` to perform the
-        # load action, which also reloads the module. However, `imp` is
-        # deprecated in Python 3, so that might need to be changed when the
-        # support for Python 2 is dropped.
-        #
-        # However, the solution for Python 3 is non-trivial, since the
-        # `importlib` built-in module does not have a similar function,
-        # therefore requires to dive into its public internals
-        # (``importlib.machinery`` and ``importlib.util``).
-        #
-        # All of that is doable, but represents a lot of work. As long as
-        # Python 2 is supported, we can keep it for now.
-        #
-        # TODO: switch to ``importlib`` when Python2 support is dropped.
-        if self.module_type == imp.PY_SOURCE:
-            with open(self.path) as mod:
-                description = ('.py', 'U', self.module_type)
-                mod = imp.load_module(self.name, mod, self.path, description)
-        elif self.module_type == imp.PKG_DIRECTORY:
-            description = ('', '', self.module_type)
-            mod = imp.load_module(self.name, None, self.path, description)
-        else:
-            raise TypeError('Unsupported module type')
-
-        return mod
+        module = importlib.util.module_from_spec(self.module_spec)
+        sys.modules[self.name] = module
+        self.module_spec.loader.exec_module(module)
+        return module
 
     def get_meta_description(self):
         """Retrieve a meta description for the plugin.


### PR DESCRIPTION
### Description

This PR cherry-picks 596adc4 to the `7.1.x` branch, fixing crash on startup with Python 3.11 as reported by #2401. I think this is the majority of what we'd need in order to do an interim release, if we decide to do one before `8.0` is out.

**As-is, this changeset breaks compatibility with Python 2.7**

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [ ] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - There are errors in some of the tests for `sopel/modules`, but they are also present on the current `HEAD` of the branch.
    ```1137 passed, 8 xfailed, 10 errors in 31.04s```
- [x] I have tested the functionality of the things this change touches
  - I'm able to start the bot, I didn't take it for much of a test-drive beyond that, though.
