### PR TITLE
mypy: use generic types instead of `typing` aliases where possible

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -18,11 +18,8 @@ import time
 from types import MappingProxyType
 from typing import (
     Any,
-    Dict,
-    Iterable,
     Mapping,
     Optional,
-    Tuple,
     TYPE_CHECKING,
     TypeVar,
     Union,
@@ -40,6 +37,7 @@ from sopel.tools import jobs as tools_jobs
 from sopel.trigger import Trigger
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from sopel.trigger import PreTrigger
 
 
@@ -56,7 +54,7 @@ class Sopel(irc.AbstractBot):
         self._daemon = daemon  # Used for iPython. TODO something saner here
         self._running_triggers = []
         self._running_triggers_lock = threading.Lock()
-        self._plugins: Dict[str, Any] = {}
+        self._plugins: dict[str, Any] = {}
         self._rules_manager = plugin_rules.Manager()
         self._cap_requests_manager = plugin_capabilities.Manager()
         self._scheduler = plugin_jobs.Scheduler(self)
@@ -128,7 +126,7 @@ class Sopel(irc.AbstractBot):
         return self._scheduler
 
     @property
-    def command_groups(self) -> Dict[str, list]:
+    def command_groups(self) -> dict[str, list]:
         """A mapping of plugin names to lists of their commands.
 
         .. versionchanged:: 7.1
@@ -153,7 +151,7 @@ class Sopel(irc.AbstractBot):
         return result
 
     @property
-    def doc(self) -> Dict[str, tuple]:
+    def doc(self) -> dict[str, tuple]:
         """A dictionary of command names to their documentation.
 
         Each command is mapped to its docstring and any available examples, if
@@ -599,7 +597,7 @@ class Sopel(irc.AbstractBot):
         self,
         rule: AbstractRuleType,
         trigger: Trigger,
-    ) -> Tuple[bool, Optional[str]]:
+    ) -> tuple[bool, Optional[str]]:
         if trigger.admin or rule.is_unblockable():
             return False, None
 
@@ -815,7 +813,7 @@ class Sopel(irc.AbstractBot):
     def _is_pretrigger_blocked(
         self,
         pretrigger: PreTrigger,
-    ) -> Union[Tuple[bool, bool], Tuple[None, None]]:
+    ) -> Union[tuple[bool, bool], tuple[None, None]]:
         if not (
             self.settings.core.nick_blocks
             or self.settings.core.host_blocks
@@ -966,7 +964,7 @@ class Sopel(irc.AbstractBot):
 
     def resume_capability_negotiation(
         self,
-        cap_req: Tuple[str, ...],
+        cap_req: tuple[str, ...],
         plugin_name: str,
     ) -> None:
         """Resume capability negotiation and close when necessary.

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -18,7 +18,6 @@ import time
 from types import MappingProxyType
 from typing import (
     Any,
-    Mapping,
     Optional,
     TYPE_CHECKING,
     TypeVar,
@@ -37,7 +36,7 @@ from sopel.tools import jobs as tools_jobs
 from sopel.trigger import Trigger
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Iterable, Mapping
     from sopel.trigger import PreTrigger
 
 

--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -30,7 +30,6 @@ import getpass
 import logging
 import os.path
 import re
-from typing import List
 
 from sopel.lifecycle import deprecated
 
@@ -608,7 +607,7 @@ class ListAttribute(BaseValidated):
         else:
             default = []
         print(prompt)
-        values: List[str] = []
+        values: list[str] = []
         value = input(each_prompt + ' ') or default
         if (value == default) and not default:
             value = ''

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -30,7 +30,7 @@ import functools
 import logging
 import re
 import time
-from typing import Callable, Dict, List, Optional, Tuple, TYPE_CHECKING
+from typing import Callable, Optional, TYPE_CHECKING
 
 from sopel import config, plugin
 from sopel.irc import isupport, utils
@@ -64,7 +64,7 @@ MODE_PREFIX_PRIVILEGES = {
 
 
 def _handle_account_and_extjoin_capabilities(
-    cap_req: Tuple[str, ...], bot: SopelWrapper, acknowledged: bool,
+    cap_req: tuple[str, ...], bot: SopelWrapper, acknowledged: bool,
 ) -> plugin.CapabilityNegotiation:
     if acknowledged:
         return plugin.CapabilityNegotiation.DONE
@@ -89,7 +89,7 @@ def _handle_account_and_extjoin_capabilities(
 
 
 def _handle_sasl_capability(
-    cap_req: Tuple[str, ...], bot: SopelWrapper, acknowledged: bool,
+    cap_req: tuple[str, ...], bot: SopelWrapper, acknowledged: bool,
 ) -> plugin.CapabilityNegotiation:
     # Manage CAP REQ :sasl
     auth_method = bot.settings.core.auth_method
@@ -1026,8 +1026,8 @@ def _receive_cap_ls_reply(bot: SopelWrapper, trigger: Trigger) -> None:
 
 def _handle_cap_acknowledgement(
     bot: SopelWrapper,
-    cap_req: Tuple[str, ...],
-    results: List[Tuple[bool, Optional[plugin.CapabilityNegotiation]]],
+    cap_req: tuple[str, ...],
+    results: list[tuple[bool, Optional[plugin.CapabilityNegotiation]]],
     was_completed: bool,
 ) -> None:
     if any(
@@ -1050,11 +1050,11 @@ def _handle_cap_acknowledgement(
 
 def _receive_cap_ack(bot: SopelWrapper, trigger: Trigger) -> None:
     was_completed = bot.cap_requests.is_complete
-    cap_ack: Tuple[str, ...] = bot.capabilities.handle_ack(bot, trigger)
+    cap_ack: tuple[str, ...] = bot.capabilities.handle_ack(bot, trigger)
 
     try:
         result: Optional[
-            List[Tuple[bool, Optional[plugin.CapabilityNegotiation]]]
+            list[tuple[bool, Optional[plugin.CapabilityNegotiation]]]
         ] = bot.cap_requests.acknowledge(bot, cap_ack)
     except config.ConfigurationError as error:
         LOGGER.error(
@@ -1089,7 +1089,7 @@ def _receive_cap_nak(bot: SopelWrapper, trigger: Trigger) -> None:
 
     try:
         result: Optional[
-            List[Tuple[bool, Optional[plugin.CapabilityNegotiation]]]
+            list[tuple[bool, Optional[plugin.CapabilityNegotiation]]]
         ] = bot.cap_requests.deny(bot, cap_ack)
     except config.ConfigurationError as error:
         LOGGER.error(
@@ -1130,7 +1130,7 @@ def _receive_cap_del(bot: SopelWrapper, trigger: Trigger) -> None:
     # TODO: what to do when a CAP is removed? NAK callbacks?
 
 
-CAP_HANDLERS: Dict[str, Callable[[SopelWrapper, Trigger], None]] = {
+CAP_HANDLERS: dict[str, Callable[[SopelWrapper, Trigger], None]] = {
     'LS': _receive_cap_ls_reply,  # Server is listing capabilities
     'ACK': _receive_cap_ack,  # Server is acknowledging a capability
     'NAK': _receive_cap_nak,  # Server is denying a capability

--- a/sopel/db.py
+++ b/sopel/db.py
@@ -31,6 +31,9 @@ from sqlalchemy.sql import delete, func, select, update
 from sopel.lifecycle import deprecated
 from sopel.tools.identifiers import Identifier
 
+if typing.TYPE_CHECKING:
+    from collections.abc import Iterable
+
 
 LOGGER = logging.getLogger(__name__)
 IdentifierFactory = typing.Callable[[str], Identifier]
@@ -1016,7 +1019,7 @@ class SopelDB:
 
     def get_preferred_value(
         self,
-        names: typing.Iterable[str],
+        names: Iterable[str],
         key: str,
     ) -> typing.Optional[typing.Any]:
         """Get a value for the first name which has it set.

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -39,11 +39,7 @@ import threading
 import time
 from typing import (
     Any,
-    Dict,
-    Iterable,
     Optional,
-    Set,
-    Tuple,
     TYPE_CHECKING,
 )
 
@@ -55,6 +51,7 @@ from .capabilities import Capabilities
 from .isupport import ISupport
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from sopel.config import Config
     from .abstract_backends import AbstractIRCBackend
     from .utils import MyInfo
@@ -89,7 +86,7 @@ class AbstractBot(abc.ABC):
         self.sending = threading.RLock()
         self.last_error_timestamp: Optional[datetime] = None
         self.error_count = 0
-        self.stack: Dict[identifiers.Identifier, Dict[str, Any]] = {}
+        self.stack: dict[identifiers.Identifier, dict[str, Any]] = {}
         self.hasquit = False
         self.wantsrestart = False
         self.last_raw_line = ''  # last raw line received
@@ -150,7 +147,7 @@ class AbstractBot(abc.ABC):
         warning_in='8.1',
         removed_in='9.0',
     )
-    def enabled_capabilities(self) -> Set[str]:
+    def enabled_capabilities(self) -> set[str]:
         """A set containing the IRCv3 capabilities that the bot has enabled.
 
         .. deprecated:: 8.0
@@ -177,7 +174,7 @@ class AbstractBot(abc.ABC):
         warning_in='8.1',
         removed_in='9.0',
     )
-    def server_capabilities(self) -> Dict[str, Optional[str]]:
+    def server_capabilities(self) -> dict[str, Optional[str]]:
         """A dict mapping supported IRCv3 capabilities to their options.
 
         For example, if the server specifies the capability ``sasl=EXTERNAL``,
@@ -307,7 +304,7 @@ class AbstractBot(abc.ABC):
         self,
         host: str,
         port: int,
-        source_address: Optional[Tuple[str, int]],
+        source_address: Optional[tuple[str, int]],
     ) -> AbstractIRCBackend:
         """Set up the IRC backend based on the bot's settings.
 

--- a/sopel/irc/backends.py
+++ b/sopel/irc/backends.py
@@ -20,7 +20,7 @@ import signal
 import socket
 import ssl
 import threading
-from typing import Dict, List, Optional, Tuple, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 from .abstract_backends import AbstractIRCBackend
 
@@ -148,7 +148,7 @@ class AsyncioBackend(AbstractIRCBackend):
         bot: AbstractBot,
         host: str,
         port: int,
-        source_address: Optional[Tuple[str, int]],
+        source_address: Optional[tuple[str, int]],
         server_timeout: Optional[int] = None,
         ping_interval: Optional[int] = None,
         use_ssl: bool = False,
@@ -156,7 +156,7 @@ class AsyncioBackend(AbstractIRCBackend):
         keyfile: Optional[str] = None,
         verify_ssl: bool = True,
         ca_certs: Optional[str] = None,
-        ssl_ciphers: Optional[List[str]] = None,
+        ssl_ciphers: Optional[list[str]] = None,
         ssl_minimum_version: ssl.TLSVersion = ssl.TLSVersion.TLSv1_2,
         **kwargs,
     ):
@@ -164,7 +164,7 @@ class AsyncioBackend(AbstractIRCBackend):
         # connection parameters
         self._host: str = host
         self._port: int = port
-        self._source_address: Optional[Tuple[str, int]] = source_address
+        self._source_address: Optional[tuple[str, int]] = source_address
         self._use_ssl: bool = use_ssl
         self._certfile: Optional[str] = certfile
         self._keyfile: Optional[str] = keyfile
@@ -349,7 +349,7 @@ class AsyncioBackend(AbstractIRCBackend):
 
     # run & connection
 
-    def get_connection_kwargs(self) -> Dict:
+    def get_connection_kwargs(self) -> dict:
         """Return the keyword arguments required to initiate connection."""
         ssl_context: Optional[ssl.SSLContext] = None
 
@@ -380,7 +380,7 @@ class AsyncioBackend(AbstractIRCBackend):
 
     async def _connect_to_server(
         self, **connection_kwargs
-    ) -> Tuple[
+    ) -> tuple[
         Optional[asyncio.StreamReader],
         Optional[asyncio.StreamWriter],
     ]:

--- a/sopel/irc/capabilities.py
+++ b/sopel/irc/capabilities.py
@@ -19,12 +19,8 @@ state of available and enabled capabilities.
 from __future__ import annotations
 
 from typing import (
-    Dict,
-    FrozenSet,
     NamedTuple,
     Optional,
-    Set,
-    Tuple,
     TYPE_CHECKING,
 )
 
@@ -86,8 +82,8 @@ class Capabilities:
     * :meth:`handle_del` for ``CAP ADD``
     """
     def __init__(self) -> None:
-        self._available: Dict[str, Optional[str]] = {}
-        self._enabled: Set[str] = set()
+        self._available: dict[str, Optional[str]] = {}
+        self._enabled: set[str] = set()
 
     def get_capability_info(self, name: str) -> CapabilityInfo:
         """Retrieve metadata about a capability.
@@ -108,7 +104,7 @@ class Capabilities:
         )
 
     @property
-    def available(self) -> Dict[str, Optional[str]]:
+    def available(self) -> dict[str, Optional[str]]:
         """Dict of available server capabilities.
 
         Each key is the name of a capability advertised by the server, and each
@@ -120,7 +116,7 @@ class Capabilities:
         return dict(self._available.items())  # return a copy
 
     @property
-    def enabled(self) -> FrozenSet[str]:
+    def enabled(self) -> frozenset[str]:
         """Set of enabled server capabilities.
 
         Each element is the name of a capability that is enabled on the server.
@@ -162,7 +158,7 @@ class Capabilities:
         self,
         bot: SopelWrapper,
         trigger: Trigger,
-    ) -> Tuple[str, ...]:
+    ) -> tuple[str, ...]:
         """Handle a ``CAP ACK`` command.
 
         This method behaves as a plugin callable with its ``bot`` and
@@ -197,7 +193,7 @@ class Capabilities:
         self,
         bot: SopelWrapper,
         trigger: Trigger,
-    ) -> Tuple[str, ...]:
+    ) -> tuple[str, ...]:
         """Handle a ``CAP NAK`` command.
 
         This method behaves as a plugin callable with its ``bot`` and
@@ -220,7 +216,7 @@ class Capabilities:
         self,
         bot: SopelWrapper,
         trigger: Trigger,
-    ) -> Tuple[str, ...]:
+    ) -> tuple[str, ...]:
         """Handle a ``CAP NEW`` command.
 
         This method behaves as a plugin callable with its ``bot`` and
@@ -235,7 +231,7 @@ class Capabilities:
         assert trigger.args[1] == 'NEW'
 
         # extracting capabilities
-        cap_new: Set[str] = set()
+        cap_new: set[str] = set()
         for available_capability in trigger.split():
             name, *params = available_capability.split('=', maxsplit=1)
             self._available[name] = params[0] if params else None
@@ -247,7 +243,7 @@ class Capabilities:
         self,
         bot: SopelWrapper,
         trigger: Trigger,
-    ) -> Tuple[str, ...]:
+    ) -> tuple[str, ...]:
         """Handle a ``CAP DEL`` command.
 
         This method behaves as a plugin callable with its ``bot`` and
@@ -262,7 +258,7 @@ class Capabilities:
         assert trigger.args[1] == 'DEL'
 
         # extracting capabilities
-        cap_del: Set[str] = set()
+        cap_del: set[str] = set()
         for name in trigger.split():
             if name in self._available:
                 del self._available[name]

--- a/sopel/irc/isupport.py
+++ b/sopel/irc/isupport.py
@@ -17,7 +17,6 @@ from collections import OrderedDict
 import functools
 import itertools
 import re
-from typing import Dict
 
 
 def _optional(parser, default=None):
@@ -364,7 +363,7 @@ class ISupport:
         return dict(self['MAXLIST'])
 
     @property
-    def PREFIX(self) -> Dict[str, str]:
+    def PREFIX(self) -> dict[str, str]:
         """Expose ``PREFIX`` as a dict, if advertised by the server.
 
         This exposes information about the modes and nick prefixes used for

--- a/sopel/irc/modes.py
+++ b/sopel/irc/modes.py
@@ -33,12 +33,9 @@ from __future__ import annotations
 import enum
 import logging
 from typing import (
-    Dict,
     Iterator,
-    List,
     NamedTuple,
     Optional,
-    Set,
     Tuple,
 )
 
@@ -123,28 +120,28 @@ def parse_modestring(modestring: str) -> Iterator[ModeTuple]:
 
 class ModeMessage(NamedTuple):
     """Mode message with channel's modes and channel's privileges."""
-    modes: Tuple[ModeDetails, ...]
+    modes: tuple[ModeDetails, ...]
     """Tuple of added and removed modes.
 
     Each item is a :class:`ModeDetails`.
     """
-    privileges: Tuple[PrivilegeDetails, ...]
+    privileges: tuple[PrivilegeDetails, ...]
     """Tuple of added and removed privileges.
 
     Each item is a :class:`PrivilegeDetails`.
     """
-    ignored_modes: Tuple[ModeTuple, ...]
+    ignored_modes: tuple[ModeTuple, ...]
     """Ignored modes when they are unknown or there is a missing parameter.
 
     Each item is a :class:`ModeTuple`.
     """
-    leftover_params: Tuple[str, ...]
+    leftover_params: tuple[str, ...]
     """Parameters not used by any valid mode or privilege."""
 
 
 class ModeParser:
     """ModeMessage parser for IRC's ``MODE`` messages for channel modes."""
-    PRIVILEGES: Set[str] = {
+    PRIVILEGES: set[str] = {
         "v",  # VOICE
         "h",  # HALFOP
         "o",  # OP
@@ -177,11 +174,11 @@ class ModeParser:
 
     def __init__(
         self,
-        chanmodes: Dict[str, Tuple[str, ...]] = CHANMODES,
-        type_params: Dict[str, ParamRequired] = DEFAULT_MODETYPE_PARAM_CONFIG,
-        privileges: Set[str] = PRIVILEGES,
+        chanmodes: dict[str, tuple[str, ...]] = CHANMODES,
+        type_params: dict[str, ParamRequired] = DEFAULT_MODETYPE_PARAM_CONFIG,
+        privileges: set[str] = PRIVILEGES,
     ) -> None:
-        self.chanmodes: Dict[str, Tuple[str, ...]] = dict(chanmodes)
+        self.chanmodes: dict[str, tuple[str, ...]] = dict(chanmodes)
         """Map of mode types (``str``) to their lists of modes (``tuple``).
 
         This map should come from ``ISUPPORT``, usually through
@@ -225,7 +222,7 @@ class ModeParser:
                 return letter
         raise ModeTypeUnknown(mode)
 
-    def get_mode_info(self, mode: str, is_added: bool) -> Tuple[str, bool]:
+    def get_mode_info(self, mode: str, is_added: bool) -> tuple[str, bool]:
         """Retrieve ``mode``'s information when added or removed.
 
         :raise ModeTypeUnknown: when the mode's type is unknown
@@ -271,7 +268,7 @@ class ModeParser:
             or type_param == ParamRequired.REMOVED and not is_added
         )
 
-    def parse(self, modestring: str, params: Tuple[str, ...]) -> ModeMessage:
+    def parse(self, modestring: str, params: tuple[str, ...]) -> ModeMessage:
         """Parse a ``modestring`` for a channel with its ``params``.
 
         :param modestring: suite of modes with +/- sign, such as ``+b-v``
@@ -315,8 +312,8 @@ class ModeParser:
         """
         imodes = iter(parse_modestring(modestring))
         iparams = iter(params)
-        modes: List[ModeDetails] = []
-        privileges: List[PrivilegeDetails] = []
+        modes: list[ModeDetails] = []
+        privileges: list[PrivilegeDetails] = []
 
         for mode, is_added in imodes:
             required = False

--- a/sopel/irc/modes.py
+++ b/sopel/irc/modes.py
@@ -33,11 +33,14 @@ from __future__ import annotations
 import enum
 import logging
 from typing import (
-    Iterator,
     NamedTuple,
     Optional,
     Tuple,
+    TYPE_CHECKING,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
 
 
 ModeTuple = Tuple[str, bool]

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import inspect
 import logging
 import re
-from typing import List
 
 from sopel.config.core_section import COMMAND_DEFAULT_HELP_PREFIX
 
@@ -89,7 +88,7 @@ def clean_callable(func, config):
                         COMMAND_DEFAULT_HELP_PREFIX, help_prefix, 1)
                 examples[i] = example
         if doc or examples:
-            cmds: List[str] = []
+            cmds: list[str] = []
             cmds.extend(getattr(func, 'commands', []))
             cmds.extend(getattr(func, 'nickname_commands', []))
             for command in cmds:

--- a/sopel/modules/currency.py
+++ b/sopel/modules/currency.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import logging
 import re
 import time
-from typing import Dict
 
 import requests
 
@@ -36,7 +35,7 @@ LOGGER = logging.getLogger(__name__)
 UNSUPPORTED_CURRENCY = "Sorry, {} isn't currently supported."
 UNRECOGNIZED_INPUT = "Sorry, I didn't understand the input."
 
-rates: Dict[str, float] = {}
+rates: dict[str, float] = {}
 rates_updated = 0.0
 
 

--- a/sopel/modules/meetbot.py
+++ b/sopel/modules/meetbot.py
@@ -14,7 +14,6 @@ import os
 import re
 from string import punctuation, whitespace
 import time
-from typing import Dict, List
 
 from sopel import formatting, plugin, tools
 from sopel.config import types
@@ -63,7 +62,7 @@ def setup(bot):
     bot.config.define_section("meetbot", MeetbotSection)
 
 
-meetings_dict: Dict[str, dict] = collections.defaultdict(dict)  # Saves metadata about currently running meetings
+meetings_dict: dict[str, dict] = collections.defaultdict(dict)  # Saves metadata about currently running meetings
 """
 meetings_dict is a 2D dict.
 
@@ -87,7 +86,7 @@ meeting_log_baseurl = ""
 
 # A dict of channels to the actions that have been created in them. This way
 # we can have .listactions spit them back out later on.
-meeting_actions: Dict[str, List[str]] = {}
+meeting_actions: dict[str, list[str]] = {}
 
 
 # Get the logfile name for the meeting in the requested channel

--- a/sopel/modules/safety.py
+++ b/sopel/modules/safety.py
@@ -25,7 +25,7 @@ from sopel.config import types
 from sopel.formatting import bold, color, colors
 
 if TYPE_CHECKING:
-    from typing import Dict, Optional
+    from typing import Optional
 
     from sopel.bot import Sopel, SopelWrapper
     from sopel.config import Config
@@ -275,7 +275,7 @@ def virustotal_lookup(
     url: str,
     local_only: bool = False,
     max_cache_age: Optional[timedelta] = None,
-) -> Optional[Dict]:
+) -> Optional[dict]:
     """Check VirusTotal for flags on a URL as malicious.
 
     :param url: The URL to look up

--- a/sopel/modules/tld.py
+++ b/sopel/modules/tld.py
@@ -13,7 +13,7 @@ from encodings import idna
 from html.parser import HTMLParser
 import logging
 import re
-from typing import Dict, Union
+from typing import Union
 
 import pytz
 import requests
@@ -38,7 +38,7 @@ WIKI_PAGE_NAMES = [
     'List_of_Internet_top-level_domains',
     'Country_code_top-level_domain',
 ]
-WIKI_API_PARAMS: Dict[str, Union[str, int]] = {
+WIKI_API_PARAMS: dict[str, Union[str, int]] = {
     "action": "parse",
     "format": "json",
     "prop": "text",
@@ -108,7 +108,7 @@ class WikipediaTLDListParser(HTMLParser):
         self.current_cell = ''
         self.rows = []
         self.tables = []
-        self.parsed: Dict[str, Dict[str, str]] = {}
+        self.parsed: dict[str, dict[str, str]] = {}
         self.finished = False
 
     def handle_starttag(self, tag, attrs):

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from ipaddress import ip_address
 import logging
 import re
-from typing import Generator, List, NamedTuple, Optional, TYPE_CHECKING
+from typing import Generator, NamedTuple, Optional, TYPE_CHECKING
 from urllib.parse import urlparse
 
 import dns.resolver
@@ -379,7 +379,7 @@ class URLInfo(NamedTuple):
 def process_urls(
     bot: SopelWrapper,
     trigger: Trigger,
-    urls: List[str],
+    urls: list[str],
     requested: bool = False,
 ) -> Generator[URLInfo, None, None]:
     """

--- a/sopel/modules/url.py
+++ b/sopel/modules/url.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 from ipaddress import ip_address
 import logging
 import re
-from typing import Generator, NamedTuple, Optional, TYPE_CHECKING
+from typing import NamedTuple, Optional, TYPE_CHECKING
 from urllib.parse import urlparse
 
 import dns.resolver
@@ -25,6 +25,7 @@ from sopel.config import types
 from sopel.tools import web
 
 if TYPE_CHECKING:
+    from collections.abc import Generator
     from sopel.bot import Sopel, SopelWrapper
     from sopel.config import Config
     from sopel.trigger import Trigger

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -151,7 +151,7 @@ class capability:
 
         @plugin.capability('example/cap-name')
         def capability_handler(
-            cap_req: Tuple[str, ...],
+            cap_req: tuple[str, ...],
             bot: SopelWrapper,
             acknowledged: bool,
         ) -> plugin.CapabilityNegotiation:
@@ -237,11 +237,11 @@ class capability:
             # single REQ.
             raise ValueError('Capability request too long: %s' % cap_req_text)
 
-        self._cap_req: Tuple[str, ...] = tuple(sorted(cap_req))
+        self._cap_req: tuple[str, ...] = tuple(sorted(cap_req))
         self._handler: Optional[CapabilityHandler] = handler
 
     @property
-    def cap_req(self) -> Tuple[str, ...]:
+    def cap_req(self) -> tuple[str, ...]:
         """Capability request as a sorted tuple.
 
         This is the capability request that will be sent to the server as is.
@@ -256,7 +256,7 @@ class capability:
         self,
         bot: SopelWrapper,
         acknowledged: bool,
-    ) -> Tuple[bool, Optional[CapabilityNegotiation]]:
+    ) -> tuple[bool, Optional[CapabilityNegotiation]]:
         """Execute the acknowlegement callback of a capability request.
 
         :param bot: a Sopel instance

--- a/sopel/plugins/capabilities.py
+++ b/sopel/plugins/capabilities.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 
 import logging
 from typing import (
-    Generator,
     Optional,
     TYPE_CHECKING,
     Union,
@@ -24,7 +23,7 @@ from typing import (
 
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Generator, Iterable
     from sopel.bot import Sopel, SopelWrapper
     from sopel.plugin import capability, CapabilityNegotiation
 

--- a/sopel/plugins/capabilities.py
+++ b/sopel/plugins/capabilities.py
@@ -16,20 +16,15 @@ from __future__ import annotations
 
 import logging
 from typing import (
-    Dict,
-    FrozenSet,
     Generator,
-    Iterable,
-    List,
     Optional,
-    Set,
-    Tuple,
     TYPE_CHECKING,
     Union,
 )
 
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from sopel.bot import Sopel, SopelWrapper
     from sopel.plugin import capability, CapabilityNegotiation
 
@@ -61,20 +56,20 @@ class Manager:
        capability negotiation
     """
     def __init__(self):
-        self._registered: Dict[
+        self._registered: dict[
             # CAP REQ :<text>
-            Tuple[str, ...],
+            tuple[str, ...],
             # mapping (plugin, request + status)
-            Dict[str, Tuple[capability, bool]],
+            dict[str, tuple[capability, bool]],
         ] = {}
-        self._requested: Set[Tuple[str, ...]] = set()
-        self._acknowledged: Set[Tuple[str, ...]] = set()
-        self._denied: Set[Tuple[str, ...]] = set()
+        self._requested: set[tuple[str, ...]] = set()
+        self._acknowledged: set[tuple[str, ...]] = set()
+        self._denied: set[tuple[str, ...]] = set()
 
     # properties
 
     @property
-    def registered(self) -> FrozenSet[Tuple[str, ...]]:
+    def registered(self) -> frozenset[tuple[str, ...]]:
         """Set of registered capability requests.
 
         Each element is a capability request as a tuple of capability names::
@@ -88,7 +83,7 @@ class Manager:
         return frozenset(self._registered.keys())
 
     @property
-    def requested(self) -> FrozenSet[Tuple[str, ...]]:
+    def requested(self) -> frozenset[tuple[str, ...]]:
         """Set of requested capability requests.
 
         Each element is a capability request as a tuple of capability names::
@@ -105,7 +100,7 @@ class Manager:
         return frozenset(self._requested)
 
     @property
-    def acknowledged(self) -> FrozenSet[Tuple[str, ...]]:
+    def acknowledged(self) -> frozenset[tuple[str, ...]]:
         """Set of acknowledged capability requests.
 
         Each element is a capability request as a tuple of capability names::
@@ -121,7 +116,7 @@ class Manager:
         return frozenset(self._acknowledged)
 
     @property
-    def denied(self) -> FrozenSet[Tuple[str, ...]]:
+    def denied(self) -> frozenset[tuple[str, ...]]:
         """Set of denied capability requests.
 
         Each element is a capability request as a tuple of capability names::
@@ -313,7 +308,7 @@ class Manager:
         self,
         request: Iterable[str],
         plugin_name: str,
-    ) -> Tuple[bool, bool]:
+    ) -> tuple[bool, bool]:
         """Resume the registered plugin capability request.
 
         :return: a 2-value tuple with (was completed, is completed)
@@ -346,7 +341,7 @@ class Manager:
         if cap_req not in self._requested:
             return was_completed, was_completed
 
-        handler_info: Optional[Tuple[capability, bool]] = self._registered.get(
+        handler_info: Optional[tuple[capability, bool]] = self._registered.get(
             cap_req, {},
         ).get(
             plugin_name, None,
@@ -361,8 +356,8 @@ class Manager:
     def acknowledge(
         self,
         bot: SopelWrapper,
-        cap_req: Tuple[str, ...],
-    ) -> Optional[List[Tuple[bool, Optional[CapabilityNegotiation]]]]:
+        cap_req: tuple[str, ...],
+    ) -> Optional[list[tuple[bool, Optional[CapabilityNegotiation]]]]:
         """Acknowledge a capability request and execute handlers.
 
         :param bot: bot instance to manage the capabilities for
@@ -396,8 +391,8 @@ class Manager:
     def deny(
         self,
         bot: SopelWrapper,
-        cap_req: Tuple[str, ...],
-    ) -> Optional[List[Tuple[bool, Optional[CapabilityNegotiation]]]]:
+        cap_req: tuple[str, ...],
+    ) -> Optional[list[tuple[bool, Optional[CapabilityNegotiation]]]]:
         """Deny a capability request and execute handlers.
 
         :param bot: bot instance to manage the capabilities for
@@ -430,11 +425,11 @@ class Manager:
     def _callbacks(
         self,
         bot: SopelWrapper,
-        cap_req: Tuple[str, ...],
+        cap_req: tuple[str, ...],
         acknowledged: bool,
-    ) -> List[Tuple[bool, Optional[CapabilityNegotiation]]]:
+    ) -> list[tuple[bool, Optional[CapabilityNegotiation]]]:
         # call back request handlers
-        plugin_requests: Dict[str, Tuple[capability, bool]] = self._registered.get(
+        plugin_requests: dict[str, tuple[capability, bool]] = self._registered.get(
             cap_req, {},
         )
         return [
@@ -445,10 +440,10 @@ class Manager:
     def _callback(
         self,
         plugin_name: str,
-        handler_info: Tuple[capability, bool],
+        handler_info: tuple[capability, bool],
         bot: SopelWrapper,
         acknowledged: bool,
-    ) -> Tuple[bool, Optional[CapabilityNegotiation]]:
+    ) -> tuple[bool, Optional[CapabilityNegotiation]]:
         handler = handler_info[0]
         is_done, result = handler.callback(bot, acknowledged)
         # update done status in registered
@@ -457,10 +452,10 @@ class Manager:
 
     def get(
         self,
-        cap_req: Tuple[str, ...],
+        cap_req: tuple[str, ...],
         *,
-        plugins: Union[List[str], Tuple[str, ...], Set[str]] = (),
-    ) -> Generator[Tuple[str, capability], None, None]:
+        plugins: Union[list[str], tuple[str, ...], set[str]] = (),
+    ) -> Generator[tuple[str, capability], None, None]:
         """Retrieve the registered request handlers for a capability request.
 
         :param cap_req: the capability request to retrieve handlers for

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -50,7 +50,7 @@ import inspect
 import itertools
 import os
 import sys
-from typing import List, Optional, TYPE_CHECKING
+from typing import Optional, TYPE_CHECKING
 
 # TODO: refactor along with usage in sopel.__init__ in py3.8+ world
 import importlib_metadata
@@ -161,7 +161,7 @@ class AbstractPluginHandler(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_capability_requests(self) -> List[plugin_decorators.capability]:
+    def get_capability_requests(self) -> list[plugin_decorators.capability]:
         """Retrieve the plugin's list of capability requests."""
 
     @abc.abstractmethod
@@ -363,7 +363,7 @@ class PyModulePlugin(AbstractPluginHandler):
         """
         return hasattr(self.module, 'setup')
 
-    def get_capability_requests(self) -> List[plugin_decorators.capability]:
+    def get_capability_requests(self) -> list[plugin_decorators.capability]:
         return [
             module_attribute
             for module_attribute in vars(self.module).values()

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -26,7 +26,6 @@ import re
 import threading
 from typing import (
     Any,
-    Generator,
     Optional,
     Type,
     TYPE_CHECKING,
@@ -39,7 +38,7 @@ from sopel.config.core_section import (
     COMMAND_DEFAULT_HELP_PREFIX, COMMAND_DEFAULT_PREFIX, URL_DEFAULT_SCHEMES)
 
 if TYPE_CHECKING:
-    from collections.abc import Iterable
+    from collections.abc import Generator, Iterable
     from sopel.tools.identifiers import Identifier
 
 

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -26,9 +26,7 @@ import re
 import threading
 from typing import (
     Any,
-    Dict,
     Generator,
-    Iterable,
     Optional,
     Type,
     TYPE_CHECKING,
@@ -41,6 +39,7 @@ from sopel.config.core_section import (
     COMMAND_DEFAULT_HELP_PREFIX, COMMAND_DEFAULT_PREFIX, URL_DEFAULT_SCHEMES)
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
     from sopel.tools.identifiers import Identifier
 
 
@@ -1058,8 +1057,8 @@ class Rule(AbstractRule):
         self._default_rate_message = default_rate_message
 
         # metrics
-        self._metrics_nick: Dict[Identifier, RuleMetrics] = {}
-        self._metrics_sender: Dict[Identifier, RuleMetrics] = {}
+        self._metrics_nick: dict[Identifier, RuleMetrics] = {}
+        self._metrics_sender: dict[Identifier, RuleMetrics] = {}
         self._metrics_global = RuleMetrics()
 
         # docs & tests

--- a/sopel/tests/factories.py
+++ b/sopel/tests/factories.py
@@ -5,10 +5,13 @@
 from __future__ import annotations
 
 import re
-from typing import Iterable, Optional
+from typing import Optional, TYPE_CHECKING
 
 from sopel import bot, config, plugins, trigger
 from .mocks import MockIRCBackend, MockIRCServer, MockUser
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 
 class BotFactory:

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import functools
-from typing import Any, Callable, Dict, Optional, Set, TYPE_CHECKING, Union
+from typing import Any, Callable, Optional, TYPE_CHECKING, Union
 
 from sopel import privileges
 from sopel.tools import identifiers, memories
@@ -53,7 +53,7 @@ class User:
         Will be ``None`` if Sopel has not yet received complete user
         information from the IRC server.
         """
-        self.channels: Dict[identifiers.Identifier, 'Channel'] = {}
+        self.channels: dict[identifiers.Identifier, 'Channel'] = {}
         """The channels the user is in.
 
         This maps channel name :class:`~sopel.tools.identifiers.Identifier`\\s
@@ -138,7 +138,7 @@ class Channel:
         manipulating data associated to a user by its nickname.
         """
 
-        self.users: Dict[
+        self.users: dict[
             identifiers.Identifier,
             User,
         ] = memories.SopelIdentifierMemory(
@@ -149,7 +149,7 @@ class Channel:
         This maps nickname :class:`~sopel.tools.identifiers.Identifier`\\s to
         :class:`User` objects.
         """
-        self.privileges: Dict[
+        self.privileges: dict[
             identifiers.Identifier,
             int,
         ] = memories.SopelIdentifierMemory(
@@ -164,7 +164,7 @@ class Channel:
         self.topic: str = ''
         """The topic of the channel."""
 
-        self.modes: Dict[str, Union[Set, str, bool]] = {}
+        self.modes: dict[str, Union[set, str, bool]] = {}
         """The channel's modes.
 
         For type A modes (nick/address list), the value is a set. For type B

--- a/sopel/tools/time.py
+++ b/sopel/tools/time.py
@@ -9,7 +9,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import cast, NamedTuple, Optional, Tuple, TYPE_CHECKING, Union
+from typing import cast, NamedTuple, Optional, TYPE_CHECKING, Union
 
 import pytz
 
@@ -321,13 +321,13 @@ def get_time_unit(
     hours: int = 0,
     minutes: int = 0,
     seconds: int = 0,
-) -> Tuple[
-    Tuple[int, str],
-    Tuple[int, str],
-    Tuple[int, str],
-    Tuple[int, str],
-    Tuple[int, str],
-    Tuple[int, str],
+) -> tuple[
+    tuple[int, str],
+    tuple[int, str],
+    tuple[int, str],
+    tuple[int, str],
+    tuple[int, str],
+    tuple[int, str],
 ]:
     """Map a time in (y, m, d, h, min, s) to its labels.
 

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -14,11 +14,9 @@ import re
 from typing import (
     Callable,
     cast,
-    Dict,
     Match,
     Optional,
     Sequence,
-    Tuple,
     TYPE_CHECKING,
 )
 
@@ -169,17 +167,17 @@ class PreTrigger:
         line: str,
         url_schemes: Optional[Sequence] = None,
         identifier_factory: IdentifierFactory = identifiers.Identifier,
-        statusmsg_prefixes: Tuple[str, ...] = tuple(),
+        statusmsg_prefixes: tuple[str, ...] = tuple(),
     ):
         self.make_identifier = identifier_factory
         line = line.strip('\r\n')
         self.line: str = line
-        self.urls: Tuple[str, ...] = tuple()
+        self.urls: tuple[str, ...] = tuple()
         self.plain: str = ''
         self.ctcp: Optional[str] = None
 
         # Break off IRCv3 message tags, if present
-        self.tags: Dict[str, Optional[str]] = {}
+        self.tags: dict[str, Optional[str]] = {}
         if line.startswith('@'):
             tagstring, line = line.split(' ', 1)
             for raw_tag in tagstring[1:].split(';'):


### PR DESCRIPTION
### Description
It turns out that "where possible" is equivalent to "almost everywhere". There are a _very_ few places where we still have to leave `typing` aliases in for compatibility [with Python versions before 3.9](https://peps.python.org/pep-0585/).

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - This also includes running `mypy` 1.4 under Python 3.8, to make sure none of the changes breaks that version. (I did not bother to test Python 3.7 since it's EOL any day now. Tentatively it's EOL _today_, but I haven't seen any formal announcement or update to [the Python Versions page](https://devguide.python.org/versions/) yet.)
- [x] I have tested the functionality of the things this change touches

### Notes
Follow-up to #2471; prerequisite for finishing #2477 (so I can extract a very nice, clean file for packaging externally).

Haven't touched `remind` as it's due to be removed shortly (#2478, replaced by external package).