### PR TITLE
tld: fix regressions from type-hint cleanup

### DIFF
--- a/sopel/modules/tld.py
+++ b/sopel/modules/tld.py
@@ -217,7 +217,7 @@ class WikipediaTLDListParser(HTMLParser):
         # cache parsed data for future requests to this parser
         self.parsed = tld_list
 
-        return self.tables
+        return self.parsed
 
 
 def _update_tld_data(bot, which, force=False):

--- a/sopel/modules/tld.py
+++ b/sopel/modules/tld.py
@@ -260,11 +260,15 @@ def _update_tld_data(bot, which, force=False):
     elif which == 'data':
         data_pages = []
         for title in WIKI_PAGE_NAMES:
+            # don't one-liner this; dict.update() returns None, not the updated dict
+            parameters = WIKI_API_PARAMS.copy()
+            parameters.update({"page": title})
+
             try:
                 # https://www.mediawiki.org/wiki/Special:MyLanguage/API:Get_the_contents_of_a_page
                 tld_response = requests.get(
                     "https://en.wikipedia.org/w/api.php",
-                    params=WIKI_API_PARAMS.copy().update({"page": title}),
+                    params=parameters,
                 ).json()
                 data_pages.append(tld_response["parse"]["text"])
             # py <3.5 needs ValueError instead of more specific json.decoder.JSONDecodeError


### PR DESCRIPTION
### Description
Fix regressions in the `tld` plugin from #2471. Mea culpa…

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - Not really relevant since these didn't cause test failures in the first place 😛
- [x] I have tested the functionality of the things this change touches
  - Before: `.tldcache update` spat an error into the bot log
  - After: `.tldcache update` yields DEBUG level log messages indicating success

### Notes
Kinda broke the parser in 3ffe55c097a53287a9d0d7aa159e2f33ae789a67, then hid that error by breaking the data fetch too in c24dfa209c3d2965939f227992c16168bc9fb69c when I tried to get too smart with one-line statements.