### PR TITLE
docs, dev-requirements: upgrade sphinx and try to fix some type issues with documentation

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -6,11 +6,12 @@ flake8-future-import
 flake8-import-order
 flake8-type-checking; python_version >= '3.8'
 # Sphinx theme
-furo==2022.4.7
+furo==2023.9.10
 pytest~=7.1.0
 pytest-vcr~=1.0.2
 requests-mock~=1.9.3
-sphinx>=4,<5
+sphinx>=7.1.0,<8; python_version <= '3.8'
+sphinx>=7.2.0,<8; python_version > '3.8'
 # specify exact autoprogram version because the new (in 2021) maintainer
 # showed that they will indeed make major changes in patch versions
 sphinxcontrib-autoprogram==0.1.8

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -112,6 +112,17 @@ pygments_dark_style = 'monokai'
 modindex_common_prefix = ['sopel.']
 
 
+# -- Options for autodoc -------------------------------------------------------
+
+autodoc_type_aliases = {
+    'Casemapping': 'sopel.tools.identifiers.Casemapping',
+    'IdentifierFactory': 'sopel.tools.identifiers.IdentifierFactory',
+    'ModeTuple': 'sopel.irc.modes.ModeTuple',
+    'ModeDetails': 'sopel.irc.modes.ModeDetails',
+    'PrivilegeDetails': 'sopel.irc.modes.PrivilegeDetails',
+}
+
+
 # -- Options for HTML output ---------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -11,9 +11,7 @@ from __future__ import generator_stop
 # serve to show the default.
 
 from datetime import date
-import sys, os
-parentdir = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-os.sys.path.insert(0,parentdir)
+
 from sopel import __version__
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -24,7 +22,7 @@ from sopel import __version__
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-needs_sphinx = '4.0'
+needs_sphinx = '7.1'  # todo: upgrade when Py3.8 reaches EOL
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -111,6 +111,10 @@ pygments_dark_style = 'monokai'
 # A list of ignored prefixes for module index sorting.
 modindex_common_prefix = ['sopel.']
 
+# If a signature’s length in characters exceeds the number set, each parameter
+# within the signature will be displayed on an individual logical line.
+maximum_signature_line_length = 80
+
 
 # -- Options for autodoc -------------------------------------------------------
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -109,7 +109,7 @@ pygments_style = 'friendly'
 pygments_dark_style = 'monokai'
 
 # A list of ignored prefixes for module index sorting.
-#modindex_common_prefix = []
+modindex_common_prefix = ['sopel.']
 
 
 # -- Options for HTML output ---------------------------------------------------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -25,6 +25,8 @@ Documentation
     plugin
     package
     tests
+    genindex
+    modindex
 
 .. toctree::
     :caption: Donate

--- a/docs/source/package/plugins/rules.rst
+++ b/docs/source/package/plugins/rules.rst
@@ -14,16 +14,10 @@ sopel.plugins.rules
       :members:
       :undoc-members:
 
-   .. class:: TypedRule
+   .. autoclass:: TypedRule
+      :members:
+      :undoc-members:
 
-      A :class:`~typing.TypeVar` bound to :class:`AbstractRule`. When used in
-      the :meth:`AbstractRule.from_callable` class method, it means the return
-      value must be an instance of the class used to call that method and not a
-      different subclass of ``AbstractRule``.
-
-      .. versionadded:: 8.0
-
-         This ``TypeVar`` was added as part of a goal to start type-checking
-         Sopel and is not used at runtime.
-
-      .. TODO remove when sphinx-autodoc can manage TypeVar properly.
+   .. autoclass:: RuleMetrics
+      :members:
+      :undoc-members:

--- a/docs/source/plugin/advanced.rst
+++ b/docs/source/plugin/advanced.rst
@@ -206,6 +206,10 @@ handler to run after the capability is acknowledged or denied by the server::
 .. autoclass:: sopel.plugin.CapabilityNegotiation
    :members:
 
+.. autoclass:: sopel.plugin.CapabilityHandler
+   :members:
+   :special-members: __call__
+
 
 Working with capabilities
 -------------------------

--- a/sopel/db.py
+++ b/sopel/db.py
@@ -29,14 +29,13 @@ from sqlalchemy.orm import declarative_base, scoped_session, sessionmaker
 from sqlalchemy.sql import delete, func, select, update
 
 from sopel.lifecycle import deprecated
-from sopel.tools.identifiers import Identifier
+from sopel.tools.identifiers import Identifier, IdentifierFactory
 
 if typing.TYPE_CHECKING:
     from collections.abc import Iterable
 
 
 LOGGER = logging.getLogger(__name__)
-IdentifierFactory = typing.Callable[[str], Identifier]
 
 
 def _deserialize(value):
@@ -146,7 +145,7 @@ class SopelDB:
         config,
         identifier_factory: IdentifierFactory = Identifier,
     ) -> None:
-        self.make_identifier = identifier_factory
+        self.make_identifier: IdentifierFactory = identifier_factory
 
         if config.core.db_url is not None:
             self.url = make_url(config.core.db_url)

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -124,10 +124,10 @@ class CapabilityNegotiation(enum.Enum):
 class CapabilityHandler(Protocol):
     """:class:`~typing.Protocol` definition for capability handler.
 
-    When a plugin requests a capability using the :class:`capability`, it can
-    define a callback handler for that request, that will be called upon
-    Sopel receiving either an ``ACK`` (capability enabled) or a ``NAK``
-    (capability denied) CAP message.
+    When a plugin requests a capability, it can define a callback handler for
+    that request using :class:`capability` as a decorator. That handler will be
+    called upon Sopel receiving either an ``ACK`` (capability enabled) or a
+    ``NAK`` (capability denied) CAP message.
 
     Example::
 
@@ -157,8 +157,9 @@ class CapabilityHandler(Protocol):
 
     .. note::
 
-        This protocol class is used for type checking and documentation purpose
-        only. It should not be used for other purposes.
+        This protocol class should be used for type checking and documentation
+        purposes only.
+
     """
     def __call__(
         self,

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -54,6 +54,17 @@ __all__ = [
 ]
 
 TypedRule = TypeVar('TypedRule', bound='AbstractRule')
+"""A :class:`~typing.TypeVar` bound to :class:`AbstractRule`.
+
+When used in the :meth:`AbstractRule.from_callable` class method, it means the
+return value must be an instance of the class used to call that method and not
+a different subclass of ``AbstractRule``.
+
+.. versionadded:: 8.0
+
+    This ``TypeVar`` was added as part of a goal to start type-checking
+    Sopel and is not used at runtime.
+"""
 
 LOGGER = logging.getLogger(__name__)
 

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -64,6 +64,7 @@ a different subclass of ``AbstractRule``.
 
     This ``TypeVar`` was added as part of a goal to start type-checking
     Sopel and is not used at runtime.
+
 """
 
 LOGGER = logging.getLogger(__name__)

--- a/sopel/tools/identifiers.py
+++ b/sopel/tools/identifiers.py
@@ -38,6 +38,7 @@ import string
 from typing import Callable
 
 Casemapping = Callable[[str], str]
+"""Type definition of a casemapping callable."""
 
 ASCII_TABLE = str.maketrans(string.ascii_uppercase, string.ascii_lowercase)
 RFC1459_TABLE = str.maketrans(
@@ -278,3 +279,7 @@ class Identifier(str):
 
         """
         return bool(self) and not self.startswith(self.chantypes)
+
+
+IdentifierFactory = Callable[[str], Identifier]
+"""Type definition of an identifier factory."""

--- a/sopel/tools/memories.py
+++ b/sopel/tools/memories.py
@@ -8,14 +8,9 @@ from __future__ import annotations
 
 from collections import defaultdict
 import threading
-from typing import TYPE_CHECKING
+from typing import Optional
 
-from .identifiers import Identifier
-
-if TYPE_CHECKING:
-    from typing import Callable, Optional
-
-    IdentifierFactory = Callable[[str], Identifier]
+from .identifiers import Identifier, IdentifierFactory
 
 
 class SopelMemory(dict):
@@ -156,7 +151,7 @@ class SopelIdentifierMemory(SopelMemory):
         identifier_factory: IdentifierFactory = Identifier,
     ) -> None:
         super().__init__(*args)
-        self.make_identifier = identifier_factory
+        self.make_identifier: IdentifierFactory = identifier_factory
         """A factory to transform keys into identifiers."""
 
     def _make_key(self, key: Optional[str]) -> Optional[Identifier]:

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -1,16 +1,15 @@
+"""User and channel objects used in state tracking."""
 from __future__ import annotations
 
 import functools
-from typing import Any, Callable, Optional, TYPE_CHECKING, Union
+from typing import Any, Optional, TYPE_CHECKING, Union
 
 from sopel import privileges
-from sopel.tools import identifiers, memories
+from sopel.tools import memories
+from sopel.tools.identifiers import Identifier, IdentifierFactory
 
 if TYPE_CHECKING:
-    from datetime import datetime
-
-
-IdentifierFactory = Callable[[str], identifiers.Identifier]
+    import datetime
 
 
 @functools.total_ordering
@@ -28,12 +27,12 @@ class User:
 
     def __init__(
         self,
-        nick: identifiers.Identifier,
+        nick: Identifier,
         user: Optional[str],
         host: Optional[str],
     ) -> None:
-        assert isinstance(nick, identifiers.Identifier)
-        self.nick: identifiers.Identifier = nick
+        assert isinstance(nick, Identifier)
+        self.nick: Identifier = nick
         """The user's nickname."""
         self.user: Optional[str] = user
         """The user's local username.
@@ -53,7 +52,7 @@ class User:
         Will be ``None`` if Sopel has not yet received complete user
         information from the IRC server.
         """
-        self.channels: dict[identifiers.Identifier, 'Channel'] = {}
+        self.channels: dict[Identifier, 'Channel'] = {}
         """The channels the user is in.
 
         This maps channel name :class:`~sopel.tools.identifiers.Identifier`\\s
@@ -123,11 +122,11 @@ class Channel:
 
     def __init__(
         self,
-        name: identifiers.Identifier,
-        identifier_factory: IdentifierFactory = identifiers.Identifier,
+        name: Identifier,
+        identifier_factory: IdentifierFactory = Identifier,
     ) -> None:
-        assert isinstance(name, identifiers.Identifier)
-        self.name: identifiers.Identifier = name
+        assert isinstance(name, Identifier)
+        self.name: Identifier = name
         """The name of the channel."""
 
         self.make_identifier: IdentifierFactory = identifier_factory
@@ -139,7 +138,7 @@ class Channel:
         """
 
         self.users: dict[
-            identifiers.Identifier,
+            Identifier,
             User,
         ] = memories.SopelIdentifierMemory(
             identifier_factory=self.make_identifier,
@@ -150,7 +149,7 @@ class Channel:
         :class:`User` objects.
         """
         self.privileges: dict[
-            identifiers.Identifier,
+            Identifier,
             int,
         ] = memories.SopelIdentifierMemory(
             identifier_factory=self.make_identifier,
@@ -177,17 +176,17 @@ class Channel:
             does not automatically populate all modes and lists.
         """
 
-        self.last_who: Optional[datetime] = None
+        self.last_who: Optional[datetime.datetime] = None
         """The last time a WHO was requested for the channel."""
 
-        self.join_time: Optional[datetime] = None
+        self.join_time: Optional[datetime.datetime] = None
         """The time the server acknowledged our JOIN message.
 
         Based on server-reported time if the ``server-time`` IRCv3 capability
         is available, otherwise the time Sopel received it.
         """
 
-    def clear_user(self, nick: identifiers.Identifier) -> None:
+    def clear_user(self, nick: Identifier) -> None:
         """Remove ``nick`` from this channel.
 
         :param nick: the nickname of the user to remove
@@ -426,11 +425,7 @@ class Channel:
         identifier = self.make_identifier(nick)
         return bool(self.privileges.get(identifier, 0) & privileges.VOICE)
 
-    def rename_user(
-        self,
-        old: identifiers.Identifier,
-        new: identifiers.Identifier,
-    ) -> None:
+    def rename_user(self, old: Identifier, new: Identifier) -> None:
         """Rename a user.
 
         :param old: the user's old nickname

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 from datetime import datetime, timezone
 import re
 from typing import (
-    Callable,
     cast,
     Match,
     Optional,
@@ -21,7 +20,8 @@ from typing import (
 )
 
 from sopel import formatting, tools
-from sopel.tools import identifiers, web
+from sopel.tools import web
+from sopel.tools.identifiers import Identifier, IdentifierFactory
 
 if TYPE_CHECKING:
     from sopel import config
@@ -31,10 +31,6 @@ __all__ = [
     'PreTrigger',
     'Trigger',
 ]
-
-
-IdentifierFactory = Callable[[str], identifiers.Identifier]
-
 
 COMMANDS_WITH_CONTEXT = frozenset({
     'INVITE',
@@ -163,13 +159,13 @@ class PreTrigger:
 
     def __init__(
         self,
-        own_nick: identifiers.Identifier,
+        own_nick: Identifier,
         line: str,
         url_schemes: Optional[Sequence] = None,
-        identifier_factory: IdentifierFactory = identifiers.Identifier,
+        identifier_factory: IdentifierFactory = Identifier,
         statusmsg_prefixes: tuple[str, ...] = tuple(),
     ):
-        self.make_identifier = identifier_factory
+        self.make_identifier: IdentifierFactory = identifier_factory
         line = line.strip('\r\n')
         self.line: str = line
         self.urls: tuple[str, ...] = tuple()
@@ -235,11 +231,11 @@ class PreTrigger:
         components_match = cast(
             Match, PreTrigger.component_regex.match(self.hostmask or ''))
         nick, self.user, self.host = components_match.groups()
-        self.nick: identifiers.Identifier = self.make_identifier(nick)
+        self.nick: Identifier = self.make_identifier(nick)
 
         # If we have arguments, the first one is *usually* the sender,
         # most numerics and certain general events (e.g. QUIT) excepted
-        target: Optional[identifiers.Identifier] = None
+        target: Optional[Identifier] = None
         status_prefix: Optional[str] = None
 
         if self.args and self.event in COMMANDS_WITH_CONTEXT:


### PR DESCRIPTION
### Description

First, I upgraded Sphinx to the latest version, which requires to upgrade Furo as well. That went well so that's good! Then I added links to the general index and the Python module index, because they are nice.

Then I tried to fix Sphinx autodoc's warnings regarding type annotations. I more or less figure out a way to fix one or two... but then I got stuck very hard: Sphinx, currently, does not handle type annotation properly. For some reason it works for `TypedRule` now but not with some `datetime.datetime` annotation? There are clearly bugs (that are not new to version 7.0 of Sphinx by the way), and I tried few options (such as using `autodoc_type_aliases`, or for a moment I switch to another autodoc extension, with the same issues). Sopel is not an isolated case, [as this issue shows it](https://github.com/sphinx-doc/sphinx/issues/9813).

So yeah, since it's mostly Sphinx's fault, I decided to give up on the remaining warnings. I don't think we can do much: we could, hypothetically, tinker for hours with the code... but I don't see the value here. I already spent quite a few hours on this and I'm not happy so let's not waste any more time.

**Note**: this won't work with Python 3.7 as I use a feature from Python 3.8 (`typing.Protocol`). So until @dgw publish his PR to remove Python 3.7 support, this will be a draft only.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches
