### PR TITLE
build, meta: drop Python 3.7 support, checks, and CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - "3.7"
           - "3.8"
           - "3.9"
           - "3.10"

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ First, either clone the repository with ``git clone
 https://github.com/sopel-irc/sopel.git`` or download a tarball `from GitHub
 <https://github.com/sopel-irc/sopel/releases/latest>`_.
 
-Note: Sopel requires Python 3.7+ to run.
+Note: Sopel requires Python 3.8+ to run.
 
 In the source directory (whether cloned or from the tarball) run ``pip install
 -e .``. You can then run ``sopel`` to configure and start the bot.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,14 +35,13 @@ classifiers = [
     "License :: Eiffel Forum License (EFL)",
     "License :: OSI Approved :: Eiffel Forum License",
     "Operating System :: POSIX :: Linux",
-    "Programming Language :: Python :: 3.7",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Topic :: Communications :: Chat :: Internet Relay Chat",
 ]
-requires-python = ">=3.7"
+requires-python = ">=3.8"
 dependencies = [
     "xmltodict>=0.12,<0.14",
     "pytz",

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,7 +16,7 @@ ignore =
     # Sopel no longer supports Python versions that require them.
     FI58,
     # These would require future imports that are not needed any more on Sopel's
-    # oldest supported Python version (3.7).
+    # oldest supported Python version (3.8).
     FI10,FI11,FI12,FI13,FI14,FI15,FI16,FI17,
     # We use postponed annotation evaluation
     TC2,

--- a/sopel/__init__.py
+++ b/sopel/__init__.py
@@ -13,13 +13,11 @@ It’s designed to be easy to use, easy to run, and easy to extend.
 from __future__ import annotations
 
 from collections import namedtuple
+import importlib.metadata
 import locale
 import re
 import sys
 
-# TODO: replace with stdlib importlib.metadata when dropping py3.7
-# version info used in this module works from py3.8+
-import importlib_metadata
 
 __all__ = [
     'bot',
@@ -43,7 +41,7 @@ if not loc[1] or ('UTF-8' not in loc[1] and 'utf8' not in loc[1]):
           'something like "en_US.UTF-8".', file=sys.stderr)
 
 
-__version__ = importlib_metadata.version('sopel')
+__version__ = importlib.metadata.version('sopel')
 
 
 def _version_info(version=__version__):

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -1255,8 +1255,8 @@ class Sopel(irc.AbstractBot):
             The Python documentation for the `re.search`__ function and
             the `match object`__.
 
-        .. __: https://docs.python.org/3.7/library/re.html#re.search
-        .. __: https://docs.python.org/3.7/library/re.html#match-objects
+        .. __: https://docs.python.org/3.11/library/re.html#re.search
+        .. __: https://docs.python.org/3.11/library/re.html#match-objects
 
         """
         for regex, function in self._url_callbacks.items():

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -22,8 +22,8 @@ from . import utils
 # This is in case someone somehow manages to install Sopel on an old version
 # of pip (<9.0.0), which doesn't know about `python_requires`, or tries to run
 # from source on an unsupported version of Python.
-if sys.version_info < (3, 7):
-    utils.stderr('Error: Sopel requires Python 3.7+.')
+if sys.version_info < (3, 8):
+    utils.stderr('Error: Sopel requires Python 3.8+.')
     sys.exit(1)
 
 LOGGER = logging.getLogger(__name__)

--- a/sopel/irc/isupport.py
+++ b/sopel/irc/isupport.py
@@ -13,7 +13,6 @@ When a server wants to advertise its features and settings, it can use the
 # Licensed under the Eiffel Forum License 2.
 from __future__ import annotations
 
-from collections import OrderedDict
 import functools
 import itertools
 import re
@@ -392,10 +391,7 @@ class ISupport:
         if 'PREFIX' not in self:
             raise AttributeError('PREFIX')
 
-        # This can use a normal dict once we drop python 3.6, as 3.7 promises
-        # `dict` maintains insertion order. Since `OrderedDict` subclasses
-        # `dict`, we'll not promise to always return the former.
-        return OrderedDict(self['PREFIX'])
+        return dict(self['PREFIX'])
 
     @property
     def TARGMAX(self):

--- a/sopel/modules/announce.py
+++ b/sopel/modules/announce.py
@@ -25,12 +25,8 @@ def _chunks(items, size):
     # This approach is safer than slicing with non-subscriptable types,
     # for example `dict_keys` objects
     iterator = iter(items)
-    # TODO: Simplify to assignment expression (`while cond := expr`)
-    # when dropping Python 3.7
-    chunk = tuple(itertools.islice(iterator, size))
-    while chunk:
+    while (chunk := tuple(itertools.islice(iterator, size))):
         yield chunk
-        chunk = tuple(itertools.islice(iterator, size))
 
 
 @plugin.command('announce')

--- a/sopel/modules/tld.py
+++ b/sopel/modules/tld.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 from datetime import datetime
 from encodings import idna
 from html.parser import HTMLParser
+from json import JSONDecodeError
 import logging
 import re
 from typing import Union
@@ -271,8 +272,7 @@ def _update_tld_data(bot, which, force=False):
                     params=parameters,
                 ).json()
                 data_pages.append(tld_response["parse"]["text"])
-            # py <3.5 needs ValueError instead of more specific json.decoder.JSONDecodeError
-            except (requests.exceptions.RequestException, ValueError, KeyError):
+            except (requests.exceptions.RequestException, JSONDecodeError, KeyError):
                 # Log error and continue life; it'll be fine
                 LOGGER.warning(
                     'Error fetching TLD data from "%s" on Wikipedia; will try again later.',

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -52,9 +52,6 @@ import os
 import sys
 from typing import Optional, TYPE_CHECKING, TypedDict
 
-# TODO: refactor along with usage in sopel.__init__ in py3.8+ world
-import importlib_metadata
-
 from sopel import __version__ as release, loader, plugin as plugin_decorators
 from . import exceptions
 
@@ -614,9 +611,13 @@ class EntryPointPlugin(PyModulePlugin):
         """
         version: Optional[str] = super().get_version()
 
-        if version is None and hasattr(self.module, "__package__"):
+        if (
+            version is None
+            and hasattr(self.module, "__package__")
+            and self.module.__package__ is not None
+        ):
             try:
-                version = importlib_metadata.version(self.module.__package__)
+                version = importlib.metadata.version(self.module.__package__)
             except ValueError:
                 # package name is probably empty-string; just give up
                 pass

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -87,9 +87,7 @@ def _clean_rules(rules, nick, aliases):
 
 def _compile_pattern(pattern, nick, aliases=None):
     if aliases:
-        nicks = list(aliases)  # alias_nicks.copy() doesn't work in py2
-        nicks.append(nick)
-        nick = '(?:%s)' % '|'.join(re.escape(n) for n in nicks)
+        nick = '(?:%s)' % '|'.join(re.escape(n) for n in (nick, *aliases))
     else:
         nick = re.escape(nick)
 

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -671,7 +671,7 @@ class AbstractRule(abc.ABC):
 
         This method must return a list of `match objects`__.
 
-        .. __: https://docs.python.org/3.7/library/re.html#match-objects
+        .. __: https://docs.python.org/3.11/library/re.html#match-objects
         """
 
     @abc.abstractmethod
@@ -842,7 +842,7 @@ class AbstractRule(abc.ABC):
         :return: yield a list of match object
         :rtype: generator of `re.match`__
 
-        .. __: https://docs.python.org/3.7/library/re.html#match-objects
+        .. __: https://docs.python.org/3.11/library/re.html#match-objects
         """
 
     @abc.abstractmethod

--- a/test/plugins/test_plugins_handlers.py
+++ b/test/plugins/test_plugins_handlers.py
@@ -1,11 +1,10 @@
 """Tests for the ``sopel.plugins.handlers`` module."""
 from __future__ import annotations
 
+import importlib.metadata
 import os
 import sys
 
-# TODO: use stdlib importlib.metadata when dropping py3.9
-import importlib_metadata
 import pytest
 
 from sopel.plugins import handlers
@@ -89,7 +88,7 @@ def test_get_label_entrypoint(plugin_tmpfile):
 
     # load the entry point
     try:
-        entry_point = importlib_metadata.EntryPoint(
+        entry_point = importlib.metadata.EntryPoint(
             'test_plugin', 'file_mod', 'sopel.plugins')
         plugin = handlers.EntryPointPlugin(entry_point)
         plugin.load()

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -1,10 +1,9 @@
 """Test for the ``sopel.plugins`` module."""
 from __future__ import annotations
 
+import importlib.metadata
 import sys
 
-# TODO: switch to stdlib importlib.metdata when dropping py3.9
-import importlib_metadata
 import pytest
 
 from sopel import plugins
@@ -138,7 +137,7 @@ def test_plugin_load_entry_point(tmpdir):
 
     # load the entry point
     try:
-        entry_point = importlib_metadata.EntryPoint(
+        entry_point = importlib.metadata.EntryPoint(
             'test_plugin', 'file_mod', 'sopel.plugins')
         plugin = plugins.handlers.EntryPointPlugin(entry_point)
         plugin.load()


### PR DESCRIPTION
### Description
This fulfills the last "Finally letting the dead snakes lie." part of [the 8.0.0 milestone](https://github.com/sopel-irc/sopel/milestone/15)'s description. Python 3.7 was officially EOL'd as of a month ago, on June 27.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
  - (As of when I prepped the patch.)
- [x] I have tested the functionality of the things this change touches
  - When I wrote it, I did, with `make test` etc. (Now it needs a rebase for retesting.)

### Conflict notes
@SnoopJ and @Exirel arrived at similar conclusions for dealing with aliases in `plugins/rules.py`; this has a conflict with 098d8c309058dc794dd04d0d464598482ca94505, but the approaches are quite similar. That and b0693b7b0da1047aa0f509a30f9d15ef6b71065d are both from #2471, which touched a bunch of stuff (so I knew the risk of conflicts with this relatively long-lived housekeeping branch was inevitable).

The only other little conflict is more directly my fault. While I set @SnoopJ loose on my todo list for #2471 to get it done faster, #2480—specifically, 85f8b82d3917135e309b6ce4efc601d4c79560a7—is all me. 🙈

Guess I have to rebase this one, huh? Damn, I love merging branches that diverged long before `master` because the history graph looks cool, but sometimes it's just not meant to be. 😅

### Special thanks
…to the other maintainers for humoring me when I said I wanted to reach #2500 and make this PR a numerical milestone as well as a development one. You're all awesome for tossing in extra issues & PRs to get us here! ❤️