### PR TITLE
ci, make: "lint" (flake8 & mypy) replace "quality"

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,10 @@
 ### Description
+
 What does this do? What problem does it solve? Does it resolve any GitHub issues?
 
 ### Checklist
+
 - [ ] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
 - [ ] I can and do license this contribution under the EFLv2
-- [ ] No issues are reported by `make qa` (runs `make quality` and `make test`)
+- [ ] No issues are reported by `make qa` (runs `make lint` and `make test`)
 - [ ] I have tested the functionality of the things this change touches

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,8 @@ jobs:
           python -m pip install --upgrade wheel
           python -m pip install --upgrade -r dev-requirements.txt
           python -m pip install -e .
-      - name: Check code style
-        run: make quality
+      - name: Run linters (code style and type check)
+        run: make lint
       - name: Run pytest
         run: make test_norecord
       - name: Upload coverage data to coveralls.io

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,13 @@
 .PHONY: qa
-qa: quality test coverages
+qa: lint test coverages
 
-.PHONY: quality mypy
-quality:
+.PHONY: lint lint-style lint-type
+lint: lint-style lint-type
+
+lint-style:
 	flake8
 
-mypy:
+lint-type:
 	mypy --check-untyped-defs sopel
 
 .PHONY: test test_norecord test_novcr vcr_rerecord

--- a/contrib/tox.ini
+++ b/contrib/tox.ini
@@ -6,8 +6,7 @@ envlist =
 skip_missing_interpreters = true
 ignore_base_python_conflict = true
 labels =
-    mypy = py{37,38,39,310,311}-mypy
-    quality = py{37,38,39,310,311}-quality
+    lint = py{37,38,39,310,311}-lint
     test = py{37,38,39,310,311}-test
 
 
@@ -39,8 +38,7 @@ setenv =
 
 commands =
     qa: make -C.. qa
-    mypy: make -C.. mypy
-    quality: make -C.. quality
+    lint: make -C.. lint
     test: make -C.. test
     # NOTE:there's currently no way to specify separate output directories for
     # the HTML coverage report, but the CLI report is probably fine anyway


### PR DESCRIPTION
### Description

I think Sopel 8.0 is ready to enforce type check (close #2461).

I know I did that, so I'm owning my mistake, and rename "make quality" by "make lint". A linter is something that checks your code for errors, and both flake8 and mypy are linters.

There are now 2 new make commands:

* make lint-style: perform any code style check (today: flake8 only), it could be used for a pylint check for example, or isort, or rst check, or anything that could help us with code style in the future
* make lint-type: perform any type check (today: mypy only)

The command `quality` is replaced by the command `lint`, which runs both `lint-style` and `lint-type`.

Type check is now mandatory in CI, and the PR template has been updated accordingly.

### Note

I used the kebab-case style for the lint sub-commands, while other sub-commands use the snake_case. We can either switch all to kebab-case (my preferred style for command), or I keep it to snake_case. I have a preferred option, however for the sake of consistency, I'll be happy to revert that if there is an objection.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
