### PR TITLE
test: add tests for calc, dice plugins

### DIFF
--- a/test/modules/test_modules_calc.py
+++ b/test/modules/test_modules_calc.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+from sopel.tests import rawlist
+
+
+TMP_CONFIG = """
+[core]
+owner = Admin
+nick = Sopel
+enable =
+    calc
+host = irc.libera.chat
+"""
+
+
+@pytest.fixture
+def bot(botfactory, configfactory):
+    settings = configfactory('default.ini', TMP_CONFIG)
+    return botfactory.preloaded(settings, ['calc'])
+
+
+@pytest.fixture
+def irc(bot, ircfactory):
+    return ircfactory(bot)
+
+
+@pytest.fixture
+def user(userfactory):
+    return userfactory('User')
+
+
+def test_calc_command(irc, bot, user):
+    irc.pm(user, ".calc 1 + 1")
+    assert bot.backend.message_sent == rawlist(
+        "PRIVMSG User :[calc] 2"
+    )

--- a/test/modules/test_modules_dice.py
+++ b/test/modules/test_modules_dice.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import random
+
+import pytest
+
+from sopel.tests import rawlist
+
+
+TMP_CONFIG = """
+[core]
+owner = Admin
+nick = Sopel
+enable =
+    dice
+host = irc.libera.chat
+"""
+
+
+@pytest.fixture
+def bot(botfactory, configfactory):
+    settings = configfactory('default.ini', TMP_CONFIG)
+    return botfactory.preloaded(settings, ['dice'])
+
+
+@pytest.fixture
+def irc(bot, ircfactory):
+    return ircfactory(bot)
+
+
+@pytest.fixture
+def user(userfactory):
+    return userfactory('User')
+
+
+def test_dice_command(irc, bot, user):
+    random.seed(42)
+    irc.pm(user, ".dice 1d20 + 2d10 + 7")
+    assert bot.backend.message_sent == rawlist(
+        "PRIVMSG User :[dice] 1d20 + 2d10 + 7: (4) + (1+5) + 7 = 17"
+    )


### PR DESCRIPTION
### Description

This changeset adds tests for the `calc, dice` plugins, inspired by discussion on #2464.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make quality` and `make test`)
- [x] I have tested the functionality of the things this change touches