### PR TITLE
test: add capabilities test cases for trailing space handling

### DIFF
--- a/test/irc/test_irc_capabilities.py
+++ b/test/irc/test_irc_capabilities.py
@@ -83,6 +83,20 @@ def test_capabilities_ls_multiline(mockbot, triggerfactory):
     assert manager.available == {'away-notify': None, 'account-tag': None}
 
 
+def test_capabilities_ls_trailing_space(mockbot, triggerfactory: TriggerFactory):
+    raw = 'CAP * LS :away-notify '
+    wrapped = triggerfactory.wrapper(mockbot, raw)
+    manager = Capabilities()
+    assert manager.handle_ls(wrapped, wrapped._trigger)
+    assert manager.is_available('away-notify')
+    assert not manager.is_enabled('away-notify')
+    assert manager.available == {'away-notify': None}
+    assert not manager.enabled
+
+    expected = CapabilityInfo('away-notify', None, True, False)
+    assert manager.get_capability_info('away-notify') == expected
+
+
 def test_capabilities_ack(mockbot, triggerfactory):
     raw = 'CAP * ACK :away-notify'
     wrapped = triggerfactory.wrapper(mockbot, raw)
@@ -102,6 +116,18 @@ def test_capabilities_ack(mockbot, triggerfactory):
     assert manager.is_enabled('away-notify')
     assert manager.is_enabled('account-tag')
     assert manager.enabled == frozenset({'away-notify', 'account-tag'})
+
+
+def test_capabilities_ack_trailing_space(mockbot, triggerfactory):
+    raw = 'CAP * ACK :away-notify '
+    wrapped = triggerfactory.wrapper(mockbot, raw)
+    manager = Capabilities()
+    assert manager.handle_ack(wrapped, wrapped._trigger) == ('away-notify',)
+    assert not manager.is_available('away-notify'), (
+        'ACK a capability does not update server availability.')
+    assert manager.is_enabled('away-notify'), (
+        'ACK a capability make it enabled.')
+    assert manager.enabled == frozenset({'away-notify'})
 
 
 def test_capabilities_ack_multiple(mockbot, triggerfactory):
@@ -180,6 +206,18 @@ def test_capabilities_nak(mockbot, triggerfactory):
     assert not manager.is_available('account-tag')
     assert not manager.is_enabled('away-notify')
     assert not manager.is_enabled('account-tag')
+    assert not manager.enabled
+
+
+def test_capabilities_nak_trailing_space(mockbot, triggerfactory):
+    raw = 'CAP * NAK :away-notify '
+    wrapped = triggerfactory.wrapper(mockbot, raw)
+    manager = Capabilities()
+    assert manager.handle_nak(wrapped, wrapped._trigger) == ('away-notify',)
+    assert not manager.is_available('away-notify'), (
+        'NAK a capability does not update server availability.')
+    assert not manager.is_enabled('away-notify'), (
+        'NAK a capability make it not enabled.')
     assert not manager.enabled
 
 
@@ -274,6 +312,21 @@ def test_capabilities_new(mockbot, triggerfactory):
     assert not manager.enabled
 
 
+def test_capabilities_new_trailing_space(mockbot, triggerfactory):
+    manager = Capabilities()
+
+    # NEW CAP
+    raw = 'CAP * NEW :echo-message '
+    wrapped = triggerfactory.wrapper(mockbot, raw)
+    assert manager.handle_new(wrapped, wrapped._trigger) == (
+        'echo-message',
+    )
+    assert manager.is_available('echo-message')
+    assert not manager.is_enabled('echo-message')
+    assert manager.available == {'echo-message': None}
+    assert not manager.enabled
+
+
 def test_capabilities_new_multiple(mockbot, triggerfactory):
     manager = Capabilities()
 
@@ -310,6 +363,21 @@ def test_capabilities_del(mockbot, triggerfactory):
 
     # DEL CAP
     raw = 'CAP * DEL :echo-message'
+    wrapped = triggerfactory.wrapper(mockbot, raw)
+    assert manager.handle_del(wrapped, wrapped._trigger) == (
+        'echo-message',
+    )
+    assert not manager.is_available('echo-message')
+    assert not manager.is_enabled('echo-message')
+    assert not manager.available
+    assert not manager.enabled
+
+
+def test_capabilities_del_trailing_space(mockbot, triggerfactory):
+    manager = Capabilities()
+
+    # DEL CAP
+    raw = 'CAP * DEL :echo-message '
     wrapped = triggerfactory.wrapper(mockbot, raw)
     assert manager.handle_del(wrapped, wrapped._trigger) == (
         'echo-message',

--- a/test/irc/test_irc_capabilities.py
+++ b/test/irc/test_irc_capabilities.py
@@ -221,7 +221,7 @@ def test_capabilities_nak_trailing_space(mockbot, triggerfactory):
     assert not manager.enabled
 
 
-def test_capabilities_nack_multiple(mockbot, triggerfactory):
+def test_capabilities_nak_multiple(mockbot, triggerfactory):
     raw = 'CAP * NAK :away-notify account-tag'
     wrapped = triggerfactory.wrapper(mockbot, raw)
     manager = Capabilities()
@@ -246,7 +246,7 @@ def test_capabilities_nack_multiple(mockbot, triggerfactory):
     assert not manager.enabled
 
 
-def test_capabilities_ack_and_nack(mockbot, triggerfactory):
+def test_capabilities_ack_and_nak(mockbot, triggerfactory):
     manager = Capabilities()
 
     # ACK a single CAP


### PR DESCRIPTION
Some IRCds include trailing space in capability lists, and this is not a spec violation. Default `.split()` behavior in Python should handle it fine, but it's also good to be explicit that we expect the default behavior, through tests.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
  - `Success: no issues found in 82 source files`
  - `1322 passed, 8 xfailed, 1 warning in 70.41s (0:01:10)`
- [x] I have tested the functionality of the things this change touches

### Notes
Inspired by ircv3/ircv3-specifications#530, which is not yet merged. However, since this is de facto behavior by UnrealIRCd and InspIRCd that isn't likely to change very soon even if the spec amendment is rejected, I think we should just add the tests.

Review requested from @Exirel specifically because the new capability system is his baby, and he's the most likely one to point out any incorrect assumptions I might have had about how to adapt existing test cases for this purpose.