### PR TITLE
coretasks, test: handle `core.modes` setting being `None`

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -463,8 +463,11 @@ def handle_isupport(bot, trigger):
     if not botmode_support and 'BOT' in bot.isupport:
         # yes it was! set our mode unless the config overrides it
         botmode = bot.isupport['BOT']
-        if botmode not in bot.config.core.modes:
+        modes_setting = bot.config.core.modes
+
+        if not modes_setting or botmode not in bot.config.core.modes:
             bot.write(('MODE', bot.nick, '+' + botmode))
+
     # was NAMESX support status updated?
     if not namesx_support and 'NAMESX' in bot.isupport:
         # yes it was!
@@ -472,6 +475,7 @@ def handle_isupport(bot, trigger):
             # and the multi-prefix capability is not enabled
             # so we can ask the server to use the NAMESX feature
             bot.write(('PROTOCTL', 'NAMESX'))
+
     # was UHNAMES support status updated?
     if not uhnames_support and 'UHNAMES' in bot.isupport:
         # yes it was!

--- a/test/test_coretasks.py
+++ b/test/test_coretasks.py
@@ -361,7 +361,7 @@ def test_handle_isupport_chantypes(mockbot):
     assert mockbot.make_identifier('!channel').is_nick()
 
 
-@pytest.mark.parametrize('modes', ['', 'Rw'])
+@pytest.mark.parametrize('modes', [None, '', 'Rw'])
 def test_handle_isupport_bot_mode(mockbot, modes):
     mockbot.config.core.modes = modes
 


### PR DESCRIPTION
### Description
Tin. Also added `None` to tested cases, so if it goes back to throwing an error after future changes we'll find out about it.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - The corresponding (new) test case `test/test_coretasks.py::test_handle_isupport_bot_mode[None]` initially failed with an exception traceback, as described in #2509.
    With the patch applied, it passes.

### Notes
Fun facts about this bug:

- It was introduced in #2448 (my fault).
- I considered giving `core.modes` a `default=''`, but it could still become `None` if someone puts `modes = ` into their config file. The logic changes here would still be required to handle that case, so I decided that `None` was still a more semantic "not set" value than empty-string and left it without a default value.