### PR TITLE
xkcd: address py/mixed-returns CodeQL alert

### DIFF
--- a/sopel/modules/xkcd.py
+++ b/sopel/modules/xkcd.py
@@ -58,6 +58,7 @@ def web_search(query):
     match = re.match(r'(?:https?://)?(?:m\.)?xkcd\.com/(\d+)/?', url)
     if match:
         return match.group(1)
+    return None
 
 
 def searchxkcd_search(query):


### PR DESCRIPTION
### Description

I started this branch intending to fixup several other alerts, but realized that most of them were of the same type we already decided to dismiss (no one really cares about the return value of a plugin callable).

However, `xkcd` has a real function that was flagged by this rule, so I chose to still fix it even though it means opening a dinky +1 pull request. But I won't bother milestoning this until it's merged, so it doesn't affect our release timelines in any way.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches