### PR TITLE
search: fix cases where `.suggest` gets only one item back

### DIFF
--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -213,9 +213,18 @@ def suggest(bot, trigger):
     answer = xmltodict.parse(response.text)['toplevel']
 
     try:
-        answer = answer['CompleteSuggestion'][0]['suggestion']['@data']
+        answer = answer['CompleteSuggestion']
+
+        try:
+            answer = answer[0]
+        except KeyError:
+            # only one suggestion; don't need to extract first item
+            pass
+
+        answer = answer['suggestion']['@data']
     except TypeError:
         answer = None
+
     if answer:
         bot.say(answer)
     else:

--- a/sopel/modules/search.py
+++ b/sopel/modules/search.py
@@ -186,8 +186,9 @@ def search(bot, trigger):
 
 
 @plugin.command('suggest')
-@plugin.example('.suggest wikip', 'wikipedia', online=True, vcr=True)
 @plugin.example('.suggest', '.suggest what?')
+@plugin.example('.suggest sopel irc', 'sopel irc', online=True, vcr=True)
+@plugin.example('.suggest wikip', 'wikipedia', online=True, vcr=True, user_help=True)
 @plugin.example('.suggest lkashdfiauwgaef', 'Sorry, no result.', online=True, vcr=True)
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def suggest(bot, trigger):

--- a/test/vcr/modules/search/test_example_suggest_0.yaml
+++ b/test/vcr/modules/search/test_example_suggest_0.yaml
@@ -2,10 +2,14 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: ['*/*']
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python-requests/2.24.0]
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.31.0
     method: GET
     uri: https://suggestqueries.google.com/complete/search?output=toolbar&hl=en&q=lkashdfiauwgaef
   response:
@@ -13,21 +17,38 @@ interactions:
       string: !!binary |
         H4sIAAAAAAAC/7Oxr8jNUShLLSrOzM+zVTLUM1Cyt7MpyS/ISS1LzbGz0YczAYEc0EoqAAAA
     headers:
-      Alt-Svc: ['h3-Q050=":443"; ma=2592000,h3-29=":443"; ma=2592000,h3-27=":443";
-          ma=2592000,h3-T051=":443"; ma=2592000,h3-T050=":443"; ma=2592000,h3-Q046=":443";
-          ma=2592000,h3-Q043=":443"; ma=2592000,quic=":443"; ma=2592000; v="46,43"']
-      Cache-Control: ['private, max-age=3600']
-      Content-Encoding: [gzip]
-      Content-Type: [text/xml; charset=ISO-8859-1]
-      Date: ['Fri, 09 Oct 2020 04:40:44 GMT']
-      Expires: ['Fri, 09 Oct 2020 04:40:44 GMT']
-      P3P: [CP="This is not a P3P policy! See g.co/p3phelp for more info."]
-      Server: [gws]
-      Set-Cookie: ['1P_JAR=2020-10-09-04; expires=Sun, 08-Nov-2020 04:40:44 GMT; path=/;
-          domain=.google.com; Secure', 'NID=204=Pj4KwB7kHso7RFBcgEZMNDzLIhhuv8pFbIEWxp58KBEvUO9jquasGnvLCLcy0EfiJpPNvRfn_BIff0nkUzyqRJm4wSlrZ9tvmo7ohYEmAZerMGePW9wVWHCgMhCxArooUvVQ9W804M3QGhRlQ4ZZxwXnqGnfcSAA9h7DDDuRKLg;
-          expires=Sat, 10-Apr-2021 04:40:44 GMT; path=/; domain=.google.com; HttpOnly']
-      Transfer-Encoding: [chunked]
-      X-Frame-Options: [SAMEORIGIN]
-      X-XSS-Protection: ['0']
-    status: {code: 200, message: OK}
+      Alt-Svc:
+      - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
+      Cache-Control:
+      - private, max-age=3600
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - 'object-src ''none'';base-uri ''self'';script-src ''nonce-bqn-bde_sURx7gg6smeyow''
+        ''strict-dynamic'' ''report-sample'' ''unsafe-eval'' ''unsafe-inline'' https:
+        http:;report-uri https://csp.withgoogle.com/csp/gws/xsrp'
+      Content-Type:
+      - text/xml; charset=ISO-8859-1
+      Date:
+      - Sun, 01 Oct 2023 22:08:12 GMT
+      Expires:
+      - Sun, 01 Oct 2023 22:08:12 GMT
+      P3P:
+      - CP="This is not a P3P policy! See g.co/p3phelp for more info."
+      Server:
+      - gws
+      Set-Cookie:
+      - 1P_JAR=2023-10-01-22; expires=Tue, 31-Oct-2023 22:08:12 GMT; path=/; domain=.google.com;
+        Secure
+      - NID=511=dO-EpOs4FOklsnc4Pp3npRl1SVjfpgKMbw8to-Rx9usNNf_zbI02DRK-uIdRBYYvAVDOdu_zksAU1aRpNDsefpbsuAf54C2fz4RMgIrUH5i-MEnJ5kFBbrq-d8Of2g-Cp2BZDB0-_XyI1WT5VWdwpNprOyrNJVs4wtfLPxPe_DQ;
+        expires=Mon, 01-Apr-2024 22:08:12 GMT; path=/; domain=.google.com; HttpOnly
+      Transfer-Encoding:
+      - chunked
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - '0'
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/test/vcr/modules/search/test_example_suggest_1.yaml
+++ b/test/vcr/modules/search/test_example_suggest_1.yaml
@@ -11,12 +11,13 @@ interactions:
       User-Agent:
       - python-requests/2.31.0
     method: GET
-    uri: https://suggestqueries.google.com/complete/search?output=toolbar&hl=en&q=sopel+irc
+    uri: https://suggestqueries.google.com/complete/search?output=toolbar&hl=en&q=wikip
   response:
     body:
       string: !!binary |
-        H4sIAAAAAAAC/7Oxr8jNUShLLSrOzM+zVTLUM1Cyt7MpyS/ISS1LzbGzcc7PBTJLUoNL09NTi0uA
-        iuxsiuFshZTEkkRbpeL8gtQchcyiZCV9Oxt9bFr04SYCAKTyHI5xAAAA
+        H4sIAAAAAAAC/63TPQrDMAwF4KsYH6Bpd8cZeoSeQMQPR8R/2E6a4zdTpnYoaHuD9METyExHDGpH
+        bZzTqB+3u56s6bkE7AjWPHM8Y8dr8x6tn0PWtCsrR51G/eaVCxyTHqwZvq38x6gGqvMipSH5wE2M
+        8xQhVrQArm5J9nCKk3TpXArSAo6oUqSjuqqYndgxKyWXo6LaeQ7C6k9tuH7lA1+7OeZLAwAA
     headers:
       Alt-Svc:
       - h3=":443"; ma=2592000,h3-29=":443"; ma=2592000
@@ -25,24 +26,24 @@ interactions:
       Content-Encoding:
       - gzip
       Content-Security-Policy:
-      - 'object-src ''none'';base-uri ''self'';script-src ''nonce-0QjS0PS1bkaLNV-ZwUrXtw''
+      - 'object-src ''none'';base-uri ''self'';script-src ''nonce-tweQn7Ss8hox9zQe-xYVHA''
         ''strict-dynamic'' ''report-sample'' ''unsafe-eval'' ''unsafe-inline'' https:
         http:;report-uri https://csp.withgoogle.com/csp/gws/xsrp'
       Content-Type:
       - text/xml; charset=ISO-8859-1
       Date:
-      - Sun, 01 Oct 2023 22:08:13 GMT
+      - Sun, 01 Oct 2023 22:08:12 GMT
       Expires:
-      - Sun, 01 Oct 2023 22:08:13 GMT
+      - Sun, 01 Oct 2023 22:08:12 GMT
       P3P:
       - CP="This is not a P3P policy! See g.co/p3phelp for more info."
       Server:
       - gws
       Set-Cookie:
-      - 1P_JAR=2023-10-01-22; expires=Tue, 31-Oct-2023 22:08:13 GMT; path=/; domain=.google.com;
+      - 1P_JAR=2023-10-01-22; expires=Tue, 31-Oct-2023 22:08:12 GMT; path=/; domain=.google.com;
         Secure
-      - NID=511=R9yxS4Vqfw-TpuqZFOmLmSnTAI9dE_3a_3kI-t4dINKpdeJb12NLhoIAA9S5O8uE1Lz1Qj00FYzA1bVuMEASytLNDl920QJDA8u7Yp-YiskoGG9T0FRMK4-QzMSAy4gBwmY-e2MT_5uYFM_FgFY7EoaeWpo6hotXXbbopRdg9Co;
-        expires=Mon, 01-Apr-2024 22:08:13 GMT; path=/; domain=.google.com; HttpOnly
+      - NID=511=GKP1S5d2fEPy67A69aYS0ZwYbNd_e7leYIAx6IRB4HxNWKE6YG-6ydKKf73w7khkbQ_LvVsrCodezyg_WiNpixCKw22_O0v3YtaiBlEGJ5tjKg7xQgW2wdGhVXo_svbIoz-SXgCyIsf-iMIGrKeUYQzTybvG5Jpc3PmvYcn62VQ;
+        expires=Mon, 01-Apr-2024 22:08:12 GMT; path=/; domain=.google.com; HttpOnly
       Transfer-Encoding:
       - chunked
       X-Frame-Options:


### PR DESCRIPTION
`xmltodict` presents a response with only one `<CompleteSuggestion>` element as just a plain OrderedDict, without any list wrapping it. This PR fixes the behavior, adds an `@example` test covering a query that currently returns only one result, and updates the VCR cassettes for all `@example` tests.

As a bonus, which example should appear in `.help suggest` is now explicitly specified with `user_help=True`.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
  - Same as my last PR, an unrelated error appears in my local `make lint` run that doesn't appear in our CI.
- [x] I have tested the functionality of the things this change touches