### PR TITLE
tools.memories: remove obsolete LGTM tricks

### DIFF
--- a/sopel/tools/memories.py
+++ b/sopel/tools/memories.py
@@ -58,12 +58,6 @@ class SopelMemory(dict):
         self.lock.release()
         return result
 
-    # Needed to make it explicit that we don't care about the `lock` attribute
-    # when comparing/hashing SopelMemory objects.
-    __eq__ = dict.__eq__
-    __ne__ = dict.__ne__
-    __hash__ = dict.__hash__
-
 
 class SopelMemoryWithDefault(defaultdict):
     """Same as SopelMemory, but subclasses from collections.defaultdict.


### PR DESCRIPTION
We aren't using LGTM any more, and thus don't need to trick it (46f184e6a030e955364c38546e8ce9c5cecd261f, part of #1754) into suppressing a warning about attributes that were added to `SopelMemory` vs. the base `dict` object it's extending.

I don't think this'll do anything in CI, but it fixes a mypy error that seems to only appear on my system. Since there's no technical reason for these assignments to exist, rather than wast time figuring out how to fix the type-check error, let's just remove them.

Like LGTM, the CodeQL static analysis we use now is also difficult/impossible to use effectively on a local machine, so if this brings up any new alerts I/we will have to decide what to do after the fact.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
  - Fixing an issue reported by `make lint` locally was in fact the entire reason I made this PR. 😁
- [x] I have tested the functionality of the things this change touches

### Update post-analysis

Yes, now `SopelMemory` triggers the `py/missing-equals` rule due to adding a `lock` attribute without overriding `__eq__`. IMO removing the existing silly approach is worthwhile without immediately figuring out the best way to resolve the new alert.