### PR TITLE
Add Python 3.12 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           - "3.9"
           - "3.10"
           - "3.11"
+          - "3.12"
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/Makefile
+++ b/Makefile
@@ -12,20 +12,20 @@ lint-type:
 
 .PHONY: test test_norecord test_novcr vcr_rerecord
 test:
-	coverage run -m py.test -v .
+	coverage run -m pytest -v .
 
 test_norecord:
 	# error if VCR recording for a web request is missing (useful on CI)
-	coverage run -m py.test -v . --vcr-record=none
+	coverage run -m pytest -v . --vcr-record=none
 
 test_novcr:
 	# disable VCR completely; useful to check if recordings are outdated
-	coverage run -m py.test -v . --disable-vcr
+	coverage run -m pytest -v . --disable-vcr
 
 vcr_rerecord:
 	# clear VCR cassettes and run tests to record fresh ones
 	rm -rf ./test/vcr/*
-	coverage run -m py.test -v . --vcr-record=all
+	coverage run -m pytest -v . --vcr-record=all
 
 .PHONY: coverage_report coverage_html coverages
 coverage_report:

--- a/contrib/tox.ini
+++ b/contrib/tox.ini
@@ -2,12 +2,12 @@
 package_root = .
 min_version = 4.3.3
 envlist =
-    py{38,39,310,311}-qa
+    py{38,39,310,311,312}-qa
 skip_missing_interpreters = true
 ignore_base_python_conflict = true
 labels =
-    lint = py{38,39,310,311}-lint
-    test = py{38,39,310,311}-test
+    lint = py{38,39,310,311,312}-lint
+    test = py{38,39,310,311,312}-test
 
 
 [testenv]
@@ -20,11 +20,13 @@ envname =
     py39: py39
     py310: py310
     py311: py311
+    py312: py312
 envdir =
     py38: {toxinidir}/.tox/py38
     py39: {toxinidir}/.tox/py39
     py310: {toxinidir}/.tox/py310
     py311: {toxinidir}/.tox/py311
+    py312: {toxinidir}/.tox/py312
 depends =
     base
 deps =

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,7 +7,7 @@ flake8-import-order
 flake8-type-checking; python_version >= '3.8'
 # Sphinx theme
 furo==2023.9.10
-pytest~=7.1.0
+pytest~=7.4
 pytest-vcr~=1.0.2
 requests-mock~=1.9.3
 sphinx>=7.1.0,<8; python_version <= '3.8'

--- a/docs/source/plugin/test.rst
+++ b/docs/source/plugin/test.rst
@@ -33,7 +33,7 @@ Assuming your test files are in the ``test`` folder in your project directory::
 
 You can run your test suite with::
 
-    py.test -v test/
+    pytest -v test/
 
 .. __: https://docs.pytest.org/en/stable/getting-started.html
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Communications :: Chat :: Internet Relay Chat",
 ]
 requires-python = ">=3.8"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools~=63.0", "wheel"]
+requires = ["setuptools~=66.1", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]

--- a/sopel/tests/mocks.py
+++ b/sopel/tests/mocks.py
@@ -108,7 +108,7 @@ class MockIRCServer:
         ``blocking`` arguments to the instance methods below.
 
     The :class:`~sopel.tests.factories.IRCFactory` factory can be used to
-    create such mock object, either directly or by using ``py.test`` and the
+    create such mock object, either directly or by using ``pytest`` and the
     :func:`~sopel.tests.pytest_plugin.ircfactory` fixture.
 
     .. versionadded:: 7.1
@@ -361,7 +361,7 @@ class MockUser:
     :param str host: user's host
 
     The :class:`~sopel.tests.factories.UserFactory` factory can be used to
-    create such mock object, either directly or by using ``py.test`` and the
+    create such mock object, either directly or by using ``pytest`` and the
     :func:`~sopel.tests.pytest_plugin.userfactory` fixture.
     """
     def __init__(self, nick=None, user=None, host=None):


### PR DESCRIPTION
### Description

This changeset adds Python 3.12 support to Sopel, which mostly means some chore updating of version lists. The most notable change is the adjustment of the pinned version of `setuptools` to avoid a [known incompatibility with 3.12](https://github.com/pypa/setuptools/issues/3631).

~At one point it looked like `aiohttp` would be a blocker for this support (as they still have no issued a new release with a compat bugfix :grimacing:), but the problem disappeared between the last check of a Python 3.12 RC against Sopel and the official release. :shrug:~  Edit: nope, `aiohttp` is indeed [a problem](https://github.com/sopel-irc/sopel/actions/runs/6415020971/job/17416271455?pr=2516#step:4:613) (failure in CI associated with the [known upstream bug](https://github.com/aio-libs/aiohttp/issues/7229)), so we will be waiting for them to do a new release after all. We _can_ workaround the build failure by `AIOHTTP_NO_EXTENSIONS=1` in the environment, but there isn't a compelling reason to do this in CI, we can just wait on upstream to do a release. See [related issue](https://github.com/aio-libs/aiohttp/issues/7639), hopefully that will happen in the next week or so.

Edit: since the closure of #2523, the above no longer blocks this PR. Users who want both Python 3.12 and `sopel-iplookup` will be stuck waiting on `aiohttp`, but they can add `--pre` to their install command or set the above environment variable to get around it.

Closes #2457

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
  - `1323 passed, 8 xfailed, 591 warnings in 57.03s`
- [x] I have tested the functionality of the things this change touches

### Supplemental checklist (from #2457)

* [x] Check Sopel tests against 3.12
* [x] Update CI to run with 3.12
* [x] Update classifiers list in `pyproject.toml`
* ~~[ ] Check on 3.12 support concerns for official non-core plugins~~ NAK, not this PR's problem — @dgw