### PR TITLE
README: fix link to *latest source* archive

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,8 +28,8 @@ for installing from the latest source below.
 Latest source
 =============
 First, either clone the repository with ``git clone
-https://github.com/sopel-irc/sopel.git`` or download a tarball `from GitHub
-<https://github.com/sopel-irc/sopel/releases/latest>`_.
+https://github.com/sopel-irc/sopel.git`` or download a `source archive from
+GitHub <https://github.com/sopel-irc/sopel/archive/refs/heads/master.zip>`_.
 
 Note: Sopel requires Python 3.8+ to run.
 


### PR DESCRIPTION
### Description

The old link went to the latest *release*, not master.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
  - Non-code change.
- [x] I have tested the functionality of the things this change touches
  - Non-code change.