### PR TITLE
contrib: drop Python 3.7 from tox config

### DIFF
--- a/contrib/tox.ini
+++ b/contrib/tox.ini
@@ -2,12 +2,12 @@
 package_root = .
 min_version = 4.3.3
 envlist =
-    py{37,38,39,310,311}-qa
+    py{38,39,310,311}-qa
 skip_missing_interpreters = true
 ignore_base_python_conflict = true
 labels =
-    lint = py{37,38,39,310,311}-lint
-    test = py{37,38,39,310,311}-test
+    lint = py{38,39,310,311}-lint
+    test = py{38,39,310,311}-test
 
 
 [testenv]
@@ -16,13 +16,11 @@ package = sdist
 allowlist_externals =
     make
 envname =
-    py37: py37
     py38: py38
     py39: py39
     py310: py310
     py311: py311
 envdir =
-    py37: {toxinidir}/.tox/py37
     py38: {toxinidir}/.tox/py38
     py39: {toxinidir}/.tox/py39
     py310: {toxinidir}/.tox/py310


### PR DESCRIPTION
### Description

This changeset drops Python 3.7 from the `tox` config, since this version is now EOL and no longer targeted by Sopel.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
