### PR TITLE
bot: add deprecation notice to SopelWrapper

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -1279,6 +1279,14 @@ class SopelWrapper:
     their ``bot`` argument. It acts as a proxy, providing the ``trigger``'s
     ``sender`` (source channel or private message) as the default
     ``destination`` argument for overridden methods.
+
+    .. deprecated:: 8.0
+
+        ``SopelWrapper`` is being replaced with a ``contextvars`` based
+        alternative. For more information, see `#2460`__.
+
+    .. __: https://github.com/sopel-irc/sopel/issues/2460
+
     """
     def __init__(self, sopel, trigger, output_prefix=''):
         if not output_prefix:


### PR DESCRIPTION
### Description

This changeset adds a deprecation notice to `SopelWrapper` as the first part of #2460.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
