### PR TITLE
lifecycle: issue deprecation notices in pre-releases

### DIFF
--- a/sopel/lifecycle.py
+++ b/sopel/lifecycle.py
@@ -141,8 +141,8 @@ def deprecated(
 
     @functools.wraps(func)
     def deprecated_func(*args, **kwargs):
-        warn_ver = warning_in and parse_version(warning_in)
-        this_ver = parse_version(__version__)
+        warn_ver = warning_in and parse_version(warning_in).release
+        this_ver = parse_version(__version__).release
 
         if not (warn_ver and warn_ver >= this_ver):
             original_frame = inspect.stack()[-stack_frame]

--- a/sopel/lifecycle.py
+++ b/sopel/lifecycle.py
@@ -141,8 +141,10 @@ def deprecated(
 
     @functools.wraps(func)
     def deprecated_func(*args, **kwargs):
-        if not (warning_in and
-                parse_version(warning_in) >= parse_version(__version__)):
+        warn_ver = warning_in and parse_version(warning_in)
+        this_ver = parse_version(__version__)
+
+        if not (warn_ver and warn_ver >= this_ver):
             original_frame = inspect.stack()[-stack_frame]
             mod = inspect.getmodule(original_frame[0])
             module_name = None


### PR DESCRIPTION
### Description

This changeset modifies the version check for deprecation warnings so that only the [release segment](https://peps.python.org/pep-0440/#public-version-identifiers) of a version tag is used to check if a warning should be issued. For instance, currently a `@deprecation(warning_in="8.0")` _will not warn_ in `8.0.0.dev0` because the pre-release is considered to come before the 'final' release.

@dgw mentions that this might make for noisy logs in some cases, but I'm of the opinion that if I am running `8.0.0.dev0`, I _want_ to see deprecation warnings that will be current when `8.0.0` is finalized, _before_ that version is tagged. This is a concern for both core usage of in-the-future deprecated features, and for plugin authors who are checking their plugins against a coming release (although the latter is a softer concern).

Closes #2308.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
