### PR TITLE
memories: test/fix interactions between `SopelIdentifierMemory` ↔ `dict`

### DIFF
--- a/sopel/tools/memories.py
+++ b/sopel/tools/memories.py
@@ -246,3 +246,27 @@ class SopelIdentifierMemory(SopelMemory):
 
     def update(self, maybe_mapping=tuple()):
         super().update(self._convert_keys(maybe_mapping))
+
+    def __or__(self, other):
+        if not isinstance(other, dict):
+            return NotImplemented
+
+        # self on the left, so other's keys overwrite
+        new = self.copy()
+        new.update(other)
+        return new
+
+    def __ror__(self, other):
+        if not isinstance(other, dict):
+            return NotImplemented
+
+        # self on the right, so keep only new keys from other
+        new = self.copy()
+        new.update((k, v) for k, v in other.items() if k not in self)
+        return new
+
+    def __ior__(self, other):
+        if not isinstance(other, dict):
+            return NotImplemented
+        self.update(other)
+        return self

--- a/sopel/tools/memories.py
+++ b/sopel/tools/memories.py
@@ -183,6 +183,11 @@ class SopelIdentifierMemory(SopelMemory):
     def copy(self):
         return type(self)(self, identifier_factory=self.make_identifier)
 
+    def get(self, key: str, default=_NO_DEFAULT):
+        if default is _NO_DEFAULT:
+            return super().get(self._make_key(key))
+        return super().get(self._make_key(key), default)
+
     def pop(self, key: str, default=_NO_DEFAULT):
         if default is _NO_DEFAULT:
             return super().pop(self._make_key(key))

--- a/sopel/tools/memories.py
+++ b/sopel/tools/memories.py
@@ -228,6 +228,9 @@ class SopelIdentifierMemory(SopelMemory):
     def __setitem__(self, key: Optional[str], value):
         super().__setitem__(self._make_key(key), value)
 
+    def setdefault(self, key: str, default=None):
+        return super().setdefault(self._make_key(key), default)
+
     def __delitem__(self, key: str):
         super().__delitem__(self._make_key(key))
 

--- a/sopel/tools/memories.py
+++ b/sopel/tools/memories.py
@@ -38,6 +38,12 @@ class SopelMemory(dict):
     them at the same time from different threads, we use a blocking lock in
     ``__setitem__`` and ``__contains__``.
 
+    .. note::
+
+        Unlike the :class:`dict` on which they are based, ``SopelMemory`` and
+        its derivative types do not accept key-value pairs as keyword arguments
+        at construction time.
+
     .. versionadded:: 3.1
         As ``Willie.WillieMemory``
     .. versionchanged:: 4.0
@@ -74,6 +80,12 @@ class SopelMemory(dict):
 
 class SopelMemoryWithDefault(defaultdict):
     """Same as SopelMemory, but subclasses from collections.defaultdict.
+
+    .. note::
+
+        Unlike the :class:`~collections.defaultdict` on which it is based,
+        ``SopelMemoryWithDefault`` does not accept key-value pairs as keyword
+        arguments at construction time.
 
     .. versionadded:: 4.3
         As ``WillieMemoryWithDefault``

--- a/sopel/tools/memories.py
+++ b/sopel/tools/memories.py
@@ -149,9 +149,9 @@ class SopelIdentifierMemory(SopelMemory):
         """A factory to transform keys into identifiers."""
 
     def _make_key(self, key: Optional[str]) -> Optional[Identifier]:
-        if key is not None:
-            return self.make_identifier(key)
-        return None
+        if key is None:
+            return None
+        return self.make_identifier(key)
 
     def __getitem__(self, key: Optional[str]):
         return super().__getitem__(self._make_key(key))

--- a/sopel/tools/memories.py
+++ b/sopel/tools/memories.py
@@ -161,3 +161,6 @@ class SopelIdentifierMemory(SopelMemory):
 
     def __setitem__(self, key: Optional[str], value):
         super().__setitem__(self._make_key(key), value)
+
+    def __delitem__(self, key: str):
+        super().__delitem__(self._make_key(key))

--- a/sopel/tools/memories.py
+++ b/sopel/tools/memories.py
@@ -273,3 +273,12 @@ class SopelIdentifierMemory(SopelMemory):
             return NotImplemented
         self.update(other)
         return self
+
+    def __eq__(self, other):
+        if not isinstance(other, dict):
+            return NotImplemented
+        return super().__eq__(other)
+
+    def __ne__(self, other):
+        ret = self.__eq__(other)
+        return ret if ret is NotImplemented else not ret

--- a/sopel/tools/memories.py
+++ b/sopel/tools/memories.py
@@ -164,3 +164,6 @@ class SopelIdentifierMemory(SopelMemory):
 
     def __delitem__(self, key: str):
         super().__delitem__(self._make_key(key))
+
+    def copy(self):
+        return type(self)(self, identifier_factory=self.make_identifier)

--- a/sopel/tools/memories.py
+++ b/sopel/tools/memories.py
@@ -13,6 +13,21 @@ from typing import Optional
 from .identifiers import Identifier, IdentifierFactory
 
 
+class _NO_DEFAULT:
+    """Private class to help with overriding C methods like ``dict.pop()``.
+
+    Some Python standard library features are implemented in pure C, and can
+    have a ``null`` default value for certain parameters that is impossible to
+    emulate at the Python layer. This class is our workaround for that.
+
+    .. warning::
+
+        Plugin authors **SHOULD NOT** use this class. It is not part of Sopel's
+        public API.
+
+    """
+
+
 class SopelMemory(dict):
     """A simple thread-safe ``dict`` implementation.
 
@@ -167,3 +182,8 @@ class SopelIdentifierMemory(SopelMemory):
 
     def copy(self):
         return type(self)(self, identifier_factory=self.make_identifier)
+
+    def pop(self, key: str, default=_NO_DEFAULT):
+        if default is _NO_DEFAULT:
+            return super().pop(self._make_key(key))
+        return super().pop(self._make_key(key), default)

--- a/test/tools/test_tools_memories.py
+++ b/test/tools/test_tools_memories.py
@@ -1,6 +1,8 @@
 """Tests for Sopel Memory data-structures"""
 from __future__ import annotations
 
+import pytest
+
 from sopel.tools import identifiers, memories
 
 
@@ -93,3 +95,46 @@ def test_sopel_identifier_memory_copy():
     del copied['LowerOnly']
     assert 'LowerOnly' not in copied
     assert 'LowerOnly' in memory
+
+
+def test_sopel_identifier_memory_pop():
+    memory = memories.SopelIdentifierMemory()
+    memory['SomeCamelCase'] = True
+    assert len(memory) == 1
+
+    # verify SopelIdentifierMemory.pop('key') behavior
+    pop_me = memory.copy()
+    assert len(pop_me) == 1
+    assert pop_me.pop('someCAMELcase') is True
+    assert len(memory) == 1  # sanity check
+    assert len(pop_me) == 0
+
+    # verify SopelIdentifierMemory.pop('key', None) behavior
+    pop_me = memory.copy()
+    assert len(pop_me) == 1
+    assert pop_me.pop('someCAMELcase', None) is True
+    assert len(pop_me) == 0
+
+    # verify SopelIdentifierMemory.pop('key', 'default_value') behavior
+    pop_me = memory.copy()
+    assert len(pop_me) == 1
+    assert pop_me.pop('someCAMELcase', 'DEFAULT') is True
+    assert len(pop_me) == 0
+
+    # verify SopelIdentifierMemory.pop('missing_key') behavior
+    pop_me = memory.copy()
+    assert len(pop_me) == 1
+    assert 'missing_key' not in pop_me
+    with pytest.raises(KeyError):
+        pop_me.pop('missing_key')
+    assert len(pop_me) == 1
+
+    # verify SopelIdentifierMemory.pop('missing_key', None) behavior
+    assert 'missing_key' not in pop_me
+    assert pop_me.pop('missing_key', None) is None
+    assert len(pop_me) == 1
+
+    # verify SopelIdentifierMemory.pop('missing_key', 'default_value') behavior
+    assert 'missing_key' not in pop_me
+    assert pop_me.pop('missing_key', 'DEFAULT') == 'DEFAULT'
+    assert len(pop_me) == 1

--- a/test/tools/test_tools_memories.py
+++ b/test/tools/test_tools_memories.py
@@ -6,6 +6,11 @@ import pytest
 from sopel.tools import identifiers, memories
 
 
+def test_sopel_default_memory_contains():
+    memory = memories.SopelMemoryWithDefault(list)
+    assert 'key' not in memory
+
+
 def test_sopel_identifier_memory_none():
     memory = memories.SopelIdentifierMemory()
     assert None not in memory

--- a/test/tools/test_tools_memories.py
+++ b/test/tools/test_tools_memories.py
@@ -449,3 +449,62 @@ def test_sopel_identifier_memory_ior_op_other():
         memory |= 5
     with pytest.raises(TypeError):
         memory |= 'str'
+
+
+def test_sopel_identifier_memory_eq():
+    """Test equality checks between two `SopelIdentifierMemory` instances."""
+    memory = memories.SopelIdentifierMemory({'Foo': 'bar', 'Baz': 'Luhrmann'})
+    other_memory = memories.SopelIdentifierMemory((('Foo', 'bar'), ('Baz', 'Luhrmann')))
+
+    assert memory == other_memory
+    assert other_memory == memory  # cover our bases vis-a-vis operand precedence
+
+    memory = memories.SopelIdentifierMemory({'fOO': 'bar', 'bAZ': 'Luhrmann'})
+
+    assert memory == other_memory
+    assert other_memory == memory  # cover our bases vis-a-vis operand precedence
+
+
+def test_sopel_identifier_memory_eq_dict_id():
+    """Test ``SopelIdentifierMemory`` comparison to ``dict[Identifier, Any]``.
+
+    These can be equivalent, just like two ``dict`` objects with identical
+    ``Identifier`` keys can be.
+    """
+    memory = memories.SopelIdentifierMemory({'Foo': 'bar', 'Baz': 'Luhrmann'})
+    dictionary = dict(memory)
+
+    assert dictionary == memory
+    assert memory == dictionary  # cover our bases vis-a-vis operand precedence
+
+
+def test_sopel_identifier_memory_eq_dict_str():
+    """Test ``SopelIdentifierMemory`` comparison to ``dict[str, Any]``.
+
+    These are intentionally not considered equivalent.
+    """
+    dictionary = {'Foo': 'bar', 'Baz': 'Luhrmann'}
+    memory = memories.SopelIdentifierMemory(dictionary)
+
+    assert dictionary != memory
+    assert memory != dictionary  # cover our bases vis-a-vis operand precedence
+
+    memory = memories.SopelIdentifierMemory((('Spam', 'eggs'), ('GreenEggs', 'ham')))
+
+    assert dictionary != memory
+    assert memory != dictionary  # cover our bases vis-a-vis operand precedence
+
+
+def test_sopel_identifier_memory_eq_other():
+    """Test ``SopelIdentifierMemory`` comparison to non-dict types.
+
+    Never equivalent (``NotImplemented``).
+    """
+    memory = memories.SopelIdentifierMemory({'Foo': 'bar', 'Baz': 'Luhrmann'})
+
+    assert memory != 'string'
+    assert memory != 5
+    assert memory != ('Foo', 'Bar')
+
+    # operator precedence ass-covering
+    assert 'string' != memory

--- a/test/tools/test_tools_memories.py
+++ b/test/tools/test_tools_memories.py
@@ -267,3 +267,52 @@ def test_sopel_identifier_memory_clear():
     assert memory['SpamEggs'] == 'spameggs'
     assert memory['spaMeggS'] == 'spameggs'
     assert memory['spameggs'] == memory['sPAmeGGs']
+
+
+def test_sopel_identifier_memory_update():
+    memory = memories.SopelIdentifierMemory({
+        'FromIdentifierMemory': True,
+    })
+    tuple_ = (('FromTuplePairs', True), ('FromIdentifierMemory', False))
+    list_ = [('FromTuplePairs', False), ('FromListPairs', True)]
+    dict_ = {'FromDict': True, 'FromListPairs': False}
+    set_ = set((('FromDict', False), ('FromSet', True)))
+
+    assert len(memory) == 1
+    assert memory['froMidentifieRmemorY'] is True
+    assert 'froMtuplEpairS' not in memory
+    assert 'froMlisTpairS' not in memory
+    assert 'froMdicT' not in memory
+    assert 'froMseT' not in memory
+
+    memory.update(tuple_)
+    assert len(memory) == 2
+    assert memory['froMidentifieRmemorY'] is False
+    assert memory['froMtuplEpairS'] is True
+    assert 'froMlisTpairS' not in memory
+    assert 'froMdicT' not in memory
+    assert 'froMseT' not in memory
+
+    memory.update(list_)
+    assert len(memory) == 3
+    assert memory['froMidentifieRmemorY'] is False
+    assert memory['froMtuplEpairS'] is False
+    assert memory['froMlisTpairS'] is True
+    assert 'froMdicT' not in memory
+    assert 'froMseT' not in memory
+
+    memory.update(dict_)
+    assert len(memory) == 4
+    assert memory['froMidentifieRmemorY'] is False
+    assert memory['froMtuplEpairS'] is False
+    assert memory['froMlisTpairS'] is False
+    assert memory['froMdicT'] is True
+    assert 'froMseT' not in memory
+
+    memory.update(set_)
+    assert len(memory) == 5
+    assert memory['froMidentifieRmemorY'] is False
+    assert memory['froMtuplEpairS'] is False
+    assert memory['froMlisTpairS'] is False
+    assert memory['froMdicT'] is False
+    assert memory['froMseT'] is True

--- a/test/tools/test_tools_memories.py
+++ b/test/tools/test_tools_memories.py
@@ -175,3 +175,64 @@ def test_sopel_identifier_memory_pop():
     assert 'missing_key' not in pop_me
     assert pop_me.pop('missing_key', 'DEFAULT') == 'DEFAULT'
     assert len(pop_me) == 1
+
+
+def test_sopel_identifier_memory_from_dict():
+    dictionary = {'CamelCaseKey': True, 'lowercasekey': False}
+
+    memory = memories.SopelIdentifierMemory(dictionary)
+    assert 'CamelCaseKey' in memory
+    assert 'camelcasekey' in memory
+    assert memory['cameLcasEkeY'] == dictionary['CamelCaseKey']
+    assert 'lowercasekey' in memory
+    assert 'LowerCaseKey' in memory
+    assert memory['LoWeRcAsEkEy'] == dictionary['lowercasekey']
+
+
+def test_sopel_identifier_memory_from_identifier_memory():
+    original_memory = memories.SopelIdentifierMemory(
+        {'CamelCaseKey': True, 'lowercasekey': False}
+    )
+    assert 'CamelCaseKey' in original_memory
+    assert 'camelcasekey' in original_memory
+    assert 'lowercasekey' in original_memory
+    assert 'LowerCaseKey' in original_memory
+
+    memory = memories.SopelIdentifierMemory(original_memory)
+    assert 'CamelCaseKey' in memory
+    assert 'camelcasekey' in memory
+    assert memory['cameLcasEkeY'] is True
+    assert 'lowercasekey' in memory
+    assert 'LowerCaseKey' in memory
+    assert memory['LoWeRcAsEkEy'] is False
+
+    # be sure we really have a new object
+    memory['newOnly'] = True
+    assert 'NewOnly' in memory
+    assert 'NewOnly' not in original_memory
+    del memory['cameLcasEkeY']
+    assert 'cameLcasEkeY' not in memory
+    assert 'cameLcasEkeY' in original_memory
+
+
+def test_sopel_identifier_memory_from_list():
+    pairs_list = [('CamelCaseKey', True), ('lowercasekey', False)]
+    memory = memories.SopelIdentifierMemory(pairs_list)
+
+    assert 'CamelCaseKey' in memory
+    assert 'camelcasekey' in memory
+    assert memory['cameLcasEkeY'] is True
+    assert 'lowercasekey' in memory
+    assert 'LowerCaseKey' in memory
+    assert memory['LoWeRcAsEkEy'] is False
+
+
+def test_sopel_identifier_memory_from_tuple():
+    pairs_tuple = (('CamelCaseKey', True), ('lowercasekey', False))
+    memory = memories.SopelIdentifierMemory(pairs_tuple)
+    assert 'CamelCaseKey' in memory
+    assert 'camelcasekey' in memory
+    assert memory['cameLcasEkeY'] is True
+    assert 'lowercasekey' in memory
+    assert 'LowerCaseKey' in memory
+    assert memory['LoWeRcAsEkEy'] is False

--- a/test/tools/test_tools_memories.py
+++ b/test/tools/test_tools_memories.py
@@ -58,3 +58,16 @@ def test_sopel_identifier_memory_channel_str():
     assert memory[channel] == test_value
     assert memory['#adminchannel'] == test_value
     assert memory['#AdminChannel'] == test_value
+
+
+def test_sopel_identifier_memory_del_key():
+    memory = memories.SopelIdentifierMemory()
+    memory['KeY'] = True
+    assert 'KeY' in memory
+    del memory['KeY']
+    assert 'KeY' not in memory
+
+    memory['kEy'] = True
+    assert 'KeY' in memory
+    del memory['KeY']
+    assert 'KeY' not in memory

--- a/test/tools/test_tools_memories.py
+++ b/test/tools/test_tools_memories.py
@@ -316,3 +316,116 @@ def test_sopel_identifier_memory_update():
     assert memory['froMlisTpairS'] is False
     assert memory['froMdicT'] is False
     assert memory['froMseT'] is True
+
+
+def test_sopel_identifier_memory_or_op():
+    memory = memories.SopelIdentifierMemory({
+        'FromMemory': True,
+        'FromOther': False,
+    })
+    assert len(memory) == 2
+    assert memory['froMmemorY'] is True
+    assert memory['froMotheR'] is False
+
+    other_memory = memories.SopelIdentifierMemory({
+        'FromMemory': False,
+        'FromOther': True,
+    })
+    assert len(other_memory) == 2
+    assert 'FromOther' in other_memory
+    assert other_memory['FromOther'] is True
+    assert 'fromother' in other_memory
+
+    result = memory | other_memory
+    assert len(result) == 2
+    assert result['fROmMemorY'] is False
+    assert result['fROmoTHEr'] is True
+
+    result = other_memory | memory
+    assert len(result) == 2
+    assert result['FroMMemorY'] is True
+    assert result['FroMOtheR'] is False
+
+
+def test_sopel_identifier_memory_or_op_dict():
+    memory = memories.SopelIdentifierMemory({'FromMemory': True, 'FromDict': False})
+    assert len(memory) == 2
+    assert memory['froMmemorY'] is True
+    assert memory['froMdicT'] is False
+
+    dictionary = {'FromMemory': False, 'FromDict': True, 'AlsoFromDict': True}
+    assert len(dictionary) == 3
+    assert dictionary['FromDict'] is True
+    assert dictionary['FromMemory'] is False
+    assert dictionary['AlsoFromDict'] is True
+    assert 'alsofromdict' not in dictionary
+
+    # __or__
+    result = memory | dictionary
+    assert len(result) == 3
+    assert result['fROmMemorY'] is False
+    assert result['fROmDicT'] is True
+    assert result['alsOfroMdicT'] is True
+
+    # __ror__
+    result = dictionary | memory
+    assert len(result) == 3
+    assert result['fROmMemorY'] is True
+    assert result['fROmDicT'] is False
+    assert result['alsOfroMdicT'] is True
+
+
+def test_sopel_identifier_memory_or_op_other():
+    memory = memories.SopelIdentifierMemory()
+
+    with pytest.raises(TypeError):
+        # __or__
+        memory | 5
+    with pytest.raises(TypeError):
+        # __ror__
+        'str' | memory
+
+
+def test_sopel_identifier_memory_ior_op():
+    memory = memories.SopelIdentifierMemory({'FromMemory': True})
+    assert len(memory) == 1
+    assert memory['froMmemorY'] is True
+
+    other_memory = memories.SopelIdentifierMemory({
+        'FromMemory': False,
+        'FromOther': True,
+    })
+    assert len(other_memory) == 2
+    assert 'FromOther' in other_memory
+    assert other_memory['froMotheR'] is True
+
+    memory |= other_memory
+    assert len(memory) == 2
+    assert memory['fROmMemorY'] is False
+    assert memory['fROmoTHEr'] is True
+
+
+def test_sopel_identifier_memory_ior_op_dict():
+    memory = memories.SopelIdentifierMemory({'FromMemory': True})
+    assert len(memory) == 1
+    assert memory['froMmemorY'] is True
+
+    dictionary = {'FromDict': True}
+    assert len(dictionary) == 1
+    assert 'FromDict' in dictionary
+    assert dictionary['FromDict'] is True
+    assert 'fromdict' not in dictionary
+
+    memory |= dictionary
+    assert len(memory) == 2
+    assert memory['fROmMemorY'] is True
+    assert memory['fROmDicT'] is True
+
+
+def test_sopel_identifier_memory_ior_op_other():
+    memory = memories.SopelIdentifierMemory()
+
+    with pytest.raises(TypeError):
+        memory |= 5
+    with pytest.raises(TypeError):
+        memory |= 'str'

--- a/test/tools/test_tools_memories.py
+++ b/test/tools/test_tools_memories.py
@@ -71,3 +71,25 @@ def test_sopel_identifier_memory_del_key():
     assert 'KeY' in memory
     del memory['KeY']
     assert 'KeY' not in memory
+
+
+def test_sopel_identifier_memory_copy():
+    memory = memories.SopelIdentifierMemory()
+    memory['SomeCamelCase'] = True
+    memory['loweronly'] = False
+    assert len(memory) == 2
+    assert isinstance(memory, memories.SopelIdentifierMemory)
+
+    copied = memory.copy()
+    assert len(copied) == 2
+    assert 'SomeCamelCase' in copied
+    assert 'loweronly' in copied
+    assert isinstance(memory, memories.SopelIdentifierMemory)
+
+    # be absolutely sure it's a new object
+    copied['newOnly'] = True
+    assert 'NewOnly' in copied
+    assert 'NewOnly' not in memory
+    del copied['LowerOnly']
+    assert 'LowerOnly' not in copied
+    assert 'LowerOnly' in memory

--- a/test/tools/test_tools_memories.py
+++ b/test/tools/test_tools_memories.py
@@ -62,6 +62,26 @@ def test_sopel_identifier_memory_channel_str():
     assert memory['#AdminChannel'] == test_value
 
 
+def test_sopel_identifier_memory_setdefault():
+    memory = memories.SopelIdentifierMemory()
+    assert 'foo' not in memory
+
+    memory.setdefault('Foo')
+    assert len(memory) == 1
+    assert 'foo' in memory
+    assert 'fOO' in memory
+    assert memory['fOo'] is None
+
+    memory.setdefault('bAr', 'DEFAULT')
+    assert len(memory) == 2
+    assert 'FoO' in memory
+    assert 'BaR' in memory
+    assert memory['Bar'] == 'DEFAULT'
+
+    assert memory.setdefault('baR', 'different') == 'DEFAULT'
+    assert len(memory) == 2
+
+
 def test_sopel_identifier_memory_del_key():
     memory = memories.SopelIdentifierMemory()
     memory['KeY'] = True

--- a/test/tools/test_tools_memories.py
+++ b/test/tools/test_tools_memories.py
@@ -97,6 +97,43 @@ def test_sopel_identifier_memory_copy():
     assert 'LowerOnly' in memory
 
 
+def test_sopel_identifier_memory_get():
+    memory = memories.SopelIdentifierMemory()
+    memory['SomeCamelCase'] = True
+    memory['loweronly'] = False
+    assert len(memory) == 2
+
+    # verify key-exists behavior w/implicit default
+    assert memory.get('somecamelcase') == memory['somecamelcase']
+    assert memory.get('LowerOnly') == memory['LowerOnly']
+    assert len(memory) == 2
+
+    # verify key-exists behavior w/explicit default of None
+    assert memory.get('somecamelcase', None) == memory['somecamelcase']
+    assert memory.get('LowerOnly', None) == memory['LowerOnly']
+    assert len(memory) == 2
+
+    # verify key-exists behavior w/explicit "real" default value
+    assert memory.get('somecamelcase', 'DEFAULT') == memory['somecamelcase']
+    assert memory.get('LowerOnly', 'DEFAULT') == memory['LowerOnly']
+    assert len(memory) == 2
+
+    # verify key-missing behavior w/implicit default
+    assert 'missing_key' not in memory
+    assert memory.get('missing_key') is None
+    assert len(memory) == 2
+
+    # verify key-missing behavior w/explicit default of None
+    assert 'missing_key' not in memory
+    assert memory.get('missing_key', None) is None
+    assert len(memory) == 2
+
+    # verify key-missing behavior w/explicit "real" default value
+    assert 'missing_key' not in memory
+    assert memory.get('missing_key', 'DEFAULT') == 'DEFAULT'
+    assert len(memory) == 2
+
+
 def test_sopel_identifier_memory_pop():
     memory = memories.SopelIdentifierMemory()
     memory['SomeCamelCase'] = True

--- a/test/tools/test_tools_memories.py
+++ b/test/tools/test_tools_memories.py
@@ -236,3 +236,9 @@ def test_sopel_identifier_memory_from_tuple():
     assert 'lowercasekey' in memory
     assert 'LowerCaseKey' in memory
     assert memory['LoWeRcAsEkEy'] is False
+
+
+def test_sopel_identifier_memory_from_kwargs():
+    # This is unsupported behavior, by design.
+    with pytest.raises(TypeError):
+        memories.SopelIdentifierMemory(CamelCaseKey=True, lowercasekey=False)

--- a/test/tools/test_tools_memories.py
+++ b/test/tools/test_tools_memories.py
@@ -242,3 +242,28 @@ def test_sopel_identifier_memory_from_kwargs():
     # This is unsupported behavior, by design.
     with pytest.raises(TypeError):
         memories.SopelIdentifierMemory(CamelCaseKey=True, lowercasekey=False)
+
+
+def test_sopel_identifier_memory_clear():
+    memory = memories.SopelIdentifierMemory(
+        {'FooBar': 'foobar', 'BarFoo': 'barfoo'}
+    )
+    assert isinstance(memory, memories.SopelIdentifierMemory)
+    assert len(memory) == 2
+    assert 'FooBar' in memory
+    assert memory['FooBar'] == 'foobar'
+    assert 'BarFoo' in memory
+    assert memory['BarFoo'] == 'barfoo'
+
+    memory.clear()
+    assert isinstance(memory, memories.SopelIdentifierMemory)
+    assert len(memory) == 0
+    assert 'FooBar' not in memory
+    assert 'BarFoo' not in memory
+
+    memory['spameggs'] = 'spameggs'
+    assert len(memory) == 1
+    assert 'SpamEggs' in memory
+    assert memory['SpamEggs'] == 'spameggs'
+    assert memory['spaMeggS'] == 'spameggs'
+    assert memory['spameggs'] == memory['sPAmeGGs']


### PR DESCRIPTION
### Description
Tin. Will resolve #2524.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - Copiously.

### Notes
Started as a partial, untested fix from my tablet to reserve the PR number. New day, new task list:

- [x] `del d['KeY']`
- [x] `d.clear()` (_appears_ to work, but the object becomes a regular `dict` and loses the `Identifier` magic)
- [x] `d.copy()`
     Made a copy `m` and added another item to it, verifying that the new item did not appear in the original `d`.
     However, the new object `m` is a `dict`, not a `SopelIdentifierMemory`.
- [x] `d.get('KeY')`
     Returns the default passed to `.get()`, not `key`'s value.
- [x] `d.pop('KeY')` (currently raises `KeyError`)
- [x] `d.pop('KeY', 'default')` (currently always returns `'default'`)
- [x] `d.pop('NotInDict')`
      Returns `None` but **should** raise `KeyError`.
- [x] `d.setdefault('KeY', 'default')`
     With `'key' in d`, returns `'default'` & adds `'KeY'` to `d` as a regular string, _not_ `Identifier`.
- [x] `d.update(a_plain_dict)`
     If `d` has `Identifier('thing1')` as a key, and `a_plain_dict` has `'ThinG1'` (a regular string), they will not be merged correctly and `d` will now also have a regular string key called `'ThinG1'`.
- [x] `d | a_plain_dict`
     Same problem as `d.update(a_plain_dict)`.
- [x] `d |= a_plain_dict`
     Same problem as `d.update(a_plain_dict)` and `d | a_plain_dict`.
- ~~[ ] `d == a_plain_dict`~~
     If `a_plain_dict` has the same key/value pairs but the key capitalization doesn't match `Identifier`'s canonical (lowercase) internal representation, the equality check returns `False`.
     **Decided to NAK this one and let them be unequal.** It's an easily reversible decision, since this just preserves the existing behavior (so there's no worry about plugin authors screaming that we keep changing the rules 😁).
- [x] `result = SopelIdentifierMemory({'KeY': 'foo'})`
     `result` is of type `SopelIdentifierMemory`, but without the magic. Existing keys are not converted to `Identifier`, and `'key' in result` doesn't work as expected for that type.
     In fact, even `'KeY' in result` returns `False` for the example above, and `result['KeY'] raises `KeyError`. Even basic functionality of the resulting fake identifier memory is completely broken.