### PR TITLE
CodeQL: only scan `sopel` directory

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,6 +31,9 @@ jobs:
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
+          config: |
+            paths:
+              - sopel
 
       - name: Autobuild
         uses: github/codeql-action/autobuild@v2


### PR DESCRIPTION
No more false security warnings in test files.

### Checklist
- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
  - I haven't touched any code.
- [x] I have tested the functionality of the things this change touches
  - Leaving this unchecked until I see what GHA does, since I can't test the CodeQL workflow locally.