### PR TITLE
calc: improve help output, test coverage (now 100%)

### DIFF
--- a/sopel/builtins/calc.py
+++ b/sopel/builtins/calc.py
@@ -19,10 +19,10 @@ from sopel.tools.calculation import eval_equation
 @plugin.example('.c 5 + 3', '8')
 @plugin.example('.c 0.9*10', '9')
 @plugin.example('.c 10*0.9', '9')
-@plugin.example('.c 2*(1+2)*3', '18')
-@plugin.example('.c 2**10', '1024')
-@plugin.example('.c 5 // 2', '2')
-@plugin.example('.c 5 / 2', '2.5')
+@plugin.example('.c 2*(1+2)*3', '18', user_help=True)
+@plugin.example('.c 2**10', '1024', user_help=True)
+@plugin.example('.c 5 // 2', '2', user_help=True)
+@plugin.example('.c 5 / 2', '2.5', user_help=True)
 @plugin.output_prefix('[calc] ')
 def c(bot, trigger):
     """Evaluate some calculation."""

--- a/sopel/builtins/calc.py
+++ b/sopel/builtins/calc.py
@@ -12,6 +12,10 @@ from sopel.tools.calculation import eval_equation
 
 
 @plugin.command('c', 'calc')
+@plugin.example('.c', 'Nothing to calculate.')
+@plugin.example('.c foo * bar', "Can't process expression: Node type 'Name' is not supported.")
+@plugin.example('.c 10 / 0', 'Division by zero is not supported in this universe.')
+@plugin.example('.c 10\\2', 'Invalid syntax')
 @plugin.example('.c 5 + 3', '8')
 @plugin.example('.c 0.9*10', '9')
 @plugin.example('.c 10*0.9', '9')

--- a/sopel/builtins/calc.py
+++ b/sopel/builtins/calc.py
@@ -16,9 +16,19 @@ from sopel.tools.calculation import eval_equation
 @plugin.example('.c foo * bar', "Can't process expression: Node type 'Name' is not supported.")
 @plugin.example('.c 10 / 0', 'Division by zero is not supported in this universe.')
 @plugin.example('.c 10\\2', 'Invalid syntax')
+@plugin.example('.c (10**1000000)**2',
+                "Error running calculation: "
+                "ValueError('Pow expression too complex to calculate.')")
+@plugin.example('.c (10**100000)**2 * (10**100000)**2',
+                "Error running calculation: "
+                "ValueError('Value is too large to be handled in limited time and memory.')")
 @plugin.example('.c 5 + 3', '8')
 @plugin.example('.c 0.9*10', '9')
 @plugin.example('.c 10*0.9', '9')
+@plugin.example('.c 0.5**2', '0.25')
+@plugin.example('.c 3**0', '1')
+@plugin.example('.c 0 * 5', '0')
+@plugin.example('.c 5**5', '3125')
 @plugin.example('.c 2*(1+2)*3', '18', user_help=True)
 @plugin.example('.c 2**10', '1024', user_help=True)
 @plugin.example('.c 5 // 2', '2', user_help=True)
@@ -42,6 +52,9 @@ def c(bot, trigger):
         return
     except SyntaxError:
         bot.reply('Invalid syntax')
+        return
+    except ValueError as err:
+        bot.reply("Error running calculation: %r" % err)
         return
 
     bot.say(result)


### PR DESCRIPTION
Error cases weren't covered by the `@plugin.example` tests. Fixed that.

Also declared a few more examples that should appear in the help output, to showcase more of the plugin's capabilities.

Follow-up to https://github.com/sopel-irc/sopel/pull/2503#issuecomment-1676205118.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches