### PR TITLE
config: space before zone in `default_time_format`'s default

### DIFF
--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -489,10 +489,10 @@ class CoreSection(StaticSection):
     """
 
     default_time_format = ValidatedAttribute('default_time_format',
-                                             default='%Y-%m-%d - %T%Z')
+                                             default='%Y-%m-%d - %T %Z')
     """The default format to use for time in messages.
 
-    :default: ``%Y-%m-%d - %T%Z``
+    :default: ``%Y-%m-%d - %T %Z``
 
     Used when plugins format times with :func:`sopel.tools.time.format_time`.
 
@@ -500,7 +500,7 @@ class CoreSection(StaticSection):
 
     .. code-block:: ini
 
-        default_time_format = %Y-%m-%d - %T%Z
+        default_time_format = %Y-%m-%d - %T %Z
 
     .. seealso::
 


### PR DESCRIPTION
### Description

Dates like `2023-10-26 - 23:45CDT` look a bit weird, and should be presented as `2023-10-26 - 23:45 CDT`. (The default timezone is still UTC, don't worry.)

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
  - Technically I do get 2 local failures in `make test`, from the `vcrpy` problem that #2519 is meant to fix. CI seems to bypass that, so I should be fine. _\*knocks on wood\*_
- [x] I have tested the functionality of the things this change touches

### Notes

While making this, I noticed that Sphinx does not output any of the attribute values. Because of that, we have the same default value defined in three different places. The header line for each attribute _ideally_ would look like a module-level constant, e.g. `name_of_config_attribute = ListAttribute('name_of_config_attribute', default=['list', 'of', 'defaults'])` (and `ListAttribute` there would link to the type, of course). It'd save us having to duplicate default values in docstrings, at least.

This patch can't do anything about it, and I couldn't figure out in half an hour of research how to change the docs so Sphinx _would_ do it—but now I'm annoyed, so I wanted to pass that along to everyone else. 🤪