### PR TITLE
CodeQL: restrict paths on which action should run

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,8 +3,10 @@ name: "CodeQL"
 on:
   push:
     branches: [ "master", "7.1.x" ]
+    paths: [ "sopel/**" ]
   pull_request:
     branches: [ "master", "7.1.x" ]
+    paths: [ "sopel/**" ]
   schedule:
     - cron: "8 20 * * 1"
 


### PR DESCRIPTION
Saves us from burning GHA minutes (4-5 min/run) on CodeQL analysis when no files in the `sopel/` directory were changed.

Should have done this in #2528 but alas, I forgot.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - Whether the CodeQL workflow runs when I open the PR _will be_ the test, lol
    - CodeQL workflow doesn't appear on the Checks tab for this PR; seems to have worked 🥳

### Notes

No, unnecessary Actions runs don't cost the project anything, but since it's so easy to be nice and not waste even free resources on analyzing non-code changes, I think we might as well.

Thought about it, but can't skip the CI pipeline for unrelated changes because those checks are marked as required. They also finish in just a minute or two, vs. the 4-5 minutes (or longer) that CodeQL takes to run.
