### PR TITLE
Pin `packaging` version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,7 @@ dependencies = [
     "dnspython<3.0",
     "sqlalchemy>=1.4,<1.5",
     "importlib_metadata>=3.6",
-    "packaging",
+    "packaging>=23.2",
     "sopel-help>=0.4.0",
 ]
 


### PR DESCRIPTION
@Exirel discovered that we have some problems with type analysis on `master` if one has a `packaging` version that is 'too old'.

```
$ mypy --check-untyped-defs sopel
sopel/lifecycle.py:147: error: Unsupported operand types for >= ("tuple[int, ...]" and "None")  [operator]
sopel/lifecycle.py:147: note: Right operand is of type "tuple[int, ...] | None"
```

The above was observed with `packaging==21.3`.

I tried to look in their changelog to see if there was a specific version that fixed the issue we saw, but came up empty-handed. Pinning the lower bound to the latest version is the next best thing to do, and this package has excellent compatibility, so it shouldn't be a problem.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
