### PR TITLE
privileges, plugin, tools.target, docs: channel privileges as IntFlag

### DIFF
--- a/docs/source/plugin/privileges.rst
+++ b/docs/source/plugin/privileges.rst
@@ -13,6 +13,29 @@ This will give both OP and Voice privileges to the user named "Nickname" in the
 message it registers and updates its knowledge of a user's privileges in a
 channel, which can be used by plugins in various ways.
 
+Historically, these two privilege levels ("op" and "voiced") were the only
+channel privileges available:
+
+* :attr:`~sopel.privileges.AccessLevel.OP`: channel operator, set and unset by
+  modes ``+o`` and ``-o``
+* :attr:`~sopel.privileges.AccessLevel.VOICE`: the privilege to send messages to
+  a channel with the ``+m`` mode, set and unset by modes ``+v`` and ``-v``
+
+Since then, other privileges have been adopted by IRC servers and clients:
+
+* :attr:`~sopel.privileges.AccessLevel.HALFOP`: intermediate level between VOICE
+  and OP, set and unset by modes ``+h`` and ``-h``
+* :attr:`~sopel.privileges.AccessLevel.ADMIN`: channel admin, above OP and below
+  OWNER, set and unset by modes ``+a`` and ``-a``
+* :attr:`~sopel.privileges.AccessLevel.OWNER`: channel owner, above ADMIN and OP,
+  set and unset by modes ``+q`` and ``-q``
+
+.. important::
+
+    Not all IRC networks support these added privilege modes. If you are writing
+    a plugin for public distribution, ensure your code behaves sensibly if only
+    ``+v`` (voice) and ``+o`` (op) modes exist.
+
 Access rights
 =============
 

--- a/docs/source/plugin/privileges.rst
+++ b/docs/source/plugin/privileges.rst
@@ -11,7 +11,7 @@ IRC users can have privileges in a **channel**, given by MODE messages such as:
 This will give both OP and Voice privileges to the user named "Nickname" in the
 "#example" channel (and only in this channel). When Sopel receives a MODE
 message it registers and updates its knowledge of a user's privileges in a
-channel, which can be used by plugins in various way.
+channel, which can be used by plugins in various ways.
 
 Access rights
 =============
@@ -22,9 +22,10 @@ Privileged users
 A plugin can limit who can trigger its callables using the
 :func:`~sopel.plugin.require_privilege` decorator::
 
-    from sopel import plugin, privileges
+    from sopel import plugin
+    from sopel.privileges import AccessLevel
 
-    @plugin.require_privilege(privileges.OP)
+    @plugin.require_privilege(AccessLevel.OP)
     @plugin.require_chanmsg
     @plugin.command('chanopcommand')
     def chanop_command(bot, trigger):
@@ -34,7 +35,7 @@ This way, only users with OP privileges or above in a channel can use the
 command ``chanopcommand`` in that channel: other users will be ignored by the
 bot. It is possible to tell these users why with the ``message`` parameter::
 
-    @plugin.require_privilege(privileges.OP, 'You need +o privileges.')
+    @plugin.require_privilege(AccessLevel.OP, 'You need +o privileges.')
 
 .. important::
 
@@ -50,7 +51,7 @@ Sometimes, you may want the bot to be a privileged user in a channel to allow a
 command. For that, there is the :func:`~sopel.plugin.require_bot_privilege`
 decorator::
 
-    @plugin.require_bot_privilege(privileges.OP)
+    @plugin.require_bot_privilege(AccessLevel.OP)
     @plugin.require_chanmsg
     @plugin.command('opbotcommand')
     def change_topic(bot, trigger):
@@ -63,13 +64,13 @@ the user who invokes the command.
 As with ``require_privilege``, you can provide an error message::
 
     @plugin.require_bot_privilege(
-        privileges.OP, 'The bot needs +o privileges.')
+        AccessLevel.OP, 'The bot needs +o privileges.')
 
 And you **can** use both ``require_privilege`` and ``require_bot_privilege`` on
 the same plugin callable::
 
-    @plugin.require_privilege(privileges.VOICE)
-    @plugin.require_bot_privilege(privileges.OP)
+    @plugin.require_privilege(AccessLevel.VOICE)
+    @plugin.require_bot_privilege(AccessLevel.OP)
     @plugin.require_chanmsg
     @plugin.command('special')
     def special_command(bot, trigger):
@@ -92,7 +93,7 @@ Sometimes, a command should be used only by users who are authenticated via
 IRC services. On IRC networks that provide such information to IRC clients,
 this is possible with the :func:`~sopel.plugin.require_account` decorator::
 
-    @plugin.require_privilege(privileges.VOICE)
+    @plugin.require_privilege(AccessLevel.VOICE)
     @plugin.require_account
     @plugin.require_chanmsg
     @plugin.command('danger')
@@ -130,15 +131,15 @@ then you can get that user's privileges through the **channel**'s
     user_privileges = channel.privileges[trigger.nick]
 
 You can check the user's privileges manually using bitwise operators. Here
-for example, we check if the user is voiced (+v) or above::
+for example, we check if the user is voiced (``+v``) or above::
 
-    from sopel import privileges
+    from sopel.privileges import AccessLevel
 
-    if user_privileges & privileges.VOICE:
+    if user_privileges & AccessLevel.VOICE:
         # user is voiced
-    elif user_privileges > privileges.VOICE:
+    elif user_privileges > AccessLevel.VOICE:
         # not voiced, but higher privileges
-        # like privileges.HALFOP or privileges.OP
+        # like AccessLevel.HALFOP or AccessLevel.OP
     else:
         # no privilege
 
@@ -146,9 +147,9 @@ Another option is to use dedicated methods from the ``channel`` object::
 
     if channel.is_voiced('Nickname'):
         # user is voiced
-    elif channel.has_privilege('Nickname', privileges.VOICE):
+    elif channel.has_privilege('Nickname', AccessLevel.VOICE):
         # not voiced, but higher privileges
-        # like privileges.HALFOP or privileges.OP
+        # like AccessLevel.HALFOP or AccessLevel.OP
     else:
         # no privilege
 
@@ -158,14 +159,14 @@ You can also iterate over the list of users and filter them by privileges::
     op_users = [
         user
         for nick, user in channel.users
-        if channel.is_op(nick, privileges.OP)
+        if channel.is_op(nick, AccessLevel.OP)
     ]
 
     # get users with OP privilege or above
     op_or_higher_users = [
         user
         for nick, user in channel.users
-        if channel.has_privileges(nick, privileges.OP)
+        if channel.has_privileges(nick, AccessLevel.OP)
     ]
 
 .. seealso::

--- a/docs/source/plugin/privileges.rst
+++ b/docs/source/plugin/privileges.rst
@@ -21,7 +21,10 @@ channel privileges available:
 * :attr:`~sopel.privileges.AccessLevel.VOICE`: the privilege to send messages to
   a channel with the ``+m`` mode, set and unset by modes ``+v`` and ``-v``
 
-Since then, other privileges have been adopted by IRC servers and clients:
+.. _nonstandard privilege levels:
+
+Over time, IRC servers and clients have adopted various combinations of
+nonstandard, less formally defined privilege levels:
 
 * :attr:`~sopel.privileges.AccessLevel.HALFOP`: intermediate level between VOICE
   and OP, set and unset by modes ``+h`` and ``-h``
@@ -30,11 +33,10 @@ Since then, other privileges have been adopted by IRC servers and clients:
 * :attr:`~sopel.privileges.AccessLevel.OWNER`: channel owner, above ADMIN and OP,
   set and unset by modes ``+q`` and ``-q``
 
-.. important::
-
-    Not all IRC networks support these added privilege modes. If you are writing
-    a plugin for public distribution, ensure your code behaves sensibly if only
-    ``+v`` (voice) and ``+o`` (op) modes exist.
+**It's important to note that not all IRC networks support these nonstandard
+privileges, and the ones that do may not support all of them.** If you are
+writing a plugin for public distribution, ensure your code behaves sensibly when
+only the standardized ``+v`` (voice) and ``+o`` (op) modes exist.
 
 Access rights
 =============

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -24,7 +24,14 @@ from typing import (
 )
 
 # import and expose privileges as shortcut
-from sopel.privileges import ADMIN, HALFOP, OP, OPER, OWNER, VOICE
+from sopel.privileges import AccessLevel
+
+VOICE = AccessLevel.VOICE
+HALFOP = AccessLevel.HALFOP
+OP = AccessLevel.OP
+ADMIN = AccessLevel.ADMIN
+OWNER = AccessLevel.OWNER
+OPER = AccessLevel.OPER
 
 
 if TYPE_CHECKING:
@@ -1457,7 +1464,7 @@ def require_account(
 
 
 def require_privilege(
-    level: int,
+    level: AccessLevel,
     message: Optional[str] = None,
     reply: bool = False,
 ) -> Callable:
@@ -1581,7 +1588,7 @@ def require_owner(
 
 
 def require_bot_privilege(
-    level: int,
+    level: AccessLevel,
     message: Optional[str] = None,
     reply: bool = False,
 ) -> Callable:

--- a/sopel/privileges.py
+++ b/sopel/privileges.py
@@ -15,26 +15,17 @@ __all__ = [
 class AccessLevel(enum.IntFlag):
     """Enumeration of available user privilege levels.
 
-    Comparing privileges
-    ====================
-
-    This class represents privileges as powers of two, with higher values
-    assigned to higher-level privileges::
+    This class represents privileges as comparable, combinable flags. Lower
+    privilege levels compare as *less than* (``<``) higher ones::
 
         >>> from sopel.privileges import AccessLevel
         >>> AccessLevel.VOICE < AccessLevel.HALFOP < AccessLevel.OP \\
         ... < AccessLevel.ADMIN < AccessLevel.OWNER
         True
 
-    Then a user's privileges are represented as a sum of privilege levels::
+    A user's privileges are represented as a combination of privilege levels::
 
-        >>> AccessLevel.VOICE
-        1
-        >>> AccessLevel.OP
-        4
         >>> priv = AccessLevel.VOICE | AccessLevel.OP
-        >>> priv
-        5
 
     This allows using comparators and bitwise operators to compare privileges.
     Here, ``priv`` contains both VOICE and OP privileges, but not HALFOP::
@@ -46,9 +37,9 @@ class AccessLevel(enum.IntFlag):
 
     .. important::
 
-        Do not refer directly to the integer value of a privilege level in your
-        code; the values may change. Use the appropriate member of this class as
-        a reference point instead.
+        Do not hard-code the value of a privilege level in your code; the values
+        may change. Always reference or compare to the appropriate member of
+        this class directly.
 
     """
     # values should behave as ints, but their string representations should
@@ -77,9 +68,7 @@ class AccessLevel(enum.IntFlag):
 
     .. important::
 
-        Not all IRC networks support this privilege mode. If you are writing a
-        plugin for public distribution, ensure your code behaves sensibly if
-        only ``+v`` (voice) and ``+o`` (op) modes exist.
+        Beware: This is one of the `nonstandard privilege levels`_.
 
     """
 
@@ -105,9 +94,7 @@ class AccessLevel(enum.IntFlag):
 
     .. important::
 
-        Not all IRC networks support this privilege mode. If you are writing a
-        plugin for public distribution, ensure your code behaves sensibly if
-        only ``+v`` (voice) and ``+o`` (op) modes exist.
+        Beware: This is one of the `nonstandard privilege levels`_.
 
     """
 
@@ -122,9 +109,7 @@ class AccessLevel(enum.IntFlag):
 
     .. important::
 
-        Not all IRC networks support this privilege mode. If you are writing a
-        plugin for public distribution, ensure your code behaves sensibly if
-        only ``+v`` (voice) and ``+o`` (op) modes exist.
+        Beware: This is one of the `nonstandard privilege levels`_.
 
     """
 
@@ -142,8 +127,6 @@ class AccessLevel(enum.IntFlag):
 
     .. important::
 
-        Not all IRC networks support this privilege mode. If you are writing a
-        plugin for public distribution, ensure your code behaves sensibly if
-        only ``+v`` (voice) and ``+o`` (op) modes exist.
+        Beware: This is one of the `nonstandard privilege levels`_.
 
     """

--- a/sopel/privileges.py
+++ b/sopel/privileges.py
@@ -1,146 +1,174 @@
-"""Constants for user privileges in channels.
-
-Privilege levels
-================
-
-Historically, there were two user privileges in channels:
-
-* :data:`OP`: channel operator, or chanop, set and unset by ``+o`` and ``-o``
-* :data:`VOICE`: the privilege to send messages to a channel with the
-  ``+m`` mode, set and unset by ``+v`` and ``-v``
-
-Since then, other privileges have been adopted by IRC servers and clients:
-
-* :data:`HALFOP`: intermediate level between Voiced and OP, set and unset by
-  ``+h`` and ``-h``
-* :data:`ADMIN`: channel admin, above OP and below OWNER, set and unset by
-  ``+a`` and ``-a``
-* :data:`OWNER`: channel owner, above ADMIN and OP, set and unset by ``+q`` and
-  ``-q``
-
-.. important::
-
-    Not all IRC networks support these added privilege modes. If you are
-    writing a plugin for public distribution, ensure your code behaves sensibly
-    if only +v (voice) and +o (op) modes exist.
-
-Compare privileges
-==================
-
-This module represents privileges as powers of two, with higher values assigned
-to higher-level privileges::
-
-    >>> from sopel.privileges import VOICE, HALFOP, OP, ADMIN, OWNER
-    >>> VOICE < HALFOP < OP < ADMIN < OWNER
-    True
-
-Then a user's privileges are represented as a sum of privilege levels::
-
-    >>> VOICE
-    1
-    >>> OP
-    4
-    >>> priv = VOICE | OP
-    >>> priv
-    5
-
-This allows to use comparators and bitwise operators to compare privileges::
-
-    >>> priv >= OP
-    True
-    >>> bool(priv & HALFOP)
-    False
-
-In that case, ``priv`` contains both VOICE and OP privileges, but not HALFOP.
-"""
+"""Constants for user privileges in channels."""
+# Copyright 2023 dgw, technobabbl.es
+#
+# Licensed under the Eiffel Forum License 2.
 from __future__ import annotations
+
+import enum
 
 
 __all__ = [
-    'VOICE',
-    'HALFOP',
-    'OP',
-    'ADMIN',
-    'OWNER',
-    'OPER',
+    'AccessLevel',
 ]
 
 
-VOICE = 1
-"""Privilege level for the +v channel permission
+class AccessLevel(enum.IntFlag):
+    """Enumeration of available user privilege levels.
 
-.. versionadded:: 4.1
-.. versionchanged:: 8.0
-   Moved into :mod:`sopel.privileges`.
-"""
+    Privilege levels
+    ================
 
-HALFOP = 2
-"""Privilege level for the +h channel permission
+    Historically, there were two user privilege levels in a channel:
 
-.. versionadded:: 4.1
-.. versionchanged:: 8.0
-   Moved into :mod:`sopel.privileges`.
+    * :data:`~AccessLevel.OP`: channel operator, set and unset by modes ``+o``
+      and ``-o``
+    * :data:`~AccessLevel.VOICE`: the privilege to send messages to a channel
+      with the ``+m`` mode, set and unset by modes ``+v`` and ``-v``
 
-.. important::
+    Since then, other privileges have been adopted by IRC servers and clients:
 
-    Not all IRC networks support this privilege mode. If you are writing a
-    plugin for public distribution, ensure your code behaves sensibly if only
-    ``+v`` (voice) and ``+o`` (op) modes exist.
+    * :data:`~AccessLevel.HALFOP`: intermediate level between VOICE and OP, set
+      and unset by modes ``+h`` and ``-h``
+    * :data:`~AccessLevel.ADMIN`: channel admin, above OP and below OWNER, set
+      and unset by modes ``+a`` and ``-a``
+    * :data:`~AccessLevel.OWNER`: channel owner, above ADMIN and OP, set and
+      unset by modes ``+q`` and ``-q``
 
-"""
+    .. important::
 
-OP = 4
-"""Privilege level for the +o channel permission
+        Not all IRC networks support these added privilege modes. If you are
+        writing a plugin for public distribution, ensure your code behaves
+        sensibly if only +v (voice) and +o (op) modes exist.
 
-.. versionadded:: 4.1
-.. versionchanged:: 8.0
-   Moved into :mod:`sopel.privileges`.
-"""
+    Comparing privileges
+    ====================
 
-ADMIN = 8
-"""Privilege level for the +a channel permission
+    This class represents privileges as powers of two, with higher values
+    assigned to higher-level privileges::
 
-.. versionadded:: 4.1
-.. versionchanged:: 8.0
-   Moved into :mod:`sopel.privileges`.
+        >>> from sopel.privileges import AccessLevel
+        >>> AccessLevel.VOICE < AccessLevel.HALFOP < AccessLevel.OP \\
+        ... < AccessLevel.ADMIN < AccessLevel.OWNER
+        True
 
-.. important::
+    Then a user's privileges are represented as a sum of privilege levels::
 
-    Not all IRC networks support this privilege mode. If you are writing a
-    plugin for public distribution, ensure your code behaves sensibly if only
-    ``+v`` (voice) and ``+o`` (op) modes exist.
+        >>> AccessLevel.VOICE
+        1
+        >>> AccessLevel.OP
+        4
+        >>> priv = AccessLevel.VOICE | AccessLevel.OP
+        >>> priv
+        5
 
-"""
+    This allows using comparators and bitwise operators to compare privileges.
+    Here, ``priv`` contains both VOICE and OP privileges, but not HALFOP::
 
-OWNER = 16
-"""Privilege level for the +q channel permission
+        >>> priv >= AccessLevel.OP
+        True
+        >>> bool(priv & AccessLevel.HALFOP)
+        False
 
-.. versionadded:: 4.1
-.. versionchanged:: 8.0
-   Moved into :mod:`sopel.privileges`.
+    .. important::
 
-.. important::
+        Do not refer directly to the integer value of a privilege level in your
+        code; the values may change. Use the appropriate member of this class as
+        a reference point instead.
 
-    Not all IRC networks support this privilege mode. If you are writing a
-    plugin for public distribution, ensure your code behaves sensibly if only
-    ``+v`` (voice) and ``+o`` (op) modes exist.
+    """
+    # values should behave as ints, but their string representations should
+    # still look like Enum
+    __str__ = enum.Enum.__str__
 
-"""
+    VOICE = enum.auto()
+    """Privilege level for the +v channel permission
 
-OPER = 32
-"""Privilege level for the +y/+Y channel permissions
+    .. versionadded:: 4.1
+    .. versionchanged:: 8.0
 
-Note: Except for these (non-standard) channel modes, Sopel does not monitor or
-store any user's OPER status.
+        Constant moved from :mod:`sopel.plugin` to
+        :class:`sopel.privileges.AccessLevel`.
 
-.. versionadded:: 7.0
-.. versionchanged:: 8.0
-   Moved into :mod:`sopel.privileges`.
+    """
 
-.. important::
+    HALFOP = enum.auto()
+    """Privilege level for the +h channel permission
 
-    Not all IRC networks support this privilege mode. If you are writing a
-    plugin for public distribution, ensure your code behaves sensibly if only
-    ``+v`` (voice) and ``+o`` (op) modes exist.
+    .. versionadded:: 4.1
+    .. versionchanged:: 8.0
 
-"""
+        Constant moved from :mod:`sopel.plugin` to
+        :class:`sopel.privileges.AccessLevel`.
+
+    .. important::
+
+        Not all IRC networks support this privilege mode. If you are writing a
+        plugin for public distribution, ensure your code behaves sensibly if
+        only ``+v`` (voice) and ``+o`` (op) modes exist.
+
+    """
+
+    OP = enum.auto()
+    """Privilege level for the +o channel permission
+
+    .. versionadded:: 4.1
+    .. versionchanged:: 8.0
+
+        Constant moved from :mod:`sopel.plugin` to
+        :class:`sopel.privileges.AccessLevel`.
+
+    """
+
+    ADMIN = enum.auto()
+    """Privilege level for the +a channel permission
+
+    .. versionadded:: 4.1
+    .. versionchanged:: 8.0
+
+        Constant moved from :mod:`sopel.plugin` to
+        :class:`sopel.privileges.AccessLevel`.
+
+    .. important::
+
+        Not all IRC networks support this privilege mode. If you are writing a
+        plugin for public distribution, ensure your code behaves sensibly if
+        only ``+v`` (voice) and ``+o`` (op) modes exist.
+
+    """
+
+    OWNER = enum.auto()
+    """Privilege level for the +q channel permission
+
+    .. versionadded:: 4.1
+    .. versionchanged:: 8.0
+
+        Constant moved from :mod:`sopel.plugin` to
+        :class:`sopel.privileges.AccessLevel`.
+
+    .. important::
+
+        Not all IRC networks support this privilege mode. If you are writing a
+        plugin for public distribution, ensure your code behaves sensibly if
+        only ``+v`` (voice) and ``+o`` (op) modes exist.
+
+    """
+
+    OPER = enum.auto()
+    """Privilege level for the +y/+Y channel permission
+
+    Note: Except for these (non-standard) channel modes, Sopel does not monitor
+    or store any user's OPER status.
+
+    .. versionadded:: 7.0
+    .. versionchanged:: 8.0
+
+        Constant moved from :mod:`sopel.plugin` to
+        :class:`sopel.privileges.AccessLevel`.
+
+    .. important::
+
+        Not all IRC networks support this privilege mode. If you are writing a
+        plugin for public distribution, ensure your code behaves sensibly if
+        only ``+v`` (voice) and ``+o`` (op) modes exist.
+
+    """

--- a/sopel/privileges.py
+++ b/sopel/privileges.py
@@ -15,31 +15,6 @@ __all__ = [
 class AccessLevel(enum.IntFlag):
     """Enumeration of available user privilege levels.
 
-    Privilege levels
-    ================
-
-    Historically, there were two user privilege levels in a channel:
-
-    * :data:`~AccessLevel.OP`: channel operator, set and unset by modes ``+o``
-      and ``-o``
-    * :data:`~AccessLevel.VOICE`: the privilege to send messages to a channel
-      with the ``+m`` mode, set and unset by modes ``+v`` and ``-v``
-
-    Since then, other privileges have been adopted by IRC servers and clients:
-
-    * :data:`~AccessLevel.HALFOP`: intermediate level between VOICE and OP, set
-      and unset by modes ``+h`` and ``-h``
-    * :data:`~AccessLevel.ADMIN`: channel admin, above OP and below OWNER, set
-      and unset by modes ``+a`` and ``-a``
-    * :data:`~AccessLevel.OWNER`: channel owner, above ADMIN and OP, set and
-      unset by modes ``+q`` and ``-q``
-
-    .. important::
-
-        Not all IRC networks support these added privilege modes. If you are
-        writing a plugin for public distribution, ensure your code behaves
-        sensibly if only +v (voice) and +o (op) modes exist.
-
     Comparing privileges
     ====================
 

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 import functools
 from typing import Any, Optional, TYPE_CHECKING, Union
 
-from sopel import privileges
+from sopel.privileges import AccessLevel
 from sopel.tools import memories
 from sopel.tools.identifiers import Identifier, IdentifierFactory
 
@@ -158,7 +158,7 @@ class Channel:
 
         This maps nickname :class:`~sopel.tools.identifiers.Identifier`\\s to
         bitwise integer values. This can be compared to appropriate constants
-        from :mod:`sopel.privileges`.
+        from :class:`sopel.privileges.AccessLevel`.
         """
         self.topic: str = ''
         """The topic of the channel."""
@@ -203,7 +203,7 @@ class Channel:
 
         :param user: the new user to add
         :param privs: privilege bitmask (see constants in
-                      :mod:`sopel.privileges`)
+                      :class:`sopel.privileges.AccessLevel`)
 
         Called when a new user JOINs the channel.
         """
@@ -274,7 +274,7 @@ class Channel:
 
         """
         identifier = self.make_identifier(nick)
-        return bool(self.privileges.get(identifier, 0) & privileges.OPER)
+        return bool(self.privileges.get(identifier, 0) & AccessLevel.OPER)
 
     def is_owner(self, nick: str) -> bool:
         """Tell if a user has the OWNER privilege level.
@@ -306,7 +306,7 @@ class Channel:
 
         """
         identifier = self.make_identifier(nick)
-        return bool(self.privileges.get(identifier, 0) & privileges.OWNER)
+        return bool(self.privileges.get(identifier, 0) & AccessLevel.OWNER)
 
     def is_admin(self, nick: str) -> bool:
         """Tell if a user has the ADMIN privilege level.
@@ -338,7 +338,7 @@ class Channel:
 
         """
         identifier = self.make_identifier(nick)
-        return bool(self.privileges.get(identifier, 0) & privileges.ADMIN)
+        return bool(self.privileges.get(identifier, 0) & AccessLevel.ADMIN)
 
     def is_op(self, nick: str) -> bool:
         """Tell if a user has the OP privilege level.
@@ -364,7 +364,7 @@ class Channel:
 
         """
         identifier = self.make_identifier(nick)
-        return bool(self.privileges.get(identifier, 0) & privileges.OP)
+        return bool(self.privileges.get(identifier, 0) & AccessLevel.OP)
 
     def is_halfop(self, nick: str) -> bool:
         """Tell if a user has the HALFOP privilege level.
@@ -396,7 +396,7 @@ class Channel:
 
         """
         identifier = self.make_identifier(nick)
-        return bool(self.privileges.get(identifier, 0) & privileges.HALFOP)
+        return bool(self.privileges.get(identifier, 0) & AccessLevel.HALFOP)
 
     def is_voiced(self, nick: str) -> bool:
         """Tell if a user has the VOICE privilege level.
@@ -423,7 +423,7 @@ class Channel:
 
         """
         identifier = self.make_identifier(nick)
-        return bool(self.privileges.get(identifier, 0) & privileges.VOICE)
+        return bool(self.privileges.get(identifier, 0) & AccessLevel.VOICE)
 
     def rename_user(self, old: Identifier, new: Identifier) -> None:
         """Rename a user.


### PR DESCRIPTION
### Description

Rather than [have someone open an issue](https://github.com/sopel-irc/sopel/issues/2538#issuecomment-1788027761), I decided to Just Do It. I realized that the time to change how these constants are defined/accessed is _now_, as they've been moved to a new location but the new location hasn't appeared in a release yet. After we release 8.0, it would be that much more painful to change this a second time.

**I'm open to bikeshedding on the class name here.** If nothing else, maybe it should be plural to match `sopel.formatting.colors`. I'm keeping in mind the fact that we keep thinking about better access controls on bot functions, and other stuff that might also logically have constants living in `sopel.privileges`. `AccessLevel` is perhaps not the most future-proof choice for avoiding ambiguity. Other ideas included just plain `Level`, `Channel`, `ChannelPrivilege`, `ChanPriv`, and a few more I forgot.

If we do this, the type annotation changes in `plugin` will resolve #2538. Decorators that take this type will link to it in their function signatures' type annotations:

<img width="225" alt="image" src="https://github.com/sopel-irc/sopel/assets/164140/1703698b-6416-4158-b06c-6a2a66892d31">

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
  - Thank you @SnoopJ for #2469 and also teaching me how to use it this week.
- [x] I have tested the functionality of the things this change touches

### Notes

Honestly, `privileges.Channel` made the most sense to me as far as a future collection of different kinds of privileges went. Having two different types named `Channel`—here, and in `tools.target`—sounds like a terrible idea in the long term, though. `tools.target.Channel` even has logic to manipulate the hypothetical `privileges.Channel` type. Getting into "wait, which kind of `Channel` is this?" sounded very not-fun.