### PR TITLE
plugins: avoid crash on broken symlink

### DIFF
--- a/sopel/plugins/__init__.py
+++ b/sopel/plugins/__init__.py
@@ -33,6 +33,7 @@ import importlib
 import itertools
 import logging
 import os
+from typing import TYPE_CHECKING
 
 # TODO: use stdlib importlib.metadata when possible, after dropping py3.9.
 # Stdlib does not support `entry_points(group='filter')` until py3.10, but
@@ -42,11 +43,14 @@ import importlib_metadata
 
 from . import exceptions, handlers, rules  # noqa
 
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
 
 LOGGER = logging.getLogger(__name__)
 
 
-def _list_plugin_filenames(directory):
+def _list_plugin_filenames(directory: str | os.PathLike) -> Iterable[tuple[str, str]]:
     # list plugin filenames from a directory
     # yield 2-value tuples: (name, absolute path)
     base = os.path.abspath(directory)

--- a/sopel/plugins/__init__.py
+++ b/sopel/plugins/__init__.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import collections
 import importlib
 import itertools
+import logging
 import os
 
 # TODO: use stdlib importlib.metadata when possible, after dropping py3.9.
@@ -42,12 +43,18 @@ import importlib_metadata
 from . import exceptions, handlers, rules  # noqa
 
 
+LOGGER = logging.getLogger(__name__)
+
+
 def _list_plugin_filenames(directory):
     # list plugin filenames from a directory
     # yield 2-value tuples: (name, absolute path)
     base = os.path.abspath(directory)
     for filename in os.listdir(base):
-        abspath = os.path.join(base, filename)
+        abspath = os.path.realpath(os.path.join(base, filename))
+        if not os.path.exists(abspath):
+            LOGGER.warning("Plugin path does not exist, skipping: %r", abspath)
+            continue
 
         if os.path.isdir(abspath):
             if os.path.isfile(os.path.join(abspath, '__init__.py')):

--- a/sopel/plugins/__init__.py
+++ b/sopel/plugins/__init__.py
@@ -33,7 +33,7 @@ import importlib
 import itertools
 import logging
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 # TODO: use stdlib importlib.metadata when possible, after dropping py3.9.
 # Stdlib does not support `entry_points(group='filter')` until py3.10, but
@@ -50,7 +50,7 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 
-def _list_plugin_filenames(directory: str | os.PathLike) -> Iterable[tuple[str, str]]:
+def _list_plugin_filenames(directory: Union[str, os.PathLike]) -> Iterable[tuple[str, str]]:
     # list plugin filenames from a directory
     # yield 2-value tuples: (name, absolute path)
     base = os.path.abspath(directory)

--- a/test/test_plugins.py
+++ b/test/test_plugins.py
@@ -155,3 +155,12 @@ def test_plugin_load_entry_point(tmpdir):
     assert hasattr(test_mod, 'example_url')
     assert hasattr(test_mod, 'shutdown')
     assert hasattr(test_mod, 'ignored')
+
+
+def test_plugin_skip_broken_links(tmp_path):
+    plugins_path = tmp_path
+    plugin = plugins_path.joinpath("amazing_plugin.py")
+    link_target = plugins_path.joinpath("nonexistent_file.py")
+    plugin.symlink_to(link_target)
+
+    assert list(plugins._list_plugin_filenames(plugins_path)) == []


### PR DESCRIPTION
### Description

This changeset adds a check that a plugin file actually exists on disk before it is added to the list of known plugins.

Closes #2269.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
  - Everything passes except `test_example_roll_4` on 3.8, for which I have filed #2544
- [x] I have tested the functionality of the things this change touches
