### PR TITLE
coretasks, docs: fix auto-saving `.blocks add host`; improve "Ignoring Users" docs & x-refs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -29,10 +29,15 @@ needs_sphinx = '7.1'  # todo: upgrade when Py3.8 reaches EOL
 extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.autosectionlabel',
+    'sphinx.ext.extlinks',
     'sphinx.ext.intersphinx',
     'sphinxcontrib.autoprogram',
     'sphinx_rfcsection',
 ]
+extlinks = {
+    'issue': ('https://github.com/sopel-irc/sopel/issues/%s', '#%s'),
+    'pr': ('https://github.com/sopel-irc/sopel/pull/%s', '#%s'),
+}
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3/', None),
     'sqlalchemy': ('https://docs.sqlalchemy.org/en/14/', None),

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -757,13 +757,35 @@ example, only the ``bugzilla`` and ``remind`` plugins are enabled (because
 To detect plugins from extra directories, use the :attr:`~CoreSection.extra`
 option.
 
-Ignore User
------------
+Ignoring Users
+--------------
 
-To ignore users based on their hosts and/or nicks, you can use these options:
+To ignore users by nickname and/or hostname, you can use these options:
 
 * :attr:`~CoreSection.host_blocks`
 * :attr:`~CoreSection.nick_blocks`
+
+See each setting's documentation for a full description of its allowed syntax.
+You can add them directly to the configuration file like this::
+
+    [core]
+    nick_blocks =
+        AbusiveUser
+        Guest\d+
+    host_blocks =
+        .*\.evilhost.name
+        bitco\.in
+
+Any :ref:`bot admin <Owner & Admins>` can modify these from IRC with the
+``.blocks`` command. The full syntax is:
+
+.. code-block:: text
+
+    .blocks list [nick|host]
+    .blocks [add|del] [nick|host] pattern
+
+Sopel automatically saves changes made using the ``.blocks`` command to its
+configuration file.
 
 
 Logging

--- a/docs/source/plugin/anatomy.rst
+++ b/docs/source/plugin/anatomy.rst
@@ -141,7 +141,7 @@ Bypassing restrictions
 
 By default, a :term:`Rule` will not trigger on messages from Sopel itself,
 other users that are flagged as bots, or users who are
-:ref:`ignored <Ignore User>` or :ref:`rate-limited <Rate limiting>`. In
+:ref:`ignored <Ignoring Users>` or :ref:`rate-limited <Rate limiting>`. In
 certain cases, it might be desirable to bypass these defaults using one or
 more of these decorators:
 

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -1282,10 +1282,8 @@ class SopelWrapper:
 
     .. deprecated:: 8.0
 
-        ``SopelWrapper`` is being replaced with a ``contextvars`` based
-        alternative. For more information, see `#2460`__.
-
-    .. __: https://github.com/sopel-irc/sopel/issues/2460
+        ``SopelWrapper`` will be replaced with a ``contextvars`` based
+        alternative. For more information, see :issue:`2460`.
 
     """
     def __init__(self, sopel, trigger, output_prefix=''):

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -792,10 +792,8 @@ class CoreSection(StaticSection):
 
     .. note::
 
-        We are working on a better block system; see `issue #1355`__ for more
-        information and update.
-
-    .. __: https://github.com/sopel-irc/sopel/issues/1355
+        We are working toward a better block system; see :issue:`1355` for more
+        information and updates.
 
     """
 
@@ -1054,10 +1052,8 @@ class CoreSection(StaticSection):
 
     .. note::
 
-        We are working on a better block system; see `issue #1355`__ for more
-        information and update.
-
-    .. __: https://github.com/sopel-irc/sopel/issues/1355
+        We are working toward a better block system; see :issue:`1355` for more
+        information and updates.
 
     """
 

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -777,9 +777,10 @@ class CoreSection(StaticSection):
     host_blocks = ListAttribute('host_blocks')
     """A list of hostnames which Sopel should ignore.
 
-    Messages from any user whose connection hostname matches one of these
-    values will be ignored. :ref:`Regular expression syntax <re-syntax>`
-    is supported, so remember to escape special characters:
+    Sopel will :ref:`ignore <Ignoring Users>` messages from any user whose
+    connection hostname matches one of these values.
+    :ref:`Regular expression syntax <re-syntax>` is supported, so remember to
+    escape special characters:
 
     .. code-block:: ini
 
@@ -791,6 +792,9 @@ class CoreSection(StaticSection):
         The :attr:`nick_blocks` list can be used to block users by their nick.
 
     .. note::
+
+        :ref:`Plugin callables` with the :func:`.plugin.unblockable` decorator
+        run regardless of matching ``*_blocks`` entries.
 
         We are working toward a better block system; see :issue:`1355` for more
         information and updates.
@@ -1036,9 +1040,10 @@ class CoreSection(StaticSection):
     nick_blocks = ListAttribute('nick_blocks')
     """A list of nicks which Sopel should ignore.
 
-    Messages from any user whose nickname matches one of these values will be
-    ignored. :ref:`Regular expression syntax <re-syntax>` is supported, so
-    remember to escape special characters:
+    Sopel will :ref:`ignore <Ignoring Users>` messages from any user whose
+    nickname matches one of these values.
+    :ref:`Regular expression syntax <re-syntax>` is supported, so remember to
+    escape special characters:
 
     .. code-block:: ini
 
@@ -1051,6 +1056,9 @@ class CoreSection(StaticSection):
         The :attr:`host_blocks` list can be used to block users by their host.
 
     .. note::
+
+        :ref:`Plugin callables` with the :func:`.plugin.unblockable` decorator
+        run regardless of matching ``*_blocks`` entries.
 
         We are working toward a better block system; see :issue:`1355` for more
         information and updates.

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -1353,6 +1353,7 @@ def _get_sasl_pass_and_mech(bot):
 
 
 @plugin.commands('blocks')
+@plugin.example(r'.blocks del nick falsep0sitive', user_help=True)
 @plugin.example(r'.blocks add host some\.malicious\.network', user_help=True)
 @plugin.example(r'.blocks add nick sp(a|4)mb(o|0)t\d*', user_help=True)
 @plugin.thread(False)
@@ -1360,9 +1361,9 @@ def _get_sasl_pass_and_mech(bot):
 @plugin.priority('low')
 @plugin.require_admin
 def blocks(bot, trigger):
-    """
-    Manage Sopel's blocking features.
-    See https://sopel.chat/usage/ignoring-people/ for usage notes.
+    """Manage Sopel's blocking features.
+
+    Full argspec: `list [nick|host]` or `[add|del] [nick|host] pattern`
     """
     STRINGS = {
         "success_del": "Successfully deleted block: %s",

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -1405,6 +1405,7 @@ def blocks(bot, trigger):
         elif text[2] == "host":
             hosts.add(text[3].lower())
             bot.config.core.host_blocks = list(hosts)
+            bot.config.save()
         else:
             bot.reply(STRINGS['invalid'] % ("adding"))
             return

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -333,17 +333,18 @@ class capability:
 def unblockable(
     function: Optional[Callable] = None,
 ) -> Callable:
-    """Decorate a function to exempt it from the ignore/blocks system.
+    """Decorate a function to exempt it from Sopel's ignore system.
 
     For example, this can be used to ensure that important events such as
-    ``JOIN`` are always recorded::
+    ``JOIN`` are always recorded even if the user's nickname or hostname is
+    :ref:`ignored <Ignoring Users>`::
 
         from sopel import plugin
 
         @plugin.event('JOIN')
         @plugin.unblockable
         def on_join_callable(bot, trigger):
-            # do something when a user JOIN a channel
+            # do something when a user JOINs a channel
             # a blocked nickname or hostname *will* trigger this
             pass
 


### PR DESCRIPTION
Maybe still not perfect, but there's at least a way to find out what might make a callable "blockable" (and necessitate using `unblockable` to change that), and how to bypass something that you don't want to be blocked getting blocked.

We do still need proper documentation on how to use built-in commands from `coretasks`, but I don't particularly want to link the migrated wiki page at https://sopel.chat/usage/ignoring-people/ here.

That old stuff will continue getting folded into the Sphinx docs over time. Arguably, describing the `.blocks` command in `configuration.rst` is already enough to mark the old website page for removal as part of sopel-irc/sopel.chat#45.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
  - Didn't run these, as I'm not touching code.
- [x] I have tested the functionality of the things this change touches
  - Many iterations of reviewing the rendered docs…