### PR TITLE
irc, bot, builtins: add & use `AbstractBot.make_identifier_memory()` helper

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -75,9 +75,7 @@ class Sopel(irc.AbstractBot):
         self.modeparser = modes.ModeParser()
         """A mode parser used to parse ``MODE`` messages and modestrings."""
 
-        self.channels = tools.SopelIdentifierMemory(
-            identifier_factory=self.make_identifier,
-        )
+        self.channels = self.make_identifier_memory()
         """A map of the channels that Sopel is in.
 
         The keys are :class:`~sopel.tools.identifiers.Identifier`\\s of the
@@ -85,9 +83,7 @@ class Sopel(irc.AbstractBot):
         which contain the users in the channel and their permissions.
         """
 
-        self.users = tools.SopelIdentifierMemory(
-            identifier_factory=self.make_identifier,
-        )
+        self.users = self.make_identifier_memory()
         """A map of the users that Sopel is aware of.
 
         The keys are :class:`~sopel.tools.identifiers.Identifier`\\s of the

--- a/sopel/builtins/find.py
+++ b/sopel/builtins/find.py
@@ -18,14 +18,11 @@ import re
 
 from sopel import plugin
 from sopel.formatting import bold
-from sopel.tools import SopelIdentifierMemory
 
 
 def setup(bot):
     if 'find_lines' not in bot.memory:
-        bot.memory['find_lines'] = SopelIdentifierMemory(
-            identifier_factory=bot.make_identifier,
-        )
+        bot.memory['find_lines'] = bot.make_identifier_memory()
 
 
 def shutdown(bot):
@@ -49,9 +46,7 @@ def collectlines(bot, trigger):
 
     # Add a log for the channel and nick, if there isn't already one
     if trigger.sender not in bot.memory['find_lines']:
-        bot.memory['find_lines'][trigger.sender] = SopelIdentifierMemory(
-            identifier_factory=bot.make_identifier,
-        )
+        bot.memory['find_lines'][trigger.sender] = bot.make_identifier_memory()
     if trigger.nick not in bot.memory['find_lines'][trigger.sender]:
         bot.memory['find_lines'][trigger.sender][trigger.nick] = deque(maxlen=10)
 

--- a/sopel/builtins/translate.py
+++ b/sopel/builtins/translate.py
@@ -15,7 +15,7 @@ import re
 
 import requests
 
-from sopel import plugin, tools
+from sopel import plugin
 from sopel.tools import web
 
 
@@ -25,9 +25,7 @@ PLUGIN_OUTPUT_PREFIX = '[translate] '
 
 def setup(bot):
     if 'mangle_lines' not in bot.memory:
-        bot.memory['mangle_lines'] = tools.SopelIdentifierMemory(
-            identifier_factory=bot.make_identifier,
-        )
+        bot.memory['mangle_lines'] = bot.make_identifier_memory()
 
 
 def shutdown(bot):

--- a/sopel/builtins/url.py
+++ b/sopel/builtins/url.py
@@ -133,9 +133,7 @@ def setup(bot: Sopel):
 
     # Ensure last_seen_url is in memory
     if 'last_seen_url' not in bot.memory:
-        bot.memory['last_seen_url'] = tools.SopelIdentifierMemory(
-            identifier_factory=bot.make_identifier,
-        )
+        bot.memory['last_seen_url'] = bot.make_identifier_memory()
 
     # Initialize shortened_urls as a dict if it doesn't exist.
     if 'shortened_urls' not in bot.memory:

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -45,7 +45,7 @@ from typing import (
 
 from sopel import tools, trigger
 from sopel.lifecycle import deprecated
-from sopel.tools import identifiers
+from sopel.tools import identifiers, memories
 from .backends import AsyncioBackend, UninitializedBackend
 from .capabilities import Capabilities
 from .isupport import ISupport
@@ -240,6 +240,34 @@ class AbstractBot(abc.ABC):
             name,
             casemapping=casemapping,
             chantypes=chantypes,
+        )
+
+    def make_identifier_memory(self) -> memories.SopelIdentifierMemory:
+        """Instantiate a SopelIdentifierMemory using the bot's context.
+
+        This is a shortcut for :class:`~.memories.SopelIdentifierMemory`\'s most
+        common use case, which requires remembering to pass the ``bot``\'s own
+        :meth:`make_identifier` method so the ``SopelIdentifierMemory`` will
+        cast its keys to :class:`~.tools.identifiers.Identifier`\\s that are
+        compatible with what the bot tracks internally and sends with
+        :class:`~.trigger.Trigger`\\s when a plugin callable runs.
+
+        Calling this method is equivalent to the following::
+
+            from sopel.tools import memories
+
+            memories.SopelIdentifierMemory(
+                identifier_factory=bot.make_identifier,
+            )
+
+        .. seealso::
+
+            The :mod:`.tools.memories` module describes how to use
+            :class:`~.tools.memories.SopelIdentifierMemory` and its siblings.
+
+        """
+        return memories.SopelIdentifierMemory(
+            identifier_factory=self.make_identifier,
         )
 
     def safe_text_length(self, recipient: str) -> int:

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -227,7 +227,10 @@ class AbstractBot(abc.ABC):
     # Utility
 
     def make_identifier(self, name: str) -> identifiers.Identifier:
-        """Instantiate an Identifier using the bot's context."""
+        """Instantiate an Identifier using the bot's context.
+
+        .. versionadded:: 8.0
+        """
         casemapping = {
             'ascii': identifiers.ascii_lower,
             'rfc1459': identifiers.rfc1459_lower,
@@ -259,6 +262,8 @@ class AbstractBot(abc.ABC):
             memories.SopelIdentifierMemory(
                 identifier_factory=bot.make_identifier,
             )
+
+        .. versionadded:: 8.0
 
         .. seealso::
 

--- a/test/test_irc.py
+++ b/test/test_irc.py
@@ -29,6 +29,21 @@ def bot(tmpconfig, botfactory):
     return botfactory(tmpconfig)
 
 
+def test_make_identifier(bot):
+    nick = bot.make_identifier('Test[a]')
+    assert 'test{a}' == nick
+
+
+def test_make_identifier_memory(bot):
+    memory = bot.make_identifier_memory()
+    memory['Test[a]'] = True
+    assert memory['test{a}'] is True
+
+    memory['test{a}'] = False
+    assert len(memory) == 1
+    assert memory['Test[a]'] is False
+
+
 def prefix_length(bot):
     # ':', nick, '!', '~', ident/username, '@', maximum hostname length, <0x20>
     return 1 + len(bot.nick) + 1 + 1 + len(bot.user) + 1 + 63 + 1


### PR DESCRIPTION
### Description

Here is a shortcut way of getting a new `SopelIdentifierMemory` with the `identifier_factory` kwarg filled in for you so it automatically uses the bot's awareness of casemapping from the IRC server's ISUPPORT tokens.

Manual casemapping selection is still possible by using the `SopelIdentifierMemory` constructor directly, of course, as before.

Using this new method in the bot to initialize its `users` and `channels` automatically adds this to test coverage:

<img width="492" alt="image" src="https://github.com/sopel-irc/sopel/assets/164140/f7b7be1f-dc46-4d10-be7a-b4087b8058a5">

_(NB: That is an older coverage run, from before I expanded the docstring.)_

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches