### PR TITLE
plugin: type-hint `priority` argument as `Literal[]`

### DIFF
--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -15,6 +15,7 @@ import logging
 import re
 from typing import (
     Callable,
+    Literal,
     Optional,
     Pattern,
     Protocol,
@@ -1011,7 +1012,7 @@ def label(value: str) -> Callable:
     return add_attribute
 
 
-def priority(value: str) -> Callable:
+def priority(value: Literal['low', 'medium', 'high']) -> Callable:
     """Decorate a function to be executed with higher or lower priority.
 
     :param value: one of ``high``, ``medium``, or ``low``; defaults to ``medium``

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -1015,10 +1015,11 @@ def label(value: str) -> Callable:
 def priority(value: Literal['low', 'medium', 'high']) -> Callable:
     """Decorate a function to be executed with higher or lower priority.
 
-    :param value: one of ``high``, ``medium``, or ``low``; defaults to ``medium``
+    :param value: one of ``high``, ``medium``, or ``low``
 
-    The priority allows you to control the order of callable execution, if your
-    plugin needs it.
+    The priority allows you some control over the order of callable execution,
+    if your plugin needs it. If a callable does not specify its ``priority``,
+    Sopel assumes ``medium``.
     """
     def add_attribute(function):
         function.priority = value


### PR DESCRIPTION
### Description

This will flag any use of unrecognized values for the callable priority. It makes a good intermediate step between the current free-form `str` accepted and probably turning it into an `Enum` later.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - Indeed, if I change one of the `priority` decorators in core to an unlisted value, `mypy` raises an error 👍