### PR TITLE
docs: set `maxdepth` or `titlesonly` on overly-long TOCs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -125,6 +125,7 @@ autodoc_type_aliases = {
     'ModeDetails': 'sopel.irc.modes.ModeDetails',
     'PrivilegeDetails': 'sopel.irc.modes.PrivilegeDetails',
 }
+autodoc_preserve_defaults = True
 
 
 # -- Options for HTML output ---------------------------------------------------

--- a/docs/source/configuration.rst
+++ b/docs/source/configuration.rst
@@ -232,13 +232,13 @@ In that case:
 
 .. seealso::
 
-   Sopel uses the built-in :func:`ssl.wrap_socket` function to wrap the socket
-   used for the IRC connection.
+   Sopel uses the built-in :meth:`ssl.SSLContext.wrap_socket` function to wrap
+   the socket used for the IRC connection.
 
 .. note::
 
    Sopel will try to look at one of these files for the CA certs pem file
-   required by :func:`ssl.wrap_socket`:
+   required by :meth:`ssl.SSLContext.wrap_socket`:
 
    * ``/etc/pki/tls/cert.pem``
    * ``/etc/ssl/certs/ca-certificates.crt`` (Debian)

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -20,6 +20,7 @@ Documentation
 
 .. toctree::
     :maxdepth: 2
+    :titlesonly:
 
     run
     plugin

--- a/docs/source/package/config.rst
+++ b/docs/source/package/config.rst
@@ -2,7 +2,14 @@
 Configuration functionality
 ===========================
 
+The description of :mod:`.config` below is a quick guide to the basic structure
+of configuration settings in Sopel. Consult the :mod:`.config.types` module for
+more specific information about the available kinds of options, and
+:mod:`.config.core_section` for examples of how the different setting types are
+practically used.
+
 .. toctree::
+   :titlesonly:
 
    config/types
    config/core_section

--- a/docs/source/package/config/core_section.rst
+++ b/docs/source/package/config/core_section.rst
@@ -1,6 +1,6 @@
-============
-Core Section
-============
+===================
+Core Config Section
+===================
 
 .. automodule:: sopel.config.core_section
    :members:

--- a/docs/source/package/irc.rst
+++ b/docs/source/package/irc.rst
@@ -2,13 +2,20 @@
 IRC Core Implementation
 =======================
 
+Operation of the :mod:`sopel.irc` core is supported by these utility submodules:
+
 .. toctree::
+    :titlesonly:
 
     irc/backends
     irc/modes
     irc/isupport
     irc/capabilities
     irc/utils
+
+
+sopel.irc
+=========
 
 .. automodule:: sopel.irc
     :members:

--- a/docs/source/package/plugins.rst
+++ b/docs/source/package/plugins.rst
@@ -9,6 +9,7 @@ Plugin Internal Machinery
    section exists primarily for the aid of Sopel’s core development.
 
 .. toctree::
+    :maxdepth: 2
 
     loader
     plugins/plugins

--- a/docs/source/package/tools.rst
+++ b/docs/source/package/tools.rst
@@ -2,7 +2,11 @@
 Additional Tools
 ================
 
+Sopel provides utilities for some commonly used plugin functionality. Most of
+these utility features have been collected into submodules for convenience:
+
 .. toctree::
+   :titlesonly:
 
    tools/calculation
    tools/events
@@ -12,6 +16,8 @@ Additional Tools
    tools/target
    tools/time
    tools/web
+
+Miscellaneous tools that don't fit any particular category appear below.
 
 
 sopel.tools

--- a/docs/source/tests.rst
+++ b/docs/source/tests.rst
@@ -2,11 +2,20 @@
 Testing tools
 =============
 
+The best code comes with unit tests. Sopel provides a :doc:`pytest plugin
+<tests/pytest>` with standard fixtures; :doc:`factories <tests/factories>` and
+:doc:`mocks <tests/mocks>` to support writing tests; and the
+:func:`~.tests.rawlist` function to help analyze the mocked-up bot's output.
+
 .. toctree::
+   :titlesonly:
 
    tests/pytest
    tests/factories
    tests/mocks
+
+sopel.tests
+===========
 
 .. automodule:: sopel.tests
    :members:

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -17,7 +17,7 @@
 from __future__ import annotations
 
 import abc
-from datetime import datetime, timedelta, timezone
+import datetime
 import functools
 import inspect
 import itertools
@@ -466,24 +466,24 @@ class Manager:
 class RuleMetrics:
     """Tracker of a rule's usage."""
     def __init__(self) -> None:
-        self.started_at: Optional[datetime] = None
-        self.ended_at: Optional[datetime] = None
+        self.started_at: Optional[datetime.datetime] = None
+        self.ended_at: Optional[datetime.datetime] = None
         self.last_return_value: Any = None
 
     def start(self) -> None:
         """Record a starting time (before execution)."""
-        self.started_at = datetime.now(timezone.utc)
+        self.started_at = datetime.datetime.now(datetime.timezone.utc)
 
     def end(self) -> None:
         """Record a ending time (after execution)."""
-        self.ended_at = datetime.now(timezone.utc)
+        self.ended_at = datetime.datetime.now(datetime.timezone.utc)
 
     def set_return_value(self, value: Any) -> None:
         """Set the last return value of a rule."""
         self.last_return_value = value
 
     @property
-    def last_time(self) -> Optional[datetime]:
+    def last_time(self) -> Optional[datetime.datetime]:
         """Last recorded start/end time for the associated rule."""
         # detect if we just started something or if it ended
         if (self.started_at and self.ended_at) and (self.started_at < self.ended_at):
@@ -493,7 +493,7 @@ class RuleMetrics:
 
     def is_limited(
         self,
-        time_limit: datetime,
+        time_limit: datetime.datetime,
     ) -> bool:
         """Determine if the rule hits the time limit."""
         if not self.started_at:
@@ -758,24 +758,24 @@ class AbstractRule(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def user_rate_limit(self) -> timedelta:
+    def user_rate_limit(self) -> datetime.timedelta:
         """The rule's user rate limit."""
 
     @property
     @abc.abstractmethod
-    def channel_rate_limit(self) -> timedelta:
+    def channel_rate_limit(self) -> datetime.timedelta:
         """The rule's channel rate limit."""
 
     @property
     @abc.abstractmethod
-    def global_rate_limit(self) -> timedelta:
+    def global_rate_limit(self) -> datetime.timedelta:
         """The rule's global rate limit."""
 
     @abc.abstractmethod
     def is_user_rate_limited(
         self,
         nick: Identifier,
-        at_time: Optional[datetime] = None,
+        at_time: Optional[datetime.datetime] = None,
     ) -> bool:
         """Tell when the rule reached the ``nick``'s rate limit.
 
@@ -789,7 +789,7 @@ class AbstractRule(abc.ABC):
     def is_channel_rate_limited(
         self,
         channel: Identifier,
-        at_time: Optional[datetime] = None,
+        at_time: Optional[datetime.datetime] = None,
     ) -> bool:
         """Tell when the rule reached the ``channel``'s rate limit.
 
@@ -802,7 +802,7 @@ class AbstractRule(abc.ABC):
     @abc.abstractmethod
     def is_global_rate_limited(
         self,
-        at_time: Optional[datetime] = None,
+        at_time: Optional[datetime.datetime] = None,
     ) -> bool:
         """Tell when the rule reached the global rate limit.
 
@@ -1205,43 +1205,43 @@ class Rule(AbstractRule):
         return self._metrics_global
 
     @property
-    def user_rate_limit(self) -> timedelta:
-        return timedelta(seconds=self._user_rate_limit)
+    def user_rate_limit(self) -> datetime.timedelta:
+        return datetime.timedelta(seconds=self._user_rate_limit)
 
     @property
-    def channel_rate_limit(self) -> timedelta:
-        return timedelta(seconds=self._channel_rate_limit)
+    def channel_rate_limit(self) -> datetime.timedelta:
+        return datetime.timedelta(seconds=self._channel_rate_limit)
 
     @property
-    def global_rate_limit(self) -> timedelta:
-        return timedelta(seconds=self._global_rate_limit)
+    def global_rate_limit(self) -> datetime.timedelta:
+        return datetime.timedelta(seconds=self._global_rate_limit)
 
     def is_user_rate_limited(
         self,
         nick: Identifier,
-        at_time: Optional[datetime] = None,
+        at_time: Optional[datetime.datetime] = None,
     ) -> bool:
         if at_time is None:
-            at_time = datetime.now(timezone.utc)
+            at_time = datetime.datetime.now(datetime.timezone.utc)
         metrics = self.get_user_metrics(nick)
         return metrics.is_limited(at_time - self.user_rate_limit)
 
     def is_channel_rate_limited(
         self,
         channel: Identifier,
-        at_time: Optional[datetime] = None,
+        at_time: Optional[datetime.datetime] = None,
     ) -> bool:
         if at_time is None:
-            at_time = datetime.now(timezone.utc)
+            at_time = datetime.datetime.now(datetime.timezone.utc)
         metrics = self.get_channel_metrics(channel)
         return metrics.is_limited(at_time - self.channel_rate_limit)
 
     def is_global_rate_limited(
         self,
-        at_time: Optional[datetime] = None,
+        at_time: Optional[datetime.datetime] = None,
     ) -> bool:
         if at_time is None:
-            at_time = datetime.now(timezone.utc)
+            at_time = datetime.datetime.now(datetime.timezone.utc)
         metrics = self.get_global_metrics()
         return metrics.is_limited(at_time - self.global_rate_limit)
 

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -90,6 +90,17 @@ def get_sendable_message(text, max_length=400):
     care of multibyte UTF-8 characters by working on the Unicode string,
     then making sure the bytes version is smaller than the max length.
 
+    .. note::
+
+        In most cases, letting the bot gracefully handle message truncation
+        using optional arguments to :meth:`bot.say() <.bot.Sopel.say>` is
+        preferable. However, this function is part of the public API to provide
+        for more advanced use-cases.
+
+        See also the :meth:`bot.safe_text_length() <.bot.Sopel.safe_text_length>`
+        method, whose return value can be passed as this function's
+        ``max_length`` argument.
+
     .. versionadded:: 6.6.2
     """
     unicode_max_length = max_length

--- a/sopel/tools/memories.py
+++ b/sopel/tools/memories.py
@@ -235,19 +235,35 @@ class SopelIdentifierMemory(SopelMemory):
         super().__delitem__(self._make_key(key))
 
     def copy(self):
+        """Get a shallow copy of this ``SopelIdentifierMemory``.
+
+        See :meth:`dict.copy`.
+        """
         return type(self)(self, identifier_factory=self.make_identifier)
 
     def get(self, key: str, default=_NO_DEFAULT):
+        """Get the value of ``key`` from this ``SopelIdentifierMemory``.
+
+        Takes an optional ``default`` value, just like :meth:`dict.get`.
+        """
         if default is _NO_DEFAULT:
             return super().get(self._make_key(key))
         return super().get(self._make_key(key), default)
 
     def pop(self, key: str, default=_NO_DEFAULT):
+        """Pop the value of ``key`` from this ``SopelIdentifierMemory``.
+
+        Takes an optional ``default`` value, just like :meth:`dict.pop`.
+        """
         if default is _NO_DEFAULT:
             return super().pop(self._make_key(key))
         return super().pop(self._make_key(key), default)
 
     def update(self, maybe_mapping=tuple()):
+        """Update this ``SopelIdentifierMemory`` with key-value pairs.
+
+        See :meth:`dict.update`.
+        """
         super().update(self._convert_keys(maybe_mapping))
 
     def __or__(self, other):


### PR DESCRIPTION
### Description

I set out to clean up some of the documentation appearance & make things more usable, taking into consideration the fact that we use the Furo theme now and detailed in-page TOCs are kinda redundant in a lot of places thanks to the dual sidebars.

In addition to the original impetus for this patch—`maxdepth` or `titlesonly` options on TOCs where needed—this patch also cleans up some warnings generated by `SopelIdentifierMemory` inheriting docstrings from `dict`, tells autodoc not to evaluate function argument defaults before display (eliminates `<class 'sopel.foo.nonsense.ClassName'>` from being shown, which is very ugly), and also improves the docstring of `tools.get_sendable_message()` because I don't want to open a tiny PR for that.

I'm also aware of what #2533 plans to change, and therefore avoided touching any of that PR's renamed/modified rST files at all. The comment in `index.rst` about adding install docs here is also gone; they're coming soon!

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
  - `make test` not so relevant, as no code changed; but I still ran `make lint` since I [learned my lesson](https://github.com/sopel-irc/sopel/pull/2552#issuecomment-1804700159) after skipping it earlier this week. 😅
- [x] I have tested the functionality of the things this change touches
  - Oh so many rebuilds… I'm as mad as I'll ever be now about those spurious `:py:class: reference not found` warnings we get from using type aliases for things like `Casemapping` or `IdentifierFactory`. Sphinx can't fix that soon enough.