### PR TITLE
docs: add warning when rendering preview docs

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -10,7 +10,10 @@ from __future__ import generator_stop
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
+import subprocess
 from datetime import date
+
+from packaging.version import Version
 
 from sopel import __version__
 
@@ -308,3 +311,26 @@ texinfo_documents = [
 
 # How to display URL addresses: 'footnote', 'no', or 'inline'.
 #texinfo_show_urls = 'footnote'
+
+
+try:
+    if Version(__version__).is_prerelease:
+        tags.add("preview")
+
+    is_dirty = bool(subprocess.check_output(["git", "status", "--untracked-files=no", "--porcelain"], text=True).strip())
+    commit_hash = subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    git_describe = subprocess.check_output(["git", "describe", "--tags"], text=True).strip() + ("-dirty" if is_dirty else "")
+    github_ref = "https://github.com/sopel-irc/sopel/commit/{commit_hash}".format(commit_hash=commit_hash)
+    build_info = "(built against `{git_describe} <{github_ref}>`_)".format(git_describe=git_describe, github_ref=github_ref)
+except Exception as exc:
+    build_info = "(built against an unknown commit)"
+
+
+rst_prolog = """
+.. only:: preview
+
+    .. warning:: This is preview documentation for Sopel |version| {build_info}.
+
+                 Click `here <https://sopel.chat/docs/>`_ for the latest stable documentation.
+
+""".format(build_info=build_info)


### PR DESCRIPTION
### Description

I had not realized that the [unstable documentation](https://unstable.docs.sopel.chat/) was being regularly built against `master`, and I thought it would be helpful if these preview docs included a warning about their preview-ness as well as a reference to the specific commit they were built against.

The warning added by this changeset is included on all pages using Sphinx's [`rst_prolog` directive](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-rst_prolog), but only rendered when the Sopel version is a pre-release (i.e. `.devN`) version.

Below is an example of how preview documentation renders (the link points to the relevant commit on GitHub)

![image](https://github.com/sopel-irc/sopel/assets/6125322/f1123ec2-9293-4695-8f08-f3d16629ae29)

And here's what the docs look like for a release version:

![image](https://github.com/sopel-irc/sopel/assets/6125322/5656415a-ebc1-4ae6-b9a3-03d4ad8e3c07)


### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
