### PR TITLE
coretasks: fix SASL EXTERNAL without password set

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -107,9 +107,9 @@ def _handle_sasl_capability(
         )
         return plugin.CapabilityNegotiation.ERROR
 
-    # Check SASL configuration (password is required)
+    # Check SASL configuration (password is required for PLAIN/SCRAM)
     password, mech = _get_sasl_pass_and_mech(bot)
-    if not password:
+    if mech != "EXTERNAL" and not password:
         raise config.ConfigurationError(
             'SASL authentication required but no password available; '
             'please check your configuration file.',


### PR DESCRIPTION
### Description

Fix #2560, now separate and with test (verified to fail without patch)

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
