### PR TITLE
plugin: add capability.__str__ for better logs

### DIFF
--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -273,6 +273,13 @@ class capability:
         self._cap_req: tuple[str, ...] = tuple(sorted(cap_req))
         self._handler: Optional[CapabilityHandler] = handler
 
+    def __str__(self) -> str:
+        caps = ", ".join(repr(cap) for cap in self._cap_req)
+        handler = ""
+        if self._handler and hasattr(self._handler, "__name__"):
+            handler = " ({}())".format(self._handler.__name__)
+        return "<capability {}{}>".format(caps, handler)
+
     @property
     def cap_req(self) -> tuple[str, ...]:
         """Capability request as a sorted tuple.

--- a/sopel/plugins/capabilities.py
+++ b/sopel/plugins/capabilities.py
@@ -233,7 +233,7 @@ class Manager:
         plugin_caps[plugin_name] = (
             request, False,
         )
-        LOGGER.debug('Capability Request registered: %s', str(request))
+        LOGGER.debug('Capability Request registered: %s', request)
 
     def request_available(
         self,

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -33,6 +33,19 @@ def test_capability(cap_ack_wrapped):
     assert result == (True, None)
 
 
+def test_capability_as_string():
+    handler = plugin.capability('batch')
+    assert str(handler).startswith('<capability')
+    assert str(handler).endswith("'batch'>")
+
+    def _batch_callback(cap_req, bot, acknowledged):
+        ...
+
+    handler = plugin.capability('batch', handler=_batch_callback)
+
+    assert '(_batch_callback())' in str(handler)
+
+
 def test_capability_handler_define_once():
     @plugin.capability('away-notify')
     def handler(name, bot, acknowledged):


### PR DESCRIPTION
### Description
When Sopel is started with loglevel DEBUG, it currently outputs a stack of lines like this:
```
sopel.plugins.capabilities DEBUG   : Capability Request registered: <sopel.plugin.capability object at 0x7f77903c7cd0>
```

The str(cap_req) gives no useful information. This PR adds `capability.__str__()` so it does:
```
sopel.plugins.capabilities DEBUG   : Capability Request registered: <capability 'message-tags'>
sopel.plugins.capabilities DEBUG   : Capability Request registered: <capability 'account-notify' (_handle_account_and_extjoin_capabilities())>
```

Open to format opinions.

Also, given the format, should this `__str__()` and that for Rule and Command be `__repr__()`?

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches