### PR TITLE
make: run flake8 on specific directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ qa: lint test coverages
 lint: lint-style lint-type
 
 lint-style:
-	flake8
+	flake8 sopel/ test/
 
 lint-type:
 	mypy --check-untyped-defs sopel


### PR DESCRIPTION
### Description

Tin. Run the linter on only the files we are concerned with. This is slightly friendlier to developers who have throwaway scripts or a virtual environment (other than one in `env/`) in their repository directory.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
