### PR TITLE
wikipedia: fix urlparse usage & handle Special: namespace

### DIFF
--- a/sopel/builtins/wikipedia.py
+++ b/sopel/builtins/wikipedia.py
@@ -327,12 +327,16 @@ def mw_image_description(server, image):
 def mw_info(bot, trigger, match=None):
     """Retrieves and outputs a snippet of the linked page."""
     server = match.group(1)
-    page_info = urlparse(match.group(2))
-    article = unquote(page_info.path)
+    page_info = urlparse(match.group(0))
+    # in Python 3.9+ this can be str.removeprefix() instead, but we're confident that
+    # "/wiki/" is at the start of the path anyway since it's part of the pattern
+    trim_offset = len("/wiki/")
+    article = unquote(page_info.path)[trim_offset:]
     section = unquote(page_info.fragment)
 
     if section:
-        if section.startswith('cite_note-'):  # Don't bother trying to retrieve a snippet when cite-note is linked
+        if section.startswith('cite_note-'):
+            # Don't bother trying to retrieve a section snippet if cite-note is linked
             say_snippet(bot, trigger, server, article, show_url=False)
         elif section.startswith('/media'):
             # gh2316: media fragments are usually images; try to get an image description

--- a/sopel/builtins/wikipedia.py
+++ b/sopel/builtins/wikipedia.py
@@ -334,6 +334,12 @@ def mw_info(bot, trigger, match=None):
     article = unquote(page_info.path)[trim_offset:]
     section = unquote(page_info.fragment)
 
+    if article.startswith("Special:"):
+        # The MediaWiki query API does not include pages in the Special:
+        # namespace, so there's no point bothering when we know this will error
+        LOGGER.debug("Ignoring page in Special: namespace")
+        return False
+
     if section:
         if section.startswith('cite_note-'):
             # Don't bother trying to retrieve a section snippet if cite-note is linked
@@ -367,6 +373,11 @@ def wikipedia(bot, trigger):
     if not query:
         bot.reply('What do you want me to look up?')
         return plugin.NOLIMIT
+
+    if query.startswith("Special:"):
+        bot.reply("Sorry, the MediaWiki API doesn't support querying the Special: namespace.")
+        return False
+
     server = lang + '.wikipedia.org'
     query = mw_search(server, query, 1)
     if not query:


### PR DESCRIPTION
### Description

Closes #2573.

This changeset corrects errant usage of `urllib.parse.urlparse()` in the `wikipedia` plugin, fixing a regression introduced by #2414. This fix prevents namespaces from being erroneously discarded.

In the process of this fix, I discovered that the `Special:*` namespace is a special case as far as the MediaWiki API is concerned, queries to the API for pages in this namespace don't do what you might expect, so these pages cannot be located and turned into snippets for IRC. So, instead, the URL rule ignores these pages, and issues a specific explanation if a user tries to query them using a command.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
