### PR TITLE
plugin: `require_bot_privilege()` implies `require_chanmsg()`

### DIFF
--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -1716,16 +1716,18 @@ def require_bot_privilege(
     <.bot.Sopel.say>`, but when ``reply`` is ``True`` it uses :meth:`bot.reply()
     <.bot.Sopel.reply>` instead.
 
-    Privilege requirements are ignored in private messages.
+    Use of ``require_bot_privilege()`` implies :func:`require_chanmsg`.
 
     .. versionadded:: 7.1
+    .. versionchanged:: 8.0
+        Decorated callables no longer run in response to private messages.
     """
     def actual_decorator(function):
         @functools.wraps(function)
         def guarded(bot, trigger, *args, **kwargs):
-            # If this is a privmsg, ignore privilege requirements
+            # If this is a privmsg, do not trigger
             if trigger.is_privmsg:
-                return function(bot, trigger, *args, **kwargs)
+                return
 
             if not bot.has_channel_privilege(trigger.sender, level):
                 if message and not callable(message):

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -511,19 +511,21 @@ def test_require_bot_privilege_private_message(configfactory,
     def mock(bot, trigger):
         return True
 
-    assert mock(bot, bot._trigger) is True
+    assert mock(bot, bot._trigger) is not True, (
+        'Callable requiring bot channel privilege must be ignored in private.')
 
     @plugin.command('ban')
     @plugin.require_bot_privilege(plugin.OP)
     def mock(bot, trigger):
         return True
 
-    assert mock(bot, bot._trigger) is True
+    assert mock(bot, bot._trigger) is not True, (
+        'Callable requiring bot channel privilege must be ignored in private.')
 
     @plugin.command('ban')
     @plugin.require_bot_privilege(plugin.OWNER)
     def mock(bot, trigger):
         return True
 
-    assert mock(bot, bot._trigger) is True, (
-        'There must not be privilege check for a private message.')
+    assert mock(bot, bot._trigger) is not True, (
+        'Callable requiring bot channel privilege must be ignored in private.')


### PR DESCRIPTION
### Description

If the bot needs a channel privilege for a given callable, it probably wants to do something related to channel operations, and triggering such a callable in response to a private message makes no sense.

Sorry about trying to add something into 8.0.0 this late… I've been writing the 8.0 migration guide tonight, and when I ran across #2405 I realized that #2399 should have contemplated doing this too. If we're gonna "breaking change" privilege-decorator stuff, we should do it _all_ in one major version.

If others agree that this is a good idea we can just merge the patch that's already ready to go and get on with finishing the release. (That's why I didn't open an issue first, to shorten the discuss -> implement -> review cycle.)

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches