### PR TITLE
bot: properly deprecate `search_url_callbacks()` method

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -1221,6 +1221,14 @@ class Sopel(irc.AbstractBot):
         except KeyError:
             pass
 
+    @deprecated(
+        reason=(
+            'URL handling has been unified in the Rules system via the @url '
+            'decorator. Use RuleManager.check_url_callbacks() if needed.'),
+        version='8.0',
+        warning_in='8.1',
+        removed_in='9.0',
+    )
     def search_url_callbacks(self, url):
         """Yield callbacks whose regex pattern matches the ``url``.
 


### PR DESCRIPTION
### Description

That decorator is the only thing wot *might* actually get people to notice that they're still using a deprecated feature…

~~Carelessly left out of #2121, somehow.~~ Actually was included in #2121 but reverted in #2156 due to log spam. But it's not so important that it needs to go in 8.0.0, either.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches