### PR TITLE
tell: fix edge case with `@` as the tellee

### DIFF
--- a/sopel/builtins/tell.py
+++ b/sopel/builtins/tell.py
@@ -181,7 +181,7 @@ def f_remind(bot, trigger):
         bot.reply("%s whom?" % verb)
         return
 
-    tellee = trigger.group(3).rstrip('.,:;')
+    tellee = trigger.group(3).rstrip('.,:;').lstrip('@')
 
     # all we care about is having at least one non-whitespace
     # character after the name

--- a/sopel/builtins/tell.py
+++ b/sopel/builtins/tell.py
@@ -205,7 +205,11 @@ def f_remind(bot, trigger):
         return
 
     if tellee[0] == '@':
-        tellee = tellee[1:]
+        if len(tellee) == 1:
+            bot.reply("%s whom?" % verb)
+            return
+        else:
+            tellee = tellee[1:]
 
     if tellee == bot.nick:
         bot.reply("I'm here now; you can %s me whatever you want!" % verb)


### PR DESCRIPTION
### Description

There's an annoying bug where an oversight in code that checks if a message is prepended with an @ allows for a user to make the bot spit out error messages forever until the bot is restarted. I have fixed this oversight here

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches