### PR TITLE
tell: avoid errors produced by empty tellee

### DIFF
--- a/sopel/builtins/tell.py
+++ b/sopel/builtins/tell.py
@@ -178,10 +178,13 @@ def f_remind(bot, trigger):
     verb = trigger.group(1)
 
     if not trigger.group(3):
+        tellee = ""
+    else:
+        tellee = trigger.group(3).rstrip('.,:;').lstrip('@')
+
+    if not tellee:
         bot.reply("%s whom?" % verb)
         return
-
-    tellee = trigger.group(3).rstrip('.,:;')
 
     # all we care about is having at least one non-whitespace
     # character after the name
@@ -203,9 +206,6 @@ def f_remind(bot, trigger):
     if len(tellee) > bot.isupport.get('NICKLEN', 30):
         bot.reply('That nickname is too long.')
         return
-
-    if tellee[0] == '@':
-        tellee = tellee[1:]
 
     if tellee == bot.nick:
         bot.reply("I'm here now; you can %s me whatever you want!" % verb)

--- a/sopel/builtins/tell.py
+++ b/sopel/builtins/tell.py
@@ -170,8 +170,14 @@ def _format_safe_lstrip(text):
 @plugin.command('tell', 'ask')
 @plugin.nickname_command('tell', 'ask')
 @plugin.example('$nickname, tell dgw he broke it again.', user_help=True)
+@plugin.example('.ask ', 'ask whom?')
 @plugin.example('.tell ', 'tell whom?')
+@plugin.example('.ask @', 'ask whom?')
+@plugin.example('.tell @', 'tell whom?')
 @plugin.example('.ask Exirel ', 'ask Exirel what?')
+@plugin.example('.tell Exirel ', 'tell Exirel what?')
+@plugin.example('.ask @Exirel ', 'ask Exirel what?')
+@plugin.example('.tell @Exirel ', 'tell Exirel what?')
 def f_remind(bot, trigger):
     """Give someone a message the next time they're seen"""
     teller = trigger.nick


### PR DESCRIPTION
### Description

This changeset is an alternative to #2582 that transforms the `tellee` as early as possible.

The use of `lstrip("@")` in this patch means that an arbitrary number of prefixing `@`s will be removed, so that `@@Someone` is transformed into `Someone` where it would previously have been transformed to `@Someone`, but since this is an edge case to begin with, I don't think it's any problem.

Longer term, we'd like to have better awareness of if `tellee` is a valid nick or not. I've filed #2583 for this purpose.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
