### PR TITLE
version: retrieve commit hash for git worktrees

### DIFF
--- a/sopel/builtins/version.py
+++ b/sopel/builtins/version.py
@@ -18,7 +18,6 @@ from sopel import __version__ as release, plugin
 
 logger = logging.getLogger(__name__)
 
-
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 GIT_DIR = os.path.join(PROJECT_DIR, '.git')
 
@@ -69,7 +68,7 @@ def _resolve_git_dirs(path: str) -> tuple[str, str]:
     return gitdir, head
 
 
-def git_info() -> str | None:
+def sopel_git_commit() -> str | None:
     """Determine the git commit hash of this Sopel, if applicable
     """
     gitdir, head = _resolve_git_dirs(GIT_DIR)
@@ -110,7 +109,7 @@ def version(bot, trigger):
         'Python: %s' % platform.python_version()
     ]
     try:
-        sha = git_info()
+        sha = sopel_git_commit()
     except OSError:
         logger.warning("Failed to retrieve git commit hash", exc_info=True)
         sha = None

--- a/sopel/builtins/version.py
+++ b/sopel/builtins/version.py
@@ -9,27 +9,71 @@ https://sopel.chat
 from __future__ import annotations
 
 import datetime
+import logging
 import os
 import platform
 
 from sopel import __version__ as release, plugin
 
 
+logger = logging.getLogger(__name__)
+
+
 PROJECT_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
 GIT_DIR = os.path.join(PROJECT_DIR, '.git')
 
 
-def git_info():
-    head = os.path.join(GIT_DIR, 'HEAD')
+def _read_commit(gitdir: str, head: str) -> str | None:
+    """Given paths to ``.git/`` and ``HEAD``, determine the associated commit hash
+
+    :param gitdir: path to a ``.git/`` directory
+    :param head: path to ``HEAD`` file
+    """
+    result = None
+
     if os.path.isfile(head):
         with open(head) as h:
             head_loc = h.readline()[5:-1]  # strip ref: and \n
-        head_file = os.path.join(GIT_DIR, head_loc)
+        head_file = os.path.join(gitdir, head_loc)
         if os.path.isfile(head_file):
             with open(head_file) as h:
-                sha = h.readline()
+                sha = h.readline().strip()
                 if sha:
-                    return sha
+                    result = sha
+
+    return result
+
+
+def _resolve_git_dirs(path: str) -> tuple[str, str]:
+    """Resolve a ``.git`` path to its 'true' ``.git/`` and `HEAD`
+
+    This helper is useful for dealing with the ``.git`` file stored in a
+    git worktree.
+
+    :param path: path to a .git directory or worktree reference file
+    """
+    # default to the old behavior: assume `path` is a valid .git/ to begin with
+    gitdir = path
+    head = os.path.join(path, "HEAD")
+
+    if os.path.isfile(path):
+        # this may be a worktree, let's override the result properly if so
+        with open(path, 'r') as f:
+            first, rest = next(f).strip().split(maxsplit=1)
+            if first == "gitdir:":
+                # line is "gitdir: /path/to/parentrepo/.git/worktrees/thispath"
+                gitdir = os.path.dirname(os.path.dirname(rest))
+                head = os.path.join(rest, "HEAD")
+            # else: we can't make sense of this file, stick to the default
+
+    return gitdir, head
+
+
+def git_info() -> str | None:
+    """Determine the git commit hash of this Sopel, if applicable
+    """
+    gitdir, head = _resolve_git_dirs(GIT_DIR)
+    return _read_commit(gitdir, head)
 
 
 @plugin.command('version')
@@ -65,7 +109,12 @@ def version(bot, trigger):
         'Sopel v%s' % release,
         'Python: %s' % platform.python_version()
     ]
-    sha = git_info()
+    try:
+        sha = git_info()
+    except OSError:
+        logger.warning("Failed to retrieve git commit hash", exc_info=True)
+        sha = None
+
     if sha:
         parts.append('Commit: %s' % sha)
 


### PR DESCRIPTION
### Description

Tin and personal wish fulfillment. With this changeset, the `version` command will report commit information if Sopel is running from a [`git-worktree`](https://git-scm.com/docs/git-worktree).

The current revision of the `version` plugin only supports reading commit information when the host Sopel is running inside of a 'real' git repository. I find it convenient to run Sopel from a worktree for a "near to development" copy, and it's nice to still have the commit information in this use-case.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [ ] No issues are reported by `make qa` (runs `make lint` and `make test`)
  - I did see some errors when running `mypy` because `types-urllib3` was not installed. I'm not sure if that's missing from `dev-requirements.txt` or if my local environment was in a weird state.
  - Also saw some test failures in `test_example_suggest_*` caused by content decoding errors. I only vaguely recognize the issue, but I'm confident it's not this changeset's fault.
- [x] I have tested the functionality of the things this change touches
