### PR TITLE
find: support escaping backslash, fix double-bolding, and add basic tests

### DIFF
--- a/sopel/builtins/find.py
+++ b/sopel/builtins/find.py
@@ -170,7 +170,7 @@ def findandreplace(bot, trigger):
 
     # only clean/format the new string if it's non-empty
     if new:
-        new = bold(escape_sequence_pattern.sub(decode_escape, new))
+        new = escape_sequence_pattern.sub(decode_escape, new)
 
     # If g flag is given, replace all. Otherwise, replace once.
     if 'g' in flags:
@@ -183,42 +183,43 @@ def findandreplace(bot, trigger):
     if 'i' in flags:
         regex = re.compile(re.escape(old), re.U | re.I)
 
-        def repl(s):
-            return re.sub(regex, new, s, count == 1)
+        def repl(line, subst):
+            return re.sub(regex, subst, line, count == 1)
     else:
-        def repl(s):
-            return s.replace(old, new, count)
+        def repl(line, subst):
+            return line.replace(old, subst, count)
 
     # Look back through the user's lines in the channel until you find a line
     # where the replacement works
-    new_phrase = None
+    new_line = new_display = None
     for line in history:
         if line.startswith("\x01ACTION"):
             me = True  # /me command
             line = line[8:]
         else:
             me = False
-        replaced = repl(line)
+        replaced = repl(line, new)
         if replaced != line:  # we are done
-            new_phrase = replaced
+            new_line = replaced
+            new_display = repl(line, bold(new))
             break
 
-    if not new_phrase:
+    if not new_line:
         return  # Didn't find anything
 
     # Save the new "edited" message.
     action = (me and '\x01ACTION ') or ''  # If /me message, prepend \x01ACTION
-    history.appendleft(action + new_phrase)  # history is in most-recent-first order
+    history.appendleft(action + new_line)  # history is in most-recent-first order
 
     # output
     if not me:
-        new_phrase = 'meant to say: %s' % new_phrase
+        new_display = 'meant to say: %s' % new_display
     if trigger.group(1):
-        phrase = '%s thinks %s %s' % (trigger.nick, rnick, new_phrase)
+        msg = '%s thinks %s %s' % (trigger.nick, rnick, new_display)
     else:
-        phrase = '%s %s' % (trigger.nick, new_phrase)
+        msg = '%s %s' % (trigger.nick, new_display)
 
-    bot.say(phrase)
+    bot.say(msg)
 
 
 def decode_escape(match):

--- a/test/builtins/test_builtins_find.py
+++ b/test/builtins/test_builtins_find.py
@@ -43,6 +43,7 @@ REPLACES_THAT_WORK = (
     ("An escaped / line.", r"s/\//slash/", f"An escaped {bold('slash')} line."),
     ("A piped line.", r"s|line|replacement|", f"A piped {bold('replacement')}."),
     ("An escaped | line.", r"s|\||pipe|", f"An escaped {bold('pipe')} line."),
+    ("An escaped \\ line.", r"s/\\/backslash/", f"An escaped {bold('backslash')} line."),
 )
 
 

--- a/test/builtins/test_builtins_find.py
+++ b/test/builtins/test_builtins_find.py
@@ -102,8 +102,6 @@ def test_replace_the_replacement(bot, irc, user, channel):
             channel, user.nick, bold('eggs'),
         ),
         "PRIVMSG %s :%s meant to say: %s" % (
-            channel, user.nick, bold(bold('bacon')),
-            # the test is accurate, even though the behavior here (doubled bold
-            # control characters) is less than ideal
+            channel, user.nick, bold('bacon'),
         ),
     )

--- a/test/builtins/test_builtins_find.py
+++ b/test/builtins/test_builtins_find.py
@@ -34,6 +34,11 @@ def user(userfactory):
 
 
 @pytest.fixture
+def other_user(userfactory):
+    return userfactory('other_user')
+
+
+@pytest.fixture
 def channel():
     return '#testing'
 
@@ -44,11 +49,15 @@ REPLACES_THAT_WORK = (
     ("A piped line.", r"s|line|replacement|", f"A piped {bold('replacement')}."),
     ("An escaped | line.", r"s|\||pipe|", f"An escaped {bold('pipe')} line."),
     ("An escaped \\ line.", r"s/\\/backslash/", f"An escaped {bold('backslash')} line."),
+    ("abABab", r"s/b/c/g", "abABab".replace('b', bold('c'))),  # g (global) flag
+    ("ABabAB", r"s/b/c/i", f"A{bold('c')}abAB"),  # i (case-insensitive) flag
+    ("ABabAB", r"s/b/c/ig", f"A{bold('c')}a{bold('c')}A{bold('c')}"),  # both flags
 )
 
 
 @pytest.mark.parametrize('original, command, result', REPLACES_THAT_WORK)
 def test_valid_replacements(bot, irc, user, channel, original, command, result):
+    """Verify that basic replacement functionality works."""
     irc.channel_joined(channel, [user.nick])
 
     irc.say(user, channel, original)
@@ -58,4 +67,43 @@ def test_valid_replacements(bot, irc, user, channel, original, command, result):
         "The bot should respond with exactly one line.")
     assert bot.backend.message_sent == rawlist(
         "PRIVMSG %s :%s meant to say: %s" % (channel, user.nick, result),
+    )
+
+
+def test_multiple_users(bot, irc, user, other_user, channel):
+    """Verify that correcting another user's line works."""
+    irc.channel_joined(channel, [user.nick, other_user.nick])
+
+    irc.say(other_user, channel, 'Some weather we got yesterday')
+    irc.say(user, channel, '%s: s/yester/to/' % other_user.nick)
+
+    assert len(bot.backend.message_sent) == 1, (
+        "The bot should respond with exactly one line.")
+    assert bot.backend.message_sent == rawlist(
+        "PRIVMSG %s :%s thinks %s meant to say: %s" % (
+            channel, user.nick, other_user.nick,
+            f"Some weather we got {bold('to')}day",
+        ),
+    )
+
+
+def test_replace_the_replacement(bot, irc, user, channel):
+    """Verify replacing text that was already replaced."""
+    irc.channel_joined(channel, [user.nick])
+
+    irc.say(user, channel, 'spam')
+    irc.say(user, channel, 's/spam/eggs/')
+    irc.say(user, channel, 's/eggs/bacon/')
+
+    assert len(bot.backend.message_sent) == 2, (
+        "The bot should respond twice.")
+    assert bot.backend.message_sent == rawlist(
+        "PRIVMSG %s :%s meant to say: %s" % (
+            channel, user.nick, bold('eggs'),
+        ),
+        "PRIVMSG %s :%s meant to say: %s" % (
+            channel, user.nick, bold(bold('bacon')),
+            # the test is accurate, even though the behavior here (doubled bold
+            # control characters) is less than ideal
+        ),
     )

--- a/test/builtins/test_builtins_find.py
+++ b/test/builtins/test_builtins_find.py
@@ -1,0 +1,60 @@
+"""Tests for Sopel's ``find`` plugin"""
+from __future__ import annotations
+
+import pytest
+
+from sopel.formatting import bold
+from sopel.tests import rawlist
+
+
+TMP_CONFIG = """
+[core]
+owner = Admin
+nick = Sopel
+enable =
+    find
+host = irc.libera.chat
+"""
+
+
+@pytest.fixture
+def bot(botfactory, configfactory):
+    settings = configfactory('default.ini', TMP_CONFIG)
+    return botfactory.preloaded(settings, ['find'])
+
+
+@pytest.fixture
+def irc(bot, ircfactory):
+    return ircfactory(bot)
+
+
+@pytest.fixture
+def user(userfactory):
+    return userfactory('User')
+
+
+@pytest.fixture
+def channel():
+    return '#testing'
+
+
+REPLACES_THAT_WORK = (
+    ("A simple line.", r"s/line/message/", f"A simple {bold('message')}."),
+    ("An escaped / line.", r"s/\//slash/", f"An escaped {bold('slash')} line."),
+    ("A piped line.", r"s|line|replacement|", f"A piped {bold('replacement')}."),
+    ("An escaped | line.", r"s|\||pipe|", f"An escaped {bold('pipe')} line."),
+)
+
+
+@pytest.mark.parametrize('original, command, result', REPLACES_THAT_WORK)
+def test_valid_replacements(bot, irc, user, channel, original, command, result):
+    irc.channel_joined(channel, [user.nick])
+
+    irc.say(user, channel, original)
+    irc.say(user, channel, command)
+
+    assert len(bot.backend.message_sent) == 1, (
+        "The bot should respond with exactly one line.")
+    assert bot.backend.message_sent == rawlist(
+        "PRIVMSG %s :%s meant to say: %s" % (channel, user.nick, result),
+    )


### PR DESCRIPTION
### Description

Allowing `\|` or `\/` is all well and good, but if one can't escape the escape character, things get very confusing! So let's make it possible to escape `\` itself as `\\`.

With the test scaffolding now written (OK, much of it stolen from the preexisting `test/builtins/test_builtins_isup.py`), it'll be easier to add more cases (edge or otherwise) as we think of them.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes

Early 8.0.x bugfix candidate, unless someone else feels strongly about including it in 8.0.0. Feels late in the game to add One More Thing into that milestone…