### PR TITLE
GHA: Update/fix actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,9 @@ jobs:
           - "3.11"
           - "3.12"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -29,7 +29,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@v3
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
@@ -38,9 +38,9 @@ jobs:
               - sopel
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@v3
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -22,6 +22,6 @@ jobs:
         run: |
           python -m build --sdist --wheel --outdir dist/ .
       - name: Publish distribution to PyPI
-        uses: pypa/gh-action-pypi-publish@v1
+        uses: pypa/gh-action-pypi-publish@2f6f737ca5f74c637829c0f5c3acd0e29ea5e8bf1
         with:
           password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -9,9 +9,9 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
       - name: Install PyPA/build


### PR DESCRIPTION
Both `actions/checkout` and `actions/setup-python` were using deprecated Node runtimes and generating warnings in our CI logs. Oh, and they'd also eventually stop working entirely when the deprecated runtime is removed. That's probably the best reason to update them.

I also discovered that there is no `v1` tag for `pypa/gh-action-pypi-publish`, so our existing `pypi.yml` workflow from #2328 wouldn't ever work. Because tags can be easily changed if a malicious someone gains access to the action's repository, the release action is pinned to a specific, verified, commit's SHA.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - This will be handled for the `ci.yml` workflow by PR checks, and if the checkout & setup-python actions work there we can assume the same new versions will also work in the `pypi.yml` workflow.
  - I can't really test the `pypi.yml` workflow but that's no change (it was already untested), and we'll have a chance to test it for real soon enough.