### PR TITLE
adminchannel: rework topic-mask commands

### DIFF
--- a/sopel/builtins/adminchannel.py
+++ b/sopel/builtins/adminchannel.py
@@ -365,31 +365,35 @@ def topic(bot, trigger):
 @plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV)
 @plugin.command('tmask')
 def set_mask(bot, trigger):
-    """Set the topic mask to use for the current channel
+    """Set or get the topic mask to use for the current channel.
 
-    Within the topic mask, {} is used to allow substituting in chunks of text.
+    This mask is used when running the 'topic' command. `{}` is used to allow
+    interpolating chunks of text within the topic mask.
 
-    This mask is used when running the 'topic' command.
+    If called without arguments, prints the channel's current topic mask.
     """
     new_mask = trigger.group(2)
 
     if new_mask is None:
-        bot.db.delete_channel_value(trigger.sender, 'topic_mask')
-        bot.reply('Cleared topic mask.')
+        mask = bot.db.get_channel_value(
+            trigger.sender, 'topic_mask', default_mask(trigger))
+        bot.reply('Current topic mask: {}'.format(mask))
         return
 
     bot.db.set_channel_value(trigger.sender, 'topic_mask', new_mask)
     message = (
         'Topic mask set. '
-        'Use `{prefix}topic <args>` to set topic '
-        'and `{prefix}showmask` to see current mask.'
+        'Use `{prefix}topic <args>` to set topic, '
+        '`{prefix}tmask` without arguments to see the current mask, '
+        'and `{prefix}cleartmask` to clear the topic mask.'
     ).format(prefix=bot.settings.core.help_prefix)
     bot.reply(message)
 
 
 @plugin.require_chanmsg
 @plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV)
-@plugin.command('showmask')
-def show_mask(bot, trigger):
-    """Show the topic mask for the current channel."""
-    bot.say(bot.db.get_channel_value(trigger.sender, 'topic_mask', default_mask(trigger)))
+@plugin.command('cleartmask')
+def clear_mask(bot, trigger):
+    """Clear the topic mask for the current channel."""
+    bot.db.delete_channel_value(trigger.sender, 'topic_mask')
+    bot.reply('Cleared topic mask.')

--- a/sopel/builtins/adminchannel.py
+++ b/sopel/builtins/adminchannel.py
@@ -363,6 +363,9 @@ def topic(bot, trigger):
 
 @plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV)
 @plugin.commands('tmask set', 'tmask get', 'tmask clear', 'tmask')
+@plugin.example('.tmask clear', user_help=True)
+@plugin.example('.tmask get', user_help=True)
+@plugin.example('.tmask set My {} topic mask!', user_help=True)
 def topic_mask_management(bot, trigger):
     """Set, get, or clear the current channel's topic mask.
 

--- a/sopel/builtins/adminchannel.py
+++ b/sopel/builtins/adminchannel.py
@@ -331,9 +331,8 @@ def topic(bot, trigger):
         return
     channel = trigger.sender.lower()
 
-    mask = None
-    mask = bot.db.get_channel_value(channel, 'topic_mask')
-    mask = mask or default_mask(trigger)
+    mask = bot.db.get_channel_value(
+        channel, 'topic_mask', default_mask(trigger))
     mask = mask.replace('%s', '{}')
     narg = len(re.findall('{}', mask))
 
@@ -372,7 +371,14 @@ def set_mask(bot, trigger):
 
     This mask is used when running the 'topic' command.
     """
-    bot.db.set_channel_value(trigger.sender, 'topic_mask', trigger.group(2))
+    new_mask = trigger.group(2)
+
+    if new_mask is None:
+        bot.db.delete_channel_value(trigger.sender, 'topic_mask')
+        bot.reply('Cleared topic mask.')
+        return
+
+    bot.db.set_channel_value(trigger.sender, 'topic_mask', new_mask)
     message = (
         'Topic mask set. '
         'Use `{prefix}topic <args>` to set topic '


### PR DESCRIPTION
### Description

- `.tmask get` shows the current topic mask
  - `.tmask` without arguments assumes the `get` subcommand
- `.tmask set` now sets the topic mask, and provides a usage hint if called without further arguments
- `.tmask clear` is added to explicitly clear the topic mask

In combination, the above should be sufficient to resolve #2596.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes

If no one minds adding this to 8.0.0 while the release notes are still under peer review, I'm happy to get it shipped sooner.

_(Because it's modifying command behavior, if we don't ship this patch in 8.0.0, I believe the semver-appropriate thing to do would be to ship the first commit in 8.0.1 and hold the second for 8.1.0.)_