### PR TITLE
Miscellaneous type-checking updates

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -22,7 +22,9 @@ sphinx-rfcsection~=0.1.1
 vcrpy @ git+https://github.com/sopel-irc/vcrpy@uncap-urllib3
 # type check
 mypy>=1.3,<2
+# for `pkg_resources`; first version in which it's typed
+# we don't use `pkg_resources` directly, but mypy still cares
+setuptools>=71.1
 sqlalchemy[mypy]>=1.4,<1.5
-types-pkg-resources~=0.1.3
 types-pytz
 types-requests>=2,<3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ dependencies = [
     "importlib_metadata>=3.6",
     "packaging>=23.2",
     "sopel-help>=0.4.0",
+    "typing_extensions>=4.4",  # for @typing.override, added in py3.12
 ]
 
 [project.urls]

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -160,7 +160,7 @@ class OutputRedirect:
 
         :param str string: the string to write
         """
-        if not self.quiet:
+        if not self.quiet and sys.__stderr__ and sys.__stdout__:
             try:
                 if self.stderr:
                     sys.__stderr__.write(string)
@@ -179,9 +179,9 @@ class OutputRedirect:
 
     def flush(self):
         """Flush the file writing buffer."""
-        if self.stderr:
+        if self.stderr and sys.__stderr__:
             sys.__stderr__.flush()
-        else:
+        elif sys.__stdout__:
             sys.__stdout__.flush()
 
 

--- a/sopel/tools/memories.py
+++ b/sopel/tools/memories.py
@@ -10,6 +10,8 @@ from collections import defaultdict
 import threading
 from typing import Any, Optional, TYPE_CHECKING, Union
 
+from typing_extensions import override
+
 from .identifiers import Identifier, IdentifierFactory
 
 if TYPE_CHECKING:
@@ -259,6 +261,7 @@ class SopelIdentifierMemory(SopelMemory):
             return super().pop(self._make_key(key))
         return super().pop(self._make_key(key), default)
 
+    @override
     def update(self, maybe_mapping=tuple()):
         """Update this ``SopelIdentifierMemory`` with key-value pairs.
 


### PR DESCRIPTION
### Description

`types-pkg-resources` was yanked, which I discovered when submitting #2613. `pkg_resources` itself is typed in setuptools>=71.1, negating the need to install type stubs.

When testing that fix, I updated `mypy` and friends (`pip install -U -r dev-requirements.txt`) and found a few more new type-check errors caught by the newer tools:

- `SopelIdentifierMemory.update()`'s signature isn't compatible with its supertype (fixed by adding `typing_extensions.override` decorator; can't go stdlib-only until py3.12…)
- `tools.OutputRedirect` calls methods on `sys.__stdout__` and `sys.__stderr__`, which are allowed to be `None` and therefore have to be guarded with `if`s (I'm glad this class is deprecated)

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes

All of this needs backporting to the `8.0.x` maintenance branch, which is why this has the 8.0.1 milestone.