### PR TITLE
docs: add advanced tip about scheduling function calls

### DIFF
--- a/docs/source/plugin/advanced.rst
+++ b/docs/source/plugin/advanced.rst
@@ -15,6 +15,45 @@ If something is not in here, feel free to ask about it on our IRC channel, or
 maybe open an issue with the solution if you devise one yourself.
 
 
+Running a function on a schedule
+================================
+
+Sopel provides the :func:`@plugin.interval <sopel.plugin.interval>` decorator
+to run plugin callables periodically, but plugin developers semi-frequently ask
+how to run a function at the same time every day/week.
+
+Integrating this kind of feature into Sopel's plugin API is trickier than one
+might think, and it's actually simpler to have plugins just use a library like
+`schedule`__ directly::
+
+    import schedule
+
+    from sopel import plugin
+
+
+    def scheduled_message(bot):
+        bot.say("This is the scheduled message.", "#channelname")
+
+
+    def setup(bot):
+        # schedule the message at midnight every day
+        schedule.every().day.at('00:00').do(scheduled_message, bot=bot)
+
+
+    @plugin.interval(60)
+    def run_schedule(bot):
+        schedule.run_pending()
+
+As long as the ``bot`` is passed as an argument, the scheduled function can
+access config settings or any other attributes/properties it needs.
+
+Multiple plugins all setting up their own checks with ``interval`` naturally
+creates *some* overhead, but it shouldn't be significant compared to all the
+other things happening inside a Sopel bot with numerous plugins.
+
+.. __: https://pypi.org/project/schedule/
+
+
 Restricting commands to certain channels
 ========================================
 

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -1193,10 +1193,6 @@ def rate(
 
         @rate(10, 10, 2, message='Sorry {nick}, you hit the {rate_limit_type} rate limit!')
 
-    Rate-limited functions that use scheduled future commands should import
-    :class:`threading.Timer` instead of :mod:`sched`, or rate limiting will
-    not work properly.
-
     .. versionchanged:: 8.0
 
         Optional keyword argument ``message`` was added in Sopel 8.


### PR DESCRIPTION
How to do this was discussed fairly well in #1222 a while ago, and I just cribbed an example from there.

I also found an apparently obsolete note about using `sched` with `@plugin.rate` and friends while poking around the topic of scheduled callables, because I tested what it said and found that the caveat no longer applies (see #825).

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes

Along the way I also briefly considered giving the `bot` a `schedule` instance that it provides to plugins, but I'm not ready to commit to that kind of API addition yet. Putting this into the tips & tricks section is better than pointing to a random issue comment on the occasions when "how do I schedule a function at a specific time?" comes up, and it doesn't preclude API additions at a later time if we come up with a sane decorator interface for it.