### PR TITLE
config.types.ChoiceAttribute: log the invalid value if validation fails

### DIFF
--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -649,7 +649,10 @@ class ChoiceAttribute(BaseValidated):
         if value in self.choices:
             return value
         else:
-            raise ValueError('Value must be in {}'.format(self.choices))
+            raise ValueError(
+                '{!r} is not one of the valid choices: {}'
+                .format(value, ', '.join(self.choices))
+            )
 
     def serialize(self, value):
         """Make sure ``value`` is valid and safe to write in the config file.
@@ -662,7 +665,10 @@ class ChoiceAttribute(BaseValidated):
         if value in self.choices:
             return value
         else:
-            raise ValueError('Value must be in {}'.format(self.choices))
+            raise ValueError(
+                '{!r} is not one of the valid choices: {}'
+                .format(value, ', '.join(self.choices))
+            )
 
 
 class FilenameAttribute(BaseValidated):


### PR DESCRIPTION
### Description

This should make debugging a bad configuration easier, especially if the value is read from an environment variable.

It should also help with figuring out weird errors related to invisible characters in the configuration file, but that's not the primary motivation here.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches