### PR TITLE
ci, contrib, dice, meta: enable testing on Python 3.13 + fix warnings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,7 @@ jobs:
           - "3.10"
           - "3.11"
           - "3.12"
+          - "3.13"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/contrib/tox.ini
+++ b/contrib/tox.ini
@@ -2,12 +2,12 @@
 package_root = .
 min_version = 4.3.3
 envlist =
-    py{38,39,310,311,312}-qa
+    py{38,39,310,311,312,313}-qa
 skip_missing_interpreters = true
 ignore_base_python_conflict = true
 labels =
-    lint = py{38,39,310,311,312}-lint
-    test = py{38,39,310,311,312}-test
+    lint = py{38,39,310,311,312,313}-lint
+    test = py{38,39,310,311,312,313}-test
 
 
 [testenv]
@@ -21,12 +21,14 @@ envname =
     py310: py310
     py311: py311
     py312: py312
+    py313: py313
 envdir =
     py38: {toxinidir}/.tox/py38
     py39: {toxinidir}/.tox/py39
     py310: {toxinidir}/.tox/py310
     py311: {toxinidir}/.tox/py311
     py312: {toxinidir}/.tox/py312
+    py313: {toxinidir}/.tox/py313
 depends =
     base
 deps =

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Communications :: Chat :: Internet Relay Chat",
 ]
 requires-python = ">=3.8"

--- a/sopel/builtins/dice.py
+++ b/sopel/builtins/dice.py
@@ -269,7 +269,9 @@ def roll(bot: SopelWrapper, trigger: Trigger):
 
     arg_str_raw = trigger.group(2).split("#", 1)[0].strip()
     arg_str = arg_str_raw.replace("%", "%%")
-    arg_str = re.sub(dice_regexp, "%s", arg_str, 0, re.IGNORECASE | re.VERBOSE)
+    arg_str = re.sub(
+        dice_regexp, "%s", arg_str,
+        flags=re.IGNORECASE | re.VERBOSE)
 
     dice_expressions = [
         match for match in

--- a/sopel/builtins/url.py
+++ b/sopel/builtins/url.py
@@ -437,7 +437,10 @@ def process_urls(
             except ValueError:
                 # Extra try/except here in case the DNS resolution fails, see #2348
                 try:
-                    ips = [ip_address(ip) for ip in dns.resolver.resolve(parsed_url.hostname)]
+                    ips = [
+                        ip_address(ip.to_text())
+                        for ip in dns.resolver.resolve(parsed_url.hostname)
+                    ]
                 except Exception as exc:
                     LOGGER.debug(
                         "Cannot resolve hostname %s, ignoring URL %s"


### PR DESCRIPTION
### Description

- ci: Added Python 3.13 to CI workflow
- contrib: Added Python 3.13 envs to tox config
- dice: removed unnecessary `count` parameter to `re.sub()` and pass `flags` as a kwarg
  (py3.13 deprecates these as positional args)
- url: fix type-check error with `dnspython` 2.7
  Use `Rdata.to_text()` to get each result as a string, which is one of the types that `ipaddress.ip_address()` accepts.
- meta: add Python 3.13 classifier for PyPI releases of 8.1+

With the above changes, the only warning emitted during `pytest` runs under Python 3.13 is from SQLAlchemy, which isn't new; it's because we haven't fully migrated to their 2.0 style yet, and not related to which Python version is used.

The type-check error from `dnspython` 2.7 isn't strictly Python 3.13-related, but this patch wouldn't pass linting without it. That change doesn't seem like it needs its own PR (though it might need to be backported for 8.0.1; we'll see).

Closes #2608.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
  - Shockingly, I even ran the whole `tox` job on every version listed, after updating them all to the latest patch release available in `pyenv`. Maybe not necessary, but I was making sure the `tox` config still worked after I edited it.