### PR TITLE
bot, rules: fix rate limiting rules without a rate limit

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -602,30 +602,26 @@ class Sopel(irc.AbstractBot):
         if trigger.admin or rule.is_unblockable():
             return False, None
 
+        nick = trigger.nick
         is_channel = trigger.sender and not trigger.sender.is_nick()
         channel = trigger.sender if is_channel else None
 
         at_time = trigger.time
-
-        user_metrics = rule.get_user_metrics(trigger.nick)
-        channel_metrics = rule.get_channel_metrics(channel)
-        global_metrics = rule.get_global_metrics()
-
-        if user_metrics.is_limited(at_time - rule.user_rate_limit):
+        if rule.is_user_rate_limited(nick, at_time):
             template = rule.user_rate_template
             rate_limit_type = "user"
             rate_limit = rule.user_rate_limit
-            metrics = user_metrics
-        elif is_channel and channel_metrics.is_limited(at_time - rule.channel_rate_limit):
+            metrics = rule.get_user_metrics(nick)
+        elif channel and rule.is_channel_rate_limited(channel, at_time):
             template = rule.channel_rate_template
             rate_limit_type = "channel"
             rate_limit = rule.channel_rate_limit
-            metrics = channel_metrics
-        elif global_metrics.is_limited(at_time - rule.global_rate_limit):
+            metrics = rule.get_channel_metrics(channel)
+        elif rule.is_global_rate_limited(at_time):
             template = rule.global_rate_template
             rate_limit_type = "global"
             rate_limit = rule.global_rate_limit
-            metrics = global_metrics
+            metrics = rule.get_global_metrics()
         else:
             return False, None
 

--- a/test/plugins/test_plugins_rules.py
+++ b/test/plugins/test_plugins_rules.py
@@ -1566,14 +1566,16 @@ def test_rule_rate_limit(mockbot, triggerfactory):
         global_rate_limit=20,
         channel_rate_limit=20,
     )
-    assert rule.is_user_rate_limited(mocktrigger.nick) is False
-    assert rule.is_channel_rate_limited(mocktrigger.sender) is False
-    assert rule.is_global_rate_limited() is False
+    at_time = datetime.datetime.now(datetime.timezone.utc)
+    assert rule.is_user_rate_limited(mocktrigger.nick, at_time) is False
+    assert rule.is_channel_rate_limited(mocktrigger.sender, at_time) is False
+    assert rule.is_global_rate_limited(at_time) is False
 
     rule.execute(mockbot, mocktrigger)
-    assert rule.is_user_rate_limited(mocktrigger.nick) is True
-    assert rule.is_channel_rate_limited(mocktrigger.sender) is True
-    assert rule.is_global_rate_limited() is True
+    at_time = datetime.datetime.now(datetime.timezone.utc)
+    assert rule.is_user_rate_limited(mocktrigger.nick, at_time) is True
+    assert rule.is_channel_rate_limited(mocktrigger.sender, at_time) is True
+    assert rule.is_global_rate_limited(at_time) is True
 
 
 def test_rule_rate_limit_no_limit(mockbot, triggerfactory):
@@ -1592,14 +1594,16 @@ def test_rule_rate_limit_no_limit(mockbot, triggerfactory):
         global_rate_limit=0,
         channel_rate_limit=0,
     )
-    assert rule.is_user_rate_limited(mocktrigger.nick) is False
-    assert rule.is_channel_rate_limited(mocktrigger.sender) is False
-    assert rule.is_global_rate_limited() is False
+    at_time = datetime.datetime.now(datetime.timezone.utc)
+    assert rule.is_user_rate_limited(mocktrigger.nick, at_time) is False
+    assert rule.is_channel_rate_limited(mocktrigger.sender, at_time) is False
+    assert rule.is_global_rate_limited(at_time) is False
 
     rule.execute(mockbot, mocktrigger)
-    assert rule.is_user_rate_limited(mocktrigger.nick) is False
-    assert rule.is_channel_rate_limited(mocktrigger.sender) is False
-    assert rule.is_global_rate_limited() is False
+    at_time = datetime.datetime.now(datetime.timezone.utc)
+    assert rule.is_user_rate_limited(mocktrigger.nick, at_time) is False
+    assert rule.is_channel_rate_limited(mocktrigger.sender, at_time) is False
+    assert rule.is_global_rate_limited(at_time) is False
 
 
 def test_rule_rate_limit_ignore_rate_limit(mockbot, triggerfactory):
@@ -1619,14 +1623,16 @@ def test_rule_rate_limit_ignore_rate_limit(mockbot, triggerfactory):
         channel_rate_limit=20,
         threaded=False,  # make sure there is no race-condition here
     )
-    assert rule.is_user_rate_limited(mocktrigger.nick) is False
-    assert rule.is_channel_rate_limited(mocktrigger.sender) is False
-    assert rule.is_global_rate_limited() is False
+    at_time = datetime.datetime.now(datetime.timezone.utc)
+    assert rule.is_user_rate_limited(mocktrigger.nick, at_time) is False
+    assert rule.is_channel_rate_limited(mocktrigger.sender, at_time) is False
+    assert rule.is_global_rate_limited(at_time) is False
 
     rule.execute(mockbot, mocktrigger)
-    assert rule.is_user_rate_limited(mocktrigger.nick) is False
-    assert rule.is_channel_rate_limited(mocktrigger.sender) is False
-    assert rule.is_global_rate_limited() is False
+    at_time = datetime.datetime.now(datetime.timezone.utc)
+    assert rule.is_user_rate_limited(mocktrigger.nick, at_time) is False
+    assert rule.is_channel_rate_limited(mocktrigger.sender, at_time) is False
+    assert rule.is_global_rate_limited(at_time) is False
 
 
 def test_rule_rate_limit_messages(mockbot, triggerfactory):


### PR DESCRIPTION
### Description

Fix #2627 by checking if the rate limit is actually set (equal or less than 0s).

I decided to make the `at_time` parameter mandatory, as it's all internal stuffs and it makes it clearer what time we are comparing it to. That's how I figured out that it was about the repeating call to the same rule for a single trigger: it would check against the same trigger object, but compare it to the latest call to `now()`. That's why the bug was visible on `url` rules, and it affected `find` rules as well.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
