### PR TITLE
pytest_plugin: disable flood protection for example tests

### DIFF
--- a/sopel/tests/pytest_plugin.py
+++ b/sopel/tests/pytest_plugin.py
@@ -18,6 +18,8 @@ TEMPLATE_TEST_CONFIG = """
 nick = {name}
 owner = {owner}
 admin = {admin}
+# avoid wasting cycles in time.sleep() during `repeat`ed tests
+flood_max_wait = 0
 """
 
 


### PR DESCRIPTION
### Description

_This patch feels almost too simple to work, but it does._

For quite a while, we've had three tests from the `rand` plugin that take several seconds each. I had a Sopelunk with the Git version of [`pytest-profiling`](https://github.com/man-group/pytest-plugins/tree/master/pytest-profiling) (because they haven't released in about 5 years and the last package is broken on modern Pythons) and discovered that about 98% of the time spent on the five tests selected by `pytest -k rand.py` was in `time.sleep()`.

Drilling down, I saw that was being called from `bot.say()`, which led pretty quickly to the real culprit: Flood protection.

There's no server to flood during tests, so we can just turn that protection off. With this change, those five tests from `rand` went from ~12 seconds on my test system down to about 0.25 sec.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches