### PR TITLE
Pin `mypy` to 1.11.2

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -21,7 +21,8 @@ sphinx-rfcsection~=0.1.1
 # (or until py3.9 EOL... in 10/2025, I HOPE NOT)
 vcrpy @ git+https://github.com/sopel-irc/vcrpy@uncap-urllib3
 # type check
-mypy>=1.3,<2
+# often breaks CI on master, so pin and update deliberately, on our own terms
+mypy==1.11.2
 # for `pkg_resources`; first version in which it's typed
 # we don't use `pkg_resources` directly, but mypy still cares
 setuptools>=71.1


### PR DESCRIPTION
### Description

Tin. CI fails at the moment, and it would be nice if it kept working.

I have started a `mypy-1.12` branch to work on the broken things. but it'll require some coordination with #2616 and #2629.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches