### PR TITLE
plugins.handlers: fix some PyFilePlugin logic errors

### DIFF
--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -471,7 +471,7 @@ class PyFilePlugin(PyModulePlugin):
             spec = importlib.util.spec_from_file_location(
                 name,
                 os.path.join(filename, '__init__.py'),
-                submodule_search_locations=filename,
+                submodule_search_locations=[filename],
             )
         else:
             raise exceptions.PluginError('Invalid Sopel plugin: %s' % filename)
@@ -487,9 +487,9 @@ class PyFilePlugin(PyModulePlugin):
 
     def _load(self):
         module = importlib.util.module_from_spec(self.module_spec)
-        sys.modules[self.name] = module
         if not self.module_spec.loader:
             raise exceptions.PluginError('Could not determine loader for plugin: %s' % self.filename)
+        sys.modules[self.name] = module
         self.module_spec.loader.exec_module(module)
         return module
 

--- a/test/plugins/test_plugins_handlers.py
+++ b/test/plugins/test_plugins_handlers.py
@@ -100,3 +100,45 @@ def test_get_label_entrypoint(plugin_tmpfile):
     assert meta['label'] == 'plugin label'
     assert meta['type'] == handlers.EntryPointPlugin.PLUGIN_TYPE
     assert meta['source'] == 'test_plugin = file_mod'
+
+
+MOCK_PARENT_MODULE = """
+from sopel import plugin
+
+from .sub import foo
+
+
+@plugin.command('mock')
+def mock(bot, trigger):
+    bot.say(foo)
+"""
+
+MOCK_SUB_MODULE = """
+foo = 'bar baz'
+"""
+
+
+@pytest.fixture
+def plugin_folder(tmp_path):
+    root = tmp_path / 'test_folder_plugin'
+    root.mkdir()
+
+    parent = root / '__init__.py'
+    with open(parent, 'w') as f:
+        f.write(MOCK_PARENT_MODULE)
+
+    submodule = root / 'sub.py'
+    with open(submodule, 'w') as f:
+        f.write(MOCK_SUB_MODULE)
+
+    return str(root)
+
+
+def test_folder_plugin_imports(plugin_folder):
+    """Ensure submodule imports work as expected in folder plugins.
+
+    Regression test for https://github.com/sopel-irc/sopel/issues/2619
+    """
+    handler = handlers.PyFilePlugin(plugin_folder)
+    handler.load()
+    assert handler.module.foo == 'bar baz'


### PR DESCRIPTION
### Description

This fixes submodule search locations for `PyFilePlugin`s, checks whether the module spec is valid _before_ adding it to `sys.modules` (instead of checking after), and adds a regression test for the submodule search location fix.

Fixing `submodule_search_locations` resolves #2619.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches