### PR TITLE
sopel: don't use bot.search_url_callbacks internally

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -716,9 +716,14 @@ class Sopel(irc.AbstractBot):
         :param func: the function to call
         :type func: :term:`function`
         :param sopel: a SopelWrapper instance
-        :type sopel: :class:`SopelWrapper`
-        :param Trigger trigger: the Trigger object for the line from the server
-                                that triggered this call
+        :param trigger: the Trigger object for the line from the server that
+                        triggered this call
+
+        .. deprecated:: 8.1
+
+            This method is deprecated and will be removed in Sopel 9.0. The
+            new rules system uses :meth:`call_rule` instead.
+
         """
         nick = trigger.nick
         current_time = time.time()
@@ -1120,6 +1125,7 @@ class Sopel(irc.AbstractBot):
         # Avoid calling shutdown methods if we already have.
         self.shutdown_methods = []
 
+    # TODO: Remove in Sopel 9.0
     # URL callbacks management
 
     @deprecated(

--- a/sopel/builtins/url.py
+++ b/sopel/builtins/url.py
@@ -478,7 +478,8 @@ def check_callbacks(
     )
     return (
         excluded or
-        any(bot.search_url_callbacks(url)) or
+        # TODO: _url_callbacks is deprecated and will be removed in Sopel 9.0
+        any(pattern.search(url) for pattern in bot._url_callbacks.keys()) or
         bot.rules.check_url_callback(bot, url)
     )
 

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -1612,15 +1612,21 @@ def track_topic(bot, trigger):
 def handle_url_callbacks(bot, trigger):
     """Dispatch callbacks on URLs
 
-    For each URL found in the trigger, trigger the URL callback registered by
-    the ``@url`` decorator.
+    For each URL found in the trigger, trigger the URL callback registered
+    through the now deprecated :meth:`sopel.bot.Sopel.register_url_callback`.
+
+    .. deprecated:: 8.1
+
+        This is deprecated and will be removed in Sopel 9.0.
+
     """
     # find URLs in the trigger
     for url in trigger.urls:
         # find callbacks for said URL
-        for function, match in bot.search_url_callbacks(url):
+        for pattern, function in bot._url_callbacks.items():
+            match = pattern.search(url)
             # trigger callback defined by the `@url` decorator
-            if hasattr(function, 'url_regex'):
+            if match and hasattr(function, 'url_regex'):
                 # bake the `match` argument in before passing the callback on
                 @functools.wraps(function)
                 def decorated(bot, trigger):


### PR DESCRIPTION
### Description

Both `coretasks` and `url` used `bot.search_url_callbacks`, that was deprecated some time ago and wants to emit warning in Sopel 8.1. Because it was used, we didn't bump Sopel's version to 8.1.0.dev0 yet, and that was annoying.

Therefore, I replaced that by a direct access to the private attribute `_url_callbacks`, and then bumped to Sopel 8.1.0.dev0. And by the way, we should be able to remove `bot.call` in Sopel 9.

Thank you for your service, `register_url_callback`, but I can't wait to remove you and your sister methods!

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
