### PR TITLE
bot, plugins: deprecate bot.{add|remove}_plugin

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -41,7 +41,9 @@ from sopel.trigger import Trigger
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
 
-    from sopel.plugins.handlers import AbstractPluginHandler
+    from sopel.plugins.handlers import (
+        AbstractPluginHandler, PluginMetaDescription,
+    )
     from sopel.trigger import PreTrigger
 
 
@@ -344,6 +346,37 @@ class Sopel(irc.AbstractBot):
 
     # plugins management
 
+    def set_plugin_handler(
+        self,
+        handler: AbstractPluginHandler,
+    ) -> None:
+        """Record a plugin ``handler``.
+
+        :param handler: the plugin handler to record
+
+        Recording a plugin handler associates only its name to :attr:`plugins`.
+        To register a plugin handler's callables, jobs, etc., you should use
+        its :meth:`~sopel.plugins.handlers.AbstractPluginHandler.register`
+        method.
+
+        .. versionadded:: 8.1
+        """
+        self._plugins[handler.name] = handler
+
+    def clear_plugin_handler(self, name: str) -> None:
+        """Remove the plugin handler for ``name``.
+
+        :param name: plugin name to forget
+
+        Removing a plugin handler removes only its name from :attr:``plugins``.
+        To unregister a plugin handler's callables, jobs, etc. you should use
+        its :meth:`~sopel.plugins.handlers.AbstractPluginHandler.unregister`
+        method.
+
+        .. versionadded:: 8.1
+        """
+        del self._plugins[name]
+
     def reload_plugin(self, name: str) -> None:
         """Reload a plugin.
 
@@ -359,10 +392,12 @@ class Sopel(irc.AbstractBot):
             raise plugins.exceptions.PluginNotRegistered(name)
 
         plugin_handler = self._plugins[name]
+
         # tear down
         plugin_handler.shutdown(self)
         plugin_handler.unregister(self)
         LOGGER.info("Unloaded plugin %s", name)
+
         # reload & setup
         plugin_handler.reload()
         plugin_handler.setup(self)
@@ -394,8 +429,13 @@ class Sopel(irc.AbstractBot):
             LOGGER.info("Reloaded %s plugin %s from %s",
                         meta['type'], name, meta['source'])
 
-    # TODO: deprecate both add_plugin and remove_plugin; see #2425
+    # TODO: Remove in Sopel 9.0
 
+    @deprecated(
+        'Use direct access to add rules, jobs, etc.',
+        version='8.1',
+        removed_in='9.0',
+    )
     def add_plugin(
         self,
         plugin: AbstractPluginHandler,
@@ -414,6 +454,12 @@ class Sopel(irc.AbstractBot):
                           should be called on shutdown
         :param urls: an iterable of functions from the ``plugin`` to call when
                      matched against a URL
+
+        .. deprecated:: 8.1
+
+            This method is deprecated and replaced by direct call to register
+            methods. It will be removed in Sopel 9.0.
+
         """
         self._plugins[plugin.name] = plugin
         self.register_callables(callables)
@@ -421,6 +467,11 @@ class Sopel(irc.AbstractBot):
         self.register_shutdowns(shutdowns)
         self.register_urls(urls)
 
+    @deprecated(
+        'Use direct access to remove rules, jobs, etc.',
+        version='8.1',
+        removed_in='9.0',
+    )
     def remove_plugin(
         self,
         plugin: AbstractPluginHandler,
@@ -439,6 +490,12 @@ class Sopel(irc.AbstractBot):
                           should be called on shutdown
         :param urls: an iterable of functions from the ``plugin`` to call when
                      matched against a URL
+
+        .. deprecated:: 8.1
+
+            This method is deprecated and replaced by direct call to unregister
+            methods. It will be removed in Sopel 9.0.
+
         """
         name = plugin.name
         if not self.has_plugin(name):
@@ -461,7 +518,7 @@ class Sopel(irc.AbstractBot):
         """
         return name in self._plugins
 
-    def get_plugin_meta(self, name: str) -> dict:
+    def get_plugin_meta(self, name: str) -> PluginMetaDescription:
         """Get info about a registered plugin by its name.
 
         :param str name: name of the plugin about which to get info
@@ -571,7 +628,7 @@ class Sopel(irc.AbstractBot):
         # call on shutdown
         self.shutdown_methods = self.shutdown_methods + list(shutdowns)
 
-    def unregister_shutdowns(self, shutdowns: Iterable) -> None:
+    def unregister_shutdowns(self, shutdowns: Iterable[Callable]) -> None:
         self.shutdown_methods = [
             shutdown
             for shutdown in self.shutdown_methods

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -51,18 +51,20 @@ import itertools
 import logging
 import os
 import sys
-from typing import Optional, TYPE_CHECKING, TypedDict
+from typing import ClassVar, TYPE_CHECKING, TypedDict
 
 from sopel import __version__ as release, loader, plugin as plugin_decorators
 from . import exceptions
 
 
 if TYPE_CHECKING:
+    from types import ModuleType
+
     # TODO: Replace by `importlib.metadata` from stdlib in Python 3.10+
     from importlib_metadata import EntryPoint
 
     from sopel.bot import Sopel
-    from types import ModuleType
+    from sopel.config import Config
 
 
 LOGGER = logging.getLogger(__name__)
@@ -85,7 +87,7 @@ class PluginMetaDescription(TypedDict):
     label: str
     type: str
     source: str
-    version: Optional[str]
+    version: str | None
 
 
 class AbstractPluginHandler(abc.ABC):
@@ -112,7 +114,7 @@ class AbstractPluginHandler(abc.ABC):
     """
 
     @abc.abstractmethod
-    def load(self):
+    def load(self) -> None:
         """Load the plugin.
 
         This method must be called first, in order to setup, register, shutdown,
@@ -120,7 +122,7 @@ class AbstractPluginHandler(abc.ABC):
         """
 
     @abc.abstractmethod
-    def reload(self):
+    def reload(self) -> None:
         """Reload the plugin.
 
         This method can be called once the plugin is already loaded. It will
@@ -132,7 +134,6 @@ class AbstractPluginHandler(abc.ABC):
         """Retrieve a display label for the plugin.
 
         :return: a human readable label for display purpose
-        :rtype: str
 
         This method should, at least, return ``<module_name> plugin``.
         """
@@ -142,17 +143,15 @@ class AbstractPluginHandler(abc.ABC):
         """Retrieve a meta description for the plugin.
 
         :return: Metadata about the plugin
-        :rtype: :class:`dict`
 
         The expected keys are detailed in :class:`PluginMetaDescription`.
         """
 
     @abc.abstractmethod
-    def get_version(self):
+    def get_version(self) -> str | None:
         """Retrieve the plugin's version.
 
         :return: the plugin's version string
-        :rtype: str
         """
         raise NotImplementedError
 
@@ -161,18 +160,16 @@ class AbstractPluginHandler(abc.ABC):
         """Tell if the plugin is loaded or not.
 
         :return: ``True`` if the plugin is loaded, ``False`` otherwise
-        :rtype: bool
 
         This must return ``True`` if the :meth:`load` method has been called
         with success.
         """
 
     @abc.abstractmethod
-    def setup(self, bot):
+    def setup(self, bot: Sopel) -> None:
         """Run the plugin's setup action.
 
         :param bot: instance of Sopel
-        :type bot: :class:`sopel.bot.Sopel`
         """
 
     @abc.abstractmethod
@@ -180,7 +177,6 @@ class AbstractPluginHandler(abc.ABC):
         """Tell if the plugin has a setup action.
 
         :return: ``True`` if the plugin has a setup, ``False`` otherwise
-        :rtype: bool
         """
 
     @abc.abstractmethod
@@ -188,27 +184,24 @@ class AbstractPluginHandler(abc.ABC):
         """Retrieve the plugin's list of capability requests."""
 
     @abc.abstractmethod
-    def register(self, bot):
+    def register(self, bot: Sopel) -> None:
         """Register the plugin with the ``bot``.
 
         :param bot: instance of Sopel
-        :type bot: :class:`sopel.bot.Sopel`
         """
 
     @abc.abstractmethod
-    def unregister(self, bot):
+    def unregister(self, bot: Sopel) -> None:
         """Unregister the plugin from the ``bot``.
 
         :param bot: instance of Sopel
-        :type bot: :class:`sopel.bot.Sopel`
         """
 
     @abc.abstractmethod
-    def shutdown(self, bot):
+    def shutdown(self, bot: Sopel) -> None:
         """Run the plugin's shutdown action.
 
         :param bot: instance of Sopel
-        :type bot: :class:`sopel.bot.Sopel`
         """
 
     @abc.abstractmethod
@@ -217,15 +210,13 @@ class AbstractPluginHandler(abc.ABC):
 
         :return: ``True`` if the plugin has a ``shutdown`` action, ``False``
                  otherwise
-        :rtype: bool
         """
 
     @abc.abstractmethod
-    def configure(self, settings):
+    def configure(self, settings: Config) -> None:
         """Configure Sopel's ``settings`` for this plugin.
 
         :param settings: Sopel's configuration
-        :type settings: :class:`sopel.config.Config`
 
         This method will be called by Sopel's configuration wizard.
         """
@@ -236,7 +227,6 @@ class AbstractPluginHandler(abc.ABC):
 
         :return: ``True`` if the plugin has a ``configure`` action, ``False``
                  otherwise
-        :rtype: bool
         """
 
 
@@ -266,34 +256,40 @@ class PyModulePlugin(AbstractPluginHandler):
 
     """
 
-    PLUGIN_TYPE = 'python-module'
+    PLUGIN_TYPE: ClassVar[str] = 'python-module'
     """The plugin's type.
 
     Metadata for the plugin; this should be considered to be a constant and
     should not be modified at runtime.
     """
 
-    def __init__(self, name, package=None):
+    package: str | None
+    """Dotted path of the plugin's Python module's package."""
+
+    module_name: str
+    """Name of the Python module for this plugin."""
+
+    def __init__(self, name: str, package: str | None = None) -> None:
         self.name = name
         self.package = package
         if package:
-            self.module_name = self.package + '.' + self.name
+            self.module_name = package + '.' + name
         else:
             self.module_name = name
 
-        self._module = None
+        self._module: ModuleType | None = None
 
     @property
     def module(self) -> ModuleType:
+        """Python module represented by this plugin."""
         if self._module is None:
             raise RuntimeError('No module for plugin %s' % self.name)
         return self._module
 
-    def get_label(self):
+    def get_label(self) -> str:
         """Retrieve a display label for the plugin.
 
         :return: a human readable label for display purpose
-        :rtype: str
 
         By default, this is ``<name> plugin``. If the plugin's module has a
         docstring, its first line is used as the plugin's label.
@@ -335,13 +331,12 @@ class PyModulePlugin(AbstractPluginHandler):
             'version': self.get_version(),
         }
 
-    def get_version(self) -> Optional[str]:
+    def get_version(self) -> str | None:
         """Retrieve the plugin's version.
 
         :return: the plugin's version string
-        :rtype: Optional[str]
         """
-        version: Optional[str] = None
+        version: str | None = None
         if self.is_loaded() and hasattr(self.module, "__version__"):
             version = str(self.module.__version__)
         elif self.module_name.startswith("sopel."):
@@ -349,28 +344,28 @@ class PyModulePlugin(AbstractPluginHandler):
 
         return version
 
-    def load(self):
+    def load(self) -> None:
         """Load the plugin's module using :func:`importlib.import_module`.
 
         This method assumes the module is available through ``sys.path``.
         """
         self._module = importlib.import_module(self.module_name)
 
-    def reload(self):
+    def reload(self) -> None:
         """Reload the plugin's module using :func:`importlib.reload`.
 
         This method assumes the plugin is already loaded.
         """
         self._module = importlib.reload(self.module)
 
-    def is_loaded(self):
+    def is_loaded(self) -> bool:
         return self._module is not None
 
-    def setup(self, bot):
+    def setup(self, bot: Sopel) -> None:
         if self.has_setup():
             self.module.setup(bot)
 
-    def has_setup(self):
+    def has_setup(self) -> bool:
         """Tell if the plugin has a setup action.
 
         :return: ``True`` if the plugin has a setup, ``False`` otherwise
@@ -393,25 +388,36 @@ class PyModulePlugin(AbstractPluginHandler):
         for cap_request in self.get_capability_requests():
             bot.cap_requests.register(self.name, cap_request)
 
-        # plugin callables go through ``bot.add_plugin``
-        relevant_parts = loader.clean_module(self.module, bot.config)
-        for part in itertools.chain(*relevant_parts):
-            # annotate all callables in relevant_parts with `plugin_name`
-            # attribute to make per-channel config work; see #1839
+        callables, jobs, _, urls = loader.clean_module(
+            self.module,
+            bot.config,
+        )
+
+        for part in itertools.chain(callables, jobs, urls):
+            # annotate all plugin callables with a `plugin_name` attribute
+            # to make per-channel config work; see #1839
             setattr(part, 'plugin_name', self.name)
 
-        # TODO: replace add_plugin to direct call to register_* methods
-        bot.add_plugin(self, *relevant_parts)
+        bot.register_callables(callables)
+        bot.register_jobs(jobs)
+        if self.has_shutdown():
+            bot.register_shutdowns([self.module.shutdown])
+        bot.register_urls(urls)
+        bot.set_plugin_handler(self)
 
-    def unregister(self, bot):
-        relevant_parts = loader.clean_module(self.module, bot.config)
-        bot.remove_plugin(self, *relevant_parts)
+    def unregister(self, bot: Sopel) -> None:
+        name = self.name
+        bot.rules.unregister_plugin(name)
+        bot.scheduler.unregister_plugin(name)
+        if self.has_shutdown():
+            bot.unregister_shutdowns([self.module.shutdown])
+        bot.clear_plugin_handler(name)
 
-    def shutdown(self, bot):
+    def shutdown(self, bot: Sopel) -> None:
         if self.has_shutdown():
             self.module.shutdown(bot)
 
-    def has_shutdown(self):
+    def has_shutdown(self) -> bool:
         """Tell if the plugin has a shutdown action.
 
         :return: ``True`` if the plugin has a ``shutdown`` action, ``False``
@@ -423,11 +429,11 @@ class PyModulePlugin(AbstractPluginHandler):
         """
         return hasattr(self.module, 'shutdown')
 
-    def configure(self, settings):
+    def configure(self, settings: Config) -> None:
         if self.has_configure():
             self.module.configure(settings)
 
-    def has_configure(self):
+    def has_configure(self) -> bool:
         """Tell if the plugin has a configure action.
 
         :return: ``True`` if the plugin has a ``configure`` action, ``False``
@@ -457,14 +463,14 @@ class PyFilePlugin(PyModulePlugin):
     not being in the Python path.
     """
 
-    PLUGIN_TYPE = 'python-file'
+    PLUGIN_TYPE: ClassVar[str] = 'python-file'
     """The plugin's type.
 
     Metadata for the plugin; this should be considered to be a constant and
     should not be modified at runtime.
     """
 
-    def __init__(self, filename):
+    def __init__(self, filename: str):
         good_file = (
             os.path.isfile(filename) and
             filename.endswith('.py') and not filename.startswith('_')
@@ -499,7 +505,7 @@ class PyFilePlugin(PyModulePlugin):
 
         super().__init__(name)
 
-    def _load(self):
+    def _load(self) -> ModuleType:
         module = importlib.util.module_from_spec(self.module_spec)
         if not self.module_spec.loader:
             raise exceptions.PluginError('Could not determine loader for plugin: %s' % self.filename)
@@ -533,10 +539,10 @@ class PyFilePlugin(PyModulePlugin):
         })
         return data
 
-    def load(self):
+    def load(self) -> None:
         self._module = self._load()
 
-    def reload(self):
+    def reload(self) -> None:
         """Reload the plugin.
 
         Unlike :class:`PyModulePlugin`, it is not possible to use the
@@ -603,7 +609,7 @@ class EntryPointPlugin(PyModulePlugin):
 
     """
 
-    PLUGIN_TYPE = 'setup-entrypoint'
+    PLUGIN_TYPE: ClassVar[str] = 'setup-entrypoint'
     """The plugin's type.
 
     Metadata for the plugin; this should be considered to be a constant and
@@ -614,16 +620,15 @@ class EntryPointPlugin(PyModulePlugin):
         self.entry_point: EntryPoint = entry_point
         super().__init__(entry_point.name)
 
-    def load(self):
+    def load(self) -> None:
         self._module = self.entry_point.load()
 
-    def get_version(self) -> Optional[str]:
+    def get_version(self) -> str | None:
         """Retrieve the plugin's version.
 
         :return: the plugin's version string
-        :rtype: Optional[str]
         """
-        version: Optional[str] = super().get_version()
+        version: str | None = super().get_version()
 
         # Note: we need to check for attribute because of older Python version
         # and we need to check if .dist is not None because hasattr does not


### PR DESCRIPTION
### Description

Related to #2425 (first two tasks).

Both methods to add/remove plugins rely on values direct from `loader.clean_module`, which is inconvenient at time. In order to rework smoothly this interface, these methods are now deprecated and they will be removed in Sopel 9.0.

We still need methods to record the plugin handler to the plugin name in `bot.plugins`, but they don't do more than that. Everything else is now directly handled and controlled by the plugin handler.

For good measure, I've fully type check `sopel.plugins.handlers`. This will create merge conflict with #2634 and I'm sorry about that, yet it was too good an opportunity to miss it.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
