### PR TITLE
Support `invite-notify` CAP

### DIFF
--- a/sopel/builtins/admin.py
+++ b/sopel/builtins/admin.py
@@ -291,7 +291,13 @@ def me(bot, trigger):
 @plugin.priority('low')
 def invite_join(bot, trigger):
     """Join a channel Sopel is invited to, if the inviter is an admin."""
+    nick = trigger.args[0]
     channel = trigger.args[1]
+
+    if nick != bot.nick:
+        # this handler only cares if the invitee was the bot
+        return
+
     if trigger.admin:
         LOGGER.info(
             'Got invited to "%s" by an admin.', channel)

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -147,6 +147,7 @@ def _handle_sasl_capability(
 CAP_ECHO_MESSAGE = plugin.capability('echo-message')
 CAP_MULTI_PREFIX = plugin.capability('multi-prefix')
 CAP_AWAY_NOTIFY = plugin.capability('away-notify')
+CAP_INVITE_NOTIFY = plugin.capability('invite-notify')
 CAP_CHGHOST = plugin.capability('chghost')
 CAP_CAP_NOTIFY = plugin.capability('cap-notify')
 CAP_SERVER_TIME = plugin.capability('server-time')
@@ -939,6 +940,16 @@ def _periodic_send_who(bot):
         # selected_channel's last who is either none or the oldest valid
         LOGGER.debug("Sending WHO for channel: %s", selected_channel)
         _send_who(bot, selected_channel)
+
+
+@plugin.event('INVITE')
+@plugin.thread(False)
+@plugin.unblockable
+@plugin.priority('medium')
+def track_invite(bot, trigger):
+    """Track users being invited to channels."""
+    LOGGER.info(
+        '%s invited %s to %s', trigger.nick, trigger.args[0], trigger.args[1])
 
 
 @plugin.event('JOIN')

--- a/test/builtins/test_builtins_admin.py
+++ b/test/builtins/test_builtins_admin.py
@@ -1,0 +1,56 @@
+"""Tests for Sopel's ``admin`` plugin"""
+from __future__ import annotations
+
+import pytest
+
+from sopel.tests import rawlist
+
+
+BOT_NICK = 'TestBot'
+TEST_CHAN = '#test'
+TMP_CONFIG = f"""
+[core]
+owner = Uowner
+nick = {BOT_NICK}
+
+[admin]
+auto_accept_invite = True
+"""
+
+
+@pytest.fixture
+def tmpconfig(configfactory):
+    return configfactory('conf.ini', TMP_CONFIG)
+
+
+@pytest.fixture
+def mockbot(tmpconfig, botfactory):
+    return botfactory.preloaded(tmpconfig, ['admin'])
+
+
+def test_invite_accept_admin(mockbot):
+    """Verify that bot admins' invites are accepted."""
+    mockbot.on_message(f":Uowner!owner@sopel.chat INVITE {BOT_NICK} {TEST_CHAN}")
+    assert len(mockbot.backend.message_sent) == 1
+    assert mockbot.backend.message_sent == rawlist('JOIN #test')
+
+
+def test_invite_accept_non_admin_auto(mockbot):
+    """Verify that non-admin invites are accepted if enabled."""
+    mockbot.settings.admin.auto_accept_invite = True
+    mockbot.on_message(f":Henry!king@monar.ch INVITE {BOT_NICK} {TEST_CHAN}")
+    assert len(mockbot.backend.message_sent) == 1
+    assert mockbot.backend.message_sent == rawlist('JOIN #test')
+
+
+def test_invite_accept_non_admin_no_auto(mockbot):
+    """Verify that non-admin invites are ignored if disabled."""
+    mockbot.settings.admin.auto_accept_invite = False
+    mockbot.on_message(f":Henry!king@monar.ch INVITE {BOT_NICK} {TEST_CHAN}")
+    assert len(mockbot.backend.message_sent) == 0
+
+
+def test_invite_accept_not_us(mockbot):
+    """Verify that the plugin ignores invites not meant for it."""
+    mockbot.on_message(":Henry!king@monar.ch INVITE Anne #boudoir")
+    assert len(mockbot.backend.message_sent) == 0

--- a/test/test_coretasks.py
+++ b/test/test_coretasks.py
@@ -578,6 +578,15 @@ def test_recv_chghost_invalid(mockbot, ircfactory, caplog):
     assert 'insufficient arguments' in caplog.messages[2]
 
 
+def test_track_invite(mockbot, caplog):
+    """Verify handling of INVITE event (when invite-notify CAP is available)"""
+    caplog.set_level(logging.INFO)
+    mockbot.on_message(":Henry!king@monar.ch INVITE Anne #boudoir")
+
+    assert len(caplog.messages) == 1
+    assert caplog.messages[0] == 'Henry invited Anne to #boudoir'
+
+
 def test_join_time(mockbot):
     """Make sure channel.join_time is set from JOIN echo time tag"""
     mockbot.on_message(


### PR DESCRIPTION
### Description

Sopel now requests the `invite-notify` CAP. I couldn't think of anything useful for it to do with the notifications, except to log them like other channel events are, at the INFO level. A test case added for `coretasks` checks the expected log message.

The `admin` plugin's `invite_join` handler now ignores `INVITE`s not targeted at the bot. A new `builtins/test_builtins_admin.py` test suite validates its invite-handling behavior. Of the four test cases, `test_invite_accept_not_us` was the only one not already passing prior to patching the plugin.

Progresses #971.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes

Discovering some other old branches that I'd never created PRs for got me thinking, and I looked in the Branches list for other things that I might've forgotten about. This was one of them. Then I realized that `admin` would be broken-ish without changes, so I added that to the old branch before PRing it.

Initially, I'm targeting this feature for Sopel 8.1—but it has _potential_ as a "breaking change" for third-party plugin code that also listens for the `'INVITE'` event, if (like `admin`) they aren't checking the target nick.

In the very most cautious of worlds, we'd have to hold this until 9.0. I'd rather not, though, if we can consider `'INVITE'` handlers niche enough that it's not worth delaying.