### PR TITLE
cli.plugins: include version number in `sopel-plugins show`

### DIFF
--- a/sopel/cli/plugins.py
+++ b/sopel/cli/plugins.py
@@ -283,6 +283,7 @@ def handle_show(options):
         })
 
     print('Plugin:', description['name'])
+    print('Version:', description['version'] or 'unknown')
     print('Status:', description['status'])
     print('Type:', description['type'])
     print('Source:', description['source'])


### PR DESCRIPTION
### Description

There are definitely more improvements I'd like to make in the `sopel-plugins` CLI (e.g. #2459), but this one is simple enough to ship with a patch release.

Several times, I've wished that it was possible to see which version of a plugin Sopel sees without starting the bot to use the `.version pluginname` command on IRC.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches