### PR TITLE
irc: `versionadded` notes + `Optional` annotation migration

### DIFF
--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -78,9 +78,12 @@ class AbstractBot(abc.ABC):
         self.backend: AbstractIRCBackend = UninitializedBackend(self)
         """IRC Connection Backend."""
         self._connection_registered = threading.Event()
-        """Flag stating whether the IRC Connection is registered yet."""
+        """Flag stating whether the IRC connection is registered yet."""
         self.settings = settings
-        """Bot settings."""
+        """The bot's settings.
+
+        .. versionadded:: 7.0
+        """
 
         # internal machinery
         self.sending = threading.RLock()
@@ -136,7 +139,10 @@ class AbstractBot(abc.ABC):
 
     @property
     def capabilities(self) -> Capabilities:
-        """Capabilities negotiated with the server."""
+        """Capabilities negotiated with the server.
+
+        .. versionadded:: 8.0
+        """
         return self._capabilities
 
     @property
@@ -201,7 +207,10 @@ class AbstractBot(abc.ABC):
 
     @property
     def isupport(self) -> ISupport:
-        """Features advertised by the server."""
+        """Features advertised by the server.
+
+        .. versionadded:: 7.0
+        """
         return self._isupport
 
     @property
@@ -287,6 +296,8 @@ class AbstractBot(abc.ABC):
         single line of text. This method computes a safe length of text that
         can be sent using ``PRIVMSG`` or ``NOTICE`` by subtracting the size
         required by the server to convey the bot's message.
+
+        .. versionadded:: 8.0
 
         .. seealso::
 
@@ -512,6 +523,8 @@ class AbstractBot(abc.ABC):
         This method exists to update the casemapping rules for the
         :class:`~sopel.tools.identifiers.Identifier` that represents the bot's
         nick, e.g. after ISUPPORT info is received.
+
+        .. versionadded:: 8.0
         """
         self._nick = self.make_identifier(str(self._nick))
 
@@ -519,6 +532,8 @@ class AbstractBot(abc.ABC):
         """Change the current nick without configuration modification.
 
         :param new_nick: new nick to be used by the bot
+
+        .. versionadded:: 7.1
         """
         if self.backend is None:
             raise RuntimeError(ERR_BACKEND_NOT_INITIALIZED)

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -39,7 +39,6 @@ import threading
 import time
 from typing import (
     Any,
-    Optional,
     TYPE_CHECKING,
 )
 
@@ -71,7 +70,7 @@ class AbstractBot(abc.ABC):
         self._name: str = settings.core.name
         self._isupport = ISupport()
         self._capabilities = Capabilities()
-        self._myinfo: Optional[MyInfo] = None
+        self._myinfo: MyInfo | None = None
         self._nick: identifiers.Identifier = self.make_identifier(
             settings.core.nick)
 
@@ -87,7 +86,7 @@ class AbstractBot(abc.ABC):
 
         # internal machinery
         self.sending = threading.RLock()
-        self.last_error_timestamp: Optional[datetime] = None
+        self.last_error_timestamp: datetime | None = None
         self.error_count = 0
         self.stack: dict[identifiers.Identifier, dict[str, Any]] = {}
         self.hasquit = False
@@ -180,7 +179,7 @@ class AbstractBot(abc.ABC):
         warning_in='8.1',
         removed_in='9.0',
     )
-    def server_capabilities(self) -> dict[str, Optional[str]]:
+    def server_capabilities(self) -> dict[str, str | None]:
         """A dict mapping supported IRCv3 capabilities to their options.
 
         For example, if the server specifies the capability ``sasl=EXTERNAL``,
@@ -225,7 +224,7 @@ class AbstractBot(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def hostmask(self) -> Optional[str]:
+    def hostmask(self) -> str | None:
         """The bot's hostmask."""
 
     # Utility
@@ -343,7 +342,7 @@ class AbstractBot(abc.ABC):
         self,
         host: str,
         port: int,
-        source_address: Optional[tuple[str, int]],
+        source_address: tuple[str, int] | None,
     ) -> AbstractIRCBackend:
         """Set up the IRC backend based on the bot's settings.
 
@@ -579,7 +578,7 @@ class AbstractBot(abc.ABC):
         logger = logging.getLogger('sopel.raw')
         logger.info("%s\t%r", prefix, line)
 
-    def write(self, args: Iterable[str], text: Optional[str] = None) -> None:
+    def write(self, args: Iterable[str], text: str | None = None) -> None:
         """Send a command to the server.
 
         :param args: an iterable of strings, which will be joined by spaces
@@ -626,7 +625,7 @@ class AbstractBot(abc.ABC):
         """
         self.say('\001ACTION {}\001'.format(text), dest)
 
-    def join(self, channel: str, password: Optional[str] = None) -> None:
+    def join(self, channel: str, password: str | None = None) -> None:
         """Join a ``channel``.
 
         :param channel: the channel to join
@@ -646,7 +645,7 @@ class AbstractBot(abc.ABC):
         self,
         nick: str,
         channel: str,
-        text: Optional[str] = None,
+        text: str | None = None,
     ) -> None:
         """Kick a ``nick`` from a ``channel``.
 
@@ -674,7 +673,7 @@ class AbstractBot(abc.ABC):
 
         self.backend.send_notice(dest, text)
 
-    def part(self, channel: str, msg: Optional[str] = None) -> None:
+    def part(self, channel: str, msg: str | None = None) -> None:
         """Leave a channel.
 
         :param channel: the channel to leave
@@ -685,7 +684,7 @@ class AbstractBot(abc.ABC):
 
         self.backend.send_part(channel, reason=msg)
 
-    def quit(self, message: Optional[str] = None) -> None:
+    def quit(self, message: str | None = None) -> None:
         """Disconnect from IRC and close the bot.
 
         :param message: optional QUIT message to send (e.g. "Bye!")
@@ -704,7 +703,7 @@ class AbstractBot(abc.ABC):
         # problematic because whomever called quit might still want to do
         # something before the main thread quits.
 
-    def restart(self, message: Optional[str] = None) -> None:
+    def restart(self, message: str | None = None) -> None:
         """Disconnect from IRC and restart the bot.
 
         :param message: optional QUIT message to send (e.g. "Be right back!")


### PR DESCRIPTION
### Description

This takes care of #2602 as far as what directly prompted me to slot it into the 8.0.1 milestone, with new `versionadded` annotations in the docstrings of stuff that's new-ish (added in 7.x or later). I figure after this PR, that issue can become a general checklist of which submodules have been looked at again since 8.0.0 and live un-milestoned for a while.

Maybe we should also have a tracking issue for the second half of this PR, which starts the process of something we talked about in other patches: Replacing use of `typing.Optional` with `| None`. Right now I think "just migrate the files you touch" is better than a "touch ALL the things!" PR, but we still should keep track of what's been done.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
  - Ran `make lint` only locally, as no runtime code is touched
- [x] I have tested the functionality of the things this change touches