### PR TITLE
Update master's version metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ namespaces = false
 
 [project]
 name = "sopel"
-version = "8.0.0"
+version = "8.1.0.dev0"
 description = "Simple and extensible IRC bot"
 maintainers = [
   { name="dgw" },


### PR DESCRIPTION
### Description

<Sopel> [update] A new Sopel version, 8.0.1, is available; I am running 8.0.0. Please update me.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
