### PR TITLE
build: pin urllib3<2.3 to accommodate our old fork of vcrpy

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -20,6 +20,9 @@ sphinx-rfcsection~=0.1.1
 # use fork of vcrpy 5.x until kevin1024/vcrpy#777 is (hopefully) accepted
 # (or until py3.9 EOL... in 10/2025, I HOPE NOT)
 vcrpy @ git+https://github.com/sopel-irc/vcrpy@uncap-urllib3
+# also have to use a version of urllib3 that doesn't use the `version_string`
+# attr of the response object, because vcrpy won't support it until 7.x
+urllib3<2.3
 # type check
 # often breaks CI on master, so pin and update deliberately, on our own terms
 mypy==1.11.2

--- a/sopel/tools/time.py
+++ b/sopel/tools/time.py
@@ -94,7 +94,7 @@ def validate_timezone(zone: Optional[str]) -> str:
     except pytz.exceptions.UnknownTimeZoneError:
         raise ValueError('Invalid time zone.')
 
-    return cast(str, tz.zone)
+    return cast('str', tz.zone)
 
 
 def validate_format(tformat: str) -> str:

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -229,7 +229,7 @@ class PreTrigger:
 
         # The regex will always match any string, even an empty one
         components_match = cast(
-            Match, PreTrigger.component_regex.match(self.hostmask or ''))
+            'Match', PreTrigger.component_regex.match(self.hostmask or ''))
         nick, self.user, self.host = components_match.groups()
         self.nick: Identifier = self.make_identifier(nick)
 


### PR DESCRIPTION
### Description

I had the itch to work on a feature for 8.1, but noticed that unrelated tests were failing when I started validating my changes…

`urllib3` 2.3.0, released 22 December 2024, broke compatibility with `vcrpy` 5.x by using a `response.version_string` attribute that's missing from the mocked-up response objects. ([The diff](https://github.com/urllib3/urllib3/commit/f9d37add7983d441b151146db447318dff4186c9) looks pretty innocuous, but every change has the potential to [break _someone's_ workflow](https://xkcd.com/1172/), right?.)

Upstream has fixed this for vcrpy 7.x, but we're on an old fork of vcrpy 5.x due to incompatibilities with mixed `urllib` versions across older versions of Python (see #2456).

I'll add a note to #2456 with an update on the current state of this. We can remove the pin again when py3.9 support drops in October 2025. Original hope was to get a PR merged upstream in vcrpy that fixes the urllib version issues with Python < 3.10, but that hasn't gone anywhere.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes

Milestoned for 8.0.2 because it'll need backporting to the maintenance branch (otherwise CI there will be broken).