### PR TITLE
privileges, url: fix privilege check in `.urlban` command family

### DIFF
--- a/sopel/builtins/url.py
+++ b/sopel/builtins/url.py
@@ -64,7 +64,7 @@ class UrlSection(types.StaticSection):
     """A list of regular expressions to match URLs for which the title should not be shown."""
     exclude_required_access = types.ChoiceAttribute(
         'exclude_required_access',
-        choices=privileges.__all__,
+        choices=[level.name for level in privileges.AccessLevel],
         default='OP',
     )
     """Minimum channel access level required to edit ``exclude`` list using chat commands."""
@@ -168,7 +168,7 @@ def _user_can_change_excludes(bot: SopelWrapper, trigger: Trigger) -> bool:
     channel = bot.channels[trigger.sender]
     user_access = channel.privileges[trigger.nick]
 
-    if user_access >= getattr(privileges, required_access):
+    if user_access >= getattr(privileges.AccessLevel, required_access):
         return True
 
     return False


### PR DESCRIPTION
### Description

This is a possible resolution for #2649.

Maybe there's a better way to do this—maybe it would be better to just use `AccessLevel._member_names_` directly—but suggesting an alternative approach when appropriate is what code review's for, right?

The commits are separated out so it'll be easy to bring whatever is useful (especially the new test case) over to a new approach if someone has a better idea.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
  - mypy and pytest pass; only flake8 complains a little (fixed by #2647).
- [x] I have tested the functionality of the things this change touches

### An alternative of my own

Defining these shortcut constants from `sopel.plugin` (below) in `sopel.privileges` instead could be useful:

https://github.com/sopel-irc/sopel/blob/99c4a0036d208ac9343c145f1f003122e8fec410/sopel/plugin.py#L26-L34

I do wonder if we should in fact make `sopel.privileges.__all__` export the list of privilege names, and keep `AccessLevel` as more of an internal thing. It would remove any need for a weird module-level constant (`sopel.privileges.names`), and simplify adding the aliases back to `sopel.plugin` (to one line: `from sopel.privileges import *`).