### PR TITLE
bot, plugin, plugin.rules: optionally include admins in rate limits too

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -599,7 +599,9 @@ class Sopel(irc.AbstractBot):
         rule: AbstractRuleType,
         trigger: Trigger,
     ) -> tuple[bool, Optional[str]]:
-        if trigger.admin or rule.is_unblockable():
+        if rule.is_unblockable():
+            return False, None
+        if trigger.admin and not rule.is_admin_rate_limited():
             return False, None
 
         nick = trigger.nick

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -1135,6 +1135,7 @@ def rate(
     server: int = 0,
     *,
     message: Optional[str] = None,
+    include_admins: Optional[bool] = False,
 ) -> Callable:
     """Decorate a function to be rate-limited.
 
@@ -1146,6 +1147,8 @@ def rate(
                    who triggered it or where
     :param message: optional keyword argument; default message sent as NOTICE
                     when a rate limit is reached
+    :param include_admins: optional boolean to include admins in the rate limit
+                           (default ``False``)
 
     How often a function can be triggered on a per-user basis, in a channel,
     or across the server (bot) can be controlled with this decorator. A value
@@ -1217,6 +1220,7 @@ def rate(
         if not hasattr(function, 'global_rate'):
             function.global_rate = server
         function.default_rate_message = message
+        function.rate_limit_admins = include_admins
         return function
     return add_attribute
 
@@ -1224,12 +1228,15 @@ def rate(
 def rate_user(
     rate: int,
     message: Optional[str] = None,
+    include_admins: Optional[bool] = False,
 ) -> Callable:
     """Decorate a function to be rate-limited for a user.
 
     :param rate: seconds between permitted calls of this function by the same
                  user
     :param message: optional; message sent as NOTICE when a user hits the limit
+    :param include_admins: optional boolean to include admins in the rate limit
+                           (default ``False``)
 
     This decorator can be used alone or with the :func:`rate` decorator, as it
     will always take precedence::
@@ -1258,6 +1265,7 @@ def rate_user(
     def add_attribute(function):
         function.user_rate = rate
         function.user_rate_message = message
+        function.rate_limit_admins = include_admins
         return function
     return add_attribute
 
@@ -1265,12 +1273,15 @@ def rate_user(
 def rate_channel(
     rate: int,
     message: Optional[str] = None,
+    include_admins: Optional[bool] = False,
 ) -> Callable:
     """Decorate a function to be rate-limited for a channel.
 
     :param rate: seconds between permitted calls of this function in the same
                  channel, regardless of triggering user
     :param message: optional; message sent as NOTICE when a user hits the limit
+    :param include_admins: optional boolean to include admins in the rate limit
+                           (default ``False``)
 
     This decorator can be used alone or with the :func:`rate` decorator, as it
     will always take precedence::
@@ -1302,6 +1313,7 @@ def rate_channel(
     def add_attribute(function):
         function.channel_rate = rate
         function.channel_rate_message = message
+        function.rate_limit_admins = include_admins
         return function
     return add_attribute
 
@@ -1309,12 +1321,15 @@ def rate_channel(
 def rate_global(
     rate: int,
     message: Optional[str] = None,
+    include_admins: Optional[bool] = False,
 ) -> Callable:
     """Decorate a function to be rate-limited for the whole server.
 
     :param rate: seconds between permitted calls of this function no matter who
                  triggered it or where
     :param message: optional; message sent as NOTICE when a user hits the limit
+    :param include_admins: optional boolean to include admins in the rate limit
+                           (default ``False``)
 
     This decorator can be used alone or with the :func:`rate` decorator, as it
     will always take precedence.
@@ -1345,6 +1360,7 @@ def rate_global(
     def add_attribute(function):
         function.global_rate = rate
         function.global_rate_message = message
+        function.rate_limit_admins = include_admins
         return function
     return add_attribute
 

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -735,6 +735,13 @@ class AbstractRule(abc.ABC):
         """
 
     @abc.abstractmethod
+    def is_admin_rate_limited(self) -> bool:
+        """Tell if admins should be included in this rule's rate limits.
+
+        :return: ``True`` when admins should be rate limited, else ``False``
+        """
+
+    @abc.abstractmethod
     def get_user_metrics(self, nick: Identifier) -> RuleMetrics:
         """Get the rule's usage metrics for the given user."""
 
@@ -929,6 +936,7 @@ class Rule(AbstractRule):
             'threaded': getattr(handler, 'thread', True),
             'output_prefix': getattr(handler, 'output_prefix', ''),
             'unblockable': getattr(handler, 'unblockable', False),
+            'rate_limit_admins': getattr(handler, 'rate_limit_admins', False),
             'user_rate_limit': getattr(handler, 'user_rate', 0),
             'channel_rate_limit': getattr(handler, 'channel_rate', 0),
             'global_rate_limit': getattr(handler, 'global_rate', 0),
@@ -1027,6 +1035,7 @@ class Rule(AbstractRule):
                  threaded=True,
                  output_prefix=None,
                  unblockable=False,
+                 rate_limit_admins=False,
                  user_rate_limit=0,
                  channel_rate_limit=0,
                  global_rate_limit=0,
@@ -1056,6 +1065,7 @@ class Rule(AbstractRule):
 
         # rate limiting
         self._unblockable = bool(unblockable)
+        self._rate_limit_admins = bool(rate_limit_admins)
         self._user_rate_limit = user_rate_limit
         self._channel_rate_limit = channel_rate_limit
         self._global_rate_limit = global_rate_limit
@@ -1193,6 +1203,9 @@ class Rule(AbstractRule):
 
     def is_unblockable(self):
         return self._unblockable
+
+    def is_admin_rate_limited(self):
+        return self._rate_limit_admins
 
     def get_user_metrics(self, nick: Identifier) -> RuleMetrics:
         return self._metrics_nick.get(nick, RuleMetrics())

--- a/test/plugins/test_plugins_rules.py
+++ b/test/plugins/test_plugins_rules.py
@@ -819,6 +819,16 @@ def test_rule_unblockable():
     assert rule.is_unblockable()
 
 
+def test_rule_rate_limit_admins():
+    regex = re.compile('.*')
+
+    rule = rules.Rule([regex])
+    assert not rule.is_admin_rate_limited()
+
+    rule = rules.Rule([regex], rate_limit_admins=True)
+    assert rule.is_admin_rate_limited()
+
+
 def test_rule_parse_wildcard():
     # match everything
     regex = re.compile(r'.*')
@@ -1109,6 +1119,7 @@ def test_kwargs_from_callable(mockbot):
     assert 'threaded' in kwargs
     assert 'output_prefix' in kwargs
     assert 'unblockable' in kwargs
+    assert 'rate_limit_admins' in kwargs
     assert 'user_rate_limit' in kwargs
     assert 'channel_rate_limit' in kwargs
     assert 'global_rate_limit' in kwargs
@@ -1129,6 +1140,7 @@ def test_kwargs_from_callable(mockbot):
     assert kwargs['threaded'] is True
     assert kwargs['output_prefix'] == ''
     assert kwargs['unblockable'] is False
+    assert kwargs['rate_limit_admins'] is False
     assert kwargs['user_rate_limit'] == 0
     assert kwargs['channel_rate_limit'] == 0
     assert kwargs['global_rate_limit'] == 0
@@ -1249,7 +1261,9 @@ def test_kwargs_from_callable_unblockable(mockbot):
 def test_kwargs_from_callable_rate_limit(mockbot):
     # prepare callable
     @plugin.rule(r'hello', r'hi', r'hey', r'hello|hi')
-    @plugin.rate(user=20, channel=30, server=40, message='Default message.')
+    @plugin.rate(
+        user=20, channel=30, server=40, message='Default message.',
+        include_admins=True)
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -1257,6 +1271,7 @@ def test_kwargs_from_callable_rate_limit(mockbot):
 
     # get kwargs
     kwargs = rules.Rule.kwargs_from_callable(handler)
+    assert 'rate_limit_admins' in kwargs
     assert 'user_rate_limit' in kwargs
     assert 'channel_rate_limit' in kwargs
     assert 'global_rate_limit' in kwargs
@@ -1264,6 +1279,7 @@ def test_kwargs_from_callable_rate_limit(mockbot):
     assert 'channel_rate_message' in kwargs
     assert 'global_rate_message' in kwargs
     assert 'default_rate_message' in kwargs
+    assert kwargs['rate_limit_admins'] is True
     assert kwargs['user_rate_limit'] == 20
     assert kwargs['channel_rate_limit'] == 30
     assert kwargs['global_rate_limit'] == 40
@@ -1276,7 +1292,7 @@ def test_kwargs_from_callable_rate_limit(mockbot):
 def test_kwargs_from_callable_rate_limit_user(mockbot):
     # prepare callable
     @plugin.rule(r'hello', r'hi', r'hey', r'hello|hi')
-    @plugin.rate_user(20, 'User message.')
+    @plugin.rate_user(20, 'User message.', True)
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -1284,6 +1300,7 @@ def test_kwargs_from_callable_rate_limit_user(mockbot):
 
     # get kwargs
     kwargs = rules.Rule.kwargs_from_callable(handler)
+    assert 'rate_limit_admins' in kwargs
     assert 'user_rate_limit' in kwargs
     assert 'channel_rate_limit' in kwargs
     assert 'global_rate_limit' in kwargs
@@ -1291,6 +1308,7 @@ def test_kwargs_from_callable_rate_limit_user(mockbot):
     assert 'channel_rate_message' in kwargs
     assert 'global_rate_message' in kwargs
     assert 'default_rate_message' in kwargs
+    assert kwargs['rate_limit_admins'] is True
     assert kwargs['user_rate_limit'] == 20
     assert kwargs['channel_rate_limit'] == 0
     assert kwargs['global_rate_limit'] == 0
@@ -1303,7 +1321,7 @@ def test_kwargs_from_callable_rate_limit_user(mockbot):
 def test_kwargs_from_callable_rate_limit_channel(mockbot):
     # prepare callable
     @plugin.rule(r'hello', r'hi', r'hey', r'hello|hi')
-    @plugin.rate_channel(20, 'Channel message.')
+    @plugin.rate_channel(20, 'Channel message.', True)
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -1311,6 +1329,7 @@ def test_kwargs_from_callable_rate_limit_channel(mockbot):
 
     # get kwargs
     kwargs = rules.Rule.kwargs_from_callable(handler)
+    assert 'rate_limit_admins' in kwargs
     assert 'user_rate_limit' in kwargs
     assert 'channel_rate_limit' in kwargs
     assert 'global_rate_limit' in kwargs
@@ -1318,6 +1337,7 @@ def test_kwargs_from_callable_rate_limit_channel(mockbot):
     assert 'channel_rate_message' in kwargs
     assert 'global_rate_message' in kwargs
     assert 'default_rate_message' in kwargs
+    assert kwargs['rate_limit_admins'] is True
     assert kwargs['user_rate_limit'] == 0
     assert kwargs['channel_rate_limit'] == 20
     assert kwargs['global_rate_limit'] == 0
@@ -1330,7 +1350,7 @@ def test_kwargs_from_callable_rate_limit_channel(mockbot):
 def test_kwargs_from_callable_rate_limit_server(mockbot):
     # prepare callable
     @plugin.rule(r'hello', r'hi', r'hey', r'hello|hi')
-    @plugin.rate_global(20, 'Server message.')
+    @plugin.rate_global(20, 'Server message.', True)
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
@@ -1338,6 +1358,7 @@ def test_kwargs_from_callable_rate_limit_server(mockbot):
 
     # get kwargs
     kwargs = rules.Rule.kwargs_from_callable(handler)
+    assert 'rate_limit_admins' in kwargs
     assert 'user_rate_limit' in kwargs
     assert 'channel_rate_limit' in kwargs
     assert 'global_rate_limit' in kwargs
@@ -1345,6 +1366,7 @@ def test_kwargs_from_callable_rate_limit_server(mockbot):
     assert 'channel_rate_message' in kwargs
     assert 'global_rate_message' in kwargs
     assert 'default_rate_message' in kwargs
+    assert kwargs['rate_limit_admins'] is True
     assert kwargs['user_rate_limit'] == 0
     assert kwargs['channel_rate_limit'] == 0
     assert kwargs['global_rate_limit'] == 20


### PR DESCRIPTION
### Description

Implementation of my own idea from #2435, an optional `include_admins` kwarg to `@plugin.rate` and related decorators.

With #2647 settled, I can now open this and (hopefully) not run into any unrelated CI fails.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
  - It passed locally when I was working on the patch. Haven't rerun things on top of the current `master` branch, but the lazy way is letting CI do it for me.
- [x] I have tested the functionality of the things this change touches