### PR TITLE
bot: round rate limit `time_left` value up, eliminate microseconds

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -8,9 +8,11 @@
 from __future__ import annotations
 
 from ast import literal_eval
+from datetime import timedelta
 import inspect
 import itertools
 import logging
+import math
 import re
 import threading
 import time
@@ -631,7 +633,11 @@ class Sopel(irc.AbstractBot):
             return False, None
 
         next_time = metrics.last_time + rate_limit
-        time_left = next_time - at_time
+        time_left = timedelta(
+            seconds=math.ceil(
+                (next_time - at_time).total_seconds()
+            )
+        )
 
         message: Optional[str] = None
 

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -1174,8 +1174,8 @@ def test_rate_limit_time_left_field(mockbot, match_hello_rule, limit_type):
     # assert there is now a NOTICE which contains templated time left information
     assert mockbot.backend.message_sent
     patt = (br"NOTICE Test :"
-            br"time_left=\d+:\d+:\d+(\.\d+)? "
-            br"time_left_sec=\d+(\.\d+)?")
+            br"time_left=\d+:\d+:\d+ "
+            br"time_left_sec=\d+")
     assert re.match(patt, mockbot.backend.message_sent[0])
 
 


### PR DESCRIPTION
### Description

This makes rate limit feedback from the bot more readable. Fixes #2651.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches