### PR TITLE
ci: make `v` prefix optional in maintenance branch names

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,12 +5,12 @@ on:
   push:
     branches:
       - master
-      - v[0-9]+.[0-9]+.x
+      - v?[0-9]+.[0-9]+.x
       - gha-*
   pull_request:
     branches:
       - master
-      - v[0-9]+.[0-9]+.x
+      - v?[0-9]+.[0-9]+.x
 
 jobs:
   tests:

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -22,6 +22,7 @@ sphinx-rfcsection~=0.1.1
 vcrpy @ git+https://github.com/sopel-irc/vcrpy@uncap-urllib3
 # also have to use a version of urllib3 that doesn't use the `version_string`
 # attr of the response object, because vcrpy won't support it until 7.x
+# reverting to mainline vcrpy is tracked in #2456
 urllib3<2.3
 # type check
 # often breaks CI on master, so pin and update deliberately, on our own terms


### PR DESCRIPTION
We aren't using the `v` prefix for maintenance branches. What we have are names like `7.1.x`, `8.0.x`, etc. and CI hasn't been running for 8.0 series maintenance patches like it should.

I already proposed this in the 8.0.2 release-prep PR (#2654), but it needs to be in the master branch too so future maintenance branches will get the new patterns automatically.