### PR TITLE
lmgtfy: switch domain to a working archive

### DIFF
--- a/sopel/builtins/lmgtfy.py
+++ b/sopel/builtins/lmgtfy.py
@@ -13,8 +13,8 @@ from sopel import plugin
 
 
 @plugin.command('lmgtfy', 'lmgify', 'gify', 'gtfy')
-@plugin.example('.lmgtfy sopel', 'https://lmgtfy.com/?q=sopel')
-@plugin.example('.lmgtfy sopel bot', 'https://lmgtfy.com/?q=sopel+bot', user_help=True)
+@plugin.example('.lmgtfy sopel', 'https://lmgtfy2.com/?q=sopel')
+@plugin.example('.lmgtfy sopel bot', 'https://lmgtfy2.com/?q=sopel+bot', user_help=True)
 @plugin.example('.lmgtfy', 'https://www.google.com/', user_help=True)
 def googleit(bot, trigger):
     """Let me just… Google that for you."""
@@ -23,4 +23,4 @@ def googleit(bot, trigger):
     qs = urlencode({
         'q': trigger.group(2),
     })
-    bot.say('https://lmgtfy.com/?%s' % qs)
+    bot.say('https://lmgtfy2.com/?%s' % qs)


### PR DESCRIPTION
### Description

As reported on IRC, `lmgtfy.com` no longer works. It redirects to `lmgtfy.app`, whose TLS certificate expired in 2023.

Using the archived copy at `lmgtfy2.com` works.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
  - ~~I've done this patch in the web editor, so I haven't run the checks myself. It's trivial though, should be OK. I'll just let GHA run the checks after the PR is opened.~~
  - Successfully passed `make qa` locally on 2025-06-11
- [x] I have tested the functionality of the things this change touches
  - ~~Similar to the above, I will ask the original reporter to test this solution as I'm on my tablet/GH web.~~
  - The original reporter did not get back to me. Manually tested myself and found working as of 2025-06-11