### PR TITLE
Introduce dedicated plugin abort exception

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -35,6 +35,7 @@ from sopel.plugins import (
     jobs as plugin_jobs,
     rules as plugin_rules,
 )
+from sopel.plugins.exceptions import PluginAbort
 from sopel.tools import jobs as tools_jobs
 from sopel.trigger import Trigger
 
@@ -702,6 +703,15 @@ class Sopel(irc.AbstractBot):
 
         try:
             rule.execute(sopel, trigger)
+        except PluginAbort as abort:
+            LOGGER.warning("Plugin aborted while handling trigger %r", trigger, exc_info=abort)
+
+            if len(abort.args) == 1:
+                message = abort.args[0]
+                if not isinstance(message, str):
+                    message = repr(message)
+
+                self.say(message, trigger.sender)
         except KeyboardInterrupt:
             raise
         except Exception as error:

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -707,7 +707,7 @@ class Sopel(irc.AbstractBot):
             LOGGER.warning("Plugin aborted while handling trigger %r", trigger, exc_info=abort)
 
             if abort.message:
-                self.say(message, trigger.sender)
+                self.say(abort.message, trigger.sender)
         except KeyboardInterrupt:
             raise
         except Exception as error:

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -706,11 +706,7 @@ class Sopel(irc.AbstractBot):
         except PluginAbort as abort:
             LOGGER.warning("Plugin aborted while handling trigger %r", trigger, exc_info=abort)
 
-            if len(abort.args) == 1:
-                message = abort.args[0]
-                if not isinstance(message, str):
-                    message = repr(message)
-
+            if abort.message:
                 self.say(message, trigger.sender)
         except KeyboardInterrupt:
             raise

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -43,8 +43,9 @@ if TYPE_CHECKING:
 __all__ = [
     # constants
     'NOLIMIT', 'VOICE', 'HALFOP', 'OP', 'ADMIN', 'OWNER', 'OPER',
-    # decorators
+    # functions
     'abort',
+    # decorators
     'action_command',
     'action_commands',
     'allow_bots',

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -14,6 +14,7 @@ import functools
 import logging
 import re
 from typing import (
+    Any,
     Callable,
     Literal,
     Optional,
@@ -2029,6 +2030,6 @@ def output_prefix(prefix: str) -> Callable:
     return add_attribute
 
 
-def abort(*args, **kwargs) -> None:
+def abort(*args: Any, **kwargs: Any) -> None:
     """Abort execution of a plugin event"""
     raise PluginAbort(*args, **kwargs)

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -16,6 +16,7 @@ import re
 from typing import (
     Callable,
     Literal,
+    NoReturn,
     Optional,
     Pattern,
     Protocol,
@@ -2030,6 +2031,6 @@ def output_prefix(prefix: str) -> Callable:
     return add_attribute
 
 
-def abort(msg: str | None = None) -> None:
+def abort(msg: str | None = None) -> NoReturn:
     """Abort execution of a plugin event"""
     raise PluginAbort(msg)

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -23,6 +23,7 @@ from typing import (
     Union,
 )
 
+from sopel.plugins.exceptions import PluginAbort
 # import and expose privileges as shortcut
 from sopel.privileges import AccessLevel
 
@@ -42,6 +43,7 @@ __all__ = [
     # constants
     'NOLIMIT', 'VOICE', 'HALFOP', 'OP', 'ADMIN', 'OWNER', 'OPER',
     # decorators
+    'abort',
     'action_command',
     'action_commands',
     'allow_bots',
@@ -2025,3 +2027,8 @@ def output_prefix(prefix: str) -> Callable:
         function.output_prefix = prefix
         return function
     return add_attribute
+
+
+def abort(*args, **kwargs) -> None:
+    """Abort execution of a plugin event"""
+    raise PluginAbort(*args, **kwargs)

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -14,7 +14,6 @@ import functools
 import logging
 import re
 from typing import (
-    Any,
     Callable,
     Literal,
     Optional,
@@ -2031,6 +2030,6 @@ def output_prefix(prefix: str) -> Callable:
     return add_attribute
 
 
-def abort(*args: Any, **kwargs: Any) -> None:
+def abort(msg: str | None = None) -> None:
     """Abort execution of a plugin event"""
-    raise PluginAbort(*args, **kwargs)
+    raise PluginAbort(msg)

--- a/sopel/plugins/exceptions.py
+++ b/sopel/plugins/exceptions.py
@@ -27,4 +27,11 @@ class PluginSettingsError(PluginError):
 
 
 class PluginAbort(PluginError):
-    """Exception raised by plugin code to abort handling of the current event."""
+    """Exception raised by plugin code to abort handling of the current event.
+
+    If a message is provided, the bot will send this message to the sender when
+    the abort is received by the core during event handling.
+    """
+    def __init__(self, message: str | None = None):
+        self.message = message
+        super().__init__(message)

--- a/sopel/plugins/exceptions.py
+++ b/sopel/plugins/exceptions.py
@@ -24,3 +24,7 @@ class PluginSettingsError(PluginError):
     for example in its ``setup`` function, in any of its rules or commands,
     and in the loader function for the :func:`sopel.plugin.url_lazy` decorator.
     """
+
+
+class PluginAbort(PluginError):
+    """Exception raised by plugin code to abort handling of the current event."""


### PR DESCRIPTION
### Description

Closes #2656.

This changeset introduces a new exception: `sopel.plugins.exceptions.PluginAbort` (also exposed as `sopel.plugin.PluginAbort`) as well as the helper `sopel.plugin.abort()` for raising it.

This exception can be used by a plugin to immediately abort that plugin's handling of an event, optionally sending a message if an argument is given. I found myself for the N+1th time accidentally forgetting to `return` from a plugin after I had done `bot.say("This plugin definitely will not continue execution because I always remember the return")` and thinking that [there must be a better way](https://youtu.be/p33CVV29OG8?t=571).

Because this feature adds new major API, it will not be appropriate before Sopel 9.0 (if indeed it is wanted at all!)

### Feature demo

```python
# abort_demo.py
from sopel import plugin
from sopel.plugins.exceptions import PluginAbort


@plugin.command("abort1")
def abort1(bot, trigger):
    bot.say("this message should be visible")

    # ...
    # do some elaborate plugin things
    # ...
    
    # bail out if some of the elaborate things went wrong before this plugin
    # finishes and spits out the Answer to Life, the Universe, and Everything
    can_continue = False
    if not can_continue:
        raise PluginAbort("PluginAbort: this message should also be visible")

    bot.say("this message should NOT be visible")


@plugin.command("abort2")
def abort2(bot, trigger):
    bot.say("this message should be visible")
    plugin.abort("PluginAbort: this message should also be visible")
    bot.say("this message should NOT be visible")


@plugin.command("abort3")
def abort3(bot, trigger):
    bot.say("this message should be visible")
    plugin.abort([1, 2, 3])
    bot.say("this message should NOT be visible")
```

```python
<SnoopJ> ,abort1                                                                                                                                                        
<mediocrebot> this message should be visible                                                                                                                            
<mediocrebot> PluginAbort: this message should also be visible                                                                                                          
<SnoopJ> ,abort2                                                                                                                                                        
<mediocrebot> this message should be visible                                                                                                                            
<mediocrebot> PluginAbort: this message should also be visible                                                                                                          
<SnoopJ> ,abort3                                                                                                                                                        
<mediocrebot> this message should be visible                                                                                                                            
<mediocrebot> [1, 2, 3]
```

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
