### PR TITLE
cli.plugins: add `sopel-plugins new` subcommand

### DIFF
--- a/sopel/cli/plugins.py
+++ b/sopel/cli/plugins.py
@@ -152,6 +152,36 @@ def build_parser():
             It makes sure the plugin is added to the ``core.enable`` list.
         """))
 
+    # sopel-plugins new
+    new_parser = subparsers.add_parser(
+        'new',
+        formatter_class=argparse.RawTextHelpFormatter,
+        help="Create a new plugin",
+        description=inspect.cleandoc("""
+            Create a new plugin using the ``cookiecutter`` template.
+
+            The ``cookiecutter`` package must be installed to use this command.
+        """))
+    # don't add the common arguments; they're meaningless for this command
+    new_parser.add_argument(
+        'name',
+        nargs='?',
+        default='beawesome',
+        help='Name of the new plugin',
+    )
+    new_parser.add_argument(
+        '-d', '--directory',
+        nargs='?',
+        default='.',
+        help='Directory in which to create the new plugin',
+    )
+    new_parser.add_argument(
+        '-t', '--template',
+        nargs='?',
+        default='gh:sopel-irc/plugin',
+        help='URL or filesystem path to a custom plugin template',
+    )
+
     return parser
 
 
@@ -541,6 +571,47 @@ def handle_enable(options):
     return 0
 
 
+def handle_new(options):
+    """Create a new plugin from Sopel's current template.
+
+    :param options: parsed arguments
+    :type options: :class:`argparse.Namespace`
+    :return: 0 if everything went fine;
+             1 if the process was aborted;
+             2 if ``cookiecutter`` isn't available
+
+    .. seealso::
+
+        `The template repo`_ on GitHub.
+
+        .. _The template repo: https://github.com/sopel-irc/plugin
+
+    """
+    try:
+        # cookiecutter doesn't advertise type annotations, as of writing
+        from cookiecutter.main import cookiecutter  # type: ignore
+    except ImportError:
+        utils.stderr(
+            'The `cookiecutter` package is required to create a new plugin.')
+        utils.stderr(
+            'Hint: `pip install cookiecutter`')
+        return 2
+
+    template = options.template
+    plugin_name = options.name
+    output_dir = options.directory
+
+    try:
+        cookiecutter(
+            template,
+            output_dir=output_dir,
+            extra_context={'plugin_name': plugin_name},
+        )
+    except EOFError:
+        utils.stderr('Operation cancelled.')
+        return 1
+
+
 def main():
     """Console entry point for ``sopel-plugins``."""
     parser = build_parser()
@@ -562,6 +633,8 @@ def main():
             return handle_disable(options)
         elif action == 'enable':
             return handle_enable(options)
+        elif action == 'new':
+            return handle_new(options)
     except KeyboardInterrupt:
         utils.stderr('Bye!')
         return ERR_CODE


### PR DESCRIPTION
### Description

This new `new` action for `sopel-plugins` creates a plugin using [our repo template](https://github.com/sopel-irc/plugin) and the [`cookiecutter`](https://pypi.org/project/cookiecutter/) tool.

Command options overview:

* Specifying a plugin name will pre-fill that `plugin_name` in the `cookiecutter` prompts\
  e.g. `sopel-plugins new foobar`
* The new repo is created in `.` by default, but the parent directory can be changed without `cd`ing using `-d`/`--directory`\
  e.g. `sopel-plugins new foobar -d ~/experiments`
* Supports using a customized template with the `-t`/`--template` flag
  e.g. `sopel-plugins new -t gh:ASopelHacker/fancy-template`

Using `sopel-plugins new` only requires the user to install the `cookiecutter` script entry point somewhere on `$PATH` where Sopel can find it using `subprocess.run()`. This differs from the approach I described in #2660 using `cookiecutter` programmatically as a Python module, because it's more flexible for the end user (they can use the recommended `pipx` method of installing `cookiecutter`, or maintain it however else they'd like).

Closes #2660.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes

Yes, I implemented using `cookiecutter` programmatically first. I left the two approaches separate in the commit history in case there is a compelling reason to go back. Besides the "user convenience" thing about having `cookiecutter` installed wherever-you-want instead of forcing it to be installed in Sopel's (v)env, `cookiecutter` doesn't currently advertise itself as a typed library (neither does Sopel, to be fair), and I could not find stubs for it. Having that `# type: ignore` comment bugged me.