### PR TITLE
bot, plugin, plugins: class based callables

### DIFF
--- a/docs/source/package/plugins.rst
+++ b/docs/source/package/plugins.rst
@@ -18,3 +18,4 @@ Plugin Internal Machinery
     plugins/handlers
     plugins/jobs
     plugins/rules
+    plugins/callables

--- a/docs/source/package/plugins/callables.rst
+++ b/docs/source/package/plugins/callables.rst
@@ -1,0 +1,6 @@
+=======================
+sopel.plugins.callables
+=======================
+
+.. automodule:: sopel.plugins.callables
+   :members:

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -41,6 +41,7 @@ from sopel.trigger import Trigger
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
 
+    from sopel.plugins.callables import PluginCallable
     from sopel.plugins.handlers import AbstractPluginHandler
     from sopel.trigger import PreTrigger
 
@@ -399,10 +400,10 @@ class Sopel(irc.AbstractBot):
     def add_plugin(
         self,
         plugin: AbstractPluginHandler,
-        callables: Sequence[Callable],
+        callables: Sequence[PluginCallable],
         jobs: Sequence[Callable],
         shutdowns: Sequence[Callable],
-        urls: Sequence[Callable],
+        urls: Sequence[PluginCallable],
     ) -> None:
         """Add a loaded plugin to the bot's registry.
 
@@ -478,20 +479,20 @@ class Sopel(irc.AbstractBot):
 
     # callable management
 
-    def register_callables(self, callables: Iterable) -> None:
+    def register_callables(self, callables: Iterable[PluginCallable]) -> None:
         match_any = re.compile(r'.*')
         settings = self.settings
 
         for callbl in callables:
-            rules = getattr(callbl, 'rule', [])
-            lazy_rules = getattr(callbl, 'rule_lazy_loaders', [])
-            find_rules = getattr(callbl, 'find_rules', [])
-            lazy_find_rules = getattr(callbl, 'find_rules_lazy_loaders', [])
-            search_rules = getattr(callbl, 'search_rules', [])
-            lazy_search_rules = getattr(callbl, 'search_rules_lazy_loaders', [])
-            commands = getattr(callbl, 'commands', [])
-            nick_commands = getattr(callbl, 'nickname_commands', [])
-            action_commands = getattr(callbl, 'action_commands', [])
+            rules = callbl.rules
+            lazy_rules = callbl.rule_lazy_loaders
+            find_rules = callbl.find_rules
+            lazy_find_rules = callbl.find_rules_lazy_loaders
+            search_rules = callbl.search_rules
+            lazy_search_rules = callbl.search_rules_lazy_loaders
+            commands = callbl.commands
+            nick_commands = callbl.nickname_commands
+            action_commands = callbl.action_commands
             is_rule = any([
                 rules,
                 lazy_rules,
@@ -553,7 +554,7 @@ class Sopel(irc.AbstractBot):
                 self._rules_manager.register_action_command(rule)
 
             if not is_command and not is_rule:
-                callbl.rule = [match_any]
+                callbl.rules = [match_any]
                 self._rules_manager.register(
                     plugin_rules.Rule.from_callable(self.settings, callbl))
 
@@ -578,7 +579,7 @@ class Sopel(irc.AbstractBot):
             if shutdown not in shutdowns
         ]
 
-    def register_urls(self, urls: Iterable) -> None:
+    def register_urls(self, urls: Iterable[PluginCallable]) -> None:
         for func in urls:
             url_regex = getattr(func, 'url_regex', [])
             url_lazy_loaders = getattr(func, 'url_lazy_loaders', None)

--- a/sopel/builtins/safety.py
+++ b/sopel/builtins/safety.py
@@ -360,7 +360,7 @@ def virustotal_lookup(
     }
     bot.memory[SAFETY_CACHE_KEY][url] = result
     if len(bot.memory[SAFETY_CACHE_KEY]) >= (2 * CACHE_LIMIT):
-        _clean_cache(bot)
+        _clean_cache(bot)  # type: ignore[arg-type]
     return result
 
 

--- a/sopel/builtins/tld.py
+++ b/sopel/builtins/tld.py
@@ -292,9 +292,9 @@ def _update_tld_data(bot, which, force=False):
 
 
 @plugin.interval(60 * 60)
-def update_caches(bot, force=False):
-    _update_tld_data(bot, 'list', force)
-    _update_tld_data(bot, 'data', force)
+def update_caches(bot):
+    _update_tld_data(bot, 'list', False)
+    _update_tld_data(bot, 'data', False)
 
 
 @plugin.command('tld')
@@ -383,7 +383,8 @@ def tld_cache_command(bot, trigger):
     subcommand = subcommand.lower()
     if subcommand == 'update':
         bot.reply("Requesting updated IANA list and Wikipedia data.")
-        update_caches(bot, force=True)
+        _update_tld_data(bot, 'list', True)
+        _update_tld_data(bot, 'data', True)
     elif subcommand == 'clear':
         bot.db.delete_plugin_value('tld', 'tld_data_cache')
         bot.memory['tld_data_cache'] = {}

--- a/sopel/loader.py
+++ b/sopel/loader.py
@@ -16,6 +16,11 @@ import logging
 import re
 
 from sopel.config.core_section import COMMAND_DEFAULT_HELP_PREFIX
+from sopel.plugins.callables import (
+    AbstractPluginObject,
+    PluginCallable,
+    PluginJob,
+)
 
 
 LOGGER = logging.getLogger(__name__)
@@ -232,24 +237,49 @@ def clean_module(module, config):
     callable, i.e. properties related to threading, docs, examples, rate
     limiting, commands, rules, and other features.
     """
-    callables = []
-    shutdowns = []
-    jobs = []
-    urls = []
+    callables: list[PluginCallable] = []
+    shutdowns: list = []
+    jobs: list[PluginJob] = []
+    urls: list[PluginCallable] = []
+    handler: PluginJob | PluginCallable
     for obj in vars(module).values():
         if callable(obj):
             is_sopel_callable = getattr(obj, '_sopel_callable', False) is True
             if getattr(obj, '__name__', None) == 'shutdown':
                 shutdowns.append(obj)
+                continue
             elif not is_sopel_callable:
                 continue
-            elif is_triggerable(obj):
-                clean_callable(obj, config)
-                callables.append(obj)
-            elif hasattr(obj, 'interval'):
-                clean_callable(obj, config)
-                jobs.append(obj)
-            elif is_url_callback(obj):
-                clean_callable(obj, config)
-                urls.append(obj)
+
+            if isinstance(obj, PluginJob):
+                obj.setup(config)
+
+                if obj.intervals:
+                    jobs.append(obj)
+
+            else:
+                if not isinstance(obj, AbstractPluginObject):
+                    # compatibility with old-style plugin callables
+                    clean_callable(obj, config)
+                    if getattr(obj, 'interval', []):
+                        handler = PluginJob.ensure_callable(obj)
+                    else:
+                        handler = PluginCallable.ensure_callable(obj)
+                elif isinstance(obj, PluginCallable):
+                    handler = obj
+                else:
+                    # it's a subclass of AbstractPluginObject that isn't a
+                    # plugin job or callable, and it cannot be handled
+                    continue
+
+                handler.setup(config)
+
+                if isinstance(handler, PluginJob):
+                    jobs.append(handler)
+                elif isinstance(handler, PluginCallable):
+                    if handler.is_triggerable:
+                        callables.append(handler)
+                    elif handler.is_url_callback:
+                        urls.append(handler)
+
     return callables, jobs, shutdowns, urls

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -11,12 +11,14 @@ from __future__ import annotations
 
 import enum
 import functools
+import inspect
 import logging
 import re
 from typing import (
     Callable,
     Literal,
     Optional,
+    overload,
     Pattern,
     Protocol,
     TYPE_CHECKING,
@@ -24,6 +26,12 @@ from typing import (
 )
 
 # import and expose privileges as shortcut
+from sopel.plugins.callables import (
+    AbstractPluginObject,
+    PluginCallable,
+    PluginGeneric,
+    PluginJob,
+)
 from sopel.privileges import AccessLevel
 
 VOICE = AccessLevel.VOICE
@@ -37,6 +45,7 @@ OPER = AccessLevel.OPER
 if TYPE_CHECKING:
     from collections.abc import Iterable
     from sopel.bot import SopelWrapper
+
 
 __all__ = [
     # constants
@@ -368,17 +377,19 @@ def unblockable(
         Sopel's :meth:`~sopel.bot.Sopel.dispatch` method.
 
     """
-    def add_attribute(function):
-        function.unblockable = True
-        return function
+    def decorator(function: Callable) -> PluginCallable:
+        handler = PluginCallable.ensure_callable(function)
+        handler.unblockable = True
+        return handler
 
     # hack to allow both @unblockable and @unblockable() to work
     if callable(function):
-        return add_attribute(function)
-    return add_attribute
+        return decorator(function)
+
+    return decorator
 
 
-def interval(*intervals: Union[int, float]) -> Callable:
+def interval(*intervals: Union[int, float]) -> Callable[[Callable], PluginJob]:
     """Decorate a function to be called by the bot every *n* seconds.
 
     :param intervals: one or more duration(s), in seconds
@@ -388,9 +399,9 @@ def interval(*intervals: Union[int, float]) -> Callable:
     function will be called is *n* seconds after the bot was started.
 
     Plugin functions decorated by ``interval`` must only take
-    :class:`bot <sopel.bot.Sopel>` as their argument; they do not get a ``trigger``.
-    The ``bot`` argument will not have a context, so functions like
-    ``bot.say()`` will not have a default destination.
+    :class:`bot <sopel.bot.Sopel>` as their argument; they do not get a
+    ``trigger``. The ``bot`` argument will not have a context, so functions
+    like ``bot.say()`` will not have a default destination.
 
     There is no guarantee that the bot is connected to a server or in any
     channels when the function is called, so care must be taken.
@@ -405,19 +416,21 @@ def interval(*intervals: Union[int, float]) -> Callable:
                 bot.say("It has been five seconds!", "#here")
 
     """
-    def add_attribute(function):
-        function._sopel_callable = True
-        if not hasattr(function, "interval"):
-            function.interval = []
+    def decorator(function: Callable) -> PluginJob:
+        handler = PluginJob.ensure_callable(function)
+
         for arg in intervals:
-            if arg not in function.interval:
-                function.interval.append(arg)
-        return function
+            if arg not in handler.intervals:
+                handler.intervals.append(arg)
 
-    return add_attribute
+        return handler
+
+    return decorator
 
 
-def rule(*patterns: Union[str, Pattern]) -> Callable:
+def rule(
+    *patterns: Union[str, Pattern],
+) -> Callable[[Callable], PluginCallable]:
     """Decorate a function to be called when a line matches the given pattern.
 
     :param patterns: one or more regular expression(s)
@@ -460,19 +473,21 @@ def rule(*patterns: Union[str, Pattern]) -> Callable:
         use the :func:`search` decorator instead.
 
     """
-    def add_attribute(function):
-        function._sopel_callable = True
-        if not hasattr(function, "rule"):
-            function.rule = []
+    def decorator(function: Callable) -> PluginCallable:
+        handler = PluginCallable.ensure_callable(function)
+
         for value in patterns:
-            if value not in function.rule:
-                function.rule.append(value)
-        return function
+            if value not in handler.rules:
+                handler.rules.append(value)
 
-    return add_attribute
+        return handler
+
+    return decorator
 
 
-def rule_lazy(*loaders: Callable) -> Callable:
+def rule_lazy(
+    *loaders: Callable,
+) -> Callable[[Callable], PluginCallable]:
     """Decorate a callable as a rule with lazy loading.
 
     :param loaders: one or more functions to generate a list of **compiled**
@@ -510,16 +525,17 @@ def rule_lazy(*loaders: Callable) -> Callable:
         with the :func:`sopel.tools.chain_loaders` function.
 
     """
-    def decorator(function):
-        function._sopel_callable = True
-        if not hasattr(function, 'rule_lazy_loaders'):
-            function.rule_lazy_loaders = []
-        function.rule_lazy_loaders.extend(loaders)
-        return function
+    def decorator(function: Callable) -> PluginCallable:
+        handler = PluginCallable.ensure_callable(function)
+        handler.rule_lazy_loaders.extend(loaders)
+        return handler
+
     return decorator
 
 
-def find(*patterns: Union[str, Pattern]) -> Callable:
+def find(
+    *patterns: Union[str, Pattern],
+) -> Callable[[Callable], PluginCallable]:
     """Decorate a function to be called for each time a pattern is found in a line.
 
     :param patterns: one or more regular expression(s)
@@ -562,19 +578,21 @@ def find(*patterns: Union[str, Pattern]) -> Callable:
         use the :func:`rule` decorator instead.
 
     """
-    def add_attribute(function):
-        function._sopel_callable = True
-        if not hasattr(function, "find_rules"):
-            function.find_rules = []
+    def decorator(function: Callable) -> PluginCallable:
+        handler = PluginCallable.ensure_callable(function)
+
         for value in patterns:
-            if value not in function.find_rules:
-                function.find_rules.append(value)
-        return function
+            if value not in handler.find_rules:
+                handler.find_rules.append(value)
 
-    return add_attribute
+        return handler
+
+    return decorator
 
 
-def find_lazy(*loaders: Callable) -> Callable:
+def find_lazy(
+    *loaders: Callable
+) -> Callable[[Callable], PluginCallable]:
     """Decorate a callable as a find rule with lazy loading.
 
     :param loaders: one or more functions to generate a list of **compiled**
@@ -612,16 +630,17 @@ def find_lazy(*loaders: Callable) -> Callable:
         with the :func:`sopel.tools.chain_loaders` function.
 
     """
-    def decorator(function):
-        function._sopel_callable = True
-        if not hasattr(function, 'find_rules_lazy_loaders'):
-            function.find_rules_lazy_loaders = []
-        function.find_rules_lazy_loaders.extend(loaders)
-        return function
+    def decorator(function: Callable) -> PluginCallable:
+        handler = PluginCallable.ensure_callable(function)
+        handler.find_rules_lazy_loaders.extend(loaders)
+        return handler
+
     return decorator
 
 
-def search(*patterns: Union[str, Pattern]) -> Callable:
+def search(
+    *patterns: Union[str, Pattern],
+) -> Callable[[Callable], PluginCallable]:
     """Decorate a function to be called when a pattern matches anywhere in a line.
 
     :param patterns: one or more regular expression(s)
@@ -667,19 +686,19 @@ def search(*patterns: Union[str, Pattern]) -> Callable:
         use the :func:`rule` decorator instead.
 
     """
-    def add_attribute(function):
-        function._sopel_callable = True
-        if not hasattr(function, "search_rules"):
-            function.search_rules = []
+    def decorator(function: Callable) -> PluginCallable:
+        handler = PluginCallable.ensure_callable(function)
         for value in patterns:
-            if value not in function.search_rules:
-                function.search_rules.append(value)
-        return function
+            if value not in handler.search_rules:
+                handler.search_rules.append(value)
+        return handler
 
-    return add_attribute
+    return decorator
 
 
-def search_lazy(*loaders: Callable) -> Callable:
+def search_lazy(
+    *loaders: Callable,
+) -> Callable[[Callable], PluginCallable]:
     """Decorate a callable as a search rule with lazy loading.
 
     :param loaders: one or more functions to generate a list of **compiled**
@@ -717,16 +736,15 @@ def search_lazy(*loaders: Callable) -> Callable:
         with the :func:`sopel.tools.chain_loaders` function.
 
     """
-    def decorator(function):
-        function._sopel_callable = True
-        if not hasattr(function, 'search_rules_lazy_loaders'):
-            function.search_rules_lazy_loaders = []
-        function.search_rules_lazy_loaders.extend(loaders)
-        return function
+    def decorator(function: Callable) -> PluginCallable:
+        handler = PluginCallable.ensure_callable(function)
+        handler.search_rules_lazy_loaders.extend(loaders)
+        return handler
+
     return decorator
 
 
-def thread(value: bool) -> Callable:
+def thread(value: bool) -> Callable[[Callable], PluginCallable]:
     """Decorate a function to specify if it should be run in a separate thread.
 
     :param value: if ``True``, the function is called in a separate thread;
@@ -739,16 +757,25 @@ def thread(value: bool) -> Callable:
     """
     threaded = bool(value)
 
-    def add_attribute(function):
-        function.thread = threaded
-        return function
+    def decorator(function: Callable) -> PluginCallable:
+        handler = PluginCallable.ensure_callable(function)
+        handler.threaded = threaded
+        return handler
 
-    return add_attribute
+    return decorator
 
 
-def allow_bots(
-    function: Optional[Callable] = None,
-) -> Callable:
+@overload
+def allow_bots(function: Callable) -> PluginCallable:
+    ...
+
+
+@overload
+def allow_bots(function: None = None) -> Callable[[Callable], PluginCallable]:
+    ...
+
+
+def allow_bots(function=None):
     """Decorate a function to specify that it should receive events from bots.
 
     On networks implementing the `Bot Mode specification`__, messages and
@@ -758,19 +785,30 @@ def allow_bots(
 
     .. __: https://ircv3.net/specs/extensions/bot-mode
     """
-    def add_attribute(function):
-        function.allow_bots = True
-        return function
+    def decorator(function: Callable) -> PluginCallable:
+        handler = PluginCallable.ensure_callable(function)
+        handler.allow_bots = True
+        return handler
 
     # hack to allow both @allow_bots and @allow_bots() to work
+    # this requires the two @overload signatures above
     if callable(function):
-        return add_attribute(function)
-    return add_attribute
+        return decorator(function)
+
+    return decorator
 
 
-def echo(
-    function: Optional[Callable] = None,
-) -> Callable:
+@overload
+def echo(function: Callable) -> PluginCallable:
+    ...
+
+
+@overload
+def echo(function: None = None) -> Callable[[Callable], PluginCallable]:
+    ...
+
+
+def echo(function=None):
     """Decorate a function to specify that it should receive echo messages.
 
     This decorator can be used to listen in on the messages that Sopel is
@@ -783,17 +821,19 @@ def echo(
         creating feedback loops when using this feature.
 
     """
-    def add_attribute(function):
-        function.echo = True
-        return function
+    def decorator(function: Callable) -> PluginCallable:
+        handler = PluginCallable.ensure_callable(function)
+        handler.allow_echo = True
+        return handler
 
     # hack to allow both @echo and @echo() to work
     if callable(function):
-        return add_attribute(function)
-    return add_attribute
+        return decorator(function)
+
+    return decorator
 
 
-def command(*command_list: str) -> Callable:
+def command(*command_list: str) -> Callable[[Callable], PluginCallable]:
     """Decorate a function to set one or more commands that should trigger it.
 
     :param command_list: one or more command name(s) to match
@@ -874,22 +914,25 @@ def command(*command_list: str) -> Callable:
         * use a :func:`rule` instead
 
     """
-    def add_attribute(function):
-        function._sopel_callable = True
-        if not hasattr(function, "commands"):
-            function.commands = []
+    def decorator(function: Callable) -> PluginCallable:
+        handler = PluginCallable.ensure_callable(function)
+
         for command in command_list:
-            if command not in function.commands:
-                function.commands.append(command)
-        return function
-    return add_attribute
+            if command not in handler.commands:
+                handler.commands.append(command)
+
+        return handler
+
+    return decorator
 
 
 commands = command
 """Alias to :func:`command`."""
 
 
-def nickname_command(*command_list: str) -> Callable:
+def nickname_command(
+    *command_list: str,
+) -> Callable[[Callable], PluginCallable]:
     """Decorate a function to trigger on lines starting with "$nickname: command".
 
     :param command_list: one or more command name(s) to match
@@ -927,22 +970,25 @@ def nickname_command(*command_list: str) -> Callable:
                 # command would match the rest of the line.
 
     """
-    def add_attribute(function):
-        function._sopel_callable = True
-        if not hasattr(function, 'nickname_commands'):
-            function.nickname_commands = []
+    def decorator(function: Callable) -> PluginCallable:
+        handler = PluginCallable.ensure_callable(function)
+
         for cmd in command_list:
-            if cmd not in function.nickname_commands:
-                function.nickname_commands.append(cmd)
-        return function
-    return add_attribute
+            if cmd not in handler.nickname_commands:
+                handler.nickname_commands.append(cmd)
+
+        return handler
+
+    return decorator
 
 
 nickname_commands = nickname_command
 """Alias to :func:`nickname_command`."""
 
 
-def action_command(*command_list: str) -> Callable:
+def action_command(
+    *command_list: str,
+) -> Callable[[Callable], PluginCallable]:
     """Decorate a function to trigger on CTCP ACTION lines.
 
     :param command_list: one or more command name(s) to match
@@ -979,22 +1025,23 @@ def action_command(*command_list: str) -> Callable:
                 # Would trigger on "/me hello!" and "/me hello"
 
     """
-    def add_attribute(function):
-        function._sopel_callable = True
-        if not hasattr(function, 'action_commands'):
-            function.action_commands = []
+    def decorator(function: Callable) -> PluginCallable:
+        handler = PluginCallable.ensure_callable(function)
+
         for cmd in command_list:
-            if cmd not in function.action_commands:
-                function.action_commands.append(cmd)
-        return function
-    return add_attribute
+            if cmd not in handler.action_commands:
+                handler.action_commands.append(cmd)
+
+        return handler
+
+    return decorator
 
 
 action_commands = action_command
 """Alias to :func:`action_command`."""
 
 
-def label(value: str) -> Callable:
+def label(value: str) -> Callable[[Callable], AbstractPluginObject]:
     """Decorate a function to add a rule label.
 
     :param value: a label for the rule
@@ -1014,13 +1061,17 @@ def label(value: str) -> Callable:
         some name that isn't tied to an identifier in the source code.
 
     """
-    def add_attribute(function):
-        function.rule_label = value
-        return function
-    return add_attribute
+    def decorator(function: Callable) -> AbstractPluginObject:
+        handler = PluginGeneric.ensure_callable(function)
+        handler.label = value
+        return handler
+
+    return decorator
 
 
-def priority(value: Literal['low', 'medium', 'high']) -> Callable:
+def priority(
+    value: Literal['low', 'medium', 'high'],
+) -> Callable[[Callable], PluginCallable]:
     """Decorate a function to be executed with higher or lower priority.
 
     :param value: one of ``high``, ``medium``, or ``low``
@@ -1029,13 +1080,15 @@ def priority(value: Literal['low', 'medium', 'high']) -> Callable:
     if your plugin needs it. If a callable does not specify its ``priority``,
     Sopel assumes ``medium``.
     """
-    def add_attribute(function):
-        function.priority = value
-        return function
-    return add_attribute
+    def decorator(function: Callable) -> PluginCallable:
+        handler = PluginCallable.ensure_callable(function)
+        handler.priority = value
+        return handler
+
+    return decorator
 
 
-def event(*event_list: str) -> Callable:
+def event(*event_list: str) -> Callable[[Callable], PluginCallable]:
     """Decorate a function to be triggered on specific IRC events.
 
     :param event_list: one or more event name(s) on which to trigger
@@ -1052,21 +1105,43 @@ def event(*event_list: str) -> Callable:
         numeric events, which may help your code be clearer.
 
     """
-    def add_attribute(function):
-        function._sopel_callable = True
-        if not hasattr(function, "event"):
-            function.event = []
+    def decorator(function: Callable) -> PluginCallable:
+        handler = PluginCallable.ensure_callable(function)
+
         for name in event_list:
-            if name not in function.event:
-                function.event.append(name)
-        return function
-    return add_attribute
+            if name not in handler.events:
+                handler.events.append(name)
+
+        return handler
+
+    return decorator
 
 
+@overload
 def ctcp(
-    function: Union[Callable, Optional[str]] = None,
+    function: None = None,
     *command_list: str,
-) -> Callable:
+) -> Callable[[Callable], PluginCallable]:
+    ...
+
+
+@overload
+def ctcp(
+    function: str,
+    *command_list: str,
+) -> Callable[[Callable], PluginCallable]:
+    ...
+
+
+@overload
+def ctcp(
+    function: Callable,
+    *command_list: str,
+) -> PluginCallable:
+    ...
+
+
+def ctcp(function=None, *command_list):
     """Decorate a callable to trigger on CTCP commands (mostly, ``ACTION``).
 
     :param command_list: one or more CTCP command(s) on which to trigger
@@ -1107,6 +1182,7 @@ def ctcp(
     .. __: https://datatracker.ietf.org/doc/html/draft-oakley-irc-ctcp-02#appendix-A
     """
     default_commands = ('ACTION',) + command_list
+
     if function is None:
         return ctcp(*default_commands)  # called as ``@ctcp()``
     elif callable(function):
@@ -1118,15 +1194,16 @@ def ctcp(
     # called as ``@ctcp('ACTION', ...)``
     ctcp_commands = (function,) + command_list
 
-    def add_attribute(function):
-        function._sopel_callable = True
-        if not hasattr(function, "ctcp"):
-            function.ctcp = []
+    def decorator(function: Callable) -> PluginCallable:
+        handler = PluginCallable.ensure_callable(function)
+
         for name in ctcp_commands:
-            if name not in function.ctcp:
-                function.ctcp.append(name)
-        return function
-    return add_attribute
+            if name not in handler.ctcp:
+                handler.ctcp.append(name)
+
+        return handler
+
+    return decorator
 
 
 def rate(
@@ -1134,8 +1211,8 @@ def rate(
     channel: int = 0,
     server: int = 0,
     *,
-    message: Optional[str] = None,
-) -> Callable:
+    message: str | None = None,
+) -> Callable[[Callable], PluginCallable]:
     """Decorate a function to be rate-limited.
 
     :param user: seconds between permitted calls of this function by the same
@@ -1209,22 +1286,27 @@ def rate(
         :func:`rate_global`.
 
     """
-    def add_attribute(function):
-        if not hasattr(function, 'user_rate'):
-            function.user_rate = user
-        if not hasattr(function, 'channel_rate'):
-            function.channel_rate = channel
-        if not hasattr(function, 'global_rate'):
-            function.global_rate = server
-        function.default_rate_message = message
-        return function
-    return add_attribute
+    def decorator(function: Callable) -> PluginCallable:
+        handler = PluginCallable.ensure_callable(function)
+        if handler.user_rate is None:
+            handler.user_rate = user
+
+        if handler.channel_rate is None:
+            handler.channel_rate = channel
+
+        if handler.global_rate is None:
+            handler.global_rate = server
+
+        handler.default_rate_message = message
+        return handler
+
+    return decorator
 
 
 def rate_user(
     rate: int,
-    message: Optional[str] = None,
-) -> Callable:
+    message: str | None = None,
+) -> Callable[[Callable], PluginCallable]:
     """Decorate a function to be rate-limited for a user.
 
     :param rate: seconds between permitted calls of this function by the same
@@ -1255,17 +1337,19 @@ def rate_user(
         limits.
 
     """
-    def add_attribute(function):
-        function.user_rate = rate
-        function.user_rate_message = message
-        return function
-    return add_attribute
+    def decorator(function: Callable) -> PluginCallable:
+        handler = PluginCallable.ensure_callable(function)
+        handler.user_rate = rate
+        handler.user_rate_message = message
+        return handler
+
+    return decorator
 
 
 def rate_channel(
     rate: int,
-    message: Optional[str] = None,
-) -> Callable:
+    message: str | None = None,
+) -> Callable[[Callable], PluginCallable]:
     """Decorate a function to be rate-limited for a channel.
 
     :param rate: seconds between permitted calls of this function in the same
@@ -1299,17 +1383,19 @@ def rate_channel(
         limits.
 
     """
-    def add_attribute(function):
-        function.channel_rate = rate
-        function.channel_rate_message = message
-        return function
-    return add_attribute
+    def decorator(function: Callable) -> PluginCallable:
+        handler = PluginCallable.ensure_callable(function)
+        handler.channel_rate = rate
+        handler.channel_rate_message = message
+        return handler
+
+    return decorator
 
 
 def rate_global(
     rate: int,
-    message: Optional[str] = None,
-) -> Callable:
+    message: str | None = None,
+) -> Callable[[Callable], PluginCallable]:
     """Decorate a function to be rate-limited for the whole server.
 
     :param rate: seconds between permitted calls of this function no matter who
@@ -1342,11 +1428,13 @@ def rate_global(
         limits.
 
     """
-    def add_attribute(function):
-        function.global_rate = rate
-        function.global_rate_message = message
-        return function
-    return add_attribute
+    def decorator(function: Callable) -> PluginCallable:
+        handler = PluginCallable.ensure_callable(function)
+        handler.global_rate = rate
+        handler.global_rate_message = message
+        return handler
+
+    return decorator
 
 
 def require_privmsg(
@@ -1744,7 +1832,9 @@ def require_bot_privilege(
     return actual_decorator
 
 
-def url(*url_rules: str) -> Callable:
+def url(
+    *url_rules: str,
+) -> Callable[[Callable | PluginGeneric], PluginCallable]:
     """Decorate a function to handle URLs.
 
     :param url_rules: one or more regex pattern(s) to match URLs
@@ -1791,19 +1881,48 @@ def url(*url_rules: str) -> Callable:
         :attr:`~sopel.config.core_section.CoreSection.auto_url_schemes`.
 
     """
-    def actual_decorator(function):
-        function._sopel_callable = True
-        if not hasattr(function, 'url_regex'):
-            function.url_regex = []
+    def decorator(
+        function: Callable | PluginGeneric,
+    ) -> PluginCallable:
+        # do we need to handle the match parameter?
+        # old style URL callback: callable(bot, trigger, match)
+        # new style: callable(bot, trigger)
+        # TODO: remove in Sopel 9
+        if isinstance(function, AbstractPluginObject):
+            url_handler = function.get_handler()
+        else:
+            url_handler = function
+
+        match_count = 3
+        if inspect.ismethod(url_handler):
+            # account for the 'self' parameter when the handler is a method
+            match_count = 4
+
+        argspec = inspect.getfullargspec(url_handler)
+
+        if len(argspec.args) >= match_count:
+            @functools.wraps(url_handler)
+            def wrapped_handler(bot, trigger):
+                return url_handler(bot, trigger, match=trigger)
+
+            if isinstance(function, AbstractPluginObject):
+                function._handler = wrapped_handler
+            else:
+                function = wrapped_handler
+
+        handler = PluginCallable.ensure_callable(function)
+
         for url_rule in url_rules:
             url_regex = re.compile(url_rule)
-            if url_regex not in function.url_regex:
-                function.url_regex.append(url_regex)
-        return function
-    return actual_decorator
+            if url_regex not in handler.url_regex:
+                handler.url_regex.append(url_regex)
+
+        return handler
+
+    return decorator
 
 
-def url_lazy(*loaders: Callable) -> Callable:
+def url_lazy(*loaders: Callable) -> Callable[[Callable], PluginCallable]:
     """Decorate a function to handle URL, using lazy-loading for its regex.
 
     :param loaders: one or more functions to generate a list of **compiled**
@@ -1840,12 +1959,11 @@ def url_lazy(*loaders: Callable) -> Callable:
         with the :func:`sopel.tools.chain_loaders` function.
 
     """
-    def decorator(function):
-        function._sopel_callable = True
-        if not hasattr(function, 'url_lazy_loaders'):
-            function.url_lazy_loaders = []
-        function.url_lazy_loaders.extend(loaders)
-        return function
+    def decorator(function: Callable) -> PluginCallable:
+        handler = PluginCallable.ensure_callable(function)
+        handler.url_lazy_loaders.extend(loaders)
+        return handler
+
     return decorator
 
 
@@ -1953,17 +2071,13 @@ class example:
 
         self.user_help = user_help
 
-    def __call__(self, func):
-        # mypy (as of v1.4) doesn't recognize the below check as adding an
-        # "example" attribute to `func` if it's missing, so the `func`
-        # argument isn't typed yet.
-        # When we're ready to type-hint `loader`, we can make a TypeVar like
-        # `Callable[[SopelWrapper, Trigger], Any]` (but with the attributes
-        # the loader adds) for use in places like this.
-        if not hasattr(func, "example"):
-            func.example = []
-
+    def __call__(
+        self,
+        func: Callable | PluginCallable,
+    ) -> PluginCallable:
         import sys
+
+        handler = PluginCallable.ensure_callable(func)
 
         # only inject test-related stuff if we're running tests
         # see https://stackoverflow.com/a/44595269/5991
@@ -1975,7 +2089,7 @@ class example:
             pytest = sys.modules['pytest']
 
             test = pytest_plugin.get_example_test(
-                func, self.msg, self.result, self.privmsg, self.admin,
+                handler, self.msg, self.result, self.privmsg, self.admin,
                 self.owner, self.repeat, self.use_re, self.ignore
             )
 
@@ -1985,13 +2099,15 @@ class example:
             if self.vcr:
                 test = pytest.mark.vcr(test)
 
+            func_module = handler._handler.__module__
+            func_name = handler._handler.__name__
             pytest_plugin.insert_into_module(
-                test, func.__module__, func.__name__, 'test_example'
+                test, func_module, func_name, 'test_example'
             )
             pytest_plugin.insert_into_module(
                 pytest_plugin.get_disable_setup(),
-                func.__module__,
-                func.__name__,
+                func_module,
+                func_name,
                 'disable_setup',
             )
 
@@ -2005,11 +2121,12 @@ class example:
             "is_admin": self.admin,
             "is_owner": self.owner,
         }
-        func.example.append(record)
-        return func
+        handler.examples.append(record)
+
+        return handler
 
 
-def output_prefix(prefix: str) -> Callable:
+def output_prefix(prefix: str) -> Callable[[Callable], PluginCallable]:
     """Decorate a function to add a prefix on its output.
 
     :param prefix: the prefix to add (must include trailing whitespace if
@@ -2021,7 +2138,9 @@ def output_prefix(prefix: str) -> Callable:
     * :meth:`bot.notice <sopel.bot.SopelWrapper.notice>`
 
     """
-    def add_attribute(function):
-        function.output_prefix = prefix
-        return function
-    return add_attribute
+    def decorator(function: Callable) -> PluginCallable:
+        handler = PluginCallable.ensure_callable(function)
+        handler.output_prefix = prefix
+        return handler
+
+    return decorator

--- a/sopel/plugins/__init__.py
+++ b/sopel/plugins/__init__.py
@@ -41,7 +41,7 @@ from typing import TYPE_CHECKING, Union
 # py3.10 envs include old versions of this backport.
 import importlib_metadata
 
-from . import exceptions, handlers, rules  # noqa
+from . import callables, exceptions, handlers, rules  # noqa
 
 if TYPE_CHECKING:
     from collections.abc import Iterable

--- a/sopel/plugins/callables.py
+++ b/sopel/plugins/callables.py
@@ -1,0 +1,585 @@
+"""Plugin objects' definition.
+
+.. versionadded:: 8.1
+
+The core of a plugin consists of several objects, either plugin callables or
+plugin jobs. These objects are represented by instances of
+:class:`PluginCallable` and :class:`PluginJob` respectively.
+
+.. seealso::
+
+    The :mod:`sopel.plugin`'s decorator create these objects directly.
+
+.. important::
+
+    This is all relatively new. Its usage and documentation is for Sopel core
+    development and advanced developers. It is subject to rapid changes
+    between versions without much (or any) warning.
+
+    Do **not** build your plugin based on what is here, you do **not** need to.
+
+"""
+# Copyright 2025, Florian Strzelecki <florian.strzelecki@gmail.com>
+#
+# Licensed under the Eiffel Forum License 2.
+from __future__ import annotations
+
+import abc
+import inspect
+import re
+from typing import (
+    Any,
+    Callable,
+    Literal,
+    override,
+    Type,
+    TYPE_CHECKING,
+    TypeVar,
+)
+
+from sopel.config.core_section import COMMAND_DEFAULT_HELP_PREFIX
+from sopel.lifecycle import deprecated
+
+
+if TYPE_CHECKING:
+    from sopel.bot import Sopel, SopelWrapper
+    from sopel.config import Config
+    from sopel.trigger import Trigger
+
+
+TypedPluginObject = TypeVar('TypedPluginObject', bound='AbstractPluginObject')
+"""A :class:`~typing.TypeVar` bound to :class:`AbstractPluginObject`.
+
+When used in the :meth:`AbstractPluginObject.from_plugin_object` class method,
+it means the return value must be an instance of the class used to call that
+method and not a different subclass of ``AbstractRule``.
+
+.. versionadded:: 8.1
+"""
+
+
+class AbstractPluginObject(abc.ABC):
+    """Abstract definition of a plugin object.
+
+    A plugin object encapsulates the logic and attributes required for a plugin
+    to register and execute this object.
+
+    .. versionadded:: 8.1
+    """
+    _sopel_callable = True
+
+    plugin_name: str | None
+    label: str | None
+    threaded: bool
+    doc: str | None
+
+    @property
+    @deprecated(
+        reason='`rule_label` is replaced by the `label` attribute.',
+        version='8.1',
+        removed_in='9.0',
+    )
+    def rule_label(self):
+        return self.label
+
+    @property
+    @deprecated(
+        reason='`thread` is replaced by the `threaded` attribute.',
+        version='8.1',
+        removed_in='9.0',
+    )
+    def thread(self):
+        # compatiblity property
+        # TODO: remove in Sopel 9
+        return self.threaded
+
+    @classmethod
+    def from_plugin_object(
+        cls: Type[TypedPluginObject],
+        obj: AbstractPluginObject,
+    ) -> TypedPluginObject:
+        """Convert a plugin ``obj`` to this type of plugin object.
+
+        :param obj: the plugin object to convert from
+        :return: an instance of the new plugin object from ``obj``
+
+        This class method will create a new instance of plugin object based on
+        ``obj``'s generic attributes (like its label) and the same callable,
+        assuming ``obj`` is a different type of plugin object.
+
+        .. seealso::
+
+            The :py:deco:`~sopel.plugin.label` decorator returns a
+            :class:`PluginGeneric` that needs to be converted into a plugin
+            callable or a plugin job by this class method.
+
+        """
+        handler = cls(obj.get_handler())
+        handler.plugin_name = obj.plugin_name
+        handler.label = obj.label
+        handler.threaded = obj.threaded
+        handler.doc = obj.doc
+
+        return handler
+
+    @abc.abstractmethod
+    def __init__(self, handler: Callable) -> None:
+        ...
+
+    @abc.abstractmethod
+    def get_handler(self) -> Callable:
+        """Return this plugin object's handler.
+
+        :return: the plugin object's handler
+        """
+
+
+class PluginGeneric(AbstractPluginObject):
+    @classmethod
+    def ensure_callable(
+        cls: Type[PluginGeneric],
+        obj: Callable | AbstractPluginObject,
+    ) -> AbstractPluginObject:
+        """Ensure that ``obj`` is a proper plugin object.
+
+        :param obj: a function or a plugin object
+        :return: a properly defined plugin object
+
+        If ``obj`` is already an instance of ``AbstractPluginObject``, it is
+        returned as-is. Otherwise, a new ``PluginGeneric`` is created from it.
+
+        .. note::
+
+            Since a generic plugin object doesn't hold much value, it never
+            converts a specific plugin object into a generic one as to prevent
+            meta-data loss.
+
+        """
+        if isinstance(obj, AbstractPluginObject):
+            return obj
+
+        handler = cls(obj)
+
+        # shared meta data
+        handler.label = getattr(obj, 'rule_label', handler.label)
+        handler.threaded = getattr(obj, 'thread', handler.threaded)
+
+        return handler
+
+    def __init__(self, handler: Callable) -> None:
+        self._handler = handler
+
+        # shared meta data
+        self.plugin_name = None
+        self.label = self._handler.__name__
+        self.threaded = True
+        self.doc = inspect.getdoc(self._handler)
+
+    @override
+    def get_handler(self) -> Callable:
+        return self._handler
+
+
+class PluginCallable(AbstractPluginObject):
+    """Plugin callable, i.e. execute a plugin function when triggered.
+
+    :param handler: a function to be called when the plugin callable is invoked
+    """
+    @property
+    @deprecated(
+        reason='`echo` is replaced by the `allow_echo` attribute.',
+        version='8.1',
+        removed_in='9.0',
+    )
+    def echo(self):
+        return self.allow_echo
+
+    @property
+    @deprecated(
+        reason='`event` is replaced by the `events` attribute.',
+        version='8.1',
+        removed_in='9.0',
+    )
+    def event(self):
+        return self.events
+
+    @property
+    @deprecated(
+        reason='`example` is replaced by the `examples` attribute.',
+        version='8.1',
+        removed_in='9.0',
+    )
+    def example(self):
+        return self.examples
+
+    @property
+    @deprecated(
+        reason='`rule` is replaced by the `rules` attribute.',
+        version='8.1',
+        removed_in='9.0',
+    )
+    def rule(self):
+        return self.rules
+
+    @classmethod
+    def ensure_callable(
+        cls: Type[PluginCallable],
+        obj: Callable | AbstractPluginObject,
+    ) -> PluginCallable:
+        """Ensure that ``obj`` is a plugin callable.
+
+        :param obj: a function or a plugin object
+        :return: a properly defined plugin callable
+
+        If ``obj`` is already an instance of ``AbstractPluginObject``, it
+        converts it into a plugin callable. Otherwise, a new plugin callable is
+        created, using the ``obj`` as its handler.
+        """
+        if isinstance(obj, cls):
+            return obj
+
+        if isinstance(obj, AbstractPluginObject):
+            handler = cls.from_plugin_object(obj)
+            obj = obj.get_handler()
+        else:
+            handler = cls(obj)
+
+        # shared meta data
+        handler.label = getattr(obj, 'rule_label', handler.label)
+        handler.threaded = getattr(obj, 'thread', handler.threaded)
+
+        # meta
+        handler.allow_bots = getattr(obj, 'allow_bots', handler.allow_bots)
+        handler.allow_echo = getattr(obj, 'echo', handler.allow_echo)
+        handler.priority = getattr(obj, 'priority', handler.priority)
+        handler.output_prefix = getattr(
+            obj, 'output_prefix', handler.output_prefix)
+        handler._docs = getattr(obj, '_docs', handler._docs)
+
+        # rules
+        handler.events = getattr(obj, 'event', handler.events)
+        handler.ctcp = getattr(obj, 'ctcp', handler.ctcp)
+        handler.rules = getattr(obj, 'rule', handler.rules)
+        handler.rule_lazy_loaders = getattr(
+            obj, 'rule_lazy_loaders', handler.rule_lazy_loaders)
+        handler.find_rules = getattr(obj, 'find_rules', handler.find_rules)
+        handler.search_rules = getattr(
+            obj, 'search_rules', handler.search_rules)
+
+        # urls
+        handler.url_regex = getattr(obj, 'url_regex', handler.url_regex)
+        handler.url_lazy_loaders = getattr(
+            obj, 'url_lazy_loaders', handler.url_lazy_loaders)
+
+        # named rules
+        handler.commands = getattr(
+            obj, 'commands', handler.commands)
+        handler.nickname_commands = getattr(
+            obj, 'nickname_commands', handler.nickname_commands)
+        handler.action_commands = getattr(
+            obj, 'action_commands', handler.action_commands)
+
+        # rate limiting
+        handler.user_rate = getattr(obj, 'user_rate', None)
+        handler.channel_rate = getattr(obj, 'channel_rate', None)
+        handler.global_rate = getattr(obj, 'global_rate', None)
+        handler.user_rate_message = getattr(obj, 'user_rate_message', None)
+        handler.channel_rate_message = getattr(
+            obj, 'channel_rate_message', None)
+        handler.global_rate_message = getattr(obj, 'global_rate_message', None)
+        handler.default_rate_message = getattr(
+            obj, 'default_rate_message', None)
+        handler.unblockable = getattr(obj, 'unblockable', handler.unblockable)
+
+        return handler
+
+    @property
+    def is_limitable(self) -> bool:
+        """Check if the callable is subject to rate limiting.
+
+        :return: ``True`` if it is subject to rate limiting
+
+        Limitable callables aren't necessarily triggerable directly, but they
+        all must pass through Sopel's rate-limiting machinery during
+        dispatching.
+        """
+        allowed = any([
+            self.rules,
+            self.rule_lazy_loaders,
+            self.find_rules,
+            self.find_rules_lazy_loaders,
+            self.search_rules,
+            self.search_rules_lazy_loaders,
+            self.event,
+            self.ctcp,
+            self.commands,
+            self.nickname_commands,
+            self.action_commands,
+            self.url_regex,
+            self.url_lazy_loaders,
+        ])
+
+        return allowed
+
+    @property
+    def is_triggerable(self) -> bool:
+        """Check if the callable can handle the bot's triggers.
+
+        :return: ``True`` if it can handle the bot's triggers
+
+        A triggerable is a callable that will be used by the bot to handle a
+        particular trigger (i.e. an IRC message): it can be a regex rule, an
+        event, a CTCP command, a command, a nickname command, or an action
+        command. However, it must not be a job or a URL callback.
+
+        .. seealso::
+
+            Many of the decorators defined in :mod:`sopel.plugin` make the
+            decorated function a triggerable object.
+
+        """
+        forbidden = any([
+            self.url_regex,
+            self.url_lazy_loaders,
+        ])
+
+        allowed = any([
+            self.rules,
+            self.rule_lazy_loaders,
+            self.find_rules,
+            self.find_rules_lazy_loaders,
+            self.search_rules,
+            self.search_rules_lazy_loaders,
+            self.event,
+            self.ctcp,
+            self.commands,
+            self.nickname_commands,
+            self.action_commands,
+        ])
+
+        return allowed and not forbidden
+
+    @property
+    def is_url_callback(self) -> bool:
+        """Check if the callable can handle a URL callback.
+
+        :return: ``True`` if it can handle a URL callback
+
+        A URL callback handler is a callable that will be used by the bot to
+        handle a particular URL in an IRC message.
+
+        .. seealso::
+
+            Both :func:`sopel.plugin.url` :func:`sopel.plugin.url_lazy` make
+            the decorated function a URL callback handler.
+
+        """
+        allowed = any([
+            self.url_regex,
+            self.url_lazy_loaders,
+        ])
+
+        return allowed
+
+    def __init__(
+        self,
+        handler: Callable[[SopelWrapper, Trigger], Any],
+    ) -> None:
+        self._handler = handler
+
+        # shared meta data
+        self.plugin_name: str | None = None
+        self.label: str = self._handler.__name__
+        self.threaded: bool = True
+        self.doc = inspect.getdoc(self._handler)
+
+        # documentation
+        self.examples: list[dict] = []
+        self._docs: dict = {}
+
+        # rules
+        self.events: list = []
+        self.ctcp: list = []
+        self.commands: list = []
+        self.nickname_commands: list = []
+        self.action_commands: list = []
+        self.rules: list = []
+        self.rule_lazy_loaders: list = []
+        self.find_rules: list = []
+        self.find_rules_lazy_loaders: list = []
+        self.search_rules: list = []
+        self.search_rules_lazy_loaders: list = []
+        self.url_regex: list = []
+        self.url_lazy_loaders: list = []
+
+        # allow special conditions
+        self.allow_bots: bool = False
+        self.allow_echo: bool = False
+
+        # how to run it
+        self.priority: Literal['low', 'medium', 'high'] = 'medium'
+        self.unblockable: bool = False
+
+        # rate limiting
+        self.user_rate: int | None = None
+        self.channel_rate: int | None = None
+        self.global_rate: int | None = None
+        self.default_rate_message: str | None = None
+        self.user_rate_message: str | None = None
+        self.channel_rate_message: str | None = None
+        self.global_rate_message: str | None = None
+
+        # output management
+        self.output_prefix: str = ''
+
+    def __call__(
+        self,
+        bot: SopelWrapper,
+        trigger: Trigger,
+    ) -> Any:
+        return self._handler(bot, trigger)
+
+    @override
+    def get_handler(self) -> Callable:
+        return self._handler
+
+    def setup(self, settings: Config) -> None:
+        """Setup of the plugin callable.
+
+        :param settings: the bot's configuration
+
+        This method will be called by the bot before registering the callable.
+        It ensures the value of various meta-data.
+        """
+        nick = settings.core.nick
+        help_prefix = settings.core.help_prefix
+        docs = []
+        examples = []
+
+        if self.is_limitable:
+            self.user_rate = self.user_rate or 0
+            self.channel_rate = self.channel_rate or 0
+            self.global_rate = self.global_rate or 0
+
+        if not self.is_triggerable and not self.is_url_callback:
+            return
+
+        if not self.events:
+            self.events = ['PRIVMSG']
+        else:
+            self.events = [event.upper() for event in self.events]
+
+        if self.ctcp:
+            # Can be implementation-dependent
+            _regex_type = type(re.compile(''))
+            self.ctcp = [
+                (ctcp_pattern
+                    if isinstance(ctcp_pattern, _regex_type)
+                    else re.compile(ctcp_pattern, re.IGNORECASE))
+                for ctcp_pattern in self.ctcp
+            ]
+
+        if not any([
+            self.commands,
+            self.action_commands,
+            self.nickname_commands,
+        ]):
+            # no need to handle documentation for non-command
+            return
+
+        docstring = inspect.getdoc(self._handler)
+        if docstring:
+            docs = docstring.splitlines()
+
+        if self.examples:
+            # If no examples are flagged as user-facing,
+            # just show the first one like Sopel<7.0 did
+            examples = [
+                rec["example"]
+                for rec in self.examples
+                if rec["is_help"]
+            ] or [self.examples[0]["example"]]
+
+            for i, example in enumerate(examples):
+                example = example.replace('$nickname', nick)
+                if example[0] != help_prefix and not example.startswith(nick):
+                    example = example.replace(
+                        COMMAND_DEFAULT_HELP_PREFIX, help_prefix, 1)
+                examples[i] = example
+
+        if docs or examples:
+            for command in self.commands + self.nickname_commands:
+                self._docs[command] = (docs, examples)
+
+
+class PluginJob(AbstractPluginObject):
+    @property
+    @deprecated(
+        reason='`interval` is replaced by the `intervals` attribute.',
+        version='8.1',
+        removed_in='9.0',
+    )
+    def interval(self):
+        return self.intervals
+
+    @classmethod
+    def ensure_callable(
+        cls: Type[PluginJob],
+        obj: Callable | AbstractPluginObject,
+    ) -> PluginJob:
+        """Ensure that ``obj`` is a plugin job.
+
+        :param obj: a function or a plugin object
+        :return: a properly defined plugin job
+
+        If ``obj`` is already an instance of ``AbstractPluginObject``, it
+        converts it into a plugin job. Otherwise, a new plugin job is created,
+        using the ``obj`` as its handler.
+        """
+        if isinstance(obj, cls):
+            return obj
+
+        if isinstance(obj, AbstractPluginObject):
+            handler = cls.from_plugin_object(obj)
+            obj = obj.get_handler()
+        else:
+            handler = cls(obj)
+
+        # jobs
+        handler.intervals = getattr(obj, 'interval', handler.intervals)
+        handler.threaded = getattr(obj, 'thread', handler.threaded)
+
+        return handler
+
+    def __init__(self, handler: Callable[[Sopel], Any]):
+        self._handler = handler
+
+        # shared meta data
+        self.plugin_name: str | None = None
+        self.label: str = self._handler.__name__
+        self.threaded: bool = True
+        self.doc = inspect.getdoc(self._handler)
+
+        # job
+        self.intervals: list = []
+
+    def __call__(self, bot: Sopel) -> Any:
+        return self._handler(bot)
+
+    @override
+    def get_handler(self) -> Callable:
+        return self._handler
+
+    def setup(self, settings: Config) -> None:
+        """Optional setup.
+
+        :param settings: the bot's configuration
+
+        This method will be called by the bot before registering the job.
+
+        .. note::
+
+            This methods is a no-op. It exists for subclasses that may requires
+            to perform operation before registration.
+
+        """

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -18,15 +18,12 @@ from __future__ import annotations
 
 import abc
 import datetime
-import functools
-import inspect
 import itertools
 import logging
 import re
 import threading
 from typing import (
     Any,
-    Callable,
     Optional,
     Type,
     TYPE_CHECKING,
@@ -43,6 +40,7 @@ if TYPE_CHECKING:
 
     from sopel.bot import Sopel
     from sopel.config import Config
+    from sopel.plugins.callables import PluginCallable
     from sopel.tools.identifiers import Identifier
     from sopel.trigger import PreTrigger
 
@@ -549,12 +547,12 @@ class AbstractRule(abc.ABC):
     def from_callable(
         cls: Type[TypedRule],
         settings: Config,
-        handler: Callable,
+        handler: PluginCallable,
     ) -> TypedRule:
         """Instantiate a rule object from ``settings`` and ``handler``.
 
         :param settings: Sopel's settings
-        :param handler: a function-based rule handler
+        :param handler: a plugin callable object
         :return: an instance of this class created from the ``handler``
 
         Sopel's function-based rule handlers are simple callables, decorated
@@ -891,7 +889,7 @@ class Rule(AbstractRule):
     LAZY_ATTRIBUTE = 'rule_lazy_loaders'
 
     @classmethod
-    def kwargs_from_callable(cls, handler):
+    def kwargs_from_callable(cls, handler: PluginCallable) -> dict:
         """Generate the keyword arguments to create a new instance.
 
         :param callable handler: callable used to generate keyword arguments
@@ -908,8 +906,7 @@ class Rule(AbstractRule):
         # manage examples:
         # - usages are for documentation only
         # - tests are examples that can be run and tested
-        examples = _clean_callable_examples(
-            getattr(handler, 'example', None) or tuple())
+        examples = _clean_callable_examples(handler.examples)
 
         usages = tuple(
             example
@@ -942,7 +939,7 @@ class Rule(AbstractRule):
                 handler, 'default_rate_message', None),
             'usages': usages or tuple(),
             'tests': tests,
-            'doc': inspect.getdoc(handler),
+            'doc': handler.doc,
         }
 
     @classmethod
@@ -1101,8 +1098,8 @@ class Rule(AbstractRule):
         if self._label:
             return self._label
 
-        if self._handler and self._handler.__name__:
-            return self._handler.__name__
+        if self._handler is not None:
+            return self._handler.label
 
         raise RuntimeError('Undefined rule label')
 
@@ -1366,7 +1363,7 @@ class Command(AbstractNamedRule):
     def from_callable(cls, settings, handler):
         prefix = settings.core.prefix
         help_prefix = settings.core.help_prefix
-        commands = getattr(handler, 'commands', [])
+        commands = handler.commands
         if not commands:
             raise RuntimeError('Invalid command callable: %s' % handler)
 
@@ -1774,29 +1771,8 @@ class URLCallback(Rule):
         regexes = cls.regex_from_callable(settings, handler)
         kwargs = cls.kwargs_from_callable(handler)
 
-        # do we need to handle the match parameter?
-        # old style URL callback: callable(bot, trigger, match)
-        # new style: callable(bot, trigger)
-        match_count = 3
-        if inspect.ismethod(handler):
-            # account for the 'self' parameter when the handler is a method
-            match_count = 4
-
-        execute_handler = handler
-        argspec = inspect.getfullargspec(handler)
-
-        if len(argspec.args) >= match_count:
-            @functools.wraps(handler)
-            def handler_match_wrapper(bot, trigger):
-                return handler(bot, trigger, match=trigger)
-
-            # don't directly `def execute_handler` to override it;
-            # doing incurs the wrath of pyflakes in the form of
-            # "F811: Redefinition of unused name"
-            execute_handler = handler_match_wrapper
-
         kwargs.update({
-            'handler': execute_handler,
+            'handler': handler,
             'schemes': settings.core.auto_url_schemes,
         })
 

--- a/sopel/tests/pytest_plugin.py
+++ b/sopel/tests/pytest_plugin.py
@@ -9,7 +9,7 @@ import sys
 
 import pytest
 
-from sopel import bot, loader, plugins, trigger
+from sopel import bot, plugins, trigger
 from .factories import BotFactory, ConfigFactory, IRCFactory, TriggerFactory, UserFactory
 
 
@@ -44,13 +44,12 @@ def get_disable_setup():
     return disable_setup
 
 
-def get_example_test(tested_func, msg, results, privmsg, admin,
+def get_example_test(handler, msg, results, privmsg, admin,
                      owner, repeat, use_regexp, ignore=[]):
-    """Get a function that calls ``tested_func`` with fake wrapper and trigger.
+    """Get a function that calls ``handler`` with fake wrapper and trigger.
 
-    :param callable tested_func: a Sopel callable that accepts a
-                                 :class:`~.bot.SopelWrapper` and a
-                                 :class:`~.trigger.Trigger`
+    :param handler: a plugin command to test
+    :type handler: :class:`sopel.plugins.callables.PluginCallable`
     :param str msg: message that is supposed to trigger the command
     :param list results: expected output from the callable
     :param bool privmsg: if ``True``, make the message appear to have arrived
@@ -77,11 +76,12 @@ def get_example_test(tested_func, msg, results, privmsg, admin,
         server = ircfactory(mockbot)
         server.channel_joined('#Sopel')
 
-        if not hasattr(tested_func, 'commands'):
-            raise AssertionError('Function is not a command.')
+        if not handler.commands:
+            raise AssertionError('Plugin callable is not a command.')
 
-        loader.clean_callable(tested_func, settings)
-        test_rule = plugins.rules.Command.from_callable(settings, tested_func)
+        handler.setup(settings)
+        tested_func = handler._handler
+        test_rule = plugins.rules.Command.from_callable(settings, handler)
         parse_results = list(test_rule.parse(msg))
         assert parse_results, "Example did not match any command."
 
@@ -116,7 +116,7 @@ def get_example_test(tested_func, msg, results, privmsg, admin,
         for _i in range(repeat):
             expected_output_count += len(results)
             wrapper = bot.SopelWrapper(mockbot, test_trigger)
-            tested_func(wrapper, test_trigger)
+            handler(wrapper, test_trigger)
 
             output_triggers = (
                 trigger.PreTrigger(

--- a/sopel/tools/jobs.py
+++ b/sopel/tools/jobs.py
@@ -13,10 +13,15 @@
 # Licensed under the Eiffel Forum License 2.
 from __future__ import annotations
 
-import inspect
 import logging
 import threading
 import time
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from sopel.config import Config
+    from sopel.plugins.callables import PluginJob
 
 
 LOGGER = logging.getLogger(__name__)
@@ -252,7 +257,7 @@ class Job:
 
     """
     @classmethod
-    def kwargs_from_callable(cls, handler):
+    def kwargs_from_callable(cls, handler: PluginJob) -> dict:
         """Generate the keyword arguments to create a new instance.
 
         :param handler: callable used to generate keyword arguments
@@ -269,14 +274,14 @@ class Job:
         """
 
         return {
-            'plugin': getattr(handler, 'plugin_name', None),
-            'label': getattr(handler, 'rule_label', None),
-            'threaded': getattr(handler, 'thread', True),
-            'doc': inspect.getdoc(handler),
+            'plugin': handler.plugin_name,
+            'label': handler.label,
+            'threaded': handler.threaded,
+            'doc': handler.doc,
         }
 
     @classmethod
-    def from_callable(cls, settings, handler):
+    def from_callable(cls, settings: Config, handler: PluginJob) -> Job:
         """Instantiate a Job from the bot's ``settings`` and a ``handler``.
 
         :param settings: bot's settings
@@ -286,7 +291,7 @@ class Job:
         """
         kwargs = cls.kwargs_from_callable(handler)
         return cls(
-            set(handler.interval),
+            set(handler.intervals),
             handler=handler,
             **kwargs)
 

--- a/test/builtins/test_builtins_url.py
+++ b/test/builtins/test_builtins_url.py
@@ -5,7 +5,7 @@ import re
 
 import pytest
 
-from sopel import bot, loader, plugin, plugins, trigger
+from sopel import bot, plugin, plugins, trigger
 from sopel.builtins import url
 
 
@@ -60,7 +60,7 @@ def mockbot(configfactory):
     # clean callables and set plugin name by hand
     # since the loader and plugin handlers are excluded here
     for handler in callables:
-        loader.clean_callable(handler, tmpconfig)
+        handler.setup(tmpconfig)
         handler.plugin_name = 'testplugin'
 
     # register callables

--- a/test/plugins/test_plugins_callables.py
+++ b/test/plugins/test_plugins_callables.py
@@ -1,0 +1,46 @@
+"""Tests for the ``sopel.plugins.callables`` module."""
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from sopel.plugins.callables import PluginCallable
+
+
+if TYPE_CHECKING:
+    from sopel.bot import SopelWrapper
+    from sopel.trigger import Trigger
+
+
+TMP_CONFIG = """
+[core]
+owner = testnick
+nick = TestBot
+alias_nicks =
+    AliasBot
+    SupBot
+enable = coretasks
+"""
+
+
+@pytest.fixture
+def tmpconfig(configfactory):
+    return configfactory('test.cfg', TMP_CONFIG)
+
+
+@pytest.fixture
+def mockbot(tmpconfig, botfactory):
+    return botfactory(tmpconfig)
+
+
+def test_call(mockbot, triggerfactory):
+    wrapped = triggerfactory.wrapper(
+        mockbot, ':Foo!foo@example.com PRIVMSG #channel :test message')
+    expected = 'test value: test message'
+
+    def handler(bot: SopelWrapper, trigger: Trigger):
+        return 'test value: %s' % str(trigger)
+
+    plugin_callable = PluginCallable(handler)
+    assert plugin_callable(wrapped, wrapped._trigger) == expected

--- a/test/plugins/test_plugins_rules.py
+++ b/test/plugins/test_plugins_rules.py
@@ -6,8 +6,8 @@ import re
 
 import pytest
 
-from sopel import bot, loader, plugin, trigger
-from sopel.plugins import rules
+from sopel import bot, plugin, trigger
+from sopel.plugins import callables, rules
 from sopel.tests import rawlist
 
 
@@ -542,7 +542,8 @@ def test_rule_get_rule_label_handler(mockbot):
     def the_handler_rule(wrapped, trigger):
         pass
 
-    rule = rules.Rule([regex], handler=the_handler_rule)
+    handler = callables.PluginCallable.ensure_callable(the_handler_rule)
+    rule = rules.Rule([regex], handler=handler)
     assert rule.get_rule_label() == 'the_handler_rule'
 
 
@@ -894,7 +895,7 @@ def test_rule_from_callable(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
     handler.plugin_name = 'testplugin'
 
     # create rule from a cleaned callable
@@ -935,7 +936,7 @@ def test_rule_from_callable_nick_placeholder(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
     handler.plugin_name = 'testplugin'
 
     # create rule from a cleaned callable
@@ -972,7 +973,7 @@ def test_rule_from_callable_nickname_placeholder(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
     handler.plugin_name = 'testplugin'
 
     # create rule from a cleaned callable
@@ -1006,7 +1007,7 @@ def test_rule_from_callable_lazy(mockbot):
         wrapped.say('Hi!')
         return 'The return value: %s' % trigger.group(0)
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
     handler.plugin_name = 'testplugin'
 
     # create rule from a cleaned callable
@@ -1049,7 +1050,7 @@ def test_rule_from_callable_invalid(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
     handler.plugin_name = 'testplugin'
 
     # create rule from a cleaned callable
@@ -1063,7 +1064,7 @@ def test_rule_from_callable_lazy_invalid(mockbot):
     def handler(wrapped, trigger, match=None):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
     handler.plugin_name = 'testplugin'
 
     # create rule from a cleaned callable
@@ -1077,7 +1078,7 @@ def test_rule_from_callable_lazy_invalid_no_regex(mockbot):
     def handler(wrapped, trigger, match=None):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
     handler.plugin_name = 'testplugin'
 
     # create rule from a cleaned callable
@@ -1094,7 +1095,7 @@ def test_kwargs_from_callable(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
     handler.plugin_name = 'testplugin'  # normally added by the Plugin handler
 
     # get kwargs
@@ -1121,7 +1122,7 @@ def test_kwargs_from_callable(mockbot):
     assert 'doc' in kwargs
 
     assert kwargs['plugin'] == 'testplugin'
-    assert kwargs['label'] is None
+    assert kwargs['label'] == 'handler'
     assert kwargs['priority'] == rules.PRIORITY_MEDIUM
     assert kwargs['events'] == ['PRIVMSG']
     assert kwargs['ctcp'] == []
@@ -1148,7 +1149,7 @@ def test_kwargs_from_callable_label(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # get kwargs
     kwargs = rules.Rule.kwargs_from_callable(handler)
@@ -1163,7 +1164,7 @@ def test_kwargs_from_callable_priority(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # get kwargs
     kwargs = rules.Rule.kwargs_from_callable(handler)
@@ -1178,7 +1179,7 @@ def test_kwargs_from_callable_event(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # get kwargs
     kwargs = rules.Rule.kwargs_from_callable(handler)
@@ -1193,7 +1194,7 @@ def test_kwargs_from_callable_ctcp_intent(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # get kwargs
     kwargs = rules.Rule.kwargs_from_callable(handler)
@@ -1208,7 +1209,7 @@ def test_kwargs_from_callable_allow_echo(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # get kwargs
     kwargs = rules.Rule.kwargs_from_callable(handler)
@@ -1223,7 +1224,7 @@ def test_kwargs_from_callable_threaded(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # get kwargs
     kwargs = rules.Rule.kwargs_from_callable(handler)
@@ -1238,7 +1239,7 @@ def test_kwargs_from_callable_unblockable(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # get kwargs
     kwargs = rules.Rule.kwargs_from_callable(handler)
@@ -1253,7 +1254,7 @@ def test_kwargs_from_callable_rate_limit(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # get kwargs
     kwargs = rules.Rule.kwargs_from_callable(handler)
@@ -1280,7 +1281,7 @@ def test_kwargs_from_callable_rate_limit_user(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # get kwargs
     kwargs = rules.Rule.kwargs_from_callable(handler)
@@ -1307,7 +1308,7 @@ def test_kwargs_from_callable_rate_limit_channel(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # get kwargs
     kwargs = rules.Rule.kwargs_from_callable(handler)
@@ -1334,7 +1335,7 @@ def test_kwargs_from_callable_rate_limit_server(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # get kwargs
     kwargs = rules.Rule.kwargs_from_callable(handler)
@@ -1362,7 +1363,7 @@ def test_kwargs_from_callable_examples(mockbot):
         """This is the doc you are looking for."""
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # get kwargs
     kwargs = rules.Rule.kwargs_from_callable(handler)
@@ -1395,7 +1396,7 @@ def test_kwargs_from_callable_examples_test(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # get kwargs
     kwargs = rules.Rule.kwargs_from_callable(handler)
@@ -1449,7 +1450,7 @@ def test_kwargs_from_callable_examples_help(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # get kwargs
     kwargs = rules.Rule.kwargs_from_callable(handler)
@@ -1516,7 +1517,7 @@ def test_kwargs_from_callable_examples_doc(mockbot):
         """
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # get kwargs
     kwargs = rules.Rule.kwargs_from_callable(handler)
@@ -1980,7 +1981,7 @@ def test_command_from_callable(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # create rule from a cleaned callable
     rule = rules.Command.from_callable(mockbot.settings, handler)
@@ -2034,7 +2035,7 @@ def test_command_from_callable_subcommand(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # create rule from a cleaned callable
     rule = rules.Command.from_callable(mockbot.settings, handler)
@@ -2063,7 +2064,7 @@ def test_command_from_callable_subcommand_aliases(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # create rule from a cleaned callable
     rule = rules.Command.from_callable(mockbot.settings, handler)
@@ -2117,7 +2118,7 @@ def test_command_from_callable_escaped_regex_pattern(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # create rule from a cleaned callable
     rule = rules.Command.from_callable(mockbot.settings, handler)
@@ -2147,7 +2148,7 @@ def test_command_from_callable_invalid(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # create rule from a cleaned callable
     with pytest.raises(RuntimeError):
@@ -2316,7 +2317,7 @@ def test_nick_command_from_callable_invalid(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # create rule from a cleaned callable
     with pytest.raises(RuntimeError):
@@ -2329,7 +2330,7 @@ def test_nick_command_from_callable(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # create rule from a cleaned callable
     rule = rules.NickCommand.from_callable(mockbot.settings, handler)
@@ -2418,7 +2419,7 @@ def test_nick_command_from_callable_regex_pattern(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # create rule from a cleaned callable
     rule = rules.NickCommand.from_callable(mockbot.settings, handler)
@@ -2546,7 +2547,7 @@ def test_action_command_from_callable_invalid(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # create rule from a cleaned callable
     with pytest.raises(RuntimeError):
@@ -2559,7 +2560,7 @@ def test_action_command_from_callable(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # create rule from a cleaned callable
     rule = rules.ActionCommand.from_callable(mockbot.settings, handler)
@@ -2625,7 +2626,7 @@ def test_action_command_from_callable_regex_pattern(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # create rule from a cleaned callable
     rule = rules.ActionCommand.from_callable(mockbot.settings, handler)
@@ -2701,7 +2702,7 @@ def test_find_rule_from_callable(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
     handler.plugin_name = 'testplugin'
 
     # create rule from a cleaned callable
@@ -2788,7 +2789,7 @@ def test_search_rule_from_callable(mockbot):
     def handler(wrapped, trigger):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
     handler.plugin_name = 'testplugin'
 
     # create rule from a cleaned callable
@@ -2961,7 +2962,7 @@ def test_url_callback_from_callable(mockbot):
         wrapped.say('Hi!')
         return 'The return value: %s' % match.group(0)
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
     handler.plugin_name = 'testplugin'
 
     # create rule from a cleaned callable
@@ -3042,7 +3043,7 @@ def test_url_callback_from_callable_no_match_parameter(mockbot):
         wrapped.say('Hi!')
         return 'The return value: %s' % trigger.group(0)
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
     handler.plugin_name = 'testplugin'
 
     # create rule from a cleaned callable
@@ -3081,7 +3082,7 @@ def test_url_callback_from_callable_lazy(mockbot):
         wrapped.say('Hi!')
         return 'The return value: %s' % trigger.group(0)
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
     handler.plugin_name = 'testplugin'
 
     # create rule from a cleaned callable
@@ -3122,7 +3123,7 @@ def test_url_callback_from_callable_invalid(mockbot):
     def handler(wrapped, trigger, match=None):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # create rule from a cleaned callable
     with pytest.raises(RuntimeError):
@@ -3135,7 +3136,7 @@ def test_url_callback_from_callable_lazy_invalid(mockbot):
     def handler(wrapped, trigger, match=None):
         wrapped.reply('Hi!')
 
-    loader.clean_callable(handler, mockbot.settings)
+    handler.setup(mockbot.settings)
 
     # create rule from a cleaned callable
     with pytest.raises(RuntimeError):

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -7,7 +7,7 @@ import typing
 
 import pytest
 
-from sopel import bot, loader, plugin, plugins, trigger
+from sopel import bot, plugin, plugins, trigger
 from sopel.plugins import rules
 from sopel.tests import rawlist
 from sopel.tools import Identifier, SopelMemory, target
@@ -510,7 +510,7 @@ def test_register_callables(tmpconfig):
     # clean callables and set plugin name by hand
     # since the loader and plugin handlers are excluded here
     for handler in callables:
-        loader.clean_callable(handler, tmpconfig)
+        handler.setup(tmpconfig)
         handler.plugin_name = 'testplugin'
 
     # register callables
@@ -651,7 +651,7 @@ def test_register_urls(tmpconfig):
     # clean callables and set plugin name by hand
     # since the loader and plugin handlers are excluded here
     for handler in callables:
-        loader.clean_callable(handler, tmpconfig)
+        handler.setup(tmpconfig)
         handler.plugin_name = 'testplugin'
 
     # register callables
@@ -1574,6 +1574,7 @@ def test_ignore_replay_servertime(mockbot):
     def ping(bot, trigger):
         bot.say(trigger.nick + "!")
 
+    ping.setup(mockbot.settings)
     ping.plugin_name = "testplugin"
     mockbot.register_callables([ping])
 

--- a/test/test_loader.py
+++ b/test/test_loader.py
@@ -6,7 +6,7 @@ import re
 
 import pytest
 
-from sopel import loader, plugin, plugins
+from sopel import loader, plugins
 
 
 MOCK_MODULE_CONTENT = """from __future__ import annotations
@@ -15,59 +15,68 @@ import re
 from sopel import plugin
 
 
-@plugin.commands("first")
 def first_command(bot, trigger):
     pass
 
+first_command.commands = ["first"]
+first_command._sopel_callable = True
 
-@plugin.commands("second")
 def second_command(bot, trigger):
     pass
 
+second_command.commands = ["second"]
+second_command._sopel_callable = True
 
-@plugin.interval(5)
 def interval5s(bot):
     pass
 
+interval5s.interval = 5
+interval5s._sopel_callable = True
 
-@plugin.interval(10)
 def interval10s(bot):
     pass
 
+interval10s.interval = 10
+interval10s._sopel_callable = True
 
-@plugin.url(r'.\\.example\\.com')
 def example_url(bot, trigger, match=None):
     pass
 
+example_url.url_regex = [r'.\\.example\\.com']
+example_url._sopel_callable = True
 
 def loader(settings):
     return [re.compile(r'.+\\.example\\.com')]
 
-
-@plugin.url_lazy(loader)
 def example_url_lazy(bot, trigger):
     pass
 
+example_url_lazy.url_lazy_loaders = [loader]
+example_url_lazy._sopel_callable = True
 
-@plugin.rule_lazy(loader)
 def example_rule_lazy(bot, trigger):
     pass
 
+example_rule_lazy.rule_lazy_loaders = [loader]
+example_rule_lazy._sopel_callable = True
 
-@plugin.find_lazy(loader)
 def example_find_lazy(bot, trigger):
     pass
 
+example_find_lazy.find_rules_lazy_loaders = [loader]
+example_find_lazy._sopel_callable = True
 
-@plugin.search_lazy(loader)
 def example_search_lazy(bot, trigger):
     pass
 
+example_search_lazy.search_rules_lazy_loaders = [loader]
+example_search_lazy._sopel_callable = True
 
-@plugin.event('TOPIC')
 def on_topic_command(bot):
     pass
 
+on_topic_command.event = ['TOPIC']
+on_topic_command._sopel_callable = True
 
 def shutdown():
     pass
@@ -77,9 +86,11 @@ def ignored():
     pass
 
 
-@plugin.rate(10)
 def ignored_rate():
     pass
+
+
+ignored_rate.global_rate = 10
 
 
 class Ignored:
@@ -199,21 +210,28 @@ def test_clean_module(testplugin, tmpconfig):
     callables, jobs, shutdowns, urls = loader.clean_module(
         test_mod, tmpconfig)
 
+    func_callables = [c._handler for c in callables]
+
     assert len(callables) == 6
-    assert test_mod.first_command in callables
-    assert test_mod.second_command in callables
-    assert test_mod.on_topic_command in callables
-    assert test_mod.example_rule_lazy in callables
-    assert test_mod.example_find_lazy in callables
-    assert test_mod.example_search_lazy in callables
+    assert test_mod.first_command in func_callables
+    assert test_mod.second_command in func_callables
+    assert test_mod.on_topic_command in func_callables
+    assert test_mod.example_rule_lazy in func_callables
+    assert test_mod.example_find_lazy in func_callables
+    assert test_mod.example_search_lazy in func_callables
+
+    func_jobs = [c._handler for c in jobs]
     assert len(jobs) == 2
-    assert test_mod.interval5s in jobs
-    assert test_mod.interval10s in jobs
+    assert test_mod.interval5s in func_jobs
+    assert test_mod.interval10s in func_jobs
+
     assert len(shutdowns)
     assert test_mod.shutdown in shutdowns
+
+    func_urls = [c._handler for c in urls]
     assert len(urls) == 2
-    assert test_mod.example_url in urls
-    assert test_mod.example_url_lazy in urls
+    assert test_mod.example_url in func_urls
+    assert test_mod.example_url_lazy in func_urls
 
     # assert is_triggerable behavior *after* clean_module has been called
     assert loader.is_triggerable(test_mod.first_command)
@@ -271,10 +289,10 @@ def test_clean_module_idempotency(testplugin, tmpconfig):
     new_callables, new_jobs, new_shutdowns, new_urls = loader.clean_module(
         test_mod, tmpconfig)
 
-    assert new_callables == callables
-    assert new_jobs == jobs
-    assert new_shutdowns == shutdowns
-    assert new_urls == urls
+    assert len(new_callables) == 6
+    assert len(new_jobs) == 2
+    assert len(new_shutdowns) == 1
+    assert len(new_urls) == 2
 
     # assert is_triggerable behavior
     assert loader.is_triggerable(test_mod.first_command)
@@ -754,8 +772,17 @@ def test_clean_callable_events(tmpconfig, func):
 
 
 def test_clean_callable_example(tmpconfig, func):
-    plugin.commands('test')(func)
-    plugin.example('.test hello')(func)
+    func.commands = ['test']
+    func.example = [{
+        "example": '.test hello',
+        "result": None,
+        # flags
+        "is_private_message": True,
+        "is_help": False,
+        "is_pattern": False,
+        "is_admin": False,
+        "is_owner": False,
+    }]
 
     loader.clean_callable(func, tmpconfig)
 
@@ -770,7 +797,7 @@ def test_clean_callable_example(tmpconfig, func):
 
 
 def test_clean_callable_example_not_set(tmpconfig, func):
-    plugin.commands('test')(func)
+    func.commands = ['test']
 
     loader.clean_callable(func, tmpconfig)
 
@@ -785,9 +812,17 @@ def test_clean_callable_example_not_set(tmpconfig, func):
 
 
 def test_clean_callable_example_multi_commands(tmpconfig, func):
-    plugin.commands('test')(func)
-    plugin.commands('unit')(func)
-    plugin.example('.test hello')(func)
+    func.commands = ['test', 'unit']
+    func.example = [{
+        "example": '.test hello',
+        "result": None,
+        # flags
+        "is_private_message": True,
+        "is_help": False,
+        "is_pattern": False,
+        "is_admin": False,
+        "is_owner": False,
+    }]
 
     loader.clean_callable(func, tmpconfig)
 
@@ -806,9 +841,26 @@ def test_clean_callable_example_multi_commands(tmpconfig, func):
 
 
 def test_clean_callable_example_first_only(tmpconfig, func):
-    plugin.commands('test')(func)
-    plugin.example('.test hello')(func)
-    plugin.example('.test bonjour')(func)
+    func.commands = ['test']
+    func.example = [{
+        "example": '.test hello',
+        "result": None,
+        # flags
+        "is_private_message": True,
+        "is_help": False,
+        "is_pattern": False,
+        "is_admin": False,
+        "is_owner": False,
+    }, {
+        "example": '.test bonjour',
+        "result": None,
+        # flags
+        "is_private_message": True,
+        "is_help": False,
+        "is_pattern": False,
+        "is_admin": False,
+        "is_owner": False,
+    }]
 
     loader.clean_callable(func, tmpconfig)
 
@@ -822,10 +874,26 @@ def test_clean_callable_example_first_only(tmpconfig, func):
 
 
 def test_clean_callable_example_first_only_multi_commands(tmpconfig, func):
-    plugin.commands('test')(func)
-    plugin.commands('unit')(func)
-    plugin.example('.test hello')(func)
-    plugin.example('.test bonjour')(func)
+    func.commands = ['test', 'unit']
+    func.example = [{
+        "example": '.test hello',
+        "result": None,
+        # flags
+        "is_private_message": True,
+        "is_help": False,
+        "is_pattern": False,
+        "is_admin": False,
+        "is_owner": False,
+    }, {
+        "example": '.test bonjour',
+        "result": None,
+        # flags
+        "is_private_message": True,
+        "is_help": False,
+        "is_pattern": False,
+        "is_admin": False,
+        "is_owner": False,
+    }]
 
     loader.clean_callable(func, tmpconfig)
 
@@ -844,8 +912,17 @@ def test_clean_callable_example_first_only_multi_commands(tmpconfig, func):
 
 
 def test_clean_callable_example_user_help(tmpconfig, func):
-    plugin.commands('test')(func)
-    plugin.example('.test hello', user_help=True)(func)
+    func.commands = ['test']
+    func.example = [{
+        "example": '.test hello',
+        "result": None,
+        # flags
+        "is_private_message": True,
+        "is_help": True,
+        "is_pattern": False,
+        "is_admin": False,
+        "is_owner": False,
+    }]
 
     loader.clean_callable(func, tmpconfig)
 
@@ -859,9 +936,26 @@ def test_clean_callable_example_user_help(tmpconfig, func):
 
 
 def test_clean_callable_example_user_help_multi(tmpconfig, func):
-    plugin.commands('test')(func)
-    plugin.example('.test hello', user_help=True)(func)
-    plugin.example('.test bonjour', user_help=True)(func)
+    func.commands = ['test']
+    func.example = [{
+        "example": '.test hello',
+        "result": None,
+        # flags
+        "is_private_message": True,
+        "is_help": True,
+        "is_pattern": False,
+        "is_admin": False,
+        "is_owner": False,
+    }, {
+        "example": '.test bonjour',
+        "result": None,
+        # flags
+        "is_private_message": True,
+        "is_help": True,
+        "is_pattern": False,
+        "is_admin": False,
+        "is_owner": False,
+    }]
 
     loader.clean_callable(func, tmpconfig)
 
@@ -875,9 +969,26 @@ def test_clean_callable_example_user_help_multi(tmpconfig, func):
 
 
 def test_clean_callable_example_user_help_mixed(tmpconfig, func):
-    plugin.commands('test')(func)
-    plugin.example('.test hello')(func)
-    plugin.example('.test bonjour', user_help=True)(func)
+    func.commands = ['test']
+    func.example = [{
+        "example": '.test hello',
+        "result": None,
+        # flags
+        "is_private_message": True,
+        "is_help": False,
+        "is_pattern": False,
+        "is_admin": False,
+        "is_owner": False,
+    }, {
+        "example": '.test bonjour',
+        "result": None,
+        # flags
+        "is_private_message": True,
+        "is_help": True,
+        "is_pattern": False,
+        "is_admin": False,
+        "is_owner": False,
+    }]
 
     loader.clean_callable(func, tmpconfig)
 
@@ -891,8 +1002,17 @@ def test_clean_callable_example_user_help_mixed(tmpconfig, func):
 
 
 def test_clean_callable_example_default_prefix(tmpconfig, func):
-    plugin.commands('test')(func)
-    plugin.example('.test hello')(func)
+    func.commands = ['test']
+    func.example = [{
+        "example": '.test hello',
+        "result": None,
+        # flags
+        "is_private_message": True,
+        "is_help": False,
+        "is_pattern": False,
+        "is_admin": False,
+        "is_owner": False,
+    }]
 
     tmpconfig.core.help_prefix = '!'
     loader.clean_callable(func, tmpconfig)
@@ -907,8 +1027,17 @@ def test_clean_callable_example_default_prefix(tmpconfig, func):
 
 
 def test_clean_callable_example_nickname(tmpconfig, func):
-    plugin.commands('test')(func)
-    plugin.example('$nickname: hello')(func)
+    func.commands = ['test']
+    func.example = [{
+        "example": '$nickname: hello',
+        "result": None,
+        # flags
+        "is_private_message": True,
+        "is_help": False,
+        "is_pattern": False,
+        "is_admin": False,
+        "is_owner": False,
+    }]
 
     loader.clean_callable(func, tmpconfig)
 
@@ -922,8 +1051,17 @@ def test_clean_callable_example_nickname(tmpconfig, func):
 
 
 def test_clean_callable_example_nickname_custom_prefix(tmpconfig, func):
-    plugin.commands('test')(func)
-    plugin.example('$nickname: hello')(func)
+    func.commands = ['test']
+    func.example = [{
+        "example": '$nickname: hello',
+        "result": None,
+        # flags
+        "is_private_message": True,
+        "is_help": False,
+        "is_pattern": False,
+        "is_admin": False,
+        "is_owner": False,
+    }]
 
     tmpconfig.core.help_prefix = '!'
     loader.clean_callable(func, tmpconfig)

--- a/test/test_module.py
+++ b/test/test_module.py
@@ -196,7 +196,7 @@ def test_commands():
     def mock(bot, trigger, match):
         return True
     assert mock.commands == ['sopel']
-    assert not hasattr(mock, 'rule')
+    assert not mock.rules
 
 
 def test_commands_args():
@@ -204,7 +204,7 @@ def test_commands_args():
     def mock(bot, trigger, match):
         return True
     assert mock.commands == ['sopel', 'bot']
-    assert not hasattr(mock, 'rule')
+    assert not mock.rules
 
 
 def test_commands_multiple():
@@ -214,7 +214,7 @@ def test_commands_multiple():
     def mock(bot, trigger, match):
         return True
     assert mock.commands == ['robot', 'bot', 'sopel']
-    assert not hasattr(mock, 'rule')
+    assert not mock.rules
 
 
 def test_nickname_commands():
@@ -222,7 +222,7 @@ def test_nickname_commands():
     def mock(bot, trigger, match):
         return True
     assert mock.nickname_commands == ['sopel']
-    assert not hasattr(mock, 'rule')
+    assert not mock.rules
 
 
 def test_nickname_commands_args():
@@ -230,7 +230,7 @@ def test_nickname_commands_args():
     def mock(bot, trigger, match):
         return True
     assert mock.nickname_commands == ['sopel', 'bot']
-    assert not hasattr(mock, 'rule')
+    assert not mock.rules
 
 
 def test_nickname_commands_multiple():
@@ -240,7 +240,7 @@ def test_nickname_commands_multiple():
     def mock(bot, trigger, match):
         return True
     assert mock.nickname_commands == ['robot', 'bot', 'sopel']
-    assert not hasattr(mock, 'rule')
+    assert not mock.rules
 
 
 def test_action_commands():
@@ -248,8 +248,8 @@ def test_action_commands():
     def mock(bot, trigger, match):
         return True
     assert mock.action_commands == ['sopel']
-    assert not hasattr(mock, 'ctcp')
-    assert not hasattr(mock, 'rule')
+    assert not mock.ctcp
+    assert not mock.rules
 
 
 def test_action_commands_args():
@@ -257,8 +257,8 @@ def test_action_commands_args():
     def mock(bot, trigger, match):
         return True
     assert mock.action_commands == ['sopel', 'bot']
-    assert not hasattr(mock, 'ctcp')
-    assert not hasattr(mock, 'rule')
+    assert not mock.ctcp
+    assert not mock.rules
 
 
 def test_action_commands_multiple():
@@ -268,8 +268,8 @@ def test_action_commands_multiple():
     def mock(bot, trigger, match):
         return True
     assert mock.action_commands == ['robot', 'bot', 'sopel']
-    assert not hasattr(mock, 'ctcp')
-    assert not hasattr(mock, 'rule')
+    assert not mock.ctcp
+    assert not mock.rules
 
 
 def test_all_commands():
@@ -282,8 +282,8 @@ def test_all_commands():
     assert mock.commands == ['sopel']
     assert mock.action_commands == ['me_sopel']
     assert mock.nickname_commands == ['name_sopel']
-    assert not hasattr(mock, 'ctcp')
-    assert not hasattr(mock, 'rule')
+    assert not mock.ctcp
+    assert not mock.rules
 
 
 def test_priority():

--- a/test/test_plugin.py
+++ b/test/test_plugin.py
@@ -182,7 +182,7 @@ def test_url_lazy():
         return True
 
     assert mock.url_lazy_loaders == [loader]
-    assert not hasattr(mock, 'url_regex')
+    assert mock.url_regex == []
 
 
 def test_url_lazy_args():
@@ -197,7 +197,7 @@ def test_url_lazy_args():
         return True
 
     assert mock.url_lazy_loaders == [loader_1, loader_2]
-    assert not hasattr(mock, 'url_regex')
+    assert mock.url_regex == []
 
 
 def test_url_lazy_multiple():
@@ -213,7 +213,7 @@ def test_url_lazy_multiple():
         return True
 
     assert mock.url_lazy_loaders == [loader_1, loader_2]
-    assert not hasattr(mock, 'url_regex')
+    assert mock.url_regex == []
 
 
 def test_rule_lazy():
@@ -225,7 +225,7 @@ def test_rule_lazy():
         return True
 
     assert mock.rule_lazy_loaders == [loader]
-    assert not hasattr(mock, 'rule')
+    assert mock.rules == []
 
 
 def test_rule_lazy_args():
@@ -240,7 +240,7 @@ def test_rule_lazy_args():
         return True
 
     assert mock.rule_lazy_loaders == [loader_1, loader_2]
-    assert not hasattr(mock, 'rule')
+    assert mock.rules == []
 
 
 def test_rule_lazy_multiple():
@@ -256,7 +256,7 @@ def test_rule_lazy_multiple():
         return True
 
     assert mock.rule_lazy_loaders == [loader_1, loader_2]
-    assert not hasattr(mock, 'rule')
+    assert mock.rules == []
 
 
 def test_find_lazy():
@@ -268,8 +268,8 @@ def test_find_lazy():
         return True
 
     assert mock.find_rules_lazy_loaders == [loader]
-    assert not hasattr(mock, 'rule')
-    assert not hasattr(mock, 'find_rules')
+    assert mock.rules == []
+    assert mock.find_rules == []
 
 
 def test_find_lazy_args():
@@ -284,8 +284,8 @@ def test_find_lazy_args():
         return True
 
     assert mock.find_rules_lazy_loaders == [loader_1, loader_2]
-    assert not hasattr(mock, 'rule')
-    assert not hasattr(mock, 'find_rules')
+    assert mock.rules == []
+    assert mock.find_rules == []
 
 
 def test_find_lazy_multiple():
@@ -301,8 +301,8 @@ def test_find_lazy_multiple():
         return True
 
     assert mock.find_rules_lazy_loaders == [loader_1, loader_2]
-    assert not hasattr(mock, 'rule')
-    assert not hasattr(mock, 'find_rules')
+    assert mock.rules == []
+    assert mock.find_rules == []
 
 
 def test_search_lazy():
@@ -314,8 +314,8 @@ def test_search_lazy():
         return True
 
     assert mock.search_rules_lazy_loaders == [loader]
-    assert not hasattr(mock, 'rule')
-    assert not hasattr(mock, 'search_rules')
+    assert mock.rules == []
+    assert mock.search_rules == []
 
 
 def test_search_lazy_args():
@@ -330,8 +330,8 @@ def test_search_lazy_args():
         return True
 
     assert mock.search_rules_lazy_loaders == [loader_1, loader_2]
-    assert not hasattr(mock, 'rule')
-    assert not hasattr(mock, 'search_rules')
+    assert mock.rules == []
+    assert mock.search_rules == []
 
 
 def test_search_lazy_multiple():
@@ -347,8 +347,8 @@ def test_search_lazy_multiple():
         return True
 
     assert mock.search_rules_lazy_loaders == [loader_1, loader_2]
-    assert not hasattr(mock, 'rule')
-    assert not hasattr(mock, 'search_rules')
+    assert mock.rules == []
+    assert mock.search_rules == []
 
 
 def test_ctcp():
@@ -378,58 +378,62 @@ def test_rate_user():
         return True
     assert mock.user_rate == 10
     assert mock.user_rate_message is None
-    assert not hasattr(mock, 'channel_rate')
-    assert not hasattr(mock, 'global_rate')
-    assert not hasattr(mock, 'default_rate_message')
+    assert mock.channel_rate is None
+    assert mock.global_rate is None
+    assert mock.default_rate_message is None
 
     @plugin.rate_user(20, 'User rate message.')
     def mock(bot, trigger):
         return True
     assert mock.user_rate == 20
     assert mock.user_rate_message == 'User rate message.'
-    assert not hasattr(mock, 'channel_rate')
-    assert not hasattr(mock, 'global_rate')
-    assert not hasattr(mock, 'default_rate_message')
+    assert mock.channel_rate is None
+    assert mock.global_rate is None
+    assert mock.default_rate_message is None
 
 
 def test_rate_channel():
     @plugin.rate_channel(10)
     def mock(bot, trigger):
         return True
+    assert mock.user_rate is None
+    assert mock.user_rate_message is None
     assert mock.channel_rate == 10
     assert mock.channel_rate_message is None
-    assert not hasattr(mock, 'user_rate')
-    assert not hasattr(mock, 'global_rate')
-    assert not hasattr(mock, 'default_rate_message')
+    assert mock.default_rate_message is None
 
     @plugin.rate_channel(20, 'Channel rate message.')
     def mock(bot, trigger):
         return True
+    assert mock.user_rate is None
+    assert mock.user_rate_message is None
     assert mock.channel_rate == 20
     assert mock.channel_rate_message == 'Channel rate message.'
-    assert not hasattr(mock, 'user_rate')
-    assert not hasattr(mock, 'global_rate')
-    assert not hasattr(mock, 'default_rate_message')
+    assert mock.default_rate_message is None
 
 
 def test_rate_global():
     @plugin.rate_global(10)
     def mock(bot, trigger):
         return True
+
+    assert mock.user_rate is None
+    assert mock.user_rate_message is None
+    assert mock.channel_rate is None
+    assert mock.channel_rate_message is None
     assert mock.global_rate == 10
     assert mock.global_rate_message is None
-    assert not hasattr(mock, 'user_rate')
-    assert not hasattr(mock, 'channel_rate')
-    assert not hasattr(mock, 'default_rate_message')
 
     @plugin.rate_global(20, 'Server rate message.')
     def mock(bot, trigger):
         return True
+
+    assert mock.user_rate is None
+    assert mock.user_rate_message is None
+    assert mock.channel_rate is None
+    assert mock.channel_rate_message is None
     assert mock.global_rate == 20
     assert mock.global_rate_message == 'Server rate message.'
-    assert not hasattr(mock, 'user_rate')
-    assert not hasattr(mock, 'channel_rate')
-    assert not hasattr(mock, 'default_rate_message')
 
 
 def test_rate_combine_rate_decorators():

--- a/test/tools/test_tools_jobs.py
+++ b/test/tools/test_tools_jobs.py
@@ -5,7 +5,7 @@ import time
 
 import pytest
 
-from sopel import loader, plugin
+from sopel import plugin
 from sopel.tools import jobs
 
 
@@ -205,7 +205,7 @@ def test_job_from_callable(mockconfig):
         """The job's docstring."""
         return 'tested'
 
-    loader.clean_callable(handler, mockconfig)
+    handler.setup(mockconfig)
     handler.plugin_name = 'testplugin'
 
     job = jobs.Job.from_callable(mockconfig, handler)


### PR DESCRIPTION
### Description

Behold! Plugin's decorators are now creating plugin objects, instead of adding type unsafe attributes to functions.

This is theorically backward compatible with Sopel 8.0 and below's system of plugin callable (i.e. functions only).

The `sopel.loader` module is still present, and still works. It should be easier to deprecate it, to be removed in Sopel 9.

This is minor effects on the bot itself, this is more an enabler for what's to come, opening a wide arrayd of possibilities for plugin author in term of customization of plugin callables.

The `require_*` decorators are not properly handled yet, even tho they still work "as is", they might be too dependent on the order in which they are used to decorate a callable. This will be fixed in a future commit.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
