### PR TITLE
coretasks: handle '*' placeholder for omitted channel in WHO/WHOX RPLs

### DIFF
--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -1537,6 +1537,11 @@ def _record_who(
         usr.away = away
     if is_bot is not None:
         usr.is_bot = is_bot
+
+    # `*` placeholder is returned for users with no visible channels; see #2675
+    if channel == '*':
+        return
+
     priv = 0
     if modes:
         mapping = {
@@ -1549,6 +1554,7 @@ def _record_who(
         }
         for c in modes:
             priv = priv | mapping[c]
+
     if channel not in bot.channels:
         bot.channels[channel] = target.Channel(
             channel,


### PR DESCRIPTION
### Description

Tin. Fixes #2675.

Also explicitly tests the `0` placeholder for missing account name in WHOX (regular WHO doesn't send that). We do not request the other fields that could have placeholders (`ip` and `oplevel`) in WHOX.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes

Yes, possibly the test assertions are a bit overkill. `assert`ing is cheap, and I would like to be extra sure.