### PR TITLE
dev: cap `flake8-import-order` to avoid bugs & Python 3.8 deprecation

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,8 +3,9 @@ coveralls>=2.0
 flake8>=5
 flake8-coding
 flake8-future-import
-# TODO: upgrade 'flake8-import-order' to 0.19 and address new ordering &
-# whitespace checks when dropping Python 3.8 from Sopel's support matrix
+# 'flake8-import-order' 0.19 adds slightly broken checks for TYPE_CHECKING
+# blocks; see https://github.com/PyCQA/flake8-import-order/issues/214
+# Pinned because of that, and because it drops support for Python 3.8
 flake8-import-order<0.19
 flake8-type-checking; python_version >= '3.8'
 # Sphinx theme

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,7 +3,9 @@ coveralls>=2.0
 flake8>=5
 flake8-coding
 flake8-future-import
-flake8-import-order
+# TODO: upgrade 'flake8-import-order' to 0.19 and address new ordering &
+# whitespace checks when dropping Python 3.8 from Sopel's support matrix
+flake8-import-order<0.19
 flake8-type-checking; python_version >= '3.8'
 # Sphinx theme
 furo==2023.9.10


### PR DESCRIPTION
### Description

flake8-import-order 0.19.0, released earlier this week, drops support for Python 3.7 & 3.8.

It also adds some new ordering & whitespace checks we need to fix in our code before upgrading, too.

### Checklist

_This PR is to fix a CI failure, and is therefore intentionally submitted without running the checks locally first._

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [ ] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches