### PR TITLE
Replace flake8-import-order with flake8-isort

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,10 +3,7 @@ coveralls>=2.0
 flake8>=5
 flake8-coding
 flake8-future-import
-# 'flake8-import-order' 0.19 adds slightly broken checks for TYPE_CHECKING
-# blocks; see https://github.com/PyCQA/flake8-import-order/issues/214
-# Pinned because of that, and because it drops support for Python 3.8
-flake8-import-order<0.19
+flake8-isort
 flake8-type-checking; python_version >= '3.8'
 # Sphinx theme
 furo==2023.9.10

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -1,4 +1,10 @@
 from __future__ import generator_stop
+
+from datetime import date
+
+from sopel import __version__
+
+
 # Sopel IRC Bot documentation build configuration file, created by
 # sphinx-quickstart on Mon Jul 16 23:45:29 2012.
 #
@@ -10,9 +16,7 @@ from __future__ import generator_stop
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-from datetime import date
 
-from sopel import __version__
 
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,18 @@ sopel-plugins = "sopel.cli.plugins:main"
 [project.entry-points.pytest11]
 pytest-sopel = "sopel.tests.pytest_plugin"
 
+[tool.isort]
+combine_as_imports = true
+ensure_newline_before_comments = true
+force_sort_within_sections = true
+include_trailing_comma = true
+line_length = 79
+lines_after_imports = 2
+multi_line_output = 3
+order_by_type = false
+split_on_trailing_comma = true
+use_parentheses = true
+
 [tool.pytest.ini_options]
 # NOTE: sopel/ is included here to include dynamically-generated tests
 testpaths = ["test", "sopel"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,6 @@
 [flake8]
 max-line-length = 79
-application-import-names = sopel
 type-checking-exempt-modules = typing
-import-order-style = google
 ignore =
     # Line length limit. Acceptable (for now).
     E501,

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -38,11 +38,13 @@ from sopel.plugins import (
 from sopel.tools import jobs as tools_jobs
 from sopel.trigger import Trigger
 
+
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
 
     from sopel.plugins.handlers import (
-        AbstractPluginHandler, PluginMetaDescription,
+        AbstractPluginHandler,
+        PluginMetaDescription,
     )
     from sopel.trigger import PreTrigger
 

--- a/sopel/builtins/admin.py
+++ b/sopel/builtins/admin.py
@@ -16,6 +16,7 @@ import logging
 from sopel import plugin
 from sopel.config import types
 
+
 LOGGER = logging.getLogger(__name__)
 
 ERROR_JOIN_NO_CHANNEL = 'Which channel should I join?'

--- a/sopel/builtins/clock.py
+++ b/sopel/builtins/clock.py
@@ -14,8 +14,9 @@ from sopel.tools.time import (
     get_channel_timezone,
     get_nick_timezone,
     get_timezone,
-    validate_timezone
+    validate_timezone,
 )
+
 
 PLUGIN_OUTPUT_PREFIX = '[clock] '
 ERROR_NO_TIMEZONE = (

--- a/sopel/builtins/dice.py
+++ b/sopel/builtins/dice.py
@@ -16,6 +16,7 @@ from typing import TYPE_CHECKING
 from sopel import plugin
 from sopel.tools.calculation import eval_equation
 
+
 if TYPE_CHECKING:
     from sopel.bot import SopelWrapper
     from sopel.trigger import Trigger

--- a/sopel/builtins/safety.py
+++ b/sopel/builtins/safety.py
@@ -24,6 +24,7 @@ from sopel import plugin, tools
 from sopel.config import types
 from sopel.formatting import bold, color, colors
 
+
 if TYPE_CHECKING:
     from typing import Optional
 

--- a/sopel/builtins/search.py
+++ b/sopel/builtins/search.py
@@ -16,6 +16,7 @@ import xmltodict  # type: ignore[import]
 from sopel import plugin
 from sopel.tools import web
 
+
 PLUGIN_OUTPUT_PREFIX = '[search] '
 
 header_spoof = {

--- a/sopel/builtins/url.py
+++ b/sopel/builtins/url.py
@@ -24,6 +24,7 @@ from urllib3.exceptions import LocationValueError  # type: ignore[import]
 from sopel import plugin, privileges, tools
 from sopel.config import types
 
+
 if TYPE_CHECKING:
     from collections.abc import Generator
     from typing import Iterable

--- a/sopel/builtins/wiktionary.py
+++ b/sopel/builtins/wiktionary.py
@@ -14,6 +14,7 @@ import requests
 from sopel import plugin
 from sopel.tools import web
 
+
 PLUGIN_OUTPUT_PREFIX = '[wiktionary] '
 
 uri = 'https://en.wiktionary.org/w/index.php?title=%s&printable=yes'

--- a/sopel/builtins/xkcd.py
+++ b/sopel/builtins/xkcd.py
@@ -19,6 +19,7 @@ import requests
 from sopel import plugin
 from sopel.builtins.search import duck_search
 
+
 LOGGER = logging.getLogger(__name__)
 PLUGIN_OUTPUT_PREFIX = '[xkcd] '
 

--- a/sopel/cli/__init__.py
+++ b/sopel/cli/__init__.py
@@ -5,5 +5,5 @@ from .utils import (  # noqa
     add_common_arguments,
     enumerate_configs,
     find_config,
-    load_settings
+    load_settings,
 )

--- a/sopel/cli/plugins.py
+++ b/sopel/cli/plugins.py
@@ -6,6 +6,7 @@ import inspect
 import operator
 
 from sopel import config, plugins
+
 from . import utils
 
 

--- a/sopel/cli/run.py
+++ b/sopel/cli/run.py
@@ -17,7 +17,9 @@ import sys
 import time
 
 from sopel import __version__, bot, config, logger
+
 from . import utils
+
 
 # This is in case someone somehow manages to install Sopel on an old version
 # of pip (<9.0.0), which doesn't know about `python_requires`, or tries to run

--- a/sopel/cli/utils.py
+++ b/sopel/cli/utils.py
@@ -7,6 +7,7 @@ import sys
 
 from sopel import config, plugins
 
+
 # Allow clean import *
 __all__ = [
     'enumerate_configs',

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -36,6 +36,7 @@ from sopel import config, plugin
 from sopel.irc import isupport, utils
 from sopel.tools import events, jobs, SopelMemory, target
 
+
 if TYPE_CHECKING:
     from sopel.bot import Sopel, SopelWrapper
     from sopel.tools import Identifier

--- a/sopel/db.py
+++ b/sopel/db.py
@@ -31,6 +31,7 @@ from sqlalchemy.sql import delete, func, select, update
 from sopel.lifecycle import deprecated
 from sopel.tools.identifiers import Identifier, IdentifierFactory
 
+
 if typing.TYPE_CHECKING:
     from collections.abc import Iterable
 

--- a/sopel/irc/__init__.py
+++ b/sopel/irc/__init__.py
@@ -45,13 +45,17 @@ from typing import (
 from sopel import tools, trigger
 from sopel.lifecycle import deprecated
 from sopel.tools import identifiers, memories
+
 from .backends import AsyncioBackend, UninitializedBackend
 from .capabilities import Capabilities
 from .isupport import ISupport
 
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
+
     from sopel.config import Config
+
     from .abstract_backends import AbstractIRCBackend
     from .utils import MyInfo
 

--- a/sopel/irc/modes.py
+++ b/sopel/irc/modes.py
@@ -39,6 +39,7 @@ from typing import (
     TYPE_CHECKING,
 )
 
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 

--- a/sopel/module.py
+++ b/sopel/module.py
@@ -8,18 +8,19 @@
 from __future__ import annotations
 
 from sopel.lifecycle import deprecated
+
 # Import everything from sopel.plugin at the time of replacement.
 # Everything new from this point on must *not* leak here.
 # Therefore, don't add anything to this import list. Ever.
 from sopel.plugin import (  # noqa
-    ADMIN,
     action_commands,
+    ADMIN,
     commands,
+    ctcp as _future_ctcp,
     echo,
     event,
     example,
     HALFOP,
-    ctcp as _future_ctcp,
     interval,
     nickname_commands,
     NOLIMIT,

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -26,6 +26,7 @@ from typing import (
 # import and expose privileges as shortcut
 from sopel.privileges import AccessLevel
 
+
 VOICE = AccessLevel.VOICE
 HALFOP = AccessLevel.HALFOP
 OP = AccessLevel.OP
@@ -36,6 +37,7 @@ OPER = AccessLevel.OPER
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+
     from sopel.bot import SopelWrapper
 
 __all__ = [

--- a/sopel/plugins/__init__.py
+++ b/sopel/plugins/__init__.py
@@ -43,6 +43,7 @@ import importlib_metadata
 
 from . import exceptions, handlers, rules  # noqa
 
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
 

--- a/sopel/plugins/capabilities.py
+++ b/sopel/plugins/capabilities.py
@@ -24,6 +24,7 @@ from typing import (
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterable
+
     from sopel.bot import Sopel, SopelWrapper
     from sopel.plugin import capability, CapabilityNegotiation
 

--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -54,6 +54,7 @@ import sys
 from typing import ClassVar, TYPE_CHECKING, TypedDict
 
 from sopel import __version__ as release, loader, plugin as plugin_decorators
+
 from . import exceptions
 
 

--- a/sopel/plugins/jobs.py
+++ b/sopel/plugins/jobs.py
@@ -22,6 +22,7 @@ import logging
 from sopel import tools
 from sopel.tools import jobs
 
+
 LOGGER = logging.getLogger(__name__)
 
 

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -36,7 +36,11 @@ from urllib.parse import urlparse
 
 from sopel import tools
 from sopel.config.core_section import (
-    COMMAND_DEFAULT_HELP_PREFIX, COMMAND_DEFAULT_PREFIX, URL_DEFAULT_SCHEMES)
+    COMMAND_DEFAULT_HELP_PREFIX,
+    COMMAND_DEFAULT_PREFIX,
+    URL_DEFAULT_SCHEMES,
+)
+
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterable

--- a/sopel/tests/factories.py
+++ b/sopel/tests/factories.py
@@ -8,7 +8,9 @@ import re
 from typing import Optional, TYPE_CHECKING
 
 from sopel import bot, config, plugins, trigger
+
 from .mocks import MockIRCBackend, MockIRCServer, MockUser
+
 
 if TYPE_CHECKING:
     from collections.abc import Iterable

--- a/sopel/tests/mocks.py
+++ b/sopel/tests/mocks.py
@@ -4,7 +4,6 @@
 """
 from __future__ import annotations
 
-
 from sopel.irc.abstract_backends import AbstractIRCBackend
 
 

--- a/sopel/tests/pytest_plugin.py
+++ b/sopel/tests/pytest_plugin.py
@@ -10,7 +10,14 @@ import sys
 import pytest
 
 from sopel import bot, loader, plugins, trigger
-from .factories import BotFactory, ConfigFactory, IRCFactory, TriggerFactory, UserFactory
+
+from .factories import (
+    BotFactory,
+    ConfigFactory,
+    IRCFactory,
+    TriggerFactory,
+    UserFactory,
+)
 
 
 TEMPLATE_TEST_CONFIG = """

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -20,6 +20,8 @@ import sys
 
 # Don't delete `deprecated` import - maintains backward compatibility with pre-8.0 API
 from sopel.lifecycle import deprecated
+
+from . import time, web  # NOQA
 from ._events import events  # NOQA
 
 # shortcuts & backward compatibility with pre-8.0
@@ -29,7 +31,6 @@ from .memories import (  # NOQA
     SopelMemory,
     SopelMemoryWithDefault,
 )
-from . import time, web  # NOQA
 
 
 # Long kept for Python compatibility, but it's time we let these go.

--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -18,7 +18,8 @@ import logging
 import re
 import sys
 
-from sopel.lifecycle import deprecated  # Don't delete; maintains backward compatibility with pre-8.0 API
+# Don't delete `deprecated` import - maintains backward compatibility with pre-8.0 API
+from sopel.lifecycle import deprecated
 from ._events import events  # NOQA
 
 # shortcuts & backward compatibility with pre-8.0

--- a/sopel/tools/calculation.py
+++ b/sopel/tools/calculation.py
@@ -14,6 +14,7 @@ import operator
 import time
 from typing import TYPE_CHECKING
 
+
 if TYPE_CHECKING:
     from typing import Callable, Optional
 

--- a/sopel/tools/identifiers.py
+++ b/sopel/tools/identifiers.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 import string
 from typing import Callable
 
+
 Casemapping = Callable[[str], str]
 """Type definition of a casemapping callable."""
 

--- a/sopel/tools/memories.py
+++ b/sopel/tools/memories.py
@@ -14,6 +14,7 @@ from typing_extensions import override
 
 from .identifiers import Identifier, IdentifierFactory
 
+
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
     from typing import Tuple

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -8,6 +8,7 @@ from sopel.privileges import AccessLevel
 from sopel.tools import memories
 from sopel.tools.identifiers import Identifier, IdentifierFactory
 
+
 if TYPE_CHECKING:
     import datetime
 

--- a/sopel/tools/time.py
+++ b/sopel/tools/time.py
@@ -13,6 +13,7 @@ from typing import cast, NamedTuple, Optional, TYPE_CHECKING, Union
 
 import pytz
 
+
 if TYPE_CHECKING:
     from sopel.config import Config
     from sopel.db import SopelDB

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -23,6 +23,7 @@ from sopel import formatting, tools
 from sopel.tools import web
 from sopel.tools.identifiers import Identifier, IdentifierFactory
 
+
 if TYPE_CHECKING:
     from sopel import config
 

--- a/test/builtins/test_builtins_safety.py
+++ b/test/builtins/test_builtins_safety.py
@@ -6,6 +6,7 @@ import pytest
 
 from sopel.builtins.safety import safeify_url
 
+
 URL_TESTS = (
     # Valid URLs
     ("http://example.com", ("hxxp://example[.]com")),

--- a/test/coretasks/test_coretasks_cap.py
+++ b/test/coretasks/test_coretasks_cap.py
@@ -8,6 +8,7 @@ import pytest
 from sopel import config, plugin
 from sopel.tests import rawlist
 
+
 if TYPE_CHECKING:
     from sopel.bot import Sopel, SopelWrapper
     from sopel.config import Config

--- a/test/coretasks/test_coretasks_sasl.py
+++ b/test/coretasks/test_coretasks_sasl.py
@@ -8,6 +8,7 @@ import pytest
 from sopel import coretasks
 from sopel.tests import rawlist
 
+
 if TYPE_CHECKING:
     from sopel.config import Config
     from sopel.tests.factories import BotFactory, ConfigFactory

--- a/test/irc/test_irc_capabilities.py
+++ b/test/irc/test_irc_capabilities.py
@@ -7,6 +7,7 @@ import pytest
 
 from sopel.irc.capabilities import Capabilities, CapabilityInfo
 
+
 if typing.TYPE_CHECKING:
     from sopel.tests.factories import TriggerFactory
 

--- a/test/irc/test_irc_modes.py
+++ b/test/irc/test_irc_modes.py
@@ -10,6 +10,7 @@ from sopel.irc.modes import (
     parse_modestring,
 )
 
+
 ADDED = True
 REMOVED = False
 REQUIRED = True

--- a/test/test_bot.py
+++ b/test/test_bot.py
@@ -16,7 +16,11 @@ from sopel.tools import Identifier, SopelMemory, target
 if typing.TYPE_CHECKING:
     from sopel.config import Config
     from sopel.tests.factories import (
-        BotFactory, ConfigFactory, IRCFactory, TriggerFactory, UserFactory,
+        BotFactory,
+        ConfigFactory,
+        IRCFactory,
+        TriggerFactory,
+        UserFactory,
     )
     from sopel.tests.mocks import MockIRCServer
 


### PR DESCRIPTION
### Description

Replaces flake8-import-order with flake8-isort, configuring the latter to match our current style as closely as possible.

isort can do the sorting automatically and seems more comprehensive, more configurable without code, and can (now?) be configured to match our preferences. See also https://github.com/PyCQA/flake8-import-order/issues/163

@dgw would you prefer removing the no_lines_before? "I don't actually like squishing the PROJECT and LOCAL groups together" in https://github.com/sopel-irc/sopel/pull/1752#issuecomment-631117207

Alternative to #2680

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
