### PR TITLE
bot, coretasks, config: add `hostmask` block type

### DIFF
--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -1138,11 +1138,18 @@ class Sopel(irc.AbstractBot):
                 return True
         return False
 
-    def _hostmask_blocked(self, hostmask: str) -> bool:
+    def _hostmask_blocked(self, hostmask: str | None) -> bool:
         """Check if a hostmask is blocked.
 
         :param hostmask: the hostmask to check
+
+        ``PreTrigger.hostmask`` can be ``None`` if the incoming line did not
+        include a source, in which case this method always returns ``False``.
         """
+        if not hostmask:
+            # None, or empty string, cannot match any masks
+            return False
+
         bad_masks = self.config.core.hostmask_blocks
         for bad_mask in bad_masks:
             bad_mask = bad_mask.strip()

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -878,16 +878,18 @@ class Sopel(irc.AbstractBot):
     def _is_pretrigger_blocked(
         self,
         pretrigger: PreTrigger,
-    ) -> Union[tuple[bool, bool], tuple[None, None]]:
+    ) -> tuple[bool, bool, bool] | tuple[None, None, None]:
         if not (
             self.settings.core.nick_blocks
             or self.settings.core.host_blocks
+            or self.settings.core.hostmask_blocks
         ):
-            return (None, None)
+            return (None, None, None)
 
         nick_blocked = self._nick_blocked(pretrigger.nick)
         host_blocked = self._host_blocked(pretrigger.host)
-        return (nick_blocked, host_blocked)
+        hostmask_blocked = self._hostmask_blocked(pretrigger.hostmask)
+        return (nick_blocked, host_blocked, hostmask_blocked)
 
     def dispatch(self, pretrigger: PreTrigger) -> None:
         """Dispatch a parsed message to any registered callables.
@@ -911,8 +913,10 @@ class Sopel(irc.AbstractBot):
         # list of commands running in separate threads for this dispatch
         running_triggers = []
         # nickname/hostname blocking
-        nick_blocked, host_blocked = self._is_pretrigger_blocked(pretrigger)
-        blocked = bool(nick_blocked or host_blocked)
+        nick_blocked, host_blocked, hostmask_blocked = (
+            self._is_pretrigger_blocked(pretrigger)
+        )
+        blocked = bool(nick_blocked or host_blocked or hostmask_blocked)
         list_of_blocked_rules = set()
         # account info
         nick = pretrigger.nick
@@ -953,17 +957,18 @@ class Sopel(irc.AbstractBot):
         self._update_running_triggers(running_triggers)
 
         if list_of_blocked_rules:
-            if nick_blocked and host_blocked:
-                block_type = 'both blocklists'
-            elif nick_blocked:
-                block_type = 'nick blocklist'
-            else:
-                block_type = 'host blocklist'
+            block_types = []
+            if nick_blocked:
+                block_types.append('nick')
+            if host_blocked:
+                block_types.append('host')
+            if hostmask_blocked:
+                block_types.append('hostmask')
             LOGGER.debug(
-                "%s prevented from using %s by %s.",
+                "%s prevented from using %s by %s blocklist(s).",
                 pretrigger.nick,
                 ', '.join(list_of_blocked_rules),
-                block_type,
+                ', '.join(block_types),
             )
 
     @property
@@ -1131,6 +1136,21 @@ class Sopel(irc.AbstractBot):
                 continue
             if (re.match(bad_mask + '$', host, re.IGNORECASE) or
                     bad_mask == host):
+                return True
+        return False
+
+    def _hostmask_blocked(self, hostmask: str) -> bool:
+        """Check if a hostmask is blocked.
+
+        :param hostmask: the hostmask to check
+        """
+        bad_masks = self.config.core.hostmask_blocks
+        for bad_mask in bad_masks:
+            bad_mask = bad_mask.strip()
+            if not bad_mask:
+                continue
+            if (re.match(bad_mask + '$', hostmask, re.IGNORECASE) or
+                    bad_mask == hostmask):
                 return True
         return False
 

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -24,7 +24,6 @@ from typing import (
     Sequence,
     TYPE_CHECKING,
     TypeVar,
-    Union,
 )
 
 from sopel import db, irc, logger, plugin, plugins, tools

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -794,6 +794,38 @@ class CoreSection(StaticSection):
 
         The :attr:`nick_blocks` list can be used to block users by their nick.
 
+        The :attr:`hostmask_blocks` list can be used to block users by matching
+        their full hostmask.
+
+    .. note::
+
+        :ref:`Plugin callables` with the :func:`.plugin.unblockable` decorator
+        run regardless of matching ``*_blocks`` entries.
+
+        We are working toward a better block system; see :issue:`1355` for more
+        information and updates.
+
+    """
+
+    hostmask_blocks = ListAttribute('hostmask_blocks')
+    """A list of hostmasks which Sopel should ignore.
+
+    Sopel will :ref:`ignore <Ignoring Users>` messages from any user whose
+    full hostmask (``nick!username@host``) matches one of these values.
+    :ref:`Regular expression syntax <re-syntax>` is supported, so remember to
+    escape special characters:
+
+    .. code-block:: ini
+
+        hostmask_blocks =
+            Guest.*!.*@spammydomain\\.com
+
+    .. seealso::
+
+        The :attr:`nick_blocks` list can be used to block users by nick only.
+
+        The :attr:`host_blocks` list can be used to block users by hostname only.
+
     .. note::
 
         :ref:`Plugin callables` with the :func:`.plugin.unblockable` decorator
@@ -1057,6 +1089,9 @@ class CoreSection(StaticSection):
     .. seealso::
 
         The :attr:`host_blocks` list can be used to block users by their host.
+
+        The :attr:`hostmask_blocks` list can be used to block users by matching
+        their full hostmask.
 
     .. note::
 

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -1354,6 +1354,7 @@ def _get_sasl_pass_and_mech(bot):
 
 @plugin.commands('blocks')
 @plugin.example(r'.blocks del nick falsep0sitive', user_help=True)
+@plugin.example(r'.blocks add hostmask Guest.*!.*@public\.test\.client', user_help=True)
 @plugin.example(r'.blocks add host some\.malicious\.network', user_help=True)
 @plugin.example(r'.blocks add nick sp(a|4)mb(o|0)t\d*', user_help=True)
 @plugin.thread(False)
@@ -1363,19 +1364,21 @@ def _get_sasl_pass_and_mech(bot):
 def blocks(bot, trigger):
     """Manage Sopel's blocking features.
 
-    Full argspec: `list [nick|host]` or `[add|del] [nick|host] pattern`
+    Full argspec: `list [nick|host|hostmask]` or `[add|del] [nick|host|hostmask] pattern`
     """
     STRINGS = {
         "success_del": "Successfully deleted block: %s",
         "success_add": "Successfully added block: %s",
         "no_nick": "No matching nick block found for: %s",
         "no_host": "No matching host block found for: %s",
-        "invalid": "Invalid format for %s a block. Try: .blocks add (nick|host) sopel",
+        "no_hostmask": "No matching hostmask block found for: %s",
+        "invalid": "Invalid format for %s a block. Try: .blocks add (nick|host|hostmask) pattern",
         "invalid_display": "Invalid input for displaying blocks.",
         "nonelisted": "No %s listed in the blocklist.",
         'huh': "I could not figure out what you wanted to do.",
     }
 
+    hostmasks = set(s for s in bot.config.core.hostmask_blocks if s != '')
     hosts = set(s for s in bot.config.core.host_blocks if s != '')
     nicks = set(bot.make_identifier(nick)
                 for nick in bot.config.core.nick_blocks
@@ -1395,6 +1398,12 @@ def blocks(bot, trigger):
                 bot.say("Blocked nicks: {}".format(blocked))
             else:
                 bot.reply(STRINGS['nonelisted'] % ('nicks'))
+        elif text[2] == "hostmask":
+            if len(hostmasks) > 0:
+                blocked = ', '.join(str(hostmask) for hostmask in hostmasks)
+                bot.say("Blocked hostmasks: {}".format(blocked))
+            else:
+                bot.reply(STRINGS['nonelisted'] % ('hostmasks'))
         else:
             bot.reply(STRINGS['invalid_display'])
 
@@ -1406,6 +1415,10 @@ def blocks(bot, trigger):
         elif text[2] == "host":
             hosts.add(text[3].lower())
             bot.config.core.host_blocks = list(hosts)
+            bot.config.save()
+        elif text[2] == "hostmask":
+            hostmasks.add(text[3])
+            bot.config.core.hostmask_blocks = list(hostmasks)
             bot.config.save()
         else:
             bot.reply(STRINGS['invalid'] % ("adding"))
@@ -1430,6 +1443,15 @@ def blocks(bot, trigger):
                 return
             hosts.remove(host)
             bot.config.core.host_blocks = [str(m) for m in hosts]
+            bot.config.save()
+            bot.reply(STRINGS['success_del'] % (text[3]))
+        elif text[2] == "hostmask":
+            hostmask = text[3]
+            if hostmask not in hostmasks:
+                bot.reply(STRINGS['no_hostmask'] % (text[3]))
+                return
+            hostmasks.remove(hostmask)
+            bot.config.core.hostmask_blocks = [str(m) for m in hostmasks]
             bot.config.save()
             bot.reply(STRINGS['success_del'] % (text[3]))
         else:

--- a/test/bot/test_bot_blocking.py
+++ b/test/bot/test_bot_blocking.py
@@ -1,0 +1,99 @@
+"""Tests of the bot's blocking/ignoring features.
+
+The ``[core]`` config section contains three lists that can be used to
+block/ignore users:
+
+- ``host_blocks``: hostnames
+- ``hostmask_blocks``: hostmasks
+- ``nick_blocks``: nicknames
+
+After we complete enhancements to the ignore system (see issue 1355), the tests
+here can be expanded to check both regex and non-regex pattern behavior in
+various combinations. For now, each setting is checked in isolation and we
+simply trust that ``or`` logic works as expected.
+"""
+from __future__ import annotations
+
+import typing
+
+import pytest
+
+from sopel import bot, trigger
+
+if typing.TYPE_CHECKING:
+    from sopel.config import Config
+    from sopel.tests.factories import BotFactory, ConfigFactory
+
+
+BASE_CONFIG = """
+[core]
+owner = testnick
+nick = TestBot
+enable = coretasks
+"""
+
+NICK_CONFIG = f"""
+{BASE_CONFIG}
+nick_blocks =
+    spamuser
+    escaped\\[user\\]
+"""
+
+HOST_CONFIG = f"""
+{BASE_CONFIG}
+host_blocks =
+    spamhost\\.com
+"""
+
+HOSTMASK_CONFIG = f"""
+{BASE_CONFIG}
+hostmask_blocks =
+    spamuser!.*@spamhost\\.com
+"""
+
+
+def mockbot(
+    botfactory: BotFactory,
+    configfactory: ConfigFactory,
+    config: Config,
+) -> bot.Sopel:
+    return botfactory(configfactory('test.cfg', config))
+
+
+def test_is_pretrigger_blocked_empty(
+    configfactory: ConfigFactory,
+    botfactory: BotFactory,
+):
+    """Test that no user is blocked when no blocking settings are configured."""
+    bot = mockbot(botfactory, configfactory, BASE_CONFIG)
+
+    # basic "hello" message from a user
+    line = ':Foo!foo@example.com PRIVMSG #sopel :hello'
+    pretrigger = trigger.PreTrigger(bot.nick, line)
+
+    assert bot._is_pretrigger_blocked(pretrigger) == (None, None, None)
+
+
+@pytest.mark.parametrize(
+    'cfg, result',
+    [
+        (NICK_CONFIG, (True, False, False)),
+        (HOST_CONFIG, (False, True, False)),
+        (HOSTMASK_CONFIG, (False, False, True)),
+    ],
+    ids=['nick_blocks', 'host_blocks', 'hostmask_blocks'],
+)
+def test_is_pretrigger_blocked_single(
+    configfactory: ConfigFactory,
+    botfactory: BotFactory,
+    cfg: str,
+    result: tuple[bool, bool, bool],
+):
+    """Test that each block type returns ``True`` in the correct tuple slot."""
+    bot = mockbot(botfactory, configfactory, cfg)
+
+    # basic "hello" message from a blocked user
+    line = ':spamuser!notevil@spamhost.com PRIVMSG #sopel :hello'
+    pretrigger = trigger.PreTrigger(bot.nick, line)
+
+    assert bot._is_pretrigger_blocked(pretrigger) == result


### PR DESCRIPTION
### Description

What it says on the tin. Sub-task of #1355, closes #2686.

**[Tests added July 5]** _Previous status:_ Beginning in draft status; while the current test suite passes, I haven't yet gone through the test cases to add any specific checks that might be warranted for this new feature. So far, I've only (…almost) proved that it doesn't break any existing behavior.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
