### PR TITLE
config.types: add SetAttribute type, based on ListAttribute

### DIFF
--- a/sopel/config/types.py
+++ b/sopel/config/types.py
@@ -623,6 +623,40 @@ class ListAttribute(BaseValidated):
         return self._parse(values, parent, section)
 
 
+class SetAttribute(ListAttribute):
+    """A config attribute containing a set of string values.
+
+    :type default: set
+
+    Constructor parameters are the same as for :class:`ListAttribute`, except
+    that ``default`` should be a ``set`` instead of a ``list``.
+
+    Configuration file semantics are also the same as :class:`ListAttribute`.
+    """
+    def parse(self, value):
+        """Parse ``value`` into a set.
+
+        :param str value: a multi-line string of values to parse into a set
+        :return: a set of items from ``value``
+        :rtype: set
+        """
+        items = super().parse(value)
+        return set(items)
+
+    def serialize(self, value):
+        """Serialize ``value`` into a multi-line string.
+
+        :param set value: the input set
+        :rtype: str
+        """
+        if not isinstance(value, (set, list)):
+            raise ValueError('SetAttribute value must be a set.')
+        if isinstance(value, list):
+            # convert to set to remove duplicates prior to serialization
+            value = set(value)
+        return super().serialize(value)
+
+
 class ChoiceAttribute(BaseValidated):
     """A config attribute which must be one of a set group of options.
 

--- a/test/config/test_config_types.py
+++ b/test/config/test_config_types.py
@@ -358,6 +358,67 @@ def test_list_serialize_value_error():
         option.serialize(('1', '2', '3'))  # tuple is not allowed
 
 
+def test_set_attribute():
+    option = types.SetAttribute('foo', default={'a', 'b', 'c'})
+
+    with pytest.raises(ValueError):
+        option.serialize('string')  # string is not allowed
+
+    with pytest.raises(ValueError):
+        option.serialize(('a', 'b', 'c'))  # tuple is not allowed
+
+    serialized = option.serialize({'a', 'b', 'c'})
+    # set iteration order is non-deterministic, so the test will fail sometimes
+    # if we don't sort the serialized lines
+    serialized = '\n'.join(sorted(serialized.splitlines()))
+    assert serialized == (
+        '\n'
+        'a\n'
+        'b\n'
+        'c'
+    )
+
+    parsed = option.parse(
+        """
+        a
+        b
+        c
+        """)
+    assert parsed == {'a', 'b', 'c'}
+
+
+def test_set_attribute_parse_duplicate_values():
+    # technically this just tests Python's `set()` behavior (SetAttribute just
+    # returns `set(ListAttribute.parse())`), but it's good to verify that the
+    # correct subclass's handler is being used in case we accidentally mess up
+    # the class hierarchy in a future patch
+    option = types.SetAttribute('foo')
+    parsed = option.parse(
+        """
+        a
+        a
+        b
+        c
+        b
+        """)
+    assert parsed == {'a', 'b', 'c'}
+
+
+def test_set_attribute_serialize_duplicate_values():
+    # a set can't contain duplicate values, but we can serialize a list too
+    option = types.SetAttribute('foo')
+    serialized = option.serialize(['a', 'b', 'c', 'b', 'a'])
+    # set iteration order is non-deterministic, so the test will fail sometimes
+    # if we don't sort the serialized lines
+    serialized = '\n'.join(sorted(serialized.splitlines()))
+    assert serialized == (
+        '\n'
+        'a\n'
+        'b\n'
+        'c'
+    )
+
+
 def test_choice_attribute():
     option = types.ChoiceAttribute('foo', choices=['a', 'b', 'c'])
     assert option.name == 'foo'


### PR DESCRIPTION
### Description

Implements the new config type idea from https://github.com/sopel-irc/sopel/pull/2687#discussion_r2187967100

Most of the parsing/serializing code is just inherited, with a thin layer of tweaks on top to return the correct type.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [ ] No issues are reported by `make qa` (runs `make lint` and `make test`)
  - I didn't have a chance to lint, sadly. (I hate travel days, but I don't mind leaning on CI sometimes.)
- [x] I have tested the functionality of the things this change touches
  - via tests, naturally

### Notes

Draft until #2687 gets merged, because that's the first usage site for this and there's not much point in adding the feature without something in core that uses it.