### PR TITLE
Makefile: add cleanup recipes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,9 +37,9 @@ coverage_html:
 coverages: coverage_report coverage_html
 
 .PHONY: allclean clean cleanbuild cleancache cleancov
-allclean: clean cleancov clean_docs
+allclean: clean cleancache clean_docs
 
-clean: cleanbuild cleancache
+clean: cleanbuild cleancov
 
 cleanbuild:
 	rm -rf build/*

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,20 @@ coverage_html:
 
 coverages: coverage_report coverage_html
 
+.PHONY: allclean clean cleanbuild cleancache cleancov
+allclean: clean cleancov clean_docs
+
+clean: cleanbuild cleancache
+
+cleanbuild:
+	rm -rf build/*
+
+cleancache:
+	rm -rf **/__pycache__
+
+cleancov:
+	rm -rf .coverage coverage_html_report
+
 .PHONY: clean_docs build_docs docs cleandoc
 clean_docs:
 	$(MAKE) -C docs clean


### PR DESCRIPTION
I had too many garbage files accumulating in `build/` and `**/__pycache__` from various virtual environments, packaging tests, etc. Figured these cleanups could be useful to anyone else hacking on the code, not just me.

(Submitting them in a PR also gives an opportunity for our other Make enthusiast(s) to weigh in.)