### PR TITLE
Move mypy options from Makefile to pyproject.toml

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ lint-style:
 	flake8 sopel/ test/
 
 lint-type:
-	mypy --check-untyped-defs --disallow-incomplete-defs sopel
+	mypy sopel
 
 .PHONY: test test_norecord test_novcr vcr_rerecord
 test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,8 @@ use_parentheses = true
 
 [tool.mypy]
 plugins = ["sqlalchemy.ext.mypy.plugin"]
+check_untyped_defs = true
+disallow_incomplete_defs = true
 show_error_codes = true
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
### Description

Tin. I can think of no reason not to apply these command-line flags even if the user runs `mypy` directly/manually. We should have done this sooner in `setup.cfg`, before #2682, but alas.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
  - Better not break `make test` since I didn't touch any Python… But yes, I checked `make lint`.
- [x] I have tested the functionality of the things this change touches
  - As above.

### Notes

Will cause further merge conflict with #2362—but between the existing conflicts, open review comments to be addressed, and how long it's been… That one's gonna need a rebase to test it out properly, anyway, if work on it continues.