### PR TITLE
flake8: includes instead of excludes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ qa: lint test coverages
 lint: lint-style lint-type
 
 lint-style:
-	flake8 sopel/ test/
+	flake8
 
 lint-type:
 	mypy --check-untyped-defs --disallow-incomplete-defs sopel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,12 +77,9 @@ pytest-sopel = "sopel.tests.pytest_plugin"
 max-line-length = 79
 no-accept-encodings = true
 type-checking-exempt-modules = "typing"
-exclude = [
-    ".venv",
-    "conftest.py",
-    "contrib",
-    "docs",
-    "env",
+filename = [
+    "./sopel/*.py",
+    "./test/*.py",
 ]
 ignore = [
     # Line length limit. Acceptable (for now).


### PR DESCRIPTION
### Description

Switches from `exclude` to `filename`, as suggested in https://github.com/sopel-irc/sopel/pull/2682#discussion_r2247180208

The documentation is quite unhelpful. `*.py` __recursively__ includes all .py files, so is not wanted here. Paths start with `./` and must bring their own `*.py`. Asterisks are not limited to one path segment, i.e. `./sopel/*.py` matches `./sopel/irc/backends.py`.

I'm not sure this is a correct thing to do, ~`exclude`~ `filename` feels funky and not spectacularly well-suited to this...

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
