### PR TITLE
tools.identifiers: correct handling of empty and missing CHANTYPES

### DIFF
--- a/sopel/tools/identifiers.py
+++ b/sopel/tools/identifiers.py
@@ -50,7 +50,7 @@ RFC1459_STRICT_TABLE = str.maketrans(
     string.ascii_uppercase + '[]\\',
     string.ascii_lowercase + '{}|',
 )
-DEFAULT_CHANTYPES = ('#', '&', '+', '!')
+DEFAULT_CHANTYPES = ('#', '&')  # RFC1459 baseline
 
 
 def ascii_lower(text: str) -> str:
@@ -135,12 +135,12 @@ class Identifier(str):
         identifier: str,
         *,
         casemapping: Casemapping = rfc1459_lower,
-        chantypes: tuple = DEFAULT_CHANTYPES,
+        chantypes: tuple | None = DEFAULT_CHANTYPES,
     ) -> None:
         super().__init__()
         self.casemapping: Casemapping = casemapping
         """Casemapping function to lower the identifier."""
-        self.chantypes = chantypes
+        self.chantypes = tuple() if chantypes is None else chantypes
         """Tuple of prefixes used for channels."""
         self._lowered = self.casemapping(identifier)
 

--- a/test/test_coretasks.py
+++ b/test/test_coretasks.py
@@ -371,11 +371,11 @@ def test_handle_isupport_casemapping_identifiermemory(mockbot):
 
 
 def test_handle_isupport_chantypes(mockbot):
-    # check default behavior (chantypes allows #, &, +, and !)
+    # check default behavior (unadvertised CHANTYPES token assumes # and &)
     assert not mockbot.make_identifier('#channel').is_nick()
     assert not mockbot.make_identifier('&channel').is_nick()
-    assert not mockbot.make_identifier('+channel').is_nick()
-    assert not mockbot.make_identifier('!channel').is_nick()
+    assert mockbot.make_identifier('+channel').is_nick()
+    assert mockbot.make_identifier('!channel').is_nick()
 
     # now the bot "connects" to a server using `CHANTYPES=#`
     mockbot.on_message(
@@ -386,6 +386,21 @@ def test_handle_isupport_chantypes(mockbot):
         ':are supported by this server')
 
     assert not mockbot.make_identifier('#channel').is_nick()
+    assert mockbot.make_identifier('&channel').is_nick()
+    assert mockbot.make_identifier('+channel').is_nick()
+    assert mockbot.make_identifier('!channel').is_nick()
+
+
+def test_handle_isupport_chantypes_empty(mockbot):
+    # "connect" to a server that advertises empty CHANTYPES token
+    mockbot.on_message(
+        ':irc.example.com 005 Sopel '
+        'CHANTYPES EXCEPTS INVEX CHANMODES=eIbq,k,flj,CFLMPQScgimnprstz '
+        'CHANLIMIT=#:120 PREFIX=(ov)@+ MAXLIST=bqeI:100 MODES=4 '
+        'NETWORK=example STATUSMSG=@+ CALLERID=g CASEMAPPING=ascii '
+        ':are supported by this server')
+
+    assert mockbot.make_identifier('#channel').is_nick()
     assert mockbot.make_identifier('&channel').is_nick()
     assert mockbot.make_identifier('+channel').is_nick()
     assert mockbot.make_identifier('!channel').is_nick()

--- a/test/tools/test_tools_identifiers.py
+++ b/test/tools/test_tools_identifiers.py
@@ -169,9 +169,12 @@ def test_identifier_compare_invalid(wrong_type):
 @pytest.mark.parametrize('name, chantypes', (
     ('Exirel', identifiers.DEFAULT_CHANTYPES),
     ('@Exirel', identifiers.DEFAULT_CHANTYPES),
-    ('+Exirel', ('#',)),
-    ('!Exirel', ('#',)),
+    ('+Exirel', identifiers.DEFAULT_CHANTYPES),
+    ('!Exirel', identifiers.DEFAULT_CHANTYPES),
     ('&Exirel', ('#',)),
+    # CHANTYPES token with no value (no supported channel types) is different
+    # than no CHANTYPES token at all (assume RFC1459 default)
+    ('#Exirel', None),
 ))
 def test_identifier_is_nick(name, chantypes):
     assert identifiers.Identifier(name, chantypes=chantypes).is_nick()
@@ -179,10 +182,10 @@ def test_identifier_is_nick(name, chantypes):
 
 @pytest.mark.parametrize('name, chantypes', (
     ('#Exirel', identifiers.DEFAULT_CHANTYPES),
-    ('+Exirel', identifiers.DEFAULT_CHANTYPES),
-    ('!Exirel', identifiers.DEFAULT_CHANTYPES),
     ('&Exirel', identifiers.DEFAULT_CHANTYPES),
     ('@Exirel', ('#', '@')),
+    ('+Exirel', ('#', '+')),
+    ('!Exirel', ('#', '!')),
 ))
 def test_identifier_is_nick_channel(name, chantypes):
     assert not identifiers.Identifier(name, chantypes=chantypes).is_nick()


### PR DESCRIPTION
### Description

The fix here is twofold.

If CHANTYPES is not advertised, assume only the RFC1459 baseline, '#&'.

If CHANTYPES is advertised but without a value, ensure that `Identifier`
can handle the missing value, which the `_optional(tuple)` ISUPPORT
token parser parses as `None`.

Tests updated to correspond, of course.

Closes #2591.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
