### PR TITLE
wikipedia, wiktionary: set custom user agent to comply with WMF policy

### DIFF
--- a/sopel/builtins/wiktionary.py
+++ b/sopel/builtins/wiktionary.py
@@ -11,11 +11,16 @@ import re
 
 import requests
 
-from sopel import plugin
+from sopel import __version__ as sopel_version, plugin
 from sopel.tools import web
 
 
 PLUGIN_OUTPUT_PREFIX = '[wiktionary] '
+PLUGIN_USER_AGENT = 'sopel-wiktionary/{version} (https://sopel.chat/)'.format(
+    version=sopel_version)
+WIKI_REQUEST_HEADERS = {
+    'User-Agent': PLUGIN_USER_AGENT,
+}
 
 uri = 'https://en.wiktionary.org/w/index.php?title=%s&printable=yes'
 r_sup = re.compile(r'<sup[^>]+>.+?</sup>')  # Superscripts that are references only, not ordinal indicators, etc...
@@ -54,7 +59,10 @@ def text(html):
 
 
 def wikt(word):
-    bytes = requests.get(uri % web.quote(word)).text
+    bytes = requests.get(
+        uri % web.quote(word),
+        headers=WIKI_REQUEST_HEADERS,
+    ).text
     bytes = r_ul.sub('', bytes)
 
     mode = None


### PR DESCRIPTION
### Description

Tin. Wikimedia Foundation projects began blocking the default `requests` user agent string on 2025-08-25 (today).

Refer to https://phabricator.wikimedia.org/T400119

<details>
<summary>Error comparison</summary>

Before:

```
<dgw> .wt bailiwick
<Sopel> dgw: Couldn't get any definitions for bailiwick.
<dgw> .wp bailiwick
<Sopel> Unexpected JSONDecodeError (Expecting value: line 1 column 1 (char 0)) from dgw. Message was: .wp bailiwick
```

After (note test bot nick + different command prefix):

```
<dgw> ,wt bailiwick
<SopelTest> [wiktionary] bailiwick — noun: 1. The district within which a bailie or bailiff has jurisdiction, 2. A
            person's concern or sphere of operations, their area of skill or authority
<dgw> ,wp bailiwick
<SopelTest> [wikipedia] Bailiwick | "A bailiwick ( ) is usually the area of jurisdiction of a bailiff, and once
            also applied to territories in which a privately appointed bailiff exercised the sheriff's functions
            under a royal or imperial writ. In English, the original French bailie combined with -wic, the
            Anglo-Saxon suffix (meaning a village) to produce a term meaning literally 'bailiff's […]" |
            https://en.wikipedia.org/wiki/Bailiwick
```

</details>

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes

Since Wiktionary's breakage was the initial report, I'm glad my first assumption—needing to rewrite its voodoo not-actually-a-parser in a rush—turned out to be wrong.