### PR TITLE
plugins.handlers: PyFilePlugin version falls back to file's mtime

### DIFF
--- a/sopel/plugins/handlers.py
+++ b/sopel/plugins/handlers.py
@@ -44,6 +44,7 @@ away from the rest of the application.
 from __future__ import annotations
 
 import abc
+from datetime import datetime
 import importlib
 import importlib.util
 import inspect
@@ -503,6 +504,7 @@ class PyFilePlugin(PyModulePlugin):
         self.filename = filename
         self.path = filename
         self.module_spec = spec
+        self.file_mtime: float | None = None
 
         super().__init__(name)
 
@@ -540,8 +542,26 @@ class PyFilePlugin(PyModulePlugin):
         })
         return data
 
+    def get_version(self) -> str | None:
+        """Retrieve the plugin's version.
+
+        :return: the plugin's version string
+
+        If the plugin module doesn't have a ``__version__`` attribute, this
+        method uses the file's last modification date as the version string.
+        """
+        version = super().get_version()
+        if version is None and self.file_mtime is not None:
+            # try to get version from file metadata
+            dt = datetime.fromtimestamp(self.file_mtime)
+            version = dt.strftime("%Y.%m.%d")
+
+        return version
+
     def load(self) -> None:
         self._module = self._load()
+        # update cached file modification time after successful loading
+        self.file_mtime = os.path.getmtime(self.filename)
 
     def reload(self) -> None:
         """Reload the plugin.
@@ -551,6 +571,8 @@ class PyFilePlugin(PyModulePlugin):
         module might not be available through ``sys.path``.
         """
         self._module = self._load()
+        # update cached file modification time after successful reload
+        self.file_mtime = os.path.getmtime(self.filename)
 
 
 class EntryPointPlugin(PyModulePlugin):


### PR DESCRIPTION
### Description

Alternative to the suggested implementation from #2498, putting this fallback in the plugin machinery instead of a special display-only case in `version`.

`PyFilePlugin` keeps track of the modification time when it (re)loads its `.py` file and uses that to derive a datever if there isn't a "real" version in the module.

Starting as draft… If this idea has legs I'll finish up with any needed test cases.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [ ] No issues are reported by `make qa` (runs `make lint` and `make test`)
  - Didn't run the checks yet. See note above; this is starting as a proof of concept.
- [x] I have tested the functionality of the things this change touches
  - Yes, but just manually.