### PR TITLE
bot: log rate limit events for debugging

### DIFF
--- a/test/test_coretasks.py
+++ b/test/test_coretasks.py
@@ -599,7 +599,7 @@ def test_join_time(mockbot):
 
 def test_handle_rpl_namreply_with_malformed_uhnames(mockbot, caplog):
     """Make sure Sopel can cope with expected but missing hostmask in 353"""
-    caplog.set_level(logging.DEBUG)
+    caplog.set_level(logging.DEBUG, logger='sopel.coretasks')
     mockbot.on_message(
         ':somenet.behind.znc 005 Sopel '
         'UHNAMES '
@@ -766,7 +766,7 @@ def test_handle_setname(mockbot):
 
 def test_handle_setname_no_user(mockbot, caplog):
     """Make sure Sopel ignores SETNAME message for unknown user"""
-    caplog.set_level(logging.DEBUG)
+    caplog.set_level(logging.DEBUG, logger='sopel.coretasks')
     mockbot.on_message(':Akarin!yuruyuri@hajimaru.yo SETNAME :Bun Bazooka')
 
     assert len(caplog.messages) == 1


### PR DESCRIPTION
### Description

This patch does its best to restore functionality equivalent to what `bot.call()` used to do in the newer `bot.call_rule()` code path. Example log output below, by way of demonstration (timestamps have been removed for easier reading):

```
sopel.bot            DEBUG    - Skipping rate limit checks for unblockable rule <Rule coretasks.recv_who (1)>
sopel.bot            DEBUG    - dgw hit user rate limit in #dgw for rule <Command rated.userrateadmin []>; 0:04:43 / 0:05:00 remaining
sopel.bot            DEBUG    - dgw hit channel rate limit in #dgw for rule <Command rated.chanrateadmin []>; 0:04:59 / 0:05:00 remaining
sopel.bot            DEBUG    - dgw hit global rate limit in #dgw for rule <Command rated.globrateadmin []>; 0:04:58 / 0:05:00 remaining
sopel.bot            DEBUG    - Skipping rate limit checks for dgw on rule <Command rated.globrate []>: rule does not rate-limit admins
```

Resolves #2648

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes

This also touches tests for `coretasks`, because `caplog` needed to be scoped down so it won't get unexpected debug messages added by this patch to the `sopel.bot` submodule.