### PR TITLE
sopel: replace `typing.Optional` and `typing.Union` with `|` for type annotations

### DIFF
--- a/contrib/toxfile.py
+++ b/contrib/toxfile.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pathlib import Path
 
 from tox.execute.request import StdinSource
@@ -36,7 +38,7 @@ MIT License
 Copyright (c) 2023 Masen Furer
 """
 from contextlib import contextmanager
-from typing import Any, Iterator, Optional, Sequence, Tuple
+from typing import Any, Iterator, Sequence, Tuple
 
 from tox.plugin import impl
 from tox.tox_env.api import ToxEnv
@@ -51,8 +53,8 @@ class FilteredInfo(Info):
     def __init__(
         self,
         *args: Any,
-        filter_keys: Optional[Sequence[str]] = None,
-        filter_section: Optional[str] = None,
+        filter_keys: Sequence[str] | None = None,
+        filter_section: str | None = None,
         **kwargs: Any,
     ):
         """
@@ -70,8 +72,8 @@ class FilteredInfo(Info):
         self,
         value: Any,
         section: str,
-        sub_section: Optional[str] = None,
-    ) -> Iterator[Tuple[bool, Optional[Any]]]:
+        sub_section: str | None = None,
+    ) -> Iterator[Tuple[bool, Any]]:
         """Perform comparison and update cached info after filtering `value`."""
         if self.filter_section is None or section == self.filter_section:
             try:

--- a/sopel/bot.py
+++ b/sopel/bot.py
@@ -20,7 +20,6 @@ from types import MappingProxyType
 from typing import (
     Any,
     Callable,
-    Optional,
     Sequence,
     TYPE_CHECKING,
     TypeVar,
@@ -187,7 +186,7 @@ class Sopel(irc.AbstractBot):
         )
 
     @property
-    def hostmask(self) -> Optional[str]:
+    def hostmask(self) -> str | None:
         """The current hostmask for the bot :class:`~sopel.tools.target.User`.
 
         :return: the bot's current hostmask if the bot is connected and in
@@ -662,7 +661,7 @@ class Sopel(irc.AbstractBot):
         self,
         rule: AbstractRuleType,
         trigger: Trigger,
-    ) -> tuple[bool, Optional[str]]:
+    ) -> tuple[bool, str | None]:
         if rule.is_unblockable():
             LOGGER.debug(
                 "Skipping rate limit checks for unblockable rule %s", rule)
@@ -711,7 +710,7 @@ class Sopel(irc.AbstractBot):
             )
         )
 
-        message: Optional[str] = None
+        message: str | None = None
 
         if template:
             message = template.format(
@@ -1121,8 +1120,8 @@ class Sopel(irc.AbstractBot):
 
     def error(
         self,
-        trigger: Optional[Trigger] = None,
-        exception: Optional[BaseException] = None,
+        trigger: Trigger | None = None,
+        exception: BaseException | None = None,
     ) -> None:
         """Called internally when a plugin causes an error.
 
@@ -1427,7 +1426,7 @@ class SopelWrapper:
         return setattr(self._bot, attr, value)
 
     @property
-    def default_destination(self) -> Optional[str]:
+    def default_destination(self) -> str | None:
         """Default say/reply destination for the associated Trigger.
 
         :return: the channel (with status prefix) or nick to send messages to

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -30,7 +30,7 @@ import functools
 import logging
 import re
 import time
-from typing import Callable, Optional, TYPE_CHECKING
+from typing import Callable, TYPE_CHECKING
 
 from sopel import config, plugin
 from sopel.irc import isupport, utils
@@ -1068,7 +1068,7 @@ def _receive_cap_ls_reply(bot: SopelWrapper, trigger: Trigger) -> None:
 def _handle_cap_acknowledgement(
     bot: SopelWrapper,
     cap_req: tuple[str, ...],
-    results: list[tuple[bool, Optional[callables.CapabilityNegotiation]]],
+    results: list[tuple[bool, callables.CapabilityNegotiation | None]],
     was_completed: bool,
 ) -> None:
     if any(
@@ -1094,9 +1094,9 @@ def _receive_cap_ack(bot: SopelWrapper, trigger: Trigger) -> None:
     cap_ack: tuple[str, ...] = bot.capabilities.handle_ack(bot, trigger)
 
     try:
-        result: Optional[
-            list[tuple[bool, Optional[callables.CapabilityNegotiation]]]
-        ] = bot.cap_requests.acknowledge(bot, cap_ack)
+        result: list[
+            tuple[bool, callables.CapabilityNegotiation | None]
+        ] | None = bot.cap_requests.acknowledge(bot, cap_ack)
     except config.ConfigurationError as error:
         LOGGER.error(
             'Configuration error on ACK capability "%s": %s',
@@ -1129,9 +1129,9 @@ def _receive_cap_nak(bot: SopelWrapper, trigger: Trigger) -> None:
     cap_ack = bot.capabilities.handle_nak(bot, trigger)
 
     try:
-        result: Optional[
-            list[tuple[bool, Optional[callables.CapabilityNegotiation]]]
-        ] = bot.cap_requests.deny(bot, cap_ack)
+        result: list[
+            tuple[bool, callables.CapabilityNegotiation | None]
+        ] | None = bot.cap_requests.deny(bot, cap_ack)
     except config.ConfigurationError as error:
         LOGGER.error(
             'Configuration error on NAK capability "%s": %s',
@@ -1568,11 +1568,11 @@ def _record_who(
     user: str,
     host: str,
     nick: str,
-    realname: Optional[str] = None,
-    account: Optional[str] = None,
-    away: Optional[bool] = None,
-    is_bot: Optional[bool] = None,
-    modes: Optional[str] = None,
+    realname: str | None = None,
+    account: str | None = None,
+    away: bool | None = None,
+    is_bot: bool | None = None,
+    modes: str | None = None,
 ) -> None:
     nick = bot.make_identifier(nick)
     channel = bot.make_identifier(channel)

--- a/sopel/db.py
+++ b/sopel/db.py
@@ -526,8 +526,8 @@ class SopelDB:
         self,
         nick: str,
         key: str,
-        default: typing.Optional[typing.Any] = None
-    ) -> typing.Optional[typing.Any]:
+        default: typing.Any = None
+    ) -> typing.Any:
         """Get a value from the key-value store for ``nick``.
 
         :param nick: the nickname whose values to access
@@ -790,7 +790,7 @@ class SopelDB:
         self,
         channel: str,
         key: str,
-        default: typing.Optional[typing.Any] = None,
+        default: typing.Any = None,
     ) -> typing.Any:
         """Get a value from the key-value store for ``channel``.
 
@@ -922,8 +922,8 @@ class SopelDB:
         self,
         plugin: str,
         key: str,
-        default: typing.Optional[typing.Any] = None,
-    ) -> typing.Optional[typing.Any]:
+        default: typing.Any = None,
+    ) -> typing.Any:
         """Get a value from the key-value store for ``plugin``.
 
         :param plugin: the plugin name whose values to access
@@ -983,8 +983,8 @@ class SopelDB:
         self,
         name: str,
         key: str,
-        default: typing.Any | None = None
-    ) -> typing.Any | None:
+        default: typing.Any = None
+    ) -> typing.Any:
         """Get a value from the key-value store for ``name``.
 
         :param name: nick or channel whose values to access
@@ -1009,10 +1009,10 @@ class SopelDB:
             :meth:`get_channel_value`.
 
         """
-        if not isinstance(name, Identifier):
-            identifier = self.make_identifier(name)
+        if isinstance(name, Identifier):
+            identifier = name
         else:
-            identifier = typing.cast('Identifier', name)
+            identifier = self.make_identifier(name)
 
         if identifier.is_nick():
             return self.get_nick_value(identifier, key, default)
@@ -1023,7 +1023,7 @@ class SopelDB:
         self,
         names: Iterable[str],
         key: str,
-    ) -> typing.Optional[typing.Any]:
+    ) -> typing.Any:
         """Get a value for the first name which has it set.
 
         :param names: a list of channel names and/or nicknames

--- a/sopel/irc/abstract_backends.py
+++ b/sopel/irc/abstract_backends.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 import abc
 import logging
-from typing import Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING
 
 from .utils import safe
 
@@ -102,7 +102,7 @@ class AbstractIRCBackend(abc.ABC):
 
         return data
 
-    def send_command(self, *args: str, text: Optional[str] = None) -> None:
+    def send_command(self, *args: str, text: str | None = None) -> None:
         """Send a command through the IRC connection.
 
         :param args: IRC command to send with its argument(s)
@@ -126,7 +126,7 @@ class AbstractIRCBackend(abc.ABC):
         self.irc_send(raw_command.encode('utf-8'))
         self.bot.on_message_sent(raw_command)
 
-    def prepare_command(self, *args: str, text: Optional[str] = None) -> str:
+    def prepare_command(self, *args: str, text: str | None = None) -> str:
         """Prepare an IRC command from ``args`` and optional ``text``.
 
         :param args: arguments of the IRC command to send
@@ -210,7 +210,7 @@ class AbstractIRCBackend(abc.ABC):
         """
         self.send_command('PASS', password)
 
-    def send_join(self, channel: str, password: Optional[str] = None) -> None:
+    def send_join(self, channel: str, password: str | None = None) -> None:
         """Send a ``JOIN`` command to ``channel`` with optional ``password``.
 
         :param channel: channel to join
@@ -221,7 +221,7 @@ class AbstractIRCBackend(abc.ABC):
         else:
             self.send_command('JOIN', channel, password)
 
-    def send_part(self, channel: str, reason: Optional[str] = None) -> None:
+    def send_part(self, channel: str, reason: str | None = None) -> None:
         """Send a ``PART`` command to ``channel``.
 
         :param channel: the channel to part
@@ -229,7 +229,7 @@ class AbstractIRCBackend(abc.ABC):
         """
         self.send_command('PART', channel, text=reason)
 
-    def send_quit(self, reason: Optional[str] = None) -> None:
+    def send_quit(self, reason: str | None = None) -> None:
         """Send a ``QUIT`` command.
 
         :param reason: optional text for leaving the server
@@ -243,7 +243,7 @@ class AbstractIRCBackend(abc.ABC):
         self,
         channel: str,
         nick: str,
-        reason: Optional[str] = None,
+        reason: str | None = None,
     ) -> None:
         """Send a ``KICK`` command for ``nick`` in ``channel`` .
 

--- a/sopel/irc/backends.py
+++ b/sopel/irc/backends.py
@@ -20,7 +20,7 @@ import signal
 import socket
 import ssl
 import threading
-from typing import Any, Optional, TYPE_CHECKING
+from typing import Any, TYPE_CHECKING
 
 from .abstract_backends import AbstractIRCBackend
 
@@ -148,15 +148,15 @@ class AsyncioBackend(AbstractIRCBackend):
         bot: AbstractBot,
         host: str,
         port: int,
-        source_address: Optional[tuple[str, int]],
-        server_timeout: Optional[int] = None,
-        ping_interval: Optional[int] = None,
+        source_address: tuple[str, int] | None,
+        server_timeout: int | None = None,
+        ping_interval: int | None = None,
         use_ssl: bool = False,
-        certfile: Optional[str] = None,
-        keyfile: Optional[str] = None,
+        certfile: str | None = None,
+        keyfile: str | None = None,
         verify_ssl: bool = True,
-        ca_certs: Optional[str] = None,
-        ssl_ciphers: Optional[list[str]] = None,
+        ca_certs: str | None = None,
+        ssl_ciphers: list[str] | None = None,
         ssl_minimum_version: ssl.TLSVersion = ssl.TLSVersion.TLSv1_2,
         **kwargs: Any,
     ):
@@ -164,12 +164,12 @@ class AsyncioBackend(AbstractIRCBackend):
         # connection parameters
         self._host: str = host
         self._port: int = port
-        self._source_address: Optional[tuple[str, int]] = source_address
+        self._source_address: tuple[str, int] | None = source_address
         self._use_ssl: bool = use_ssl
-        self._certfile: Optional[str] = certfile
-        self._keyfile: Optional[str] = keyfile
+        self._certfile: str | None = certfile
+        self._keyfile: str | None = keyfile
         self._verify_ssl: bool = verify_ssl
-        self._ca_certs: Optional[str] = ca_certs
+        self._ca_certs: str | None = ca_certs
         self._ssl_ciphers: str = ":".join(ssl_ciphers or [])
         self._ssl_minimum_version: ssl.TLSVersion = ssl_minimum_version
 
@@ -181,16 +181,16 @@ class AsyncioBackend(AbstractIRCBackend):
 
         # connection flags
         self._connected: bool = False
-        self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._loop: asyncio.AbstractEventLoop | None = None
 
         # connection writer & reader
-        self._writer: Optional[asyncio.StreamWriter] = None
-        self._reader: Optional[asyncio.StreamReader] = None
+        self._writer: asyncio.StreamWriter | None = None
+        self._reader: asyncio.StreamReader | None = None
 
         # connection tasks
-        self._read_task: Optional[asyncio.Task] = None
-        self._ping_task: Optional[asyncio.TimerHandle] = None
-        self._timeout_task: Optional[asyncio.TimerHandle] = None
+        self._read_task: asyncio.Task | None = None
+        self._ping_task: asyncio.TimerHandle | None = None
+        self._timeout_task: asyncio.TimerHandle | None = None
 
     # signal handlers
 
@@ -350,7 +350,7 @@ class AsyncioBackend(AbstractIRCBackend):
 
     def get_connection_kwargs(self) -> dict:
         """Return the keyword arguments required to initiate connection."""
-        ssl_context: Optional[ssl.SSLContext] = None
+        ssl_context: ssl.SSLContext | None = None
 
         if self._use_ssl:
             ssl_context = ssl.create_default_context(ssl.Purpose.SERVER_AUTH)
@@ -380,11 +380,11 @@ class AsyncioBackend(AbstractIRCBackend):
     async def _connect_to_server(
         self, **connection_kwargs: Any,
     ) -> tuple[
-        Optional[asyncio.StreamReader],
-        Optional[asyncio.StreamWriter],
+        asyncio.StreamReader | None,
+        asyncio.StreamWriter | None,
     ]:
-        reader: Optional[asyncio.StreamReader] = None
-        writer: Optional[asyncio.StreamWriter] = None
+        reader: asyncio.StreamReader | None = None
+        writer: asyncio.StreamWriter | None = None
 
         # open connection
         try:

--- a/sopel/irc/capabilities.py
+++ b/sopel/irc/capabilities.py
@@ -20,7 +20,6 @@ from __future__ import annotations
 
 from typing import (
     NamedTuple,
-    Optional,
     TYPE_CHECKING,
 )
 
@@ -48,7 +47,7 @@ class CapabilityInfo(NamedTuple):
     The name of a capability is the name as it appears in the ``CAP LS``
     subcommand, such as ``multi-prefix`` or ``sasl``.
     """
-    params: Optional[str]
+    params: str | None
     """Advertised parameters for this capability.
 
     When a server supports ``CAP`` version 302, capabilities can have
@@ -82,7 +81,7 @@ class Capabilities:
     * :meth:`handle_del` for ``CAP ADD``
     """
     def __init__(self) -> None:
-        self._available: dict[str, Optional[str]] = {}
+        self._available: dict[str, str | None] = {}
         self._enabled: set[str] = set()
 
     def get_capability_info(self, name: str) -> CapabilityInfo:
@@ -104,7 +103,7 @@ class Capabilities:
         )
 
     @property
-    def available(self) -> dict[str, Optional[str]]:
+    def available(self) -> dict[str, str | None]:
         """Dict of available server capabilities.
 
         Each key is the name of a capability advertised by the server, and each

--- a/sopel/irc/modes.py
+++ b/sopel/irc/modes.py
@@ -34,9 +34,9 @@ import enum
 import logging
 from typing import (
     NamedTuple,
-    Optional,
     Tuple,
     TYPE_CHECKING,
+    Union,
 )
 
 
@@ -55,7 +55,11 @@ parsing a modestring like ``+abc-efg``. In that example mode ``a`` and mode
 ``f`` would be represented as these tuples: ``('a', True)`` and
 ``('f', False)``.
 """
-ModeDetails = Tuple[str, str, bool, Optional[str]]
+
+# TODO: replace Union by | when dropping support for Python 3.9
+# Type aliases are evaluated at import time unlike type annotation
+# Python 3.8 and 3.9 don't support the | operator.
+ModeDetails = Tuple[str, str, bool, Union[str, None]]
 """Tuple of mode details as ``(letter, mode, is_added, param)``.
 
 Where ``type`` is the mode type (such as A, B, C, D); ``mode`` is the mode
@@ -327,7 +331,7 @@ class ModeParser:
                     priv_param: str = next(iparams)
                     privileges.append((mode, is_added, priv_param))
                 else:
-                    mode_param: Optional[str] = None
+                    mode_param: str | None = None
                     letter, required = self.get_mode_info(mode, is_added)
                     if required:
                         mode_param = next(iparams)

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -15,7 +15,6 @@ import re
 from typing import (
     Callable,
     Literal,
-    Optional,
     overload,
     Pattern,
     TYPE_CHECKING,
@@ -1604,7 +1603,7 @@ def require_account(message=None, reply=False):
 
 def require_privilege(
     level: AccessLevel,
-    message: Optional[str] = None,
+    message: str | None = None,
     reply: bool = False,
 ) -> TypedCallableDecorator:
     """Decorate a function to require at least the given channel permission.
@@ -1819,7 +1818,7 @@ def require_owner(message=None, reply=False):
 
 def require_bot_privilege(
     level: AccessLevel,
-    message: Optional[str] = None,
+    message: str | None = None,
     reply: bool = False,
 ) -> TypedCallableDecorator:
     """Decorate a function to require a minimum channel privilege for the bot.
@@ -2085,19 +2084,19 @@ class example:
     def __init__(
         self,
         msg: str,
-        result: Optional[Union[str, Iterable[str]]] = None,
+        result: str | Iterable[str] | None = None,
         privmsg: bool = False,
         admin: bool = False,
         owner: bool = False,
         repeat: int = 1,
         re: bool = False,
-        ignore: Optional[Union[str, Iterable[str]]] = None,
+        ignore: str | Iterable[str] | None = None,
         user_help: bool = False,
         online: bool = False,
         vcr: bool = False,
     ):
         # Wrap result into a list for get_example_test
-        self.result: Optional[list[str]] = None
+        self.result: list[str] | None = None
         if isinstance(result, str):
             self.result = [result]
         elif result is not None:

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -52,7 +52,9 @@ if TYPE_CHECKING:
     from sopel.bot import SopelWrapper
     from sopel.trigger import Trigger
 
-
+# TODO: replace Union by | when dropping support for Python 3.9
+# Type aliases are evaluated at import time so unlike type annotation
+# Python 3.8 and 3.9 don't support the | operator.
 TypedCallableDecorator = Callable[
     [Union[TypedPluginCallableHandler, AbstractPluginObject]],
     PluginCallable,
@@ -248,7 +250,7 @@ def unblockable(function=None):
     return decorator
 
 
-def interval(*intervals: Union[int, float]) -> TypedJobDecorator:
+def interval(*intervals: int | float) -> TypedJobDecorator:
     """Decorate a function to be called by the bot every *n* seconds.
 
     :param intervals: one or more duration(s), in seconds
@@ -289,7 +291,7 @@ def interval(*intervals: Union[int, float]) -> TypedJobDecorator:
     return decorator
 
 
-def rule(*patterns: Union[str, Pattern]) -> TypedCallableDecorator:
+def rule(*patterns: str | Pattern) -> TypedCallableDecorator:
     """Decorate a function to be called when a line matches the given pattern.
 
     :param patterns: one or more regular expression(s)
@@ -394,7 +396,7 @@ def rule_lazy(*loaders: Callable) -> TypedCallableDecorator:
     return decorator
 
 
-def find(*patterns: Union[str, Pattern]) -> TypedCallableDecorator:
+def find(*patterns: str | Pattern) -> TypedCallableDecorator:
     """Decorate a function to be called for each time a pattern is found in a line.
 
     :param patterns: one or more regular expression(s)
@@ -499,7 +501,7 @@ def find_lazy(*loaders: Callable) -> TypedCallableDecorator:
     return decorator
 
 
-def search(*patterns: Union[str, Pattern]) -> TypedCallableDecorator:
+def search(*patterns: str | Pattern) -> TypedCallableDecorator:
     """Decorate a function to be called when a pattern matches anywhere in a line.
 
     :param patterns: one or more regular expression(s)

--- a/sopel/plugins/__init__.py
+++ b/sopel/plugins/__init__.py
@@ -33,7 +33,7 @@ import importlib
 import itertools
 import logging
 import os
-from typing import TYPE_CHECKING, Union
+from typing import TYPE_CHECKING
 
 # TODO: use stdlib importlib.metadata when possible, after dropping py3.9.
 # Stdlib does not support `entry_points(group='filter')` until py3.10, but
@@ -53,7 +53,9 @@ if TYPE_CHECKING:
 LOGGER = logging.getLogger(__name__)
 
 
-def _list_plugin_filenames(directory: Union[str, os.PathLike]) -> Iterable[tuple[str, str]]:
+def _list_plugin_filenames(
+    directory: str | os.PathLike,
+) -> Iterable[tuple[str, str]]:
     # list plugin filenames from a directory
     # yield 2-value tuples: (name, absolute path)
     base = os.path.abspath(directory)

--- a/sopel/plugins/capabilities.py
+++ b/sopel/plugins/capabilities.py
@@ -14,10 +14,7 @@
 from __future__ import annotations
 
 import logging
-from typing import (
-    TYPE_CHECKING,
-    Union,
-)
+from typing import TYPE_CHECKING
 
 
 if TYPE_CHECKING:
@@ -453,7 +450,7 @@ class Manager:
         self,
         cap_req: tuple[str, ...],
         *,
-        plugins: Union[list[str], tuple[str, ...], set[str]] = (),
+        plugins: list[str] | tuple[str, ...] | set[str] = (),
     ) -> Generator[tuple[str, Capability], None, None]:
         """Retrieve the registered request handlers for a capability request.
 

--- a/sopel/plugins/capabilities.py
+++ b/sopel/plugins/capabilities.py
@@ -15,7 +15,6 @@ from __future__ import annotations
 
 import logging
 from typing import (
-    Optional,
     TYPE_CHECKING,
     Union,
 )
@@ -341,7 +340,7 @@ class Manager:
         if cap_req not in self._requested:
             return was_completed, was_completed
 
-        handler_info: Optional[tuple[Capability, bool]] = self._registered.get(
+        handler_info: tuple[Capability, bool] | None = self._registered.get(
             cap_req, {},
         ).get(
             plugin_name, None,
@@ -357,7 +356,7 @@ class Manager:
         self,
         bot: SopelWrapper,
         cap_req: tuple[str, ...],
-    ) -> Optional[list[tuple[bool, Optional[CapabilityNegotiation]]]]:
+    ) -> list[tuple[bool, CapabilityNegotiation | None]] | None:
         """Acknowledge a capability request and execute handlers.
 
         :param bot: bot instance to manage the capabilities for
@@ -392,7 +391,7 @@ class Manager:
         self,
         bot: SopelWrapper,
         cap_req: tuple[str, ...],
-    ) -> Optional[list[tuple[bool, Optional[CapabilityNegotiation]]]]:
+    ) -> list[tuple[bool, CapabilityNegotiation | None]] | None:
         """Deny a capability request and execute handlers.
 
         :param bot: bot instance to manage the capabilities for
@@ -427,7 +426,7 @@ class Manager:
         bot: SopelWrapper,
         cap_req: tuple[str, ...],
         acknowledged: bool,
-    ) -> list[tuple[bool, Optional[CapabilityNegotiation]]]:
+    ) -> list[tuple[bool, CapabilityNegotiation | None]]:
         # call back request handlers
         plugin_requests: dict[str, tuple[Capability, bool]] = self._registered.get(
             cap_req, {},
@@ -443,7 +442,7 @@ class Manager:
         handler_info: tuple[Capability, bool],
         bot: SopelWrapper,
         acknowledged: bool,
-    ) -> tuple[bool, Optional[CapabilityNegotiation]]:
+    ) -> tuple[bool, CapabilityNegotiation | None]:
         handler = handler_info[0]
         is_done, result = handler.callback(bot, acknowledged)
         # update done status in registered

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -24,7 +24,6 @@ import re
 import threading
 from typing import (
     Any,
-    Optional,
     Type,
     TYPE_CHECKING,
     TypeVar,
@@ -506,8 +505,8 @@ class Manager:
 class RuleMetrics:
     """Tracker of a rule's usage."""
     def __init__(self) -> None:
-        self.started_at: Optional[datetime.datetime] = None
-        self.ended_at: Optional[datetime.datetime] = None
+        self.started_at: datetime.datetime | None = None
+        self.ended_at: datetime.datetime | None = None
         self.last_return_value: Any = None
 
     def start(self) -> None:
@@ -523,7 +522,7 @@ class RuleMetrics:
         self.last_return_value = value
 
     @property
-    def last_time(self) -> Optional[datetime.datetime]:
+    def last_time(self) -> datetime.datetime | None:
         """Last recorded start/end time for the associated rule."""
         # detect if we just started something or if it ended
         if (self.started_at and self.ended_at) and (self.started_at < self.ended_at):
@@ -553,9 +552,9 @@ class RuleMetrics:
 
     def __exit__(
         self,
-        type: Optional[Any],
-        value: Optional[Any],
-        traceback: Optional[Any],
+        type: Any,
+        value: Any,
+        traceback: Any,
     ) -> None:
         self.end()
 
@@ -716,7 +715,7 @@ class AbstractRule(abc.ABC):
         """
 
     @abc.abstractmethod
-    def match_ctcp(self, command: Optional[str]) -> bool:
+    def match_ctcp(self, command: str | None) -> bool:
         """Tell if the rule matches this CTCP ``command``.
 
         :param command: potential matching CTCP command
@@ -851,7 +850,7 @@ class AbstractRule(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def user_rate_template(self) -> Optional[str]:
+    def user_rate_template(self) -> str | None:
         """Give the message template to send with a NOTICE to ``nick``.
 
         :return: A formatted string, or ``None`` if no message is set.
@@ -862,7 +861,7 @@ class AbstractRule(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def channel_rate_template(self) -> Optional[str]:
+    def channel_rate_template(self) -> str | None:
         """Give the message template to send with a NOTICE to ``nick``.
 
         :return: A formatted string, or ``None`` if no message is set.
@@ -873,7 +872,7 @@ class AbstractRule(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def global_rate_template(self) -> Optional[str]:
+    def global_rate_template(self) -> str | None:
         """Give the message to send with a NOTICE to ``nick``.
 
         :return: A formatted string, or ``None`` if no message is set.
@@ -1303,17 +1302,17 @@ class Rule(AbstractRule):
         return metrics.is_limited(at_time - self.global_rate_limit)
 
     @property
-    def user_rate_template(self) -> Optional[str]:
+    def user_rate_template(self) -> str | None:
         template = self._user_rate_message or self._default_rate_message
         return template
 
     @property
-    def channel_rate_template(self) -> Optional[str]:
+    def channel_rate_template(self) -> str | None:
         template = self._channel_rate_message or self._default_rate_message
         return template
 
     @property
-    def global_rate_template(self) -> Optional[str]:
+    def global_rate_template(self) -> str | None:
         template = self._global_rate_message or self._default_rate_message
         return template
 
@@ -1726,7 +1725,7 @@ class ActionCommand(AbstractNamedRule):
         pattern = self.PATTERN_TEMPLATE.format(command=pattern)
         return re.compile(pattern, re.IGNORECASE | re.VERBOSE)
 
-    def match_ctcp(self, command: Optional[str]) -> bool:
+    def match_ctcp(self, command: str | None) -> bool:
         """Tell if ``command`` is an ``ACTION``.
 
         :param command: potential matching CTCP command

--- a/sopel/tools/calculation.py
+++ b/sopel/tools/calculation.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING
 
 
 if TYPE_CHECKING:
-    from typing import Callable, Optional
+    from typing import Callable
 
 __all__ = ['eval_equation']
 
@@ -37,8 +37,8 @@ class ExpressionEvaluator:
 
     def __init__(
         self,
-        bin_ops: Optional[dict[type[ast.operator], Callable]] = None,
-        unary_ops: Optional[dict[type[ast.unaryop], Callable]] = None
+        bin_ops: dict[type[ast.operator], Callable] | None = None,
+        unary_ops: dict[type[ast.unaryop], Callable] | None = None
     ):
         self.binary_ops = bin_ops or {}
         self.unary_ops = unary_ops or {}

--- a/sopel/tools/memories.py
+++ b/sopel/tools/memories.py
@@ -19,6 +19,9 @@ if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
     from typing import Tuple
 
+    # TODO: replace Union by | when dropping support for Python 3.9
+    # Type aliases are evaluated at import time so unlike type annotation
+    # Python 3.8 and 3.9 don't support the | operator.
     MemoryConstructorInput = Union[
         Mapping[str, Any],
         Iterable[Tuple[str, Any]],

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import functools
-from typing import Any, Optional, TYPE_CHECKING, Union
+from typing import Any, TYPE_CHECKING, Union
 
 from sopel.privileges import AccessLevel
 from sopel.tools import memories
@@ -29,25 +29,25 @@ class User:
     def __init__(
         self,
         nick: Identifier,
-        user: Optional[str],
-        host: Optional[str],
+        user: str | None,
+        host: str | None,
     ) -> None:
         assert isinstance(nick, Identifier)
         self.nick: Identifier = nick
         """The user's nickname."""
-        self.user: Optional[str] = user
+        self.user: str | None = user
         """The user's local username.
 
         Will be ``None`` if Sopel has not yet received complete user
         information from the IRC server.
         """
-        self.host: Optional[str] = host
+        self.host: str | None = host
         """The user's hostname.
 
         Will be ``None`` if Sopel has not yet received complete user
         information from the IRC server.
         """
-        self.realname: Optional[str] = None
+        self.realname: str | None = None
         """The user's realname.
 
         Will be ``None`` if Sopel has not yet received complete user
@@ -59,7 +59,7 @@ class User:
         This maps channel name :class:`~sopel.tools.identifiers.Identifier`\\s
         to :class:`Channel` objects.
         """
-        self.account: Optional[str] = None
+        self.account: str | None = None
         """The IRC services account of the user.
 
         This relies on IRCv3 account tracking being enabled.
@@ -67,13 +67,13 @@ class User:
         Will be ``None`` if the user is not logged into an account (including
         when account tracking is not supported by the IRC server.)
         """
-        self.away: Optional[bool] = None
+        self.away: bool | None = None
         """Whether the user is marked as away.
 
         Will be ``None`` if the user's current away state hasn't been
         established yet (via WHO or other means such as ``away-notify``).
         """
-        self.is_bot: Optional[bool] = None
+        self.is_bot: bool | None = None
         """Whether the user is flagged as a bot.
 
         Will be ``None`` if the user hasn't yet been WHOed, or if the IRC
@@ -177,10 +177,10 @@ class Channel:
             does not automatically populate all modes and lists.
         """
 
-        self.last_who: Optional[datetime.datetime] = None
+        self.last_who: datetime.datetime | None = None
         """The last time a WHO was requested for the channel."""
 
-        self.join_time: Optional[datetime.datetime] = None
+        self.join_time: datetime.datetime | None = None
         """The time the server acknowledged our JOIN message.
 
         Based on server-reported time if the ``server-time`` IRCv3 capability

--- a/sopel/tools/target.py
+++ b/sopel/tools/target.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import functools
-from typing import Any, TYPE_CHECKING, Union
+from typing import Any, TYPE_CHECKING
 
 from sopel.privileges import AccessLevel
 from sopel.tools import memories
@@ -164,7 +164,7 @@ class Channel:
         self.topic: str = ''
         """The topic of the channel."""
 
-        self.modes: dict[str, Union[set, str, bool]] = {}
+        self.modes: dict[str, set | str | bool] = {}
         """The channel's modes.
 
         For type A modes (nick/address list), the value is a set. For type B

--- a/sopel/tools/time.py
+++ b/sopel/tools/time.py
@@ -9,7 +9,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import cast, NamedTuple, TYPE_CHECKING, Union
+from typing import cast, NamedTuple, TYPE_CHECKING
 
 import pytz
 
@@ -386,7 +386,7 @@ def get_time_unit(
 
 
 def seconds_to_human(
-    secs: Union[datetime.timedelta, float, int],
+    secs: datetime.timedelta | float | int,
     granularity: int = 2,
 ) -> str:
     """Format :class:`~datetime.timedelta` as a human-readable relative time.

--- a/sopel/tools/time.py
+++ b/sopel/tools/time.py
@@ -9,7 +9,7 @@
 from __future__ import annotations
 
 import datetime
-from typing import cast, NamedTuple, Optional, TYPE_CHECKING, Union
+from typing import cast, NamedTuple, TYPE_CHECKING, Union
 
 import pytz
 
@@ -57,7 +57,7 @@ class Duration(NamedTuple):
     """Seconds spent."""
 
 
-def validate_timezone(zone: Optional[str]) -> str:
+def validate_timezone(zone: str | None) -> str:
     """Normalize and validate an IANA timezone name.
 
     :param zone: in a strict or a human-friendly format
@@ -115,7 +115,7 @@ def validate_format(tformat: str) -> str:
     return tformat
 
 
-def get_nick_timezone(db: SopelDB, nick: str) -> Optional[str]:
+def get_nick_timezone(db: SopelDB, nick: str) -> str | None:
     """Get a nick's timezone from database.
 
     :param db: Bot's database handler (usually ``bot.db``)
@@ -133,7 +133,7 @@ def get_nick_timezone(db: SopelDB, nick: str) -> Optional[str]:
         return None
 
 
-def get_channel_timezone(db: SopelDB, channel: str) -> Optional[str]:
+def get_channel_timezone(db: SopelDB, channel: str) -> str | None:
     """Get a channel's timezone from database.
 
     :param db: Bot's database handler (usually ``bot.db``)
@@ -152,12 +152,12 @@ def get_channel_timezone(db: SopelDB, channel: str) -> Optional[str]:
 
 
 def get_timezone(
-    db: Optional[SopelDB] = None,
-    config: Optional[Config] = None,
-    zone: Optional[str] = None,
-    nick: Optional[str] = None,
-    channel: Optional[str] = None,
-) -> Optional[str]:
+    db: SopelDB | None = None,
+    config: Config | None = None,
+    zone: str | None = None,
+    nick: str | None = None,
+    channel: str | None = None,
+) -> str | None:
     """Find, and return, the appropriate timezone.
 
     :param db: bot database object (optional)
@@ -188,13 +188,13 @@ def get_timezone(
        formatting of the timezone.
 
     """
-    def _check(zone: Optional[str]) -> Optional[str]:
+    def _check(zone: str | None) -> str | None:
         try:
             return validate_timezone(zone)
         except ValueError:
             return None
 
-    tz: Optional[str] = None
+    tz: str | None = None
 
     if zone:
         tz = _check(zone)
@@ -217,12 +217,12 @@ def get_timezone(
 
 
 def format_time(
-    db: Optional[SopelDB] = None,
-    config: Optional[Config] = None,
-    zone: Optional[str] = None,
-    nick: Optional[str] = None,
-    channel: Optional[str] = None,
-    time: Optional[datetime.datetime] = None,
+    db: SopelDB | None = None,
+    config: Config | None = None,
+    zone: str | None = None,
+    nick: str | None = None,
+    channel: str | None = None,
+    time: datetime.datetime | None = None,
 ) -> str:
     """Return a formatted string of the given time in the given zone.
 
@@ -254,7 +254,7 @@ def format_time(
     ``config`` is not given, step 3 will be skipped.
     """
     target_tz: datetime.tzinfo = pytz.utc
-    tformat: Optional[str] = None
+    tformat: str | None = None
 
     # get an aware datetime
     if not time:

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -14,7 +14,6 @@ import re
 from typing import (
     cast,
     Match,
-    Optional,
     Sequence,
     TYPE_CHECKING,
 )
@@ -162,7 +161,7 @@ class PreTrigger:
         self,
         own_nick: Identifier,
         line: str,
-        url_schemes: Optional[Sequence] = None,
+        url_schemes: Sequence | None = None,
         identifier_factory: IdentifierFactory = Identifier,
         statusmsg_prefixes: tuple[str, ...] = tuple(),
     ):
@@ -171,10 +170,10 @@ class PreTrigger:
         self.line: str = line
         self.urls: tuple[str, ...] = tuple()
         self.plain: str = ''
-        self.ctcp: Optional[str] = None
+        self.ctcp: str | None = None
 
         # Break off IRCv3 message tags, if present
-        self.tags: dict[str, Optional[str]] = {}
+        self.tags: dict[str, str | None] = {}
         if line.startswith('@'):
             tagstring, line = line.split(' ', 1)
             for raw_tag in tagstring[1:].split(';'):
@@ -201,7 +200,7 @@ class PreTrigger:
         # Example: line = ':Sopel!foo@bar PRIVMSG #sopel :foobar!'
         #          print(hostmask)  # Sopel!foo@bar
         # All lines start with ":" except PING.
-        self.hostmask: Optional[str]
+        self.hostmask: str | None
         if line.startswith(':'):
             self.hostmask, line = line[1:].split(' ', 1)
         else:
@@ -236,8 +235,8 @@ class PreTrigger:
 
         # If we have arguments, the first one is *usually* the sender,
         # most numerics and certain general events (e.g. QUIT) excepted
-        target: Optional[Identifier] = None
-        status_prefix: Optional[str] = None
+        target: Identifier | None = None
+        status_prefix: str | None = None
 
         if self.args and self.event in COMMANDS_WITH_CONTEXT:
             raw_target = self.args[0]
@@ -347,7 +346,7 @@ class Trigger(str):
     status_prefix = property(lambda self: self._pretrigger.status_prefix)
     """The prefix used for the :attr:`sender` for status-specific messages.
 
-    :type: Optional[str]
+    :type: str | None
 
     This will be ``None`` by default. If a message is sent to a channel, it may
     have a status prefix for status-specific messages. In that case, the prefix
@@ -530,7 +529,7 @@ class Trigger(str):
         settings: config.Config,
         message: PreTrigger,
         match: Match,
-        account: Optional[str] = None,
+        account: str | None = None,
     ) -> 'Trigger':
         return str.__new__(cls, message.args[-1] if message.args else '')
 
@@ -539,7 +538,7 @@ class Trigger(str):
         settings: config.Config,
         message: PreTrigger,
         match: Match,
-        account: Optional[str] = None,
+        account: str | None = None,
     ) -> None:
         self._account = account
         self._pretrigger = message


### PR DESCRIPTION
### Description

Fixes #2643 and add deal with `Union` too for good measures.

The only exception is type alias with Optional or Union, which can't be replaced until Python 3.10 and above. I haven't tested this with Py3.8 but I'll trust our CI for that.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
