### PR TITLE
builtins, plugin, plugins: use Priority enum instead of literal strings

### DIFF
--- a/docs/source/plugin/advanced.rst
+++ b/docs/source/plugin/advanced.rst
@@ -128,10 +128,10 @@ Before event
 To handle an event before Sopel records any change, you should use these
 decorators together::
 
-    @plugin.event('event-name')  # replace by your event
-    @plugin.priority('high')     # ensure execution before Sopel
-    @plugin.thread(False)        # ensure sequential execution
-    @plugin.unblockable          # optional
+    @plugin.event('event-name')             # replace by your event
+    @plugin.priority(plugin.Priority.HIGH)  # ensure execution before Sopel
+    @plugin.thread(False)                   # ensure sequential execution
+    @plugin.unblockable                     # optional
     def before_event_name(bot, trigger):
         # the bot is not updated yet
 
@@ -145,10 +145,10 @@ After event
 To handle an event after Sopel recorded any change, you should use these
 decorators together::
 
-    @plugin.event('event-name')  # replace by your event
-    @plugin.priority('low')      # ensure execution after Sopel
-    @plugin.thread(False)        # optional
-    @plugin.unblockable          # optional
+    @plugin.event('event-name')             # replace by your event
+    @plugin.priority(plugin.Priority.LOW)   # ensure execution after Sopel
+    @plugin.thread(False)                   # optional
+    @plugin.unblockable                     # optional
     def after_event_name(bot, trigger):
         # the bot has been updated already
 
@@ -302,7 +302,7 @@ automatically:
     @plugin.event(events.RPL_SASLSUCCESS)
     @plugin.thread(False)
     @plugin.unblockable
-    @plugin.priority('medium')
+    @plugin.priority(plugin.Priority.MEDIUM)
     def sasl_success(bot: SopelWrapper, trigger: Trigger):
         """Resume capability negotiation on successful SASL auth."""
         LOGGER.info("Successful SASL Auth.")

--- a/sopel/builtins/admin.py
+++ b/sopel/builtins/admin.py
@@ -120,7 +120,7 @@ def _part(bot, channel, msg=None, save=True):
 @plugin.require_privmsg
 @plugin.require_admin
 @plugin.command('join')
-@plugin.priority('low')
+@plugin.priority(plugin.Priority.LOW)
 @plugin.example('.join #example key', user_help=True)
 @plugin.example('.join #example', user_help=True)
 def join(bot, trigger):
@@ -136,7 +136,7 @@ def join(bot, trigger):
 @plugin.require_privmsg
 @plugin.require_admin
 @plugin.command('tmpjoin')
-@plugin.priority('low')
+@plugin.priority(plugin.Priority.LOW)
 @plugin.example('.tmpjoin #example key', user_help=True)
 @plugin.example('.tmpjoin #example', user_help=True)
 def temporary_join(bot, trigger):
@@ -156,7 +156,7 @@ def temporary_join(bot, trigger):
 @plugin.require_privmsg
 @plugin.require_admin
 @plugin.command('part')
-@plugin.priority('low')
+@plugin.priority(plugin.Priority.LOW)
 @plugin.example('.part #example')
 def part(bot, trigger):
     """Part the specified channel. This is an admin-only command."""
@@ -171,7 +171,7 @@ def part(bot, trigger):
 @plugin.require_privmsg
 @plugin.require_admin
 @plugin.command('tmppart')
-@plugin.priority('low')
+@plugin.priority(plugin.Priority.LOW)
 @plugin.example('.tmppart #example')
 def temporary_part(bot, trigger):
     """Like ``part``, without saving. This is an admin-only command.
@@ -190,7 +190,7 @@ def temporary_part(bot, trigger):
 @plugin.require_privmsg
 @plugin.require_admin
 @plugin.command('chanlist', 'channels')
-@plugin.priority('low')
+@plugin.priority(plugin.Priority.LOW)
 def channel_list(bot, trigger):
     """Show channels Sopel is in."""
     channels = ', '.join(sorted(bot.channels.keys()))
@@ -203,7 +203,7 @@ def channel_list(bot, trigger):
 @plugin.require_privmsg
 @plugin.require_owner
 @plugin.command('restart')
-@plugin.priority('low')
+@plugin.priority(plugin.Priority.LOW)
 def restart(bot, trigger):
     """Restart the bot. This is an owner-only command."""
     quit_message = trigger.group(2)
@@ -218,7 +218,7 @@ def restart(bot, trigger):
 @plugin.require_privmsg
 @plugin.require_owner
 @plugin.command('quit')
-@plugin.priority('low')
+@plugin.priority(plugin.Priority.LOW)
 def quit(bot, trigger):
     """Quit from the server. This is an owner-only command."""
     quit_message = trigger.group(2)
@@ -233,7 +233,7 @@ def quit(bot, trigger):
 @plugin.require_owner
 @plugin.require_privmsg('This command only works as a private message.')
 @plugin.command('raw')
-@plugin.priority('low')
+@plugin.priority(plugin.Priority.LOW)
 @plugin.example('.raw PRIVMSG NickServ :CERT ADD')
 def raw(bot, trigger):
     """
@@ -250,7 +250,7 @@ def raw(bot, trigger):
 @plugin.require_admin
 @plugin.require_privmsg('This command only works as a private message.')
 @plugin.command('say', 'msg')
-@plugin.priority('low')
+@plugin.priority(plugin.Priority.LOW)
 @plugin.example('.say #YourPants Does anyone else smell neurotoxin?')
 def say(bot, trigger):
     """
@@ -273,7 +273,7 @@ def say(bot, trigger):
 @plugin.require_admin
 @plugin.require_privmsg('This command only works as a private message.')
 @plugin.command('me')
-@plugin.priority('low')
+@plugin.priority(plugin.Priority.LOW)
 def me(bot, trigger):
     """
     Send an ACTION (/me) to a given channel or nick. Can only be done in
@@ -293,7 +293,7 @@ def me(bot, trigger):
 
 
 @plugin.event('INVITE')
-@plugin.priority('low')
+@plugin.priority(plugin.Priority.LOW)
 def invite_join(bot, trigger):
     """Join a channel Sopel is invited to, if the inviter is an admin."""
     nick = trigger.args[0]
@@ -317,7 +317,7 @@ def invite_join(bot, trigger):
 
 
 @plugin.event('KICK')
-@plugin.priority('low')
+@plugin.priority(plugin.Priority.LOW)
 def hold_ground(bot, trigger):
     """
     This function monitors all kicks across all channels Sopel is in. If it
@@ -341,7 +341,7 @@ def hold_ground(bot, trigger):
 @plugin.require_privmsg
 @plugin.require_admin
 @plugin.command('mode')
-@plugin.priority('low')
+@plugin.priority(plugin.Priority.LOW)
 def mode(bot, trigger):
     """Set a user mode on Sopel. Can only be done in privmsg by an admin."""
     mode = trigger.group(3)

--- a/sopel/builtins/adminchannel.py
+++ b/sopel/builtins/adminchannel.py
@@ -94,7 +94,7 @@ def devoice(bot, trigger):
 @plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV, reply=True)
 @plugin.require_bot_privilege(plugin.HALFOP, ERROR_MESSAGE_NOT_OP, reply=True)
 @plugin.command('kick')
-@plugin.priority('high')
+@plugin.priority(plugin.Priority.HIGH)
 def kick(bot, trigger):
     """Kick a user from the channel."""
     text = trigger.group().split()
@@ -158,7 +158,7 @@ def configureHostMask(mask):
 @plugin.require_privilege(plugin.OP, ERROR_MESSAGE_NO_PRIV, reply=True)
 @plugin.require_bot_privilege(plugin.HALFOP, ERROR_MESSAGE_NOT_OP, reply=True)
 @plugin.command('ban')
-@plugin.priority('high')
+@plugin.priority(plugin.Priority.HIGH)
 def ban(bot, trigger):
     """Ban a user from the channel
 
@@ -280,7 +280,7 @@ def unquiet(bot, trigger):
 @plugin.require_bot_privilege(plugin.OP, ERROR_MESSAGE_NOT_OP, reply=True)
 @plugin.command('kickban', 'kb')
 @plugin.example('.kickban [#chan] user1 user!*@* get out of here')
-@plugin.priority('high')
+@plugin.priority(plugin.Priority.HIGH)
 def kickban(bot, trigger):
     """Kick and ban a user from the channel
 

--- a/sopel/builtins/choose.py
+++ b/sopel/builtins/choose.py
@@ -70,7 +70,7 @@ def _format_safe(text):
 
 
 @plugin.command('choose', 'choice', 'ch')
-@plugin.priority("medium")
+@plugin.priority(plugin.Priority.MEDIUM)
 @plugin.example(".choose a, b, c", r'Your options: a, b, c. My choice: (a|b|c)', re=True)
 @plugin.example(".choose a | b | c", r'Your options: a, b, c. My choice: (a|b|c)', re=True)
 @plugin.example(".choose a,b,c", r'Your options: a, b, c. My choice: (a|b|c)', re=True)

--- a/sopel/builtins/dice.py
+++ b/sopel/builtins/dice.py
@@ -215,7 +215,7 @@ def _roll_dice(dice_match: re.Match[str]) -> DicePouch:
 
 
 @plugin.command('roll', 'dice', 'd')
-@plugin.priority("medium")
+@plugin.priority(plugin.Priority.MEDIUM)
 @plugin.example(".roll", "No dice to roll.")
 @plugin.example(".roll 2d6+4^2&",
                 "I don't know how to process that. "

--- a/sopel/builtins/find.py
+++ b/sopel/builtins/find.py
@@ -34,7 +34,7 @@ def shutdown(bot):
 
 @plugin.echo
 @plugin.rule('.*')
-@plugin.priority('low')
+@plugin.priority(plugin.Priority.LOW)
 @plugin.require_chanmsg
 @plugin.unblockable
 def collectlines(bot, trigger):
@@ -74,7 +74,7 @@ def _cleanup_nickname(bot, nick, channel=None):
 
 @plugin.echo
 @plugin.event('PART')
-@plugin.priority('low')
+@plugin.priority(plugin.Priority.LOW)
 @plugin.unblockable
 def part_cleanup(bot, trigger):
     """Clean up cached data when a user leaves a channel."""
@@ -88,7 +88,7 @@ def part_cleanup(bot, trigger):
 
 @plugin.echo
 @plugin.event('QUIT')
-@plugin.priority('low')
+@plugin.priority(plugin.Priority.LOW)
 @plugin.unblockable
 def quit_cleanup(bot, trigger):
     """Clean up cached data after a user quits IRC."""
@@ -98,7 +98,7 @@ def quit_cleanup(bot, trigger):
 
 @plugin.echo
 @plugin.event('KICK')
-@plugin.priority('low')
+@plugin.priority(plugin.Priority.LOW)
 @plugin.unblockable
 def kick_cleanup(bot, trigger):
     """Clean up cached data when a user is kicked from a channel."""
@@ -146,7 +146,7 @@ def kick_cleanup(bot, trigger):
                 (?P<flags>\S+)
              )?
             """)
-@plugin.priority('high')
+@plugin.priority(plugin.Priority.HIGH)
 def findandreplace(bot, trigger):
     # Don't bother in PM
     if trigger.is_privmsg:

--- a/sopel/builtins/ping.py
+++ b/sopel/builtins/ping.py
@@ -24,7 +24,7 @@ def rude(bot, trigger):
 
 
 @plugin.rule('$nickname!')
-@plugin.priority('high')
+@plugin.priority(plugin.Priority.HIGH)
 @plugin.thread(False)
 def interjection(bot, trigger):
     bot.say(trigger.nick + '!')

--- a/sopel/builtins/reload.py
+++ b/sopel/builtins/reload.py
@@ -29,7 +29,7 @@ def _load(bot, plugin):
 
 
 @plugin.nickname_command("reload")
-@plugin.priority("low")
+@plugin.priority(plugin.Priority.LOW)
 @plugin.thread(False)
 @plugin.require_admin
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
@@ -60,7 +60,7 @@ def f_reload(bot, trigger):
 
 
 @plugin.nickname_command("load")
-@plugin.priority("low")
+@plugin.priority(plugin.Priority.LOW)
 @plugin.thread(False)
 @plugin.require_admin
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
@@ -100,7 +100,7 @@ def f_load(bot, trigger):
 
 # Catch private messages
 @plugin.command("reload")
-@plugin.priority("low")
+@plugin.priority(plugin.Priority.LOW)
 @plugin.thread(False)
 @plugin.require_privmsg
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
@@ -110,7 +110,7 @@ def pm_f_reload(bot, trigger):
 
 
 @plugin.command("load")
-@plugin.priority("low")
+@plugin.priority(plugin.Priority.LOW)
 @plugin.thread(False)
 @plugin.require_privmsg
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)

--- a/sopel/builtins/seen.py
+++ b/sopel/builtins/seen.py
@@ -65,7 +65,7 @@ def seen(bot, trigger):
 
 @plugin.thread(False)
 @plugin.rule('(.*)')
-@plugin.priority('low')
+@plugin.priority(plugin.Priority.LOW)
 @plugin.unblockable
 @plugin.require_chanmsg
 def note(bot, trigger):

--- a/sopel/builtins/tell.py
+++ b/sopel/builtins/tell.py
@@ -282,7 +282,7 @@ def nick_match_tellee(nick, tellee):
 
 
 @plugin.rule('(.*)')
-@plugin.priority('low')
+@plugin.priority(plugin.Priority.LOW)
 @plugin.unblockable
 @plugin.output_prefix('[tell] ')
 def message(bot, trigger):

--- a/sopel/builtins/translate.py
+++ b/sopel/builtins/translate.py
@@ -85,7 +85,7 @@ def translate(text, in_lang='auto', out_lang='en'):
 
 @plugin.rule(r'$nickname[,:]\s+(?:([a-z]{2}) +)?(?:([a-z]{2}|en-raw) +)?["“](.+?)["”]\? *$')
 @plugin.example('$nickname: "mon chien"? or $nickname: fr "mon chien"?')
-@plugin.priority('low')
+@plugin.priority(plugin.Priority.LOW)
 @plugin.output_prefix(PLUGIN_OUTPUT_PREFIX)
 def tr(bot, trigger):
     """Translates a phrase, with an optional language hint."""
@@ -289,7 +289,7 @@ def mangle(bot, trigger):
 
 
 @plugin.rule('(.*)')
-@plugin.priority('low')
+@plugin.priority(plugin.Priority.LOW)
 @plugin.unblockable
 def collect_mangle_lines(bot, trigger):
     bot.memory['mangle_lines'][trigger.sender] = "%s said '%s'" % (

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -298,7 +298,7 @@ def _execute_perform(bot):
 @plugin.event(events.ERR_NICKNAMEINUSE)
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def on_nickname_in_use(bot, trigger):
     """Change the bot's nick when the current one is already in use.
 
@@ -334,7 +334,7 @@ def execute_perform(bot, trigger):
 @plugin.event(events.RPL_WELCOME, events.RPL_LUSERCLIENT)
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def startup(bot, trigger):
     """Do tasks related to connecting to the network.
 
@@ -422,7 +422,7 @@ def startup(bot, trigger):
 @plugin.thread(False)
 @plugin.unblockable
 @plugin.rule('are supported by this server')
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def handle_isupport(bot, trigger):
     """Handle ``RPL_ISUPPORT`` events."""
     # remember if certain actionable tokens are known to be supported,
@@ -492,7 +492,7 @@ def handle_isupport(bot, trigger):
 @plugin.event(events.RPL_ENDOFMOTD, events.ERR_NOMOTD)
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def join_channels(bot, trigger):
     # join channels
     channels = bot.settings.core.channels
@@ -530,7 +530,7 @@ def join_channels(bot, trigger):
 @plugin.event(events.RPL_MYINFO)
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def parse_reply_myinfo(bot, trigger):
     """Handle ``RPL_MYINFO`` events."""
     # keep <client> <servername> <version> only
@@ -579,7 +579,7 @@ def enable_service_auth(bot, trigger):
 
 
 @plugin.event(events.ERR_NOCHANMODES)
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def retry_join(bot, trigger):
     """Give NickServ enough time to identify on a +R channel.
 
@@ -610,7 +610,7 @@ def retry_join(bot, trigger):
 @plugin.event(events.RPL_NAMREPLY)
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def handle_names(bot, trigger):
     """Handle NAMES responses.
 
@@ -681,13 +681,13 @@ def handle_names(bot, trigger):
 @plugin.event('MODE')
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def track_modes(bot, trigger):
     """Track changes from received MODE commands."""
     _parse_modes(bot, trigger.args)
 
 
-@plugin.priority('high')
+@plugin.priority(plugin.Priority.HIGH)
 @plugin.event(events.RPL_CHANNELMODEIS)
 @plugin.thread(False)
 @plugin.unblockable
@@ -805,7 +805,7 @@ def _parse_modes(bot, args, clear=False):
 @plugin.event('NICK')
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def track_nicks(bot, trigger):
     """Track nickname changes and maintain our chanops list accordingly."""
     old = trigger.nick
@@ -853,7 +853,7 @@ def track_nicks(bot, trigger):
 @plugin.event('SETNAME')
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def handle_setname(bot, trigger):
     """Update a user's realname when notified by the IRC server."""
     user = bot.users.get(trigger.nick)
@@ -876,7 +876,7 @@ def handle_setname(bot, trigger):
 @plugin.event('PART')
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def track_part(bot, trigger):
     """Track users leaving channels."""
     nick = trigger.nick
@@ -888,7 +888,7 @@ def track_part(bot, trigger):
 @plugin.event('KICK')
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def track_kick(bot, trigger):
     """Track users kicked from channels."""
     nick = bot.make_identifier(trigger.args[1])
@@ -971,7 +971,7 @@ def _periodic_send_who(bot):
 @plugin.event('INVITE')
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def track_invite(bot, trigger):
     """Track users being invited to channels."""
     LOGGER.info(
@@ -981,7 +981,7 @@ def track_invite(bot, trigger):
 @plugin.event('JOIN')
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def track_join(bot, trigger):
     """Track users joining channels.
 
@@ -1038,7 +1038,7 @@ def track_join(bot, trigger):
 @plugin.event('QUIT')
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def track_quit(bot, trigger):
     """Track when users quit channels."""
     for channel in bot.channels.values():
@@ -1183,7 +1183,7 @@ CAP_HANDLERS: dict[str, Callable[[SopelWrapper, Trigger], None]] = {
 @plugin.event('CAP')
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def receive_cap_list(bot: SopelWrapper, trigger: Trigger) -> None:
     """Handle client capability negotiation."""
     subcommand = trigger.args[1]
@@ -1228,7 +1228,7 @@ def send_authenticate(bot, token):
 @plugin.event('AUTHENTICATE')
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def auth_proceed(bot, trigger):
     """Handle client-initiated SASL auth.
 
@@ -1297,7 +1297,7 @@ def _make_sasl_plain_token(account, password):
 @plugin.event(events.RPL_SASLSUCCESS)
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def sasl_success(bot: SopelWrapper, trigger: Trigger) -> None:
     """Resume capability negotiation on successful SASL auth."""
     LOGGER.info("Successful SASL Auth.")
@@ -1310,7 +1310,7 @@ def sasl_success(bot: SopelWrapper, trigger: Trigger) -> None:
 @plugin.event(events.ERR_NICKLOCKED)
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def sasl_fail(bot, trigger):
     """SASL Auth Failed: log the error and quit."""
     LOGGER.error(
@@ -1325,7 +1325,7 @@ def sasl_fail(bot, trigger):
 @plugin.event(events.RPL_SASLMECHS)
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('low')
+@plugin.priority(plugin.Priority.LOW)
 def sasl_mechs(bot, trigger):
     # Presumably we're only here if we said we actually *want* sasl, but still
     # check anyway in case the server glitched.
@@ -1396,7 +1396,7 @@ def _get_sasl_pass_and_mech(bot):
 @plugin.example(r'.blocks add nick sp(a|4)mb(o|0)t\d*', user_help=True)
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('low')
+@plugin.priority(plugin.Priority.LOW)
 @plugin.require_admin
 def blocks(bot, trigger):
     """Manage Sopel's blocking features.
@@ -1501,7 +1501,7 @@ def blocks(bot, trigger):
 @plugin.event('CHGHOST')
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def recv_chghost(bot, trigger):
     """Track user/host changes."""
     if trigger.nick not in bot.users:
@@ -1527,7 +1527,7 @@ def recv_chghost(bot, trigger):
 @plugin.event('ACCOUNT')
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def account_notify(bot, trigger):
     """Track users' accounts."""
     if trigger.nick not in bot.users:
@@ -1543,7 +1543,7 @@ def account_notify(bot, trigger):
 @plugin.event(events.RPL_WHOSPCRPL)
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def recv_whox(bot, trigger):
     """Track ``WHO`` responses when ``WHOX`` is enabled."""
     if len(trigger.args) < 2 or trigger.args[1] != WHOX_QUERYTYPE:
@@ -1626,7 +1626,7 @@ def _record_who(
 @plugin.event(events.RPL_WHOREPLY)
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def recv_who(bot, trigger):
     """Track ``WHO`` responses when ``WHOX`` is not enabled."""
     channel, user, host, _, nick, status = trigger.args[1:7]
@@ -1644,7 +1644,7 @@ def recv_who(bot, trigger):
 @plugin.event('AWAY')
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def track_notify(bot, trigger):
     """Track users going away or coming back."""
     if trigger.nick not in bot.users:
@@ -1660,7 +1660,7 @@ def track_notify(bot, trigger):
 @plugin.event(events.RPL_TOPIC)
 @plugin.thread(False)
 @plugin.unblockable
-@plugin.priority('medium')
+@plugin.priority(plugin.Priority.MEDIUM)
 def track_topic(bot, trigger):
     """Track channels' topics."""
     if trigger.event != 'TOPIC':

--- a/sopel/plugin.py
+++ b/sopel/plugin.py
@@ -32,6 +32,7 @@ from sopel.plugins.callables import (
     PluginCallable,
     PluginGeneric,
     PluginJob,
+    Priority,
     TypedPluginCallableHandler,
     TypedPluginJobHandler,
 )
@@ -46,6 +47,11 @@ OP = AccessLevel.OP
 ADMIN = AccessLevel.ADMIN
 OWNER = AccessLevel.OWNER
 OPER = AccessLevel.OPER
+
+# expose priorities as shortcut
+LOW = Priority.LOW
+MEDIUM = Priority.MEDIUM
+HIGH = Priority.HIGH
 
 
 if TYPE_CHECKING:
@@ -67,7 +73,11 @@ TypedJobDecorator = Callable[
 
 __all__ = [
     # constants
-    'NOLIMIT', 'VOICE', 'HALFOP', 'OP', 'ADMIN', 'OWNER', 'OPER',
+    'NOLIMIT',
+    # privilege constants
+    'VOICE', 'HALFOP', 'OP', 'ADMIN', 'OWNER', 'OPER',
+    # priority constants
+    'LOW', 'MEDIUM', 'HIGH',
     # decorators
     'action_command',
     'action_commands',
@@ -957,21 +967,77 @@ def label(
 
 
 def priority(
-    value: Literal['low', 'medium', 'high'],
+    value: Literal['low', 'medium', 'high'] | Priority,
 ) -> TypedCallableDecorator:
     """Decorate a function to be executed with higher or lower priority.
 
-    :param value: one of ``high``, ``medium``, or ``low``
+    :param value: one of ``LOW``, ``MEDIUM``, ``HIGH``
 
     The priority allows you some control over the order of callable execution,
     if your plugin needs it. If a callable does not specify its ``priority``,
-    Sopel assumes ``medium``.
+    Sopel assumes :attr:`~sopel.plugins.callables.Priority.MEDIUM`.
+
+    Shortcuts are defined for each priority:
+
+    * ``plugin.LOW`` for :attr:`sopel.plugins.callables.Priority.LOW`
+    * ``plugin.MEDIUM`` for :attr:`sopel.plugins.callables.Priority.MEDIUM`
+    * ``plugin.HIGH`` for :attr:`sopel.plugins.callables.Priority.HIGH`
+
+    For examples this::
+
+        from sopel import plugin
+
+        @plugin.priority(plugin.MEDIUM)
+        # ...
+
+    Is equivalent to this::
+
+        from sopel.plugins.callables import Priority
+
+        @plugin.priority(Priority.MEDIUM)
+        # ...
+
+    .. versionchanged:: 8.1
+
+        This decorator now uses :class:`~sopel.plugins.callables.Priority` to
+        represent plugin callable priority.
+
+    .. important::
+
+        Using a string literal is deprecated in Sopel 8.1 and it will be
+        removed in Sopel 9. This::
+
+            from sopel import plugin
+
+            @plugin.priority('medium')
+            # ...
+
+        Must be replaced with::
+
+            from sopel import plugin
+
+            @plugin.priority(plugin.MEDIUM)
+            # ...
     """
+    priority_value = Priority[value.upper()]
+
+    if not isinstance(value, Priority):
+        deprecated(
+            'literal string `%s` for priority is deprecated; '
+            'use plugin.Priority.%s instead' % (
+                value, value.upper()
+            ),
+            version='8.1',
+            removed_in='9.0',
+            stack_frame=-2,
+            func=lambda *args: ...,
+        )()
+
     def decorator(
         function: TypedPluginCallableHandler | AbstractPluginObject
     ) -> PluginCallable:
         handler = PluginCallable.ensure_callable(function)
-        handler.priority = value
+        handler.priority = priority_value
         return handler
 
     return decorator

--- a/sopel/plugins/rules.py
+++ b/sopel/plugins/rules.py
@@ -37,6 +37,7 @@ from sopel.config.core_section import (
     COMMAND_DEFAULT_PREFIX,
     URL_DEFAULT_SCHEMES,
 )
+from sopel.plugins.callables import Priority
 
 
 if TYPE_CHECKING:
@@ -78,18 +79,6 @@ LOGGER = logging.getLogger(__name__)
 
 IGNORE_RATE_LIMIT = 1
 """Return value used to indicate that rate-limiting should be ignored."""
-PRIORITY_HIGH = 'high'
-"""Highest rule priority."""
-PRIORITY_MEDIUM = 'medium'
-"""Medium rule priority."""
-PRIORITY_LOW = 'low'
-"""Lowest rule priority."""
-PRIORITY_SCALES = {
-    PRIORITY_HIGH: 0,
-    PRIORITY_MEDIUM: 100,
-    PRIORITY_LOW: 1000,
-}
-"""Mapping of priority label to priority scale."""
 
 
 def _clean_rules(
@@ -447,11 +436,9 @@ class Manager:
         """Get triggered rules with their match objects, sorted by priorities.
 
         :param bot: Sopel instance
-        :type bot: :class:`sopel.bot.Sopel`
         :param pretrigger: IRC line
-        :type pretrigger: :class:`sopel.trigger.PreTrigger`
         :return: a tuple of ``(rule, match)``, sorted by priorities
-        :rtype: tuple
+                 (highest first)
         """
         generic_rules = self._rules.values()
         command_rules = (
@@ -484,7 +471,12 @@ class Manager:
         # static list of (rule/match), otherwise Python will raise an error
         # if any rule execution tries to alter the list of registered rules.
         # Making it immutable is the cherry on top.
-        return tuple(sorted(matches, key=lambda x: x[0].priority_scale))
+        return tuple(
+            # sorting rules in reversed order by priority (highest first)
+            # "reverse" argument is used instead of reversed() to keep
+            # registration order of rules with the same priority
+            sorted(matches, key=lambda x: x[0].get_priority(), reverse=True)
+        )
 
     def check_url_callback(self, bot, url):
         """Tell if the ``url`` matches any of the registered URL callbacks.
@@ -577,7 +569,6 @@ class AbstractRule(abc.ABC):
     * rate limiting feature
     * text parsing
     * and finally, trigger execution (i.e. actually doing something)
-
     """
     @classmethod
     @abc.abstractmethod
@@ -599,21 +590,6 @@ class AbstractRule(abc.ABC):
             properties that are expected from a plugin callable.
 
         """
-
-    @property
-    def priority_scale(self):
-        """Rule's priority on a numeric scale.
-
-        This attribute can be used to sort rules between each other, the
-        highest priority rules coming first. The default priority for a rule
-        is "medium".
-        """
-        priority_key = self.get_priority()
-
-        return (
-            PRIORITY_SCALES.get(priority_key) or
-            PRIORITY_SCALES[PRIORITY_MEDIUM]
-        )
 
     @abc.abstractmethod
     def get_plugin_name(self) -> str:
@@ -670,19 +646,16 @@ class AbstractRule(abc.ABC):
         """
 
     @abc.abstractmethod
-    def get_priority(self) -> str:
+    def get_priority(self) -> Priority:
         """Get the rule's priority.
 
-        A rule can have a priority, based on the three pre-defined priorities
-        used by Sopel: ``PRIORITY_HIGH``, ``PRIORITY_MEDIUM``, and
-        ``PRIORITY_LOW``.
+        A rule can have a priority, based on enum
+        :class:`~sopel.plugins.callables.Priority`.
 
-        .. seealso::
+        .. versionchanged:: 8.1
 
-            The :attr:`AbstractRule.priority_scale` property uses this method
-            to look up the numeric priority value, which is used to sort rules
-            by priority.
-
+            This method returns a :class:`~sopel.plugins.callables.Priority`
+            instead of a string.
         """
 
     @abc.abstractmethod
@@ -1070,7 +1043,7 @@ class Rule(AbstractRule):
         regexes: Sequence[re.Pattern],
         plugin: str | None = None,
         label: str | None = None,
-        priority: str | None = PRIORITY_MEDIUM,
+        priority: Priority | None = Priority.MEDIUM,
         handler: PluginCallable | None = None,
         events: list[str] | None = None,
         ctcp: list[re.Pattern] | None = None,
@@ -1095,7 +1068,7 @@ class Rule(AbstractRule):
         self._regexes: Sequence[re.Pattern] = regexes
         self._plugin_name: str | None = plugin
         self._label: str | None = label
-        self._priority: str = priority or PRIORITY_MEDIUM
+        self._priority: Priority = priority or Priority.MEDIUM
         self._handler: PluginCallable | None = handler
 
         # filters

--- a/test/plugins/test_plugins_callables.py
+++ b/test/plugins/test_plugins_callables.py
@@ -5,7 +5,12 @@ from typing import TYPE_CHECKING
 
 import pytest
 
-from sopel.plugins.callables import PluginCallable, PluginGeneric, PluginJob
+from sopel.plugins.callables import (
+    PluginCallable,
+    PluginGeneric,
+    PluginJob,
+    Priority,
+)
 from sopel.tests import rawlist
 
 
@@ -35,6 +40,144 @@ def tmpconfig(configfactory: ConfigFactory) -> Config:
 @pytest.fixture
 def mockbot(tmpconfig: Config, botfactory: BotFactory) -> Sopel:
     return botfactory(tmpconfig)
+
+
+# Test plugin Priority
+
+def test_priority_compare_eq():
+    assert Priority.LOW == Priority.LOW
+    assert Priority.LOW == 'low'
+    assert Priority.MEDIUM == Priority.MEDIUM
+    assert Priority.MEDIUM == 'medium'
+    assert Priority.HIGH == Priority.HIGH
+    assert Priority.HIGH == 'high'
+
+
+def test_priority_level():
+    assert Priority.LOW.level == 0
+    assert Priority.MEDIUM.level == 100
+    assert Priority.HIGH.level == 1000
+
+
+def test_priority_compare_lt():
+    assert Priority.LOW < Priority.MEDIUM
+    assert Priority.MEDIUM < Priority.HIGH
+    assert Priority.LOW < Priority.HIGH
+    assert Priority.LOW < Priority.MEDIUM < Priority.HIGH
+
+    assert (Priority.LOW < Priority.LOW) is False
+    assert (Priority.MEDIUM < Priority.MEDIUM) is False
+    assert (Priority.HIGH < Priority.HIGH) is False
+
+    assert (Priority.MEDIUM < Priority.LOW) is False
+    assert (Priority.HIGH < Priority.MEDIUM) is False
+    assert (Priority.HIGH < Priority.LOW) is False
+    assert (Priority.HIGH < Priority.MEDIUM < Priority.LOW) is False
+
+    with pytest.raises(TypeError):
+        assert Priority.LOW < 50
+
+    with pytest.raises(TypeError):
+        assert Priority.MEDIUM < 50
+
+    with pytest.raises(TypeError):
+        assert Priority.HIGH < 50
+
+
+def test_priority_compare_le():
+    assert Priority.LOW <= Priority.MEDIUM
+    assert Priority.MEDIUM <= Priority.HIGH
+    assert Priority.LOW <= Priority.HIGH
+    assert Priority.LOW <= Priority.MEDIUM <= Priority.HIGH
+
+    assert Priority.LOW <= Priority.LOW
+    assert Priority.MEDIUM <= Priority.MEDIUM
+    assert Priority.HIGH <= Priority.HIGH
+
+    assert (Priority.MEDIUM <= Priority.LOW) is False
+    assert (Priority.HIGH <= Priority.MEDIUM) is False
+    assert (Priority.HIGH <= Priority.LOW) is False
+    assert (Priority.HIGH <= Priority.MEDIUM <= Priority.LOW) is False
+
+    with pytest.raises(TypeError):
+        assert Priority.LOW <= 50
+
+    with pytest.raises(TypeError):
+        assert Priority.MEDIUM <= 50
+
+    with pytest.raises(TypeError):
+        assert Priority.HIGH <= 50
+
+
+def test_priority_compare_gt():
+    assert Priority.HIGH > Priority.MEDIUM
+    assert Priority.MEDIUM > Priority.LOW
+    assert Priority.HIGH > Priority.LOW
+    assert Priority.HIGH > Priority.MEDIUM > Priority.LOW
+
+    assert (Priority.LOW > Priority.LOW) is False
+    assert (Priority.MEDIUM > Priority.MEDIUM) is False
+    assert (Priority.HIGH > Priority.HIGH) is False
+
+    assert (Priority.LOW > Priority.MEDIUM) is False
+    assert (Priority.MEDIUM > Priority.HIGH) is False
+    assert (Priority.LOW > Priority.HIGH) is False
+    assert (Priority.LOW > Priority.MEDIUM > Priority.HIGH) is False
+
+    with pytest.raises(TypeError):
+        assert Priority.LOW > 50
+
+    with pytest.raises(TypeError):
+        assert Priority.MEDIUM > 50
+
+    with pytest.raises(TypeError):
+        assert Priority.HIGH > 50
+
+
+def test_priority_compare_ge():
+    assert Priority.HIGH >= Priority.MEDIUM
+    assert Priority.MEDIUM >= Priority.LOW
+    assert Priority.HIGH >= Priority.LOW
+    assert Priority.HIGH >= Priority.MEDIUM >= Priority.LOW
+
+    assert Priority.LOW >= Priority.LOW
+    assert Priority.MEDIUM >= Priority.MEDIUM
+    assert Priority.HIGH >= Priority.HIGH
+
+    assert (Priority.LOW >= Priority.MEDIUM) is False
+    assert (Priority.MEDIUM >= Priority.HIGH) is False
+    assert (Priority.LOW >= Priority.HIGH) is False
+    assert (Priority.LOW >= Priority.MEDIUM >= Priority.HIGH) is False
+
+    with pytest.raises(TypeError):
+        assert Priority.LOW >= 50
+
+    with pytest.raises(TypeError):
+        assert Priority.MEDIUM >= 50
+
+    with pytest.raises(TypeError):
+        assert Priority.HIGH >= 50
+
+
+def test_priority_sorting():
+    assert sorted(
+        [Priority.LOW, Priority.MEDIUM, Priority.HIGH]
+    ) == [Priority.LOW, Priority.MEDIUM, Priority.HIGH]
+    assert sorted(
+        [Priority.LOW, Priority.HIGH, Priority.MEDIUM]
+    ) == [Priority.LOW, Priority.MEDIUM, Priority.HIGH]
+    assert sorted(
+        [Priority.MEDIUM, Priority.LOW, Priority.HIGH]
+    ) == [Priority.LOW, Priority.MEDIUM, Priority.HIGH]
+    assert sorted(
+        [Priority.MEDIUM, Priority.HIGH, Priority.LOW]
+    ) == [Priority.LOW, Priority.MEDIUM, Priority.HIGH]
+    assert sorted(
+        [Priority.HIGH, Priority.LOW, Priority.MEDIUM]
+    ) == [Priority.LOW, Priority.MEDIUM, Priority.HIGH]
+    assert sorted(
+        [Priority.HIGH, Priority.MEDIUM, Priority.LOW]
+    ) == [Priority.LOW, Priority.MEDIUM, Priority.HIGH]
 
 
 # Test plugin generic


### PR DESCRIPTION
### Description

Part of #2557

Until now, plugins would use literal string to define rule priorities: `low`, `medium`, and `high`. This required a bunch of constants and not the best typing system.

This commit introduces a new way: a Priority enum that defines the three currently supported priorities (LOW, MEDIUM, HIGH). This allows us to handle sorting directly with the enum, and opens the possibility of adding new priorities in the  future with the least amount of changes required.

Now, using `@plugin.priority('medium')` will raise a deprecation warning when loading a plugin, with a helpful message to use `plugin.MEDIUM` instead. Three shortcuts have been added to `sopel.plugin` for that purpose.

This commit includes minor documentation improvements, and more tests, as per usual.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches