### PR TITLE
tools: remove deprecated code and add deprecation for tools.web

### DIFF
--- a/sopel/tools/__init__.py
+++ b/sopel/tools/__init__.py
@@ -13,13 +13,11 @@
 
 from __future__ import annotations
 
-import codecs
 import logging
 import re
-import sys
 
 # Don't delete `deprecated` import - maintains backward compatibility with pre-8.0 API
-from sopel.lifecycle import deprecated
+from sopel.lifecycle import deprecated  # NOQA
 
 from . import time, web  # NOQA
 from ._events import events  # NOQA
@@ -31,49 +29,6 @@ from .memories import (  # NOQA
     SopelMemory,
     SopelMemoryWithDefault,
 )
-
-
-# Long kept for Python compatibility, but it's time we let these go.
-raw_input = deprecated(  # pragma: no cover
-    'Use the `input` function directly.',
-    version='8.0',
-    removed_in='8.1',
-    func=input)
-iteritems = deprecated(  # pragma: no cover
-    "Use the dict object's `.items()` method directly.",
-    version='8.0',
-    removed_in='8.1',
-    func=dict.items)
-itervalues = deprecated(  # pragma: no cover
-    "Use the dict object's `.values()` method directly.",
-    version='8.0',
-    removed_in='8.1',
-    func=dict.values)
-iterkeys = deprecated(  # pragma: no cover
-    "Use the dict object's `.keys()` method directly.",
-    version='8.0',
-    removed_in='8.1',
-    func=dict.keys)
-
-
-@deprecated('Shim for Python 2 cross-compatibility, no longer needed. '
-            'Use built-in `input()` instead.',
-            version='7.1',
-            warning_in='8.0',
-            removed_in='8.1')
-def get_input(prompt):
-    """Get decoded input from the terminal (equivalent to Python 3's ``input``).
-
-    :param str prompt: what to display as a prompt on the terminal
-    :return: the user's input
-    :rtype: str
-
-    .. deprecated:: 7.1
-
-        This function will be removed in Sopel 8.1.
-
-    """
-    return input(prompt)
 
 
 def get_sendable_message(text, max_length=400):
@@ -122,93 +77,6 @@ def get_sendable_message(text, max_length=400):
             text = text[:last_space]
 
     return text, excess.lstrip()
-
-
-class OutputRedirect:
-    """Redirect the output to the terminal and a log file.
-
-    A simplified object used to write to both the terminal and a log file.
-
-    .. deprecated:: 8.0
-
-        Vestige of old logging system. Will be removed in Sopel 8.1.
-
-    """
-
-    @deprecated(
-        "Remnant of Sopel's pre-7.0 logging system. "
-        "You shouldn't have been using this anyway.",
-        version='8.0',
-        removed_in='8.1',
-    )
-    def __init__(self, logpath, stderr=False, quiet=False):
-        """Create an object which will log to both a file and the terminal.
-
-        :param str logpath: path to the log file
-        :param bool stderr: write output to stderr if ``True``, or to stdout
-                            otherwise
-        :param bool quiet: write to the log file only if ``True`` (and not to
-                           the terminal)
-
-        Create an object which will log to the file at ``logpath`` as well as
-        the terminal.
-        """
-        self.logpath = logpath
-        self.stderr = stderr
-        self.quiet = quiet
-
-    def write(self, string):
-        """Write the given ``string`` to the logfile and terminal.
-
-        :param str string: the string to write
-        """
-        if not self.quiet and sys.__stderr__ and sys.__stdout__:
-            try:
-                if self.stderr:
-                    sys.__stderr__.write(string)
-                else:
-                    sys.__stdout__.write(string)
-            except Exception:  # TODO: Be specific
-                pass
-
-        with codecs.open(self.logpath, 'ab', encoding="utf8",
-                         errors='xmlcharrefreplace') as logfile:
-            try:
-                logfile.write(string)
-            except UnicodeDecodeError:
-                # we got an invalid string, safely encode it to utf-8
-                logfile.write(str(string, 'utf8', errors="replace"))
-
-    def flush(self):
-        """Flush the file writing buffer."""
-        if self.stderr and sys.__stderr__:
-            sys.__stderr__.flush()
-        elif sys.__stdout__:
-            sys.__stdout__.flush()
-
-
-@deprecated(
-    "Plugins should use a logger object.",
-    version='8.0',
-    removed_in='8.1',
-)
-def stderr(string):
-    # don't like importing inside functions, but circular imports ensue otherwise
-    from sopel.cli.utils import stderr as _stderr
-
-    return _stderr(string)
-
-
-@deprecated(
-    "Function for internal use, moved to `sopel.cli.utils`.",
-    version='8.0',
-    removed_in='8.1',
-)
-def check_pid(pid):
-    # don't like importing inside functions, but circular imports ensue otherwise
-    from sopel.cli.utils import check_pid as _check_pid
-
-    return _check_pid(pid)
 
 
 def get_hostmask_regex(mask):

--- a/sopel/tools/web.py
+++ b/sopel/tools/web.py
@@ -3,6 +3,13 @@ The ``tools.web`` package contains utility functions for interaction with web
 applications, APIs, or websites in your plugins.
 
 .. versionadded:: 7.0
+
+.. versionchanged:: 8.1
+
+    Several utility functions are now deprecated due to Python's builtin
+    library containing the appropriate functions. These functions will be
+    removed in Sopel 9.
+
 """
 # Copyright © 2008, Sean B. Palmer, inamidst.com
 # Copyright © 2009, Michael Yanovich <yanovich.1@osu.edu>
@@ -125,6 +132,11 @@ def entity(match: re.Match) -> str:
     return '[' + value + ']'
 
 
+@deprecated(
+    version='8.1',
+    removed_in='9.0',
+    reason="Obsolete, use Python's html.unescape() function",
+)
 def decode(text: str) -> str:
     """Decode HTML entities into Unicode text.
 
@@ -136,11 +148,20 @@ def decode(text: str) -> str:
         Renamed ``html`` parameter to ``text``. (Python gained a standard
         library module named :mod:`html` in version 3.4.)
 
+    .. deprecated:: 8.1
+
+        Will be removed in Sopel 9. Migrate to Python's standard-library
+        equivalent, :func:`html.unescape`.
+
     """
-    # TODO deprecated?
     return html.unescape(text)
 
 
+@deprecated(
+    version='8.1',
+    removed_in='9.0',
+    reason="Obsolete, use Python's urllib.parse.quote() function",
+)
 def quote(string: str, safe: str = '/') -> str:
     """Safely encodes a string for use in a URL.
 
@@ -152,12 +173,21 @@ def quote(string: str, safe: str = '/') -> str:
     .. note::
         This is a shim to make writing cross-compatible plugins for both
         Python 2 and Python 3 easier.
+
+    .. deprecated:: 8.1
+
+        Will be removed in Sopel 9. Migrate to Python's standard-library
+        equivalent, :func:`urllib.parse.quote`.
     """
-    # TODO deprecated?
     return urllib.parse.quote(str(string), safe)
 
 
 # six-like shim for Unicode safety
+@deprecated(
+    version='8.1',
+    removed_in='9.0',
+    reason="Obsolete, use Python's urllib.parse.unquote() function",
+)
 def unquote(string: str) -> str:
     """Decodes a URL-encoded string.
 
@@ -167,19 +197,33 @@ def unquote(string: str) -> str:
     .. note::
 
         This is a convenient shortcut for ``urllib.parse.unquote``.
+
+    .. deprecated:: 8.1
+
+        Will be removed in Sopel 9. Migrate to Python's standard-library
+        equivalent, :func:`urllib.parse.unquote`.
     """
-    # TODO deprecated?
     return urllib.parse.unquote(string)
 
 
 def quote_query(string: str) -> str:
     """Safely encodes a URL's query parameters.
 
-    :param str string: a URL containing query parameters
-    :return str: the input URL with query parameter values URL-encoded
+    :param string: a URL containing query parameters
+    :return: the input URL with query parameter values URL-encoded
+
+    .. note::
+
+        This is a convenient function using :func:`urllib.parse.urlparse` and
+        :func:`urllib.parse.quote`.
+
     """
     parsed = urlparse(string)
-    string = string.replace(parsed.query, quote(parsed.query, "/=&"), 1)
+    string = string.replace(
+        parsed.query,
+        urllib.parse.quote(parsed.query, "/=&"),
+        1,
+    )
     return string
 
 
@@ -203,8 +247,12 @@ def iri_to_uri(iri: str) -> str:
 
 
 # direct shortcut kept for backward compatibility reasons
-# TODO consider removing this
-urlencode = urllib.parse.urlencode
+urlencode = deprecated(
+    version='8.1',
+    removed_in='9.0',
+    reason="Obsolete, use Python's urllib.parse.urlencode() function",
+    func=urllib.parse.urlencode
+)
 
 
 # Functions for URL detection

--- a/sopel/tools/web.py
+++ b/sopel/tools/web.py
@@ -9,7 +9,6 @@ applications, APIs, or websites in your plugins.
     Several utility functions are now deprecated due to Python's builtin
     library containing the appropriate functions. These functions will be
     removed in Sopel 9.
-
 """
 # Copyright © 2008, Sean B. Palmer, inamidst.com
 # Copyright © 2009, Michael Yanovich <yanovich.1@osu.edu>
@@ -152,7 +151,6 @@ def decode(text: str) -> str:
 
         Will be removed in Sopel 9. Migrate to Python's standard-library
         equivalent, :func:`html.unescape`.
-
     """
     return html.unescape(text)
 
@@ -214,9 +212,8 @@ def quote_query(string: str) -> str:
 
     .. note::
 
-        This is a convenient function using :func:`urllib.parse.urlparse` and
+        This is a convenience function using :func:`urllib.parse.urlparse` and
         :func:`urllib.parse.quote`.
-
     """
     parsed = urlparse(string)
     string = string.replace(


### PR DESCRIPTION
### Description

* remove deprecated code planned to be removed in Sopel 8.1 (I'm surprised we didn't crush these before)
* add deprecation warning on most shim-like functions in `sopel.tools.web` as per #2579 

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches