### PR TITLE
config, doc, test: clarify `nick@host` format of `owner, admins` settings

### DIFF
--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -79,7 +79,7 @@ class CoreSection(StaticSection):
     """
 
     admins = ListAttribute('admins')
-    """The list of people (other than the owner) who can administer the bot.
+    """List of nicks or ``nick@host`` who can administer the bot (other than the owner).
 
     Example:
 
@@ -1114,7 +1114,7 @@ class CoreSection(StaticSection):
     """
 
     owner = ValidatedAttribute('owner', default=NO_DEFAULT)
-    """The IRC name of the owner of the bot.
+    """The IRC nick or ``nick@host`` of the owner of the bot.
 
     **Required** even if :attr:`owner_account` is set.
     """

--- a/test/test_trigger.py
+++ b/test/test_trigger.py
@@ -18,6 +18,14 @@ admins =
 """
 
 
+TMP_CONFIG_HOSTMASK = """
+[core]
+owner = Foo@example.com
+admins =
+    Bar
+"""
+
+
 TMP_CONFIG_ACCOUNT = """
 [core]
 owner = Foo
@@ -289,11 +297,12 @@ def test_ctcp_action_pretrigger(nick):
     assert pretrigger.status_prefix is None
 
 
-def test_ctcp_action_trigger(nick, configfactory):
+@pytest.mark.parametrize("configsrc", [TMP_CONFIG, TMP_CONFIG_HOSTMASK])
+def test_ctcp_action_trigger(nick, configsrc, configfactory):
     line = ':Foo!bar@example.com PRIVMSG #Sopel :\x01ACTION Hello, world\x01'
     pretrigger = PreTrigger(nick, line)
 
-    config = configfactory('default.cfg', TMP_CONFIG)
+    config = configfactory('default.cfg', configsrc)
     fakematch = re.match('.*', line)
 
     trigger = Trigger(config, pretrigger, fakematch)
@@ -335,11 +344,12 @@ def test_ircv3_extended_join_pretrigger(nick):
     assert pretrigger.status_prefix is None
 
 
-def test_ircv3_extended_join_trigger(nick, configfactory):
+@pytest.mark.parametrize("configsrc", [TMP_CONFIG, TMP_CONFIG_HOSTMASK])
+def test_ircv3_extended_join_trigger(nick, configsrc, configfactory):
     line = ':Foo!foo@example.com JOIN #Sopel bar :Real Name'
     pretrigger = PreTrigger(nick, line)
 
-    config = configfactory('default.cfg', TMP_CONFIG)
+    config = configfactory('default.cfg', configsrc)
 
     fakematch = re.match('.*', line)
 
@@ -364,11 +374,12 @@ def test_ircv3_extended_join_trigger(nick, configfactory):
     assert trigger.admin is True
 
 
-def test_ircv3_intents_trigger(nick, configfactory):
+@pytest.mark.parametrize("configsrc", [TMP_CONFIG, TMP_CONFIG_HOSTMASK])
+def test_ircv3_intents_trigger(nick, configsrc, configfactory):
     line = '@intent=ACTION :Foo!bar@example.com PRIVMSG #Sopel :Hello, world'
     pretrigger = PreTrigger(nick, line)
 
-    config = configfactory('default.cfg', TMP_CONFIG)
+    config = configfactory('default.cfg', configsrc)
     fakematch = re.match('.*', line)
 
     trigger = Trigger(config, pretrigger, fakematch)
@@ -405,10 +416,11 @@ def test_ircv3_account_tag_trigger(nick, configfactory):
     assert trigger.owner is True
 
 
-def test_ircv3_server_time_trigger(nick, configfactory):
+@pytest.mark.parametrize("configsrc", [TMP_CONFIG, TMP_CONFIG_HOSTMASK])
+def test_ircv3_server_time_trigger(nick, configsrc, configfactory):
     line = '@time=2016-01-09T03:15:42.000Z :Foo!foo@example.com PRIVMSG #Sopel :Hello, world'
     pretrigger = PreTrigger(nick, line)
-    config = configfactory('default.cfg', TMP_CONFIG)
+    config = configfactory('default.cfg', configsrc)
     fakematch = re.match('.*', line)
 
     trigger = Trigger(config, pretrigger, fakematch)
@@ -422,10 +434,11 @@ def test_ircv3_server_time_trigger(nick, configfactory):
     assert pretrigger.time is not None
 
 
-def test_statusmsg_trigger(nick, configfactory):
+@pytest.mark.parametrize("configsrc", [TMP_CONFIG, TMP_CONFIG_HOSTMASK])
+def test_statusmsg_trigger(nick, configsrc, configfactory):
     line = ':Foo!foo@example.com PRIVMSG @#channel :text message'
     pretrigger = PreTrigger(nick, line, statusmsg_prefixes=tuple('@'))
-    config = configfactory('default.cfg', TMP_CONFIG)
+    config = configfactory('default.cfg', configsrc)
     fakematch = re.match('.*', line)
 
     trigger = Trigger(config, pretrigger, fakematch)


### PR DESCRIPTION
### Description

This changeset clarifies in the documentation that the core config field `owner` may be given as `nick@host` as well as a nick, and also covers this previously-untested usage in the `Trigger` tests. (Edit: this applies to the `admins` field as well)

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
  - `1451 passed, 8 xfailed, 1 warning in 47.36s`
- [x] I have tested the functionality of the things this change touches

### Remarks for reviewer

In moving the dummy configs to a fixture, I originally wanted to move the template out of the module namespace and into the fixture, relying on `textwrap.dedent()` to take care of the indentation:

```python
@pytest.fixture
def tmpconfig(configfactory) -> Config:
    return textwrap.dedent(f"""
        ...
    """
```

But this approach can cause trouble with trying to add a field later if also using an f-string, so I settled on a fixture that returns source. In particular, the thing I stumbled on was wanting to write:

```python
def test_ircv3_account_tag_trigger(nick, tmpconfig_src, configfactory):
    line = '@account=bar :Nick_Is_Not_Foo!foo@example.com PRIVMSG #Sopel :Hello, world'
    pretrigger = PreTrigger(nick, line)

    # NOTE: only first line of tmpconfig_src has the expected indent level
    # so the result ends up exactly the same as without the dedent()
    tmp_config_account = dedent(f"""
        {tmpconfig_src}
        owner_account = bar
    """)
```

I don't feel strongly about eliminating the module-level `TMP_CONFIG` and if desired I can update this PR to preserve it.