### PR TITLE
test: cover admin functionality of `Trigger`

### DIFF
--- a/test/test_trigger.py
+++ b/test/test_trigger.py
@@ -433,3 +433,27 @@ def test_statusmsg_trigger(nick, configfactory):
     assert trigger.sender == '#channel'
     assert trigger.sender == Identifier('#channel')
     assert trigger.status_prefix == '@'
+
+
+@pytest.mark.parametrize("senderhostmask,isadmin", [
+    ("Foo!bar@example.com", True),
+    ("Bar!bar@example.com", True),
+    ("Stranger!bar@example.com", False),
+    ("Bar!bar@stranger.domain", False)
+])
+def test_privmsg_admin(nick, senderhostmask, isadmin, configfactory):
+    line = f':{senderhostmask} PRIVMSG #Sopel :Hello world!'
+    pretrigger = PreTrigger(nick, line)
+
+    config = configfactory('default.cfg', """
+        [core]
+        owner = SomeoneElse
+        admins =
+            Foo@example.com
+            Bar@example.com
+    """)
+    fakematch = re.match('.*', line)
+
+    trigger = Trigger(config, pretrigger, fakematch)
+    assert trigger.sender == '#Sopel'
+    assert trigger.admin is isadmin, "Admin privilege does not match expectation"

--- a/test/test_trigger.py
+++ b/test/test_trigger.py
@@ -441,7 +441,7 @@ def test_statusmsg_trigger(nick, configfactory):
     ("Stranger!bar@example.com", False),
     ("Bar!bar@stranger.domain", False)
 ])
-def test_privmsg_admin(nick, senderhostmask, isadmin, configfactory):
+def test_privmsg_admin_match_host(nick, senderhostmask, isadmin, configfactory):
     line = f':{senderhostmask} PRIVMSG #Sopel :Hello world!'
     pretrigger = PreTrigger(nick, line)
 


### PR DESCRIPTION
### Description

Closes #2734 by adding a new test that checks that `Trigger.admin` is correct for a basic `PRIVMSG`. Could be expanded for other types of messages but I figured this was a good start.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches
