### PR TITLE
find: use non-deprecated re.sub() API

### DIFF
--- a/sopel/builtins/find.py
+++ b/sopel/builtins/find.py
@@ -182,9 +182,11 @@ def findandreplace(bot, trigger):
     # i flag turns off case sensitivity. re.U turns on unicode replacement.
     if 'i' in flags:
         regex = re.compile(re.escape(old), re.U | re.I)
+        # re.sub() uses count=0 to mean "replace all" and str.replace() uses -1, so we must translate here
+        re_count = int(count == 1)
 
         def repl(line, subst):
-            return re.sub(regex, subst, line, count == 1)
+            return re.sub(regex, subst, line, count=re_count)
     else:
         def repl(line, subst):
             return line.replace(old, subst, count)


### PR DESCRIPTION
### Description

This changeset resolves deprecated use of `re.sub()` in the `find` built-in. Passing the `count` parameter by position has been deprecated since Python 3.13.

Noticed this in the course of filing #2737.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
  - ```===== 1445 passed, 8 xfailed, 1 warning in 44.19s =====``` (down from 5 warnings before this changeset)
- [x] I have tested the functionality of the things this change touches
