### PR TITLE
find: simplify `findandreplace()` logic

### DIFF
--- a/sopel/builtins/find.py
+++ b/sopel/builtins/find.py
@@ -152,9 +152,9 @@ def findandreplace(bot, trigger):
     # Correcting other person vs self.
     rnick = bot.make_identifier(trigger.group('nick') or trigger.nick)
 
-    # only do something if there is conversation history to work with
     history = bot.memory['find_lines'].get(trigger.sender, {}).get(rnick, None)
     if not history:
+        # No conversation history to potentially correct; bail out.
         return
 
     sep = trigger.group('sep')
@@ -171,8 +171,11 @@ def findandreplace(bot, trigger):
 
     # If g flag is given, replace all. Otherwise, replace once.
     count = 0 if 'g' in flags else 1
+
     # If i flag is given, ignore case when replacing.
-    regex_flags = re.U | (re.I if 'i' in flags else 0)
+    regex_flags = re.U
+    if 'i' in flags:
+        regex_flags |= re.I
 
     # Precompile the regex with its flags
     regex = re.compile(re.escape(old), regex_flags)

--- a/sopel/builtins/find.py
+++ b/sopel/builtins/find.py
@@ -150,7 +150,11 @@ def kick_cleanup(bot, trigger):
 @plugin.require_chanmsg
 def findandreplace(bot, trigger):
     # Correcting other person vs self.
-    rnick = bot.make_identifier(trigger.group('nick') or trigger.nick)
+    correcting_self = True
+    rnick = trigger.nick
+    if trigger.group('nick'):
+        correcting_self = False
+        rnick = bot.make_identifier(trigger.group('nick'))
 
     history = bot.memory['find_lines'].get(trigger.sender, {}).get(rnick, None)
     if not history:
@@ -162,7 +166,6 @@ def findandreplace(bot, trigger):
 
     old = escape_sequence_pattern.sub(decode_escape, trigger.group('old'))
     new = trigger.group('new')
-    me = False  # /me command
     flags = trigger.group('flags') or ''
 
     # only clean/format the new string if it's non-empty
@@ -182,39 +185,39 @@ def findandreplace(bot, trigger):
 
     # Dynamically defined replacement function makes later calls a bit clearer
     def do_replacement(line, subst):
-        return re.sub(regex, subst, line, count=count)
+        return regex.sub(subst, line, count=count)
 
-    # Look back through the user's lines in the channel until you find a line
-    # where the replacement works
+    is_action = False  # /me command
     new_line = new_display = None
     for line in history:
+        # Look back through the user's lines in the channel for one where the
+        # replacement works
         if line.startswith("\x01ACTION"):
-            me = True  # /me command
+            is_action = True
             line = line[8:]
         else:
-            me = False
+            is_action = False
         replaced = do_replacement(line, new)
         if replaced != line:
             # we are done
             new_line = replaced
             new_display = do_replacement(line, bold(new))
             break
-
-    if not new_line:
-        # Didn't find anything
+    else:
+        # No matching line; nothing to do
         return
 
     # Save the new "edited" message.
-    action = (me and '\x01ACTION ') or ''  # If /me message, prepend \x01ACTION
+    action = '\x01ACTION ' if is_action else ''
     history.appendleft(action + new_line)  # history is in most-recent-first order
 
     # output
-    if not me:
+    if not is_action:
         new_display = 'meant to say: %s' % new_display
-    if trigger.group(1):
-        msg = '%s thinks %s %s' % (trigger.nick, rnick, new_display)
-    else:
+    if correcting_self:
         msg = '%s %s' % (trigger.nick, new_display)
+    else:
+        msg = '%s thinks %s %s' % (trigger.nick, rnick, new_display)
 
     bot.say(msg)
 

--- a/sopel/builtins/find.py
+++ b/sopel/builtins/find.py
@@ -152,7 +152,7 @@ def findandreplace(bot, trigger):
     # Correcting other person vs self.
     rnick = bot.make_identifier(trigger.group('nick') or trigger.nick)
 
-    # only do something if there is conversation to work with
+    # only do something if there is conversation history to work with
     history = bot.memory['find_lines'].get(trigger.sender, {}).get(rnick, None)
     if not history:
         return
@@ -170,23 +170,16 @@ def findandreplace(bot, trigger):
         new = escape_sequence_pattern.sub(decode_escape, new)
 
     # If g flag is given, replace all. Otherwise, replace once.
-    if 'g' in flags:
-        count = -1
-    else:
-        count = 1
+    count = 0 if 'g' in flags else 1
+    # If i flag is given, ignore case when replacing.
+    regex_flags = re.U | (re.I if 'i' in flags else 0)
 
-    # repl is a dynamically defined function which performs the substitution.
-    # i flag turns off case sensitivity. re.U turns on unicode replacement.
-    if 'i' in flags:
-        regex = re.compile(re.escape(old), re.U | re.I)
-        # re.sub() uses count=0 to mean "replace all" and str.replace() uses -1, so we must translate here
-        re_count = int(count == 1)
+    # Precompile the regex with its flags
+    regex = re.compile(re.escape(old), regex_flags)
 
-        def repl(line, subst):
-            return re.sub(regex, subst, line, count=re_count)
-    else:
-        def repl(line, subst):
-            return line.replace(old, subst, count)
+    # Dynamically defined replacement function makes later calls a bit clearer
+    def do_replacement(line, subst):
+        return re.sub(regex, subst, line, count=count)
 
     # Look back through the user's lines in the channel until you find a line
     # where the replacement works
@@ -197,14 +190,16 @@ def findandreplace(bot, trigger):
             line = line[8:]
         else:
             me = False
-        replaced = repl(line, new)
-        if replaced != line:  # we are done
+        replaced = do_replacement(line, new)
+        if replaced != line:
+            # we are done
             new_line = replaced
-            new_display = repl(line, bold(new))
+            new_display = do_replacement(line, bold(new))
             break
 
     if not new_line:
-        return  # Didn't find anything
+        # Didn't find anything
+        return
 
     # Save the new "edited" message.
     action = (me and '\x01ACTION ') or ''  # If /me message, prepend \x01ACTION

--- a/sopel/builtins/find.py
+++ b/sopel/builtins/find.py
@@ -147,11 +147,8 @@ def kick_cleanup(bot, trigger):
              )?
             """)
 @plugin.priority('high')
+@plugin.require_chanmsg
 def findandreplace(bot, trigger):
-    # Don't bother in PM
-    if trigger.is_privmsg:
-        return
-
     # Correcting other person vs self.
     rnick = bot.make_identifier(trigger.group('nick') or trigger.nick)
 

--- a/test/builtins/test_builtins_find.py
+++ b/test/builtins/test_builtins_find.py
@@ -52,6 +52,8 @@ REPLACES_THAT_WORK = (
     ("abABab", r"s/b/c/g", "abABab".replace('b', bold('c'))),  # g (global) flag
     ("ABabAB", r"s/b/c/i", f"A{bold('c')}abAB"),  # i (case-insensitive) flag
     ("ABabAB", r"s/b/c/ig", f"A{bold('c')}a{bold('c')}A{bold('c')}"),  # both flags
+    # /me (CTCP ACTION) lines
+    ("\x01ACTION does nothing.\x01", r"s/no/some/", f"does {bold('some')}thing."),
 )
 
 


### PR DESCRIPTION
### Description

Streamline the logic in `find` plugin's `findandreplace()` function:

* Remove the dance of choosing `re.sub()` or `str.replace()` depending on input. Just use `re.sub()` always.
* Bonus: Use `@plugin.require_chanmsg` decorator instead of an inline `if` block.

In follow-up to https://github.com/sopel-irc/sopel/pull/2738/files/eaf6ae38e6477aa97cbb560e25018a67665e59ae#r3204111000

Performance isn't a big concern here, so I think we're much better off with an easier-to-read function that takes slightly longer to run when a user invokes it. Chances are no one will notice the added delay.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
  - I'm pleased to report that this feature is already covered by `test/builtins/test_builtins_find.py` and none of the tests broke with the patch here 🥳
- [x] I have tested the functionality of the things this change touches