### PR TITLE
config, coretasks: add `core.owner_host` setting

### DIFF
--- a/docs/source/run/configuration.rst
+++ b/docs/source/run/configuration.rst
@@ -139,9 +139,10 @@ Owner & Admins
 --------------
 
 A Sopel instance must have exactly one owner. This is configured by the
-:attr:`~CoreSection.owner` setting. If the IRC server supports IRCv3 accounts,
-Sopel can use :attr:`~CoreSection.owner_account` to increase the security of
-ownership verification.
+:attr:`~CoreSection.owner` setting. You can specify the owner's host using
+:attr:`~CoreSection.owner_host` for some extra security. If the IRC server
+supports IRCv3 accounts, Sopel can use :attr:`~CoreSection.owner_account` for
+the most secure ownership verification.
 
 The same instance can have multiple admins. Similarly, it can be configured
 by :attr:`~CoreSection.admin_accounts` or by :attr:`~CoreSection.admins`. If
@@ -157,6 +158,16 @@ Example owner & admin configurations::
             Exirel
             HumorBaby
 
+    # Using nickname + host matching
+    [core]
+    # Will be used for alerts and ownership verification
+    owner = dgw
+    # Will be used for ownership verification only
+    owner_host = *.example.com
+    admins =
+            Exirel
+            HumorBaby
+
     # Using account matching
     [core]
     # Will be used for alerts only
@@ -167,9 +178,9 @@ Example owner & admin configurations::
             Exirel
             HumorBaby
 
-Both ``owner_account`` and ``admin_accounts`` are safer to use than
-nick-based matching, but the IRC server must support accounts.
-(Most, sadly, do not as of late 2019.)
+Both ``owner_account`` and ``admin_accounts`` are safer to use than nick-based
+matching, but the IRC server must support accounts. (The situation has improved
+as of mid-2026, but account support is still not universal.)
 
 .. important::
 

--- a/sopel/config/core_section.py
+++ b/sopel/config/core_section.py
@@ -1126,6 +1126,19 @@ class CoreSection(StaticSection):
     capabilities.
     """
 
+    owner_host = ValidatedAttribute('owner_host')
+    """The bot owner's hostname.
+
+    **Optional**, and has no effect if :attr:`owner_account` is set.
+
+    A step above just matching the nick with :attr:`owner`, this can be used to
+    more securely verify the owner's identity by matching their hostname as well
+    as nickname.
+
+    On networks that support IRCv3 account capabilities, it's recommended to use
+    :attr:`owner_account` instead, as that is the most secure option.
+    """
+
     pid_dir = FilenameAttribute('pid_dir', directory=True, default='.')
     """The directory in which to put the file Sopel uses to track its process ID.
 

--- a/sopel/coretasks.py
+++ b/sopel/coretasks.py
@@ -34,6 +34,7 @@ from typing import Callable, TYPE_CHECKING
 
 from sopel import config, plugin
 from sopel.irc import isupport, utils
+from sopel.lifecycle import deprecated
 from sopel.plugins import callables
 from sopel.tools import events, jobs, SopelMemory, target
 
@@ -186,6 +187,18 @@ def setup(bot: Sopel) -> None:
             doc=None,
         )
         bot.scheduler.register(job)
+
+    # Alert on deprecated settings usage
+    if '@' in bot.settings.core.owner:
+        deprecated(
+            "Using a host in core.owner setting is deprecated. "
+            "Please move the host to core.owner_host and keep only "
+            "the nickname in core.owner.",
+            version="8.1",
+            removed_in="9.0",
+            stack_output=False,
+            func=lambda *args: ...,
+        )()
 
 
 def shutdown(bot):

--- a/sopel/trigger.py
+++ b/sopel/trigger.py
@@ -554,6 +554,11 @@ class Trigger(str):
 
         if settings.core.owner_account:
             self._owner = settings.core.owner_account == self.account
+        elif settings.core.owner_host:
+            self._owner = (
+                match_host_or_nick(settings.core.owner_host) and
+                match_host_or_nick(settings.core.owner)
+            )
         else:
             self._owner = match_host_or_nick(settings.core.owner)
         self._admin = (

--- a/test/test_trigger.py
+++ b/test/test_trigger.py
@@ -435,6 +435,80 @@ def test_statusmsg_trigger(nick, configfactory):
     assert trigger.status_prefix == '@'
 
 
+@pytest.mark.parametrize("usernick,isowner", [
+    ("Foo", True),
+    ("Bar", False),
+])
+def test_privmsg_owner_nick_only(nick, usernick, isowner, configfactory):
+    line = f':{usernick}!bar@example.com PRIVMSG #Sopel :Hello world!'
+    pretrigger = PreTrigger(nick, line)
+
+    config = configfactory('default.cfg', """
+        [core]
+        nick = Sopel
+        owner = Foo
+        admins =
+            Bar
+    """)
+    fakematch = re.match('.*', line)
+
+    trigger = Trigger(config, pretrigger, fakematch)
+    assert trigger.owner is isowner, "Owner privilege does not match expectation"
+    assert trigger.admin is True
+
+
+@pytest.mark.parametrize("usernick,host,isowner,isadmin", [
+    ("Foo", "ip10-1-1-8.example.com", True, True),
+    ("Foo", "ip10-1-1-16.stranger.domain", False, False),
+    ("Bar", "ip10-1-1-8.example.com", False, True),
+    ("Bar", "ip10-1-1-16.stranger.domain", False, True),
+])
+def test_privmsg_owner_match_host(nick, usernick, host, isowner, isadmin, configfactory):
+    line = f':{usernick}!bar@{host} PRIVMSG #Sopel :Hello world!'
+    pretrigger = PreTrigger(nick, line)
+
+    config = configfactory('default.cfg', """
+        [core]
+        nick = Sopel
+        owner = Foo
+        owner_host = *.example.com
+        admins =
+            Bar
+    """)
+    fakematch = re.match('.*', line)
+
+    trigger = Trigger(config, pretrigger, fakematch)
+    assert trigger.owner is isowner, "Owner privilege does not match expectation"
+    assert trigger.admin is isadmin, "Admin privilege does not match expectation"
+
+
+@pytest.mark.parametrize("senderhostmask,account,isowner,isadmin", [
+    ("Foo!foo@example.net", "foo", True, True),
+    ("Bar!bar@example.net", "foo", True, True),
+    ("Bar!bar@example.net", "bar", False, True),
+    ("Stranger!stranger@example.com", "foo", True, True),
+    ("AnonymousUser!anon@example.com", None, False, False),
+])
+def test_privmsg_owner_match_account(nick, senderhostmask, account, isowner, isadmin, configfactory):
+    line = f'@account={account} :{senderhostmask} PRIVMSG #Sopel :Hello world!'
+    pretrigger = PreTrigger(nick, line)
+
+    config = configfactory('default.cfg', """
+        [core]
+        nick = Sopel
+        owner = Foo
+        owner_host = example.com  # host should be ignored if account is set
+        owner_account = foo
+        admins =
+            Bar
+    """)
+    fakematch = re.match('.*', line)
+
+    trigger = Trigger(config, pretrigger, fakematch)
+    assert trigger.owner is isowner, "Owner privilege does not match expectation"
+    assert trigger.admin is isadmin, "Admin privilege does not match expectation"
+
+
 @pytest.mark.parametrize("senderhostmask,isadmin", [
     ("Foo!bar@example.com", True),
     ("Bar!bar@example.com", True),


### PR DESCRIPTION
Using '@' in `core.owner` is deprecated and will emit a warning. Milestoned for 8.1.0 so we have a runway before removing support for '@' in `core.owner` completely in 9.0.

Fallback order of owner validation logic is now as follows:

- `core.account` set: check account name, ignore nick/host
- `core.owner_host` set, `core.account` not set: check nick & hostname
- `core.owner` set only: check nick (YOLO)

Possible that I missed some docs mentions, but I updated the major ones (in `core_section` itself and the `run/configuration.rst` page's section on Owner & Admins.

### Checklist

- [x] I have read [CONTRIBUTING.md](https://github.com/sopel-irc/sopel/blob/master/CONTRIBUTING.md)
- [x] I can and do license this contribution under the EFLv2
- [x] No issues are reported by `make qa` (runs `make lint` and `make test`)
- [x] I have tested the functionality of the things this change touches

### Notes

If we want to give the same sort of treatment to `core.admins` the semantics will have to be a little different, and that deserves its own PR.

Not flagging as a resolution for #2736 since the potential for problems will still exist until final removal of '@' in `core.owner` and the value is validated to contain only a nick-like string.